### PR TITLE
Add `can-duplicate` tag, & refactor for dynamic element setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+## 1.3.0 - 2023-08-07
+
+- Added support for `can-duplicate` capability to duplicate elements. Make factories for playhtml elements!!
+
 ## 1.2.0 - 2023-08-03
 
 - Added support for yjs's `awareness` protocol to handle synced data that shouldn't be persisted.

--- a/README.md
+++ b/README.md
@@ -115,26 +115,30 @@ We welcome any contributions if you have custom `can-play` elements that you wou
 
 https://github.com/spencerc99/playhtml/assets/14796580/9c2b9bf6-142c-41e2-8c8f-93a3b121a73e
 
-Creates a movable object using 2D `translate` on the element. Dragging the element around will move it
+Creates a movable element using 2D `translate` on the element. Dragging the element around will move it
 
 **troubleshooting**
 
 - This currently doesn't work on `inline` display elements.
 - This currently doesn't work on touch screens.
 
-### `can-spin`
-
-Creates a rotatable object using a `rotate` `transform` on the element. Dragging the element to the left or right will rotate it counter-clockwise and clockwise respectively.
-
 ### `can-toggle`
 
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">today i installed some lamps on the demos-and-chill website<br><br>then <a href="https://twitter.com/_jzhao?ref_src=twsrc%5Etfw">@_jzhao</a> and i fought on whether to keep them on or not. <a href="https://t.co/sCspTwmRpS">pic.twitter.com/sCspTwmRpS</a></p>&mdash; spencer chang ☀️ (spencerchang.me @ bsky) (@spencerc99) <a href="https://twitter.com/spencerc99/status/1681048824884895744?ref_src=twsrc%5Etfw">July 17, 2023</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 
-Creates an object that can be switched on and off. Clicking the element will toggle the `clicked` class on the element.
+Creates an element that can be switched on and off. Clicking the element will toggle the `clicked` class on the element.
+
+### `can-duplicate`
+
+Creates an element that duplicates a target element (specified by the value of the `can-duplicate` attribute, which can be an element's ID or custom CSS selector) when clicked. Optionally can specify where the duplicate element is inserted in the DOM via the `can-duplicate-to` setting (default is as a sibling to the original element).
 
 ### `can-grow`
 
-Creates an object that can be resized using a `scale` `transform`. Clicking the object will grow it, clicking with <kbd>ALT</kbd> will shrink it. Currently, the max size is 2x the original size and the min size is 1/2 the original size.
+Creates an element that can be resized using a `scale` `transform`. Clicking the element will grow it, clicking with <kbd>ALT</kbd> will shrink it. Currently, the max size is 2x the original size and the min size is 1/2 the original size.
+
+### `can-spin`
+
+Creates a rotatable element using a `rotate` `transform` on the element. Dragging the element to the left or right will rotate it counter-clockwise and clockwise respectively.
 
 ### `can-post`
 

--- a/home.scss
+++ b/home.scss
@@ -230,6 +230,9 @@ footer {
 }
 
 #customCandle {
+  float: right;
+  position: relative;
+  z-index: 5;
 }
 
 /**

--- a/home.scss
+++ b/home.scss
@@ -230,10 +230,6 @@ footer {
 }
 
 #customCandle {
-  width: 80px;
-  float: right;
-  z-index: 5;
-  position: relative;
 }
 
 /**

--- a/home.scss
+++ b/home.scss
@@ -406,4 +406,5 @@ kbd {
 
 .candle {
   width: 80px;
+  cursor: pointer;
 }

--- a/home.scss
+++ b/home.scss
@@ -403,3 +403,7 @@ kbd {
     animation-timing-function: ease-out;
   }
 }
+
+.candle {
+  width: 80px;
+}

--- a/index.html
+++ b/index.html
@@ -111,7 +111,6 @@
             can-play
             id="customCandle"
             src="/candle-gif.gif"
-            can-move
             class="candle"
           />
         </div>
@@ -152,7 +151,6 @@
           };
           makeCandleBtn.updateElement = ({ data, localData, setLocalData }) => {
             let numAdded = 0;
-            console.log(localData);
             for (const candleId of data) {
               if (localData.has(candleId)) continue;
               const duplicateElementId =
@@ -167,7 +165,6 @@
               numAdded++;
             }
             if (numAdded) {
-              console.log("calling setup again");
               // TODO: this is causing duplicate setup. Need to make it a singleton such that only one instance is running at a time... maybe use the debounce logic?
               // TOOD: this should just target the exact elements that were added
               setTimeout(() => setupElements(), 1000);

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
         </details>
         <h2>existing tags</h2>
         <div id="candleFactory">
-          <button id="makeCandleBtn" can-duplicate="customCandle" can-play>
+          <button id="makeCandleBtn" can-duplicate="customCandle">
             Make candle
           </button>
           <!-- candle credit: https://nyknck.itch.io/candle -->
@@ -123,42 +123,13 @@
             candle.onClick = (_e, { data, setData }) => {
               setData(!data);
             };
-            candle.updateElement = ({ data }) => {
-              candle.src = data ? "/candle-gif.gif" : "/candle-off.png";
+            candle.updateElement = ({ element, data }) => {
+              element.src = data ? "/candle-gif.gif" : "/candle-off.png";
             };
             candle.resetShortcut = "shiftKey";
           }
 
           enchantCandle(customCandle);
-
-          makeCandleBtn.defaultData = [];
-          makeCandleBtn.defaultLocalData = new Set();
-          makeCandleBtn.onClick = (_e, { data, setData }) => {
-            const duplicateElementId =
-              makeCandleBtn.getAttribute("can-duplicate");
-            newCandleId =
-              duplicateElementId +
-              "-" +
-              Math.random().toString(36).substr(2, 9);
-
-            setData([...data, newCandleId]);
-          };
-          makeCandleBtn.updateElement = ({ data, localData, setLocalData }) => {
-            for (const candleId of data) {
-              if (localData.has(candleId)) continue;
-              const duplicateElementId =
-                makeCandleBtn.getAttribute("can-duplicate");
-              const elementToDuplicate =
-                document.getElementById(duplicateElementId);
-              const newCandle = elementToDuplicate.cloneNode(true);
-              newCandle.id = candleId;
-              enchantCandle(newCandle);
-              document.getElementById("candleFactory").appendChild(newCandle);
-              localData.add(candleId);
-              playhtml.setupPlayElement(newCandle);
-            }
-            setLocalData(localData);
-          };
         </script>
         <script></script>
         <ol>

--- a/index.html
+++ b/index.html
@@ -144,7 +144,6 @@
             setData([...data, newCandleId]);
           };
           makeCandleBtn.updateElement = ({ data, localData, setLocalData }) => {
-            let numAdded = 0;
             for (const candleId of data) {
               if (localData.has(candleId)) continue;
               const duplicateElementId =
@@ -156,13 +155,9 @@
               enchantCandle(newCandle);
               document.getElementById("candleFactory").appendChild(newCandle);
               localData.add(candleId);
-              numAdded++;
+              playhtml.setupPlayElement(newCandle);
             }
-            if (numAdded) {
-              // TODO: this should just target the exact elements that were added
-              setTimeout(() => playhtml.setupElements(), 1000);
-              setLocalData(localData);
-            }
+            setLocalData(localData);
           };
         </script>
         <script></script>

--- a/index.html
+++ b/index.html
@@ -102,26 +102,79 @@
           </p>
         </details>
         <h2>existing tags</h2>
-        <!-- candle credit: https://nyknck.itch.io/candle -->
-        <img can-play id="customCandle" src="/candle-gif.gif" can-move />
+        <div id="candleFactory">
+          <button id="makeCandleBtn" can-duplicate="customCandle" can-play>
+            Make candle
+          </button>
+          <!-- candle credit: https://nyknck.itch.io/candle -->
+          <img
+            can-play
+            id="customCandle"
+            src="/candle-gif.gif"
+            can-move
+            class="candle"
+          />
+        </div>
+
         <!-- Set data for custom (can-play) playhtml elements -->
         <!-- IMPORTANT: this data must be set _before_ importing the playhtml library. -->
         <script>
-          customCandle.defaultData = true;
-          customCandle.onClick = (_e, { data, setData }) => {
-            setData(!data);
+          function enchantCandle(candle) {
+            candle.defaultData = true;
+            candle.onClick = (_e, { data, setData }) => {
+              setData(!data);
+            };
+            // candle.additionalSetup = ({ getData, setData }) => {
+            //   candle.addEventListener("click", (_e) => {
+            //     const data = getData();
+            //     setData(!data);
+            //   });
+            // };
+            candle.updateElement = ({ data }) => {
+              candle.src = data ? "/candle-gif.gif" : "/candle-off.png";
+            };
+            candle.resetShortcut = "shiftKey";
+          }
+
+          enchantCandle(customCandle);
+
+          makeCandleBtn.defaultData = [];
+          makeCandleBtn.defaultLocalData = new Set();
+          makeCandleBtn.onClick = (_e, { data, setData }) => {
+            const duplicateElementId =
+              makeCandleBtn.getAttribute("can-duplicate");
+            newCandleId =
+              duplicateElementId +
+              "-" +
+              Math.random().toString(36).substr(2, 9);
+
+            setData([...data, newCandleId]);
           };
-          // customCandle.additionalSetup = ({ getData, setData }) => {
-          //   customCandle.addEventListener("click", (_e) => {
-          //     const data = getData();
-          //     setData(!data);
-          //   });
-          // };
-          customCandle.updateElement = ({ data }) => {
-            customCandle.src = data ? "/candle-gif.gif" : "/candle-off.png";
+          makeCandleBtn.updateElement = ({ data, localData, setLocalData }) => {
+            let numAdded = 0;
+            console.log(localData);
+            for (const candleId of data) {
+              if (localData.has(candleId)) continue;
+              const duplicateElementId =
+                makeCandleBtn.getAttribute("can-duplicate");
+              const elementToDuplicate =
+                document.getElementById(duplicateElementId);
+              const newCandle = elementToDuplicate.cloneNode(true);
+              newCandle.id = candleId;
+              enchantCandle(newCandle);
+              document.getElementById("candleFactory").appendChild(newCandle);
+              localData.add(candleId);
+              numAdded++;
+            }
+            if (numAdded) {
+              console.log("calling setup again");
+              // TODO: this is causing duplicate setup. Need to make it a singleton such that only one instance is running at a time... maybe use the debounce logic?
+              setTimeout(() => setupElements(), 1000);
+              setLocalData(localData);
+            }
           };
-          customCandle.resetShortcut = "shiftKey";
         </script>
+        <script></script>
         <ol>
           <!-- TODO: move this into React to dynamically update -->
           <li>

--- a/index.html
+++ b/index.html
@@ -123,12 +123,6 @@
             candle.onClick = (_e, { data, setData }) => {
               setData(!data);
             };
-            // candle.additionalSetup = ({ getData, setData }) => {
-            //   candle.addEventListener("click", (_e) => {
-            //     const data = getData();
-            //     setData(!data);
-            //   });
-            // };
             candle.updateElement = ({ data }) => {
               candle.src = data ? "/candle-gif.gif" : "/candle-off.png";
             };
@@ -165,9 +159,8 @@
               numAdded++;
             }
             if (numAdded) {
-              // TODO: this is causing duplicate setup. Need to make it a singleton such that only one instance is running at a time... maybe use the debounce logic?
-              // TOOD: this should just target the exact elements that were added
-              setTimeout(() => setupElements(), 1000);
+              // TODO: this should just target the exact elements that were added
+              setTimeout(() => playhtml.setupElements(), 1000);
               setLocalData(localData);
             }
           };

--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
             if (numAdded) {
               console.log("calling setup again");
               // TODO: this is causing duplicate setup. Need to make it a singleton such that only one instance is running at a time... maybe use the debounce logic?
+              // TOOD: this should just target the exact elements that were added
               setTimeout(() => setupElements(), 1000);
               setLocalData(localData);
             }

--- a/index.html
+++ b/index.html
@@ -102,36 +102,40 @@
           </p>
         </details>
         <h2>existing tags</h2>
-        <div id="candleFactory">
+        <!-- candle credit: https://nyknck.itch.io/candle -->
+        <img
+          can-play
+          can-move
+          id="customCandle"
+          src="/candle-gif.gif"
+          class="candle"
+        />
+        <!-- <div id="candleFactory">
           <button id="makeCandleBtn" can-duplicate="customCandle">
             Make candle
           </button>
-          <!-- candle credit: https://nyknck.itch.io/candle -->
           <img
             can-play
+            can-move
             id="customCandle"
             src="/candle-gif.gif"
             class="candle"
           />
-        </div>
+        </div> -->
 
         <!-- Set data for custom (can-play) playhtml elements -->
         <!-- IMPORTANT: this data must be set _before_ importing the playhtml library. -->
         <script>
-          function enchantCandle(candle) {
-            candle.defaultData = true;
-            candle.onClick = (_e, { data, setData }) => {
-              setData(!data);
-            };
-            candle.updateElement = ({ element, data }) => {
-              element.src = data ? "/candle-gif.gif" : "/candle-off.png";
-            };
-            candle.resetShortcut = "shiftKey";
-          }
-
-          enchantCandle(customCandle);
+          const candle = document.getElementById("customCandle");
+          candle.defaultData = true;
+          candle.onClick = (_e, { data, setData }) => {
+            setData(!data);
+          };
+          candle.updateElement = ({ element, data }) => {
+            element.src = data ? "/candle-gif.gif" : "/candle-off.png";
+          };
+          candle.resetShortcut = "shiftKey";
         </script>
-        <script></script>
         <ol>
           <!-- TODO: move this into React to dynamically update -->
           <li>
@@ -140,10 +144,12 @@
               >with your code</a
             >!)
           </li>
+          <!-- TODO: spotlight elements on the page that match these -->
           <li>can-move</li>
+          <li>can-toggle</li>
+          <li>can-duplicate</li>
           <li>can-spin</li>
           <li>can-grow</li>
-          <li>can-toggle</li>
           <li>can-post</li>
           <li>
             <a href="https://github.com/spencerc99/playhtml/pulls"
@@ -155,6 +161,7 @@
         <ol>
           <li><a href="/story.html">one word story</a></li>
           <li><a href="/fridge.html">fridge poetry</a></li>
+          <li>candle factory (coming soon)</li>
           <li>communal garden (coming soon)</li>
           <li>puzzle (coming soon)</li>
         </ol>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playhtml",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "type": "module",
   "main": "./dist/playhtml.umd.js",

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -321,6 +321,9 @@ export const TagTypeToElement: Record<
       });
     },
   } as ElementInitializer<FormData[]>,
+  // TODO: add ability to add max # of duplicates
+  // TODO: add lifespan to automatically prune
+  // TODO: add limit per person / per timeframe.
   [TagType.CanDuplicate]: {
     defaultData: [],
     defaultLocalData: [],

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -19,14 +19,6 @@ const ModifierKeyToName: Record<ModifierKey, string> = {
   metaKey: "Meta",
 };
 
-// TODO: Expose these to the user to simplify accessing data in `globalData`
-// function retrieveElementData(element: HTMLElement, key: string): any {
-//   return JSON.parse(element.dataset[key] || "null");
-// }
-// function setElementData(element: HTMLElement, key: string, value: any): void {
-//   element.dataset[key] = JSON.stringify(value);
-// }
-
 // TODO: should be able to have set of allowable elements
 // TODO: should be able to accept arbitrary input? (like max/min)
 // TODO: should be able to add permission conditions?
@@ -140,7 +132,6 @@ function getClientCoordinates(e: MouseEvent | TouchEvent): {
   return { clientX: e.clientX, clientY: e.clientY };
 }
 
-// TODO: make it a function that takes in element to get result?
 export const TagTypeToElement: Record<
   Exclude<TagType, "can-play">,
   ElementInitializer
@@ -225,7 +216,6 @@ export const TagTypeToElement: Record<
     resetShortcut: "shiftKey",
   },
   [TagType.CanGrow]: {
-    // TODO: turn this into a function so you can accept arbitrary user input?
     defaultData: { scale: 1 },
     defaultLocalData: { maxScale: 2, isHovering: false },
     updateElement: ({ element, data }) => {
@@ -279,7 +269,6 @@ export const TagTypeToElement: Record<
         (entry) => !addedEntries.has(entry.id)
       );
 
-      // TODO: add typing indicators for anyone who has it filled out
       const guestbookDiv = getElementFromId("guestbookMessages")!;
       entriesToAdd.forEach((entry) => {
         const newEntry = document.createElement("div");
@@ -562,7 +551,6 @@ export class ElementHandler<T = any, U = any, V = any> {
     };
   }
 
-  // TODO: turn from setter into a method to allow for debouncing
   /**
    * Public-use setter for data that makes the change to all clients.
    */

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom"/>
-import { getElementFromId } from "./main";
-import { GrowData, MoveData, SpinData, TagType } from "./types";
+import { getElementFromId, playhtml } from "./main";
+import { CanDuplicateTo, GrowData, MoveData, SpinData, TagType } from "./types";
 
 // @ts-ignore
 const debounce = (fn: Function, ms = 300) => {
@@ -321,6 +321,63 @@ export const TagTypeToElement: Record<
       });
     },
   } as ElementInitializer<FormData[]>,
