### PR TITLE
Refactor interface for easier extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,13 +34,13 @@
 
       <div class="content">
         <h1>
-          play<span class="letter" id="h" can-click="text-shadow">h</span
-          ><span class="letter" id="t" can-click="text-shadow">t</span
-          ><span class="letter" id="m" can-click="text-shadow">m</span
-          ><span class="letter" id="l" can-click="text-shadow">l</span>
+          play<span class="letter" id="h" can-toggle>h</span
+          ><span class="letter" id="t" can-toggle>t</span
+          ><span class="letter" id="m" can-toggle>m</span
+          ><span class="letter" id="l" can-toggle>l</span>
         </h1>
         <div id="lampContainer">
-          <img id="lamp" src="/noguchi-hanging-lamp.png" can-click="filter" />
+          <img id="lamp" src="/noguchi-hanging-lamp.png" can-toggle />
         </div>
         <i>interactive, collaborative html elements with a single attribute.</i>
         <p>

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -38,29 +38,6 @@
 // ondrag - combination of clicked and onmousemove
 // onhover
 
-// <div onclick={onClick}></div>
-
-// function createCapability(onClick: (stateObject) => {}): { onClick: (e: MouseEvent) => void; onDrag; onHover} {
-//     const stateObject: CSSPropertyRule = {};
-//     return {
-//         onClick: () => {
-
-//         },
-//         onDrag: () => {},
-//         onHover: () => {},
-//     }
-// }
-
-// bindCapability(element, capability) {
-//     element.addEventListener("click", capability.onClick);
-//     element.addEventListener("drag", capability.onDrag);
-//     element.addEventListener("hover", capability.onHover);
-// }
-
-// function onClick(e: MouseEvent)  {
-
-// }
-
 /*
 // alternatively the wish / listen method
 // wish="can-move"

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,16 @@ import {
 } from "./elements";
 
 export type Position = { x: number; y: number };
+export type MoveData = {
+  x: number;
+  y: number;
+  startMouseX: number;
+  startMouseY: number;
+};
+export type SpinData = {
+  rotation: number;
+  startMouseX: number;
+};
 
 export interface TagTypeToElement {
   [TagType.CanPlay]: Element;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,11 @@ export type SpinData = {
   rotation: number;
   startMouseX: number;
 };
+export type GrowData = {
+  scale: number;
+  maxScale: number;
+  isHovering: boolean;
+};
 
 export interface TagTypeToElement {
   [TagType.CanPlay]: Element;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,20 +9,22 @@ import {
 export type Position = { x: number; y: number };
 
 export interface TagTypeToElement {
+  [TagType.CanPlay]: Element;
   [TagType.CanMove]: MoveElement;
   [TagType.CanSpin]: SpinElement;
   [TagType.CanGrow]: GrowElement;
   // [TagType.CanDraw]: DrawElement;
   // [TagType.CanBounce]: BounceElement;
-  [TagType.CanClick]: ClickElement;
+  [TagType.CanToggle]: ClickElement;
 }
 
 // Supported Tags
 export enum TagType {
+  "CanPlay" = "can-play",
   "CanMove" = "can-move",
   "CanSpin" = "can-spin",
   "CanGrow" = "can-grow",
-  "CanClick" = "can-click",
+  "CanToggle" = "can-toggle",
   // "CanDraw" = "can-draw",
   // "CanBounce" = "can-bounce",
   // "CanHover" = "can-hover",


### PR DESCRIPTION
This PR refactors the interface so that people adding new capabilities to the library only need to worry about adding to a single mapping with support for any event listener on the element as a point to update the synced state.

The `CanPlay` tag offers a general-purpose tag for a fully custom handler