### PR TITLE
more ergonomic use of presence in react

### DIFF
--- a/.changeset/identity-cache.md
+++ b/.changeset/identity-cache.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Cache `generatePersistentPlayerIdentity()` at the module level so repeated calls return a reference-stable identity. Previously each call re-parsed localStorage, producing a new object with identical data — causing React effect deps and memo comparisons keyed on identity to invalidate on every render. Also fixes two edge cases where corrupt or locked localStorage would cause different identities to be returned across calls in the same session.

--- a/.changeset/react-pre-init-hooks.md
+++ b/.changeset/react-pre-init-hooks.md
@@ -1,0 +1,7 @@
+---
+"@playhtml/react": minor
+---
+
+Add `usePresence`, `usePageData`, and `usePresenceRoom` hooks that are safe to call before playhtml has finished initializing. They return empty/default values and no-op setters until sync completes, then wire up automatically — no `hasSynced` guards needed at call sites.
+
+Also adds `isLoading` to `PlayContext` as the preferred way to check init state. `hasSynced` is still present (inverse semantics) but deprecated.

--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,7 @@
     },
     "extension": {
       "name": "@playhtml/extension",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@playhtml/common": "workspace:*",
         "@playhtml/react": "workspace:*",
@@ -63,7 +63,7 @@
     },
     "extension/website": {
       "name": "wewere-online",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@playhtml/common": "workspace:*",
         "@playhtml/react": "workspace:*",
@@ -90,7 +90,7 @@
     },
     "packages/common": {
       "name": "@playhtml/common",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "devDependencies": {
         "typescript": "^5.0.2",
         "vite": "^7.1.2",
@@ -99,9 +99,9 @@
     },
     "packages/playhtml": {
       "name": "playhtml",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "dependencies": {
-        "@playhtml/common": "0.5.0",
+        "@playhtml/common": "0.6.0",
         "@syncedstore/core": "^0.6.0",
         "y-partyserver": "^1.0.0",
         "yjs": "13.6.18",
@@ -118,11 +118,11 @@
     },
     "packages/react": {
       "name": "@playhtml/react",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
-        "@playhtml/common": "^0.5.0",
+        "@playhtml/common": "^0.6.0",
         "classnames": "^2.3.2",
-        "playhtml": "^2.8.0",
+        "playhtml": "^2.9.0",
         "react": "^16.8.0  || ^17.0.0 || ^18.2.0 || ^19.0.0",
         "react-dom": "^16.8.0  || ^17.0.0 || ^18.2.0 || ^19.0.0",
       },

--- a/packages/common/src/cursor-types.ts
+++ b/packages/common/src/cursor-types.ts
@@ -104,12 +104,24 @@ function ensurePrimaryColorAndSave(identity: PlayerIdentity): void {
 }
 
 export const PLAYER_IDENTITY_STORAGE_KEY = "playhtml_player_identity";
+
+// Module-level cache so repeated calls return a reference-stable identity.
+// Identity is set-once per tab: JSON.parse allocates a new object on each
+// localStorage read, which would otherwise cause React effect deps and memo
+// comparisons keyed on identity to invalidate on every render.
+let cachedPlayerIdentity: PlayerIdentity | null = null;
+
 /**
  * Loads player identity from localStorage, or generates a new one with a random
  * primary color. Ensures primary color always exists (assigns random and saves if missing).
  * Identity is persisted so the same publicKey and color are reused across sessions.
+ *
+ * The returned reference is cached for the lifetime of the JS context —
+ * subsequent calls return the same object, not a fresh parse.
  */
 export function generatePersistentPlayerIdentity(): PlayerIdentity {
+  if (cachedPlayerIdentity) return cachedPlayerIdentity;
+
   const stored = localStorage.getItem(PLAYER_IDENTITY_STORAGE_KEY);
   if (stored) {
     try {
@@ -119,6 +131,7 @@ export function generatePersistentPlayerIdentity(): PlayerIdentity {
         if (!hasValidPrimaryColor(identity)) {
           ensurePrimaryColorAndSave(identity);
         }
+        cachedPlayerIdentity = identity;
         return identity;
       }
     } catch (e) {
@@ -135,5 +148,6 @@ export function generatePersistentPlayerIdentity(): PlayerIdentity {
   } catch (e) {
     console.warn("Failed to save player identity to localStorage:", e);
   }
+  cachedPlayerIdentity = identity;
   return identity;
 }

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -13,7 +13,9 @@ export interface PlayContextInfo
     | "removePlayEventListener"
     | "deleteElementData"
   > {
+  /** @deprecated Use `isLoading` instead. */
   hasSynced: boolean;
+  isLoading: boolean;
   isProviderMissing: boolean;
   configureCursors: (options: Partial<CursorOptions>) => void;
   getMyPlayerIdentity: () => PlayerIdentity | null;
@@ -46,6 +48,7 @@ export const PlayContext = createContext<PlayContextInfo>({
   },
   removePlayEventListener: () => {},
   hasSynced: false,
+  isLoading: true,
   isProviderMissing: true,
   configureCursors: () => {
     throw new Error(
@@ -205,6 +208,7 @@ export function PlayProvider({
         removePlayEventListener: playhtml.removePlayEventListener,
         deleteElementData: playhtml.deleteElementData,
         hasSynced,
+        isLoading: !hasSynced,
         isProviderMissing: false,
         configureCursors,
         getMyPlayerIdentity,

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -1,0 +1,154 @@
+// ABOUTME: Tests for usePresence, usePageData, usePresenceRoom hooks
+// ABOUTME: Verifies pre-init no-op behavior and post-sync wiring
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, waitFor } from "@testing-library/react";
+import "@testing-library/dom";
+import { PlayProvider, usePresence, usePageData, usePresenceRoom } from "../index";
+
+describe("usePresence", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns empty map and null identity before init, then wires up", async () => {
+    const seen: Array<{ size: number; hasIdentity: boolean }> = [];
+
+    function TestComponent() {
+      const { presences, myIdentity } = usePresence("selection");
+      seen.push({ size: presences.size, hasIdentity: myIdentity !== null });
+      return <div />;
+    }
+
+    render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    // First render: pre-sync — empty presences, null identity
+    expect(seen[0]).toEqual({ size: 0, hasIdentity: false });
+
+    // After init resolves, identity becomes available
+    await waitFor(() => {
+      expect(seen.at(-1)?.hasIdentity).toBe(true);
+    });
+  });
+
+  it("setMyPresence is a no-op pre-sync, works post-sync", async () => {
+    const warnSpy = vi.spyOn(console, "warn");
+    let captured: ReturnType<typeof usePresence> | null = null;
+
+    function TestComponent() {
+      captured = usePresence("selection");
+      return <div />;
+    }
+
+    render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    // Pre-sync call should warn
+    act(() => {
+      captured!.setMyPresence({ x: 1 });
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("setMyPresence called before init"),
+    );
+
+    // Post-sync call should succeed and populate presences
+    await waitFor(() => {
+      expect(captured!.myIdentity).not.toBeNull();
+    });
+
+    act(() => {
+      captured!.setMyPresence({ x: 2 });
+    });
+
+    await waitFor(() => {
+      expect(captured!.presences.size).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("usePageData", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns defaultValue pre-sync, then real data post-sync", async () => {
+    const seen: Array<{ count: number }> = [];
+
+    function TestComponent() {
+      const [data] = usePageData("counter", { count: 0 });
+      seen.push(data);
+      return <div>{data.count}</div>;
+    }
+
+    const { getByText } = render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    expect(seen[0]).toEqual({ count: 0 });
+    await waitFor(() => expect(getByText("0")).toBeDefined());
+  });
+
+  it("setData no-ops pre-sync, writes post-sync", async () => {
+    const warnSpy = vi.spyOn(console, "warn");
+    let captured: ReturnType<typeof usePageData<{ count: number }>> | null = null;
+
+    function TestComponent() {
+      captured = usePageData("counter", { count: 0 });
+      return <div>{captured[0].count}</div>;
+    }
+
+    const { getByText } = render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    // Pre-sync setData warns
+    act(() => {
+      captured![1]({ count: 5 });
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("setData called before init"),
+    );
+
+    // Wait for sync, then setData should flow through
+    await waitFor(() => expect(getByText("0")).toBeDefined());
+
+    act(() => {
+      captured![1]({ count: 42 });
+    });
+
+    await waitFor(() => expect(getByText("42")).toBeDefined());
+  });
+});
+
+describe("usePresenceRoom", () => {
+  it("returns null pre-sync, then a room post-sync", async () => {
+    const seen: Array<boolean> = [];
+
+    function TestComponent() {
+      const room = usePresenceRoom("voice");
+      seen.push(room !== null);
+      return <div />;
+    }
+
+    render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    expect(seen[0]).toBe(false);
+    await waitFor(() => expect(seen.at(-1)).toBe(true));
+  });
+});

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -11,6 +11,9 @@ afterEach(() => {
 });
 
 // Create a mock playhtml instance
+const presenceListeners = new Map<string, Set<(presences: Map<string, unknown>) => void>>();
+const mockPresences = new Map<string, unknown>();
+
 const mockedPlayhtml = {
   isInitialized: false,
   init: vi.fn().mockImplementation(() => {
@@ -26,6 +29,46 @@ const mockedPlayhtml = {
   dispatchPlayEvent: vi.fn(),
   registerPlayEventListener: vi.fn().mockReturnValue("mock-id"),
   removePlayEventListener: vi.fn(),
+  presence: {
+    setMyPresence: vi.fn((channel: string, data: unknown) => {
+      mockPresences.set("me", { ...data, isMe: true, cursor: null });
+      const listeners = presenceListeners.get(channel);
+      if (listeners) for (const cb of listeners) cb(new Map(mockPresences));
+    }),
+    getPresences: vi.fn(() => new Map(mockPresences)),
+    onPresenceChange: vi.fn(
+      (channel: string, callback: (presences: Map<string, unknown>) => void) => {
+        let set = presenceListeners.get(channel);
+        if (!set) {
+          set = new Set();
+          presenceListeners.set(channel, set);
+        }
+        set.add(callback);
+        return () => set!.delete(callback);
+      },
+    ),
+    getMyIdentity: vi.fn(() => ({ stableId: "me", name: "Me", color: "#fff" })),
+  },
+  createPageData: vi.fn((_name: string, defaultValue: unknown) => {
+    let data = defaultValue;
+    const listeners = new Set<(d: unknown) => void>();
+    return {
+      getData: () => data,
+      setData: (next: unknown | ((draft: unknown) => void)) => {
+        data = typeof next === "function" ? (next as any)(data) ?? data : next;
+        for (const cb of listeners) cb(data);
+      },
+      onUpdate: (cb: (d: unknown) => void) => {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      destroy: vi.fn(),
+    };
+  }),
+  createPresenceRoom: vi.fn((_name: string) => ({
+    presence: mockedPlayhtml.presence,
+    destroy: vi.fn(),
+  })),
 };
 
 // Make mock available to tests

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Custom React hooks for playhtml functionality
 // ABOUTME: Cursor, presence, page-data, and presence-room hooks that safely no-op pre-sync
 
-import { useCallback, useContext, useEffect, useRef, useState, RefObject } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState, RefObject } from "react";
 import { PlayContext } from "./PlayProvider";
 import playhtml from "./playhtml-singleton";
 import {
@@ -12,6 +12,10 @@ import {
   PresenceView,
 } from "@playhtml/common";
 import type { CursorZoneOptions } from "playhtml";
+
+function warnPreInit(call: string): void {
+  console.warn(`[@playhtml/react] ${call} called before init — ignored.`);
+}
 
 /**
  * Hook to access cursor presences from the playhtml context
@@ -47,7 +51,11 @@ export function useCursorZone(
 
 /**
  * Subscribe to a presence channel. Safe to call before playhtml has initialized:
- * returns an empty map and a no-op setter until sync completes, then wires up.
+ * returns an empty map, a setter that warns and no-ops, and `null` identity
+ * until sync completes — then wires up automatically.
+ *
+ * Type parameter `T` is an assertion about the shape of presence values; no
+ * runtime validation is performed.
  */
 export function usePresence<T extends Record<string, unknown> = Record<string, unknown>>(
   channel: string,
@@ -71,9 +79,7 @@ export function usePresence<T extends Record<string, unknown> = Record<string, u
   const setMyPresence = useCallback(
     (data: T) => {
       if (isLoading) {
-        console.warn(
-          `[@playhtml/react] usePresence("${channel}").setMyPresence called before init — ignored.`,
-        );
+        warnPreInit(`usePresence("${channel}").setMyPresence`);
         return;
       }
       playhtml.presence.setMyPresence(channel, data);
@@ -81,16 +87,22 @@ export function usePresence<T extends Record<string, unknown> = Record<string, u
     [isLoading, channel],
   );
 
-  const myIdentity = isLoading ? null : playhtml.presence.getMyIdentity();
+  const myIdentity = useMemo(
+    () => (isLoading ? null : playhtml.presence.getMyIdentity()),
+    [isLoading],
+  );
 
   return { presences, setMyPresence, myIdentity };
 }
 
 /**
  * Subscribe to a page-data channel. Safe to call before playhtml has initialized:
- * returns the default value and a no-op setter until sync completes, then wires up.
+ * returns the default value and a setter that warns and no-ops until sync
+ * completes — then wires up automatically.
  *
  * Shape mirrors `useState` — `[data, setData]`.
+ *
+ * `defaultValue` is only read on first mount and when `name` changes.
  */
 export function usePageData<T>(
   name: string,
@@ -118,15 +130,13 @@ export function usePageData<T>(
   const setData = useCallback(
     (next: T | ((draft: T) => void)) => {
       const channel = channelRef.current;
-      if (!channel) {
-        console.warn(
-          `[@playhtml/react] usePageData("${name}") setData called before init — ignored.`,
-        );
+      if (isLoading || !channel) {
+        warnPreInit(`usePageData("${name}").setData`);
         return;
       }
       channel.setData(next);
     },
-    [name],
+    [isLoading, name],
   );
 
   return [data, setData];
@@ -134,7 +144,8 @@ export function usePageData<T>(
 
 /**
  * Join a presence room. Safe to call before playhtml has initialized:
- * returns `null` until sync completes.
+ * returns `null` until sync completes. When `name` changes, briefly returns
+ * `null` during the transition between rooms.
  */
 export function usePresenceRoom(name: string): PresenceRoom | null {
   const { isLoading } = useContext(PlayContext);

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,9 +1,16 @@
 // ABOUTME: Custom React hooks for playhtml functionality
-// ABOUTME: Provides hooks for cursor presences, cursor zones, and other playhtml features
+// ABOUTME: Cursor, presence, page-data, and presence-room hooks that safely no-op pre-sync
 
-import { useContext, useEffect, RefObject } from "react";
+import { useCallback, useContext, useEffect, useRef, useState, RefObject } from "react";
 import { PlayContext } from "./PlayProvider";
-import { CursorPresenceView } from "@playhtml/common";
+import playhtml from "./playhtml-singleton";
+import {
+  CursorPresenceView,
+  PageDataChannel,
+  PlayerIdentity,
+  PresenceRoom,
+  PresenceView,
+} from "@playhtml/common";
 import type { CursorZoneOptions } from "playhtml";
 
 /**
@@ -36,4 +43,112 @@ export function useCursorZone(
       unregisterCursorZone(element.id);
     };
   }, [ref.current, ref.current?.id]);
+}
+
+/**
+ * Subscribe to a presence channel. Safe to call before playhtml has initialized:
+ * returns an empty map and a no-op setter until sync completes, then wires up.
+ */
+export function usePresence<T extends Record<string, unknown> = Record<string, unknown>>(
+  channel: string,
+): {
+  presences: Map<string, PresenceView<T>>;
+  setMyPresence: (data: T) => void;
+  myIdentity: PlayerIdentity | null;
+} {
+  const { isLoading } = useContext(PlayContext);
+  const [presences, setPresences] = useState<Map<string, PresenceView<T>>>(() => new Map());
+
+  useEffect(() => {
+    if (isLoading) return;
+    setPresences(playhtml.presence.getPresences() as Map<string, PresenceView<T>>);
+    const unsub = playhtml.presence.onPresenceChange(channel, (next) => {
+      setPresences(new Map(next) as Map<string, PresenceView<T>>);
+    });
+    return unsub;
+  }, [isLoading, channel]);
+
+  const setMyPresence = useCallback(
+    (data: T) => {
+      if (isLoading) {
+        console.warn(
+          `[@playhtml/react] usePresence("${channel}").setMyPresence called before init — ignored.`,
+        );
+        return;
+      }
+      playhtml.presence.setMyPresence(channel, data);
+    },
+    [isLoading, channel],
+  );
+
+  const myIdentity = isLoading ? null : playhtml.presence.getMyIdentity();
+
+  return { presences, setMyPresence, myIdentity };
+}
+
+/**
+ * Subscribe to a page-data channel. Safe to call before playhtml has initialized:
+ * returns the default value and a no-op setter until sync completes, then wires up.
+ *
+ * Shape mirrors `useState` — `[data, setData]`.
+ */
+export function usePageData<T>(
+  name: string,
+  defaultValue: T,
+): [T, (data: T | ((draft: T) => void)) => void] {
+  const { isLoading } = useContext(PlayContext);
+  const [data, setDataState] = useState<T>(defaultValue);
+  const channelRef = useRef<PageDataChannel<T> | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const channel = playhtml.createPageData<T>(name, defaultValue);
+    channelRef.current = channel;
+    setDataState(channel.getData());
+    const unsub = channel.onUpdate((next) => setDataState(next));
+    return () => {
+      unsub();
+      channel.destroy();
+      channelRef.current = null;
+    };
+    // defaultValue intentionally excluded — it only seeds the initial state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoading, name]);
+
+  const setData = useCallback(
+    (next: T | ((draft: T) => void)) => {
+      const channel = channelRef.current;
+      if (!channel) {
+        console.warn(
+          `[@playhtml/react] usePageData("${name}") setData called before init — ignored.`,
+        );
+        return;
+      }
+      channel.setData(next);
+    },
+    [name],
+  );
+
+  return [data, setData];
+}
+
+/**
+ * Join a presence room. Safe to call before playhtml has initialized:
+ * returns `null` until sync completes.
+ */
+export function usePresenceRoom(name: string): PresenceRoom | null {
+  const { isLoading } = useContext(PlayContext);
+  const [room, setRoom] = useState<PresenceRoom | null>(null);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const r = playhtml.createPresenceRoom(name);
+    setRoom(r);
+    return () => {
+      r.destroy();
+      setRoom(null);
+    };
+  }, [isLoading, name]);
+
+  return room;
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -488,7 +488,13 @@ export function withSharedState<T extends object, V = any, P = any>(
 export { playhtml };
 export { PlayProvider, PlayContext } from "./PlayProvider";
 export { usePlayContext } from "./usePlayContext";
-export { useCursorPresences, useCursorZone } from "./hooks";
+export {
+  useCursorPresences,
+  useCursorZone,
+  usePresence,
+  usePageData,
+  usePresenceRoom,
+} from "./hooks";
 export {
   CanMoveElement,
   CanSpinElement,


### PR DESCRIPTION
## Summary

  Adds defensive React hooks in `@playhtml/react` that are safe to call before
  playhtml has finished initializing. Consumers no longer need `hasSynced`
  guards at every call site — the hooks return empty/default values pre-sync
  and wire up automatically once ready.

  - **Adds three new React hooks** in `@playhtml/react` that gate on
    `isLoading` and return safe defaults pre-sync:
    - `usePresence<T>(channel)` → `{ presences, setMyPresence, myIdentity }`
    - `usePageData<T>(name, defaultValue)` → `[data, setData]` (useState shape)
    - `usePresenceRoom(name)` → `PresenceRoom | null`
  - **Adds `isLoading` to `PlayContext`** to match React Query / SWR
    conventions. `hasSynced` remains but is marked `@deprecated`.
  - **Caches `generatePersistentPlayerIdentity()`** at the module level in
    `@playhtml/common` so repeated calls return a reference-stable identity.
    Fixes render churn for React consumers using `myIdentity` in effect deps,
    plus two pre-existing inconsistency bugs in corrupt/locked localStorage
    scenarios.

  ## Test plan

  - [x] `bun run -C packages/playhtml test` — 99 passing
  - [x] `bun run -C packages/react test` — 13 passing (5 new hook tests)
  - [x] `bunx tsc` clean across workspace
  - [ ] Manual smoke test with `website/` demos
  - [ ] Verify downstream `feat/presence-room-events` still works (rebased
        onto this branch; should be clean)