+  [TagType.CanDuplicate]: {
+    defaultData: [],
+    defaultLocalData: [],
+    updateElement: ({ data, localData, setLocalData, element }) => {
+      const duplicateElementId = element.getAttribute(TagType.CanDuplicate)!;
+      const elementToDuplicate = document.getElementById(duplicateElementId);
+      let lastElement: HTMLElement | null =
+        document.getElementById(localData.slice(-1)?.[0]) ?? null;
+      if (!elementToDuplicate) {
+        console.error(
+          `Element with id ${duplicateElementId} not found. Cannot duplicate.`
+        );
+        return;
+      }
+
+      const canDuplicateTo = element.getAttribute(CanDuplicateTo);
+      function insertDuplicatedElement(newElement: Node) {
+        if (canDuplicateTo) {
+          const duplicateToElement =
+            document.getElementById(canDuplicateTo) ||
+            document.querySelector(canDuplicateTo);
+          if (duplicateToElement) {
+            duplicateToElement.appendChild(newElement);
+            return;
+          }
+        }
+
+        // By default insert after the latest element inserted (or the element to duplicate if none yet)
+        elementToDuplicate!.parentNode!.insertBefore(
+          newElement,
+          (lastElement || elementToDuplicate!).nextSibling
+        );
+      }
+
+      const addedElements = new Set(localData);
+      for (const elementId of data) {
+        if (addedElements.has(elementId)) continue;
+
+        const newElement = elementToDuplicate.cloneNode(true) as HTMLElement;
+        Object.assign(newElement, { ...elementToDuplicate });
+        newElement.id = elementId;
+
+        insertDuplicatedElement(newElement);
+        localData.push(elementId);
+        playhtml.setupPlayElement(newElement);
+        lastElement = newElement;
+      }
+      setLocalData(localData);
+    },
+    onClick: (_e: MouseEvent, { data, element, setData }) => {
+      const duplicateElementId = element.getAttribute(TagType.CanDuplicate)!;
+      const newElementId =
+        duplicateElementId + "-" + Math.random().toString(36).substr(2, 9);
+
+      setData([...data, newElementId]);
+    },
+  } as ElementInitializer<string[]>,
 };
 
 interface FormData {

--- a/src/main.ts
+++ b/src/main.ts
@@ -309,16 +309,47 @@ function maybeSetupTag(tag: TagType): void {
 }
 
 /**
+ * Returns true if the given element is set up properly for the given tag, false otherwise.
+ */
+function isElementValidForTag(element: HTMLElement, tag: TagType): boolean {
+  const tagAttribute = element.getAttribute(tag);
+  switch (tag) {
+    case TagType.CanPlay:
+    case TagType.CanMove:
+    case TagType.CanSpin:
+    case TagType.CanGrow:
+    case TagType.CanToggle:
+    case TagType.CanPost:
+      return true;
+    case TagType.CanDuplicate:
+      if (!tagAttribute) {
+        return false;
+      }
+
+      if (!document.getElementById(tagAttribute)) {
+        console.warn(
+          `${TagType.CanDuplicate} element (${element.id}) duplicate element ("${tagAttribute}") not found.`
+        );
+      }
+
+      return true;
+    default:
+      console.error(`Unhandled tag found in validation: ${tag}`);
+      return false;
+  }
+}
+
+/**
  * Sets up a playhtml element to handle the given tag's capabilities.
- *
- * @param element
- * @param tag
- * @returns
  */
 export function setupPlayElementForTag<T extends TagType>(
   element: HTMLElement,
   tag: T
 ): void {
+  if (!isElementValidForTag(element, tag)) {
+    return;
+  }
+
   if (!element.id) {
     // TODO: better way for unique ID here? but actually having it reversible is a nice property
     const selectorId = element.getAttribute("selector-id");

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,10 +214,12 @@ function onChangeAwareness() {
  */
 export function setupElements(): void {
   console.log(
-    `࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂
-࿂࿂࿂࿂ INITIALIZING playhtml ࿂࿂࿂࿂
-࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂`,
-    globalData.toJSON()
+    `࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂
+࿂࿂࿂࿂  ࿂    ࿂    ࿂    ࿂    ࿂  ࿂࿂࿂࿂
+࿂࿂࿂࿂ booting up playhtml... ࿂࿂࿂࿂
+࿂࿂࿂࿂  https://playhtml.fun  ࿂࿂࿂࿂
+࿂࿂࿂࿂   ࿂     ࿂     ࿂     ࿂   ࿂࿂࿂࿂
+࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂࿂`
   );
 
   for (const tag of Object.values(TagType)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export type GrowData = {
   isHovering: boolean;
 };
 
+export const CanDuplicateTo = "can-duplicate-to";
+
 // Supported Tags
 export enum TagType {
   "CanPlay" = "can-play",
@@ -18,6 +20,7 @@ export enum TagType {
   "CanSpin" = "can-spin",
   "CanGrow" = "can-grow",
   "CanToggle" = "can-toggle",
+  "CanDuplicate" = "can-duplicate",
   "CanPost" = "can-post",
   // "CanDraw" = "can-draw",
   // "CanBounce" = "can-bounce",


### PR DESCRIPTION
- adds support for `can-duplicate` with a candle factory as an example
- reactors for reusability and setting up new playhtml elements dynamically