### PR TITLE
Handle event API uniformity

### DIFF
--- a/.changeset/presence-room-events.md
+++ b/.changeset/presence-room-events.md
@@ -1,0 +1,12 @@
+---
+"playhtml": minor
+"@playhtml/common": minor
+"@playhtml/react": minor
+---
+
+Add dispatchEvent/onEvent to PresenceRoom and playhtml for cleaner event API
+
+- `room.dispatchEvent(type, payload?)` and `room.onEvent(type, callback)` for domain-scoped events via PresenceRoom
+- `playhtml.dispatchEvent(type, payload?)` and `playhtml.onEvent(type, callback)` for page-scoped events
+- `onEvent` returns an unsubscribe function directly (no ID tracking needed)
+- Deprecate `dispatchPlayEvent`, `registerPlayEventListener`, `removePlayEventListener` (still functional, no breaking change)

--- a/.changeset/presence-room-loading.md
+++ b/.changeset/presence-room-loading.md
@@ -1,0 +1,7 @@
+---
+"@playhtml/common": minor
+"playhtml": minor
+"@playhtml/react": minor
+---
+
+Add `isLoading` and `onLoadingChange` to `PresenceRoom` so consumers can gate `dispatchEvent` on the room's own WebSocket sync state (separate from the page's sync state). `usePresenceRoom` now returns `{ room, isLoading }` where `isLoading` combines playhtml's load state with the room's own.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you have dynamic elements that are hydrated after the initial load, you can c
 
 #### eventing
 
-You can set up imperative logic that doesn't depend on a data value changing (like triggering confetti when someone clicks in an area) by registering events with playhtml. You can either pass in a list of events when you call `playhtml.init` or you can call `playhtml.registerPlayEventListener` to register an event at any time.
+You can set up imperative logic that doesn't depend on a data value changing (like triggering confetti when someone clicks in an area) by listening for events. You can listen with `playhtml.onEvent` and dispatch with `playhtml.dispatchEvent`.
 
 https://github.com/spencerc99/playhtml/assets/14796580/bd8ecfaf-73ab-4aa2-9312-8917809f52a2
 
@@ -97,27 +97,22 @@ https://github.com/spencerc99/playhtml/assets/14796580/bd8ecfaf-73ab-4aa2-9312-8
 </div>
 <!-- Import confetti library -->
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
-<script>
-  confettiZone.addEventListener("click", onClickConfettiZone);
-  function onClickConfettiZone(e) {
-    playhtml.dispatchPlayEvent({ type: "confetti" });
-  }
-</script>
 <script type="module">
   import "https://unpkg.com/playhtml@latest";
-  playhtml.init({
-    events: {
-      confetti: {
-        type: "confetti",
-        onEvent: (data) => {
-          window.confetti({
-            particleCount: 100,
-            spread: 70,
-            origin: { y: 0.6 },
-          });
-        },
-      },
-    },
+  playhtml.init({});
+
+  // Listen for confetti events from any connected client
+  playhtml.onEvent("confetti", () => {
+    window.confetti({
+      particleCount: 100,
+      spread: 70,
+      origin: { y: 0.6 },
+    });
+  });
+
+  // Dispatch when someone clicks the zone
+  confettiZone.addEventListener("click", () => {
+    playhtml.dispatchEvent("confetti");
   });
 </script>
 ```

--- a/claude-plugin/skills/building-playhtml-elements/SKILL.md
+++ b/claude-plugin/skills/building-playhtml-elements/SKILL.md
@@ -64,6 +64,7 @@ const Counter = withSharedState(
 );
 
 // Component receives: data, setData, awareness, setMyAwareness, ref
+// Config can be dynamic: withSharedState((props) => ({ defaultData: ... }), component)
 // For events: usePlayContext() → { dispatchPlayEvent, registerPlayEventListener }
 // For cursors: usePlayContext() → { cursors, configureCursors }
 ```
@@ -80,7 +81,25 @@ setData((draft) => { draft.items.push(newItem); });
 
 ## Built-in Capabilities
 
-Use instead of `can-play` when they fit: `can-move`, `can-toggle`, `can-spin`, `can-grow`, `can-duplicate`, `can-mirror`. See `packages/common/src/index.ts` for implementations.
+Use instead of `can-play` when they fit:
+
+- `can-move`: Draggable with x,y position
+- `can-toggle`: Click to toggle on/off state
+- `can-spin`: Rotatable element
+- `can-grow`: Click to scale up/down
+- `can-duplicate`: Click to clone element
+- `can-hover`: Collaborative hover via awareness. Sets `data-playhtml-hover` attribute when ANY user hovers. Style with both `:hover` and `[data-playhtml-hover]`. No persistent data.
+- `can-mirror`: Syncs full DOM state (attributes, children, form values) via MutationObserver. Also tracks hover/focus awareness. Good for rich content or form elements.
+
+React components: `CanMoveElement`, `CanToggleElement`, `CanSpinElement`, `CanGrowElement`, `CanDuplicateElement`, `CanHoverElement`.
+
+## Advanced APIs
+
+For state or presence not tied to a DOM element:
+
+- **`playhtml.createPageData(name, defaultValue)`**: Persistent shared data channel. Returns `{ getData, setData, onUpdate, destroy }`. Use for app-level state (shared settings, vote tallies, page metadata). Call after init.
+- **`playhtml.createPresenceRoom(name)`**: Domain-scoped presence room. Returns `{ presence, destroy }`. Presence API: `setMyPresence(channel, data)`, `getPresences()`, `onPresenceChange(channel, cb)`, `getMyIdentity()`. Use for cross-page awareness (who's on which page, lobbies).
+- **`playhtml.presence`**: Built-in page-level presence API (same shape). Available after init.
 
 ## Cursors (optional)
 

--- a/docs/data-structure-design.md
+++ b/docs/data-structure-design.md
@@ -141,13 +141,11 @@ defaultData: {
 
 ```javascript
 // Dispatch
-playhtml.dispatchPlayEvent({ type: "confetti" });
+playhtml.dispatchEvent("confetti");
 
-// Listen
-playhtml.registerPlayEventListener("confetti", {
-  onEvent: () => {
-    /* trigger animation */
-  },
+// Listen (returns unsubscribe function)
+const unsub = playhtml.onEvent("confetti", () => {
+  /* trigger animation */
 });
 ```
 

--- a/docs/llm-prompting-guide.md
+++ b/docs/llm-prompting-guide.md
@@ -36,7 +36,7 @@ DATA TYPES (choose the right one):
 
 1. **Persistent data** (defaultData): State that syncs and persists (position, count, messages, etc.)
 2. **Awareness**: Temporary presence data (which users are online, their colors, cursor positions)
-3. **Events**: One-time triggers (confetti, notifications, animations) - use dispatchPlayEvent/registerPlayEventListener
+3. **Events**: One-time triggers (confetti, notifications, animations) - use dispatchEvent/onEvent
 
 KEY APIs:
 
@@ -53,7 +53,7 @@ React (withSharedState):
 
 - withSharedState({ defaultData: {...} }, ({ data, setData, ref }) => JSX)
 - For awareness: { myDefaultAwareness: value } in config, use setMyAwareness
-- For events: usePlayContext() → { registerPlayEventListener, dispatchPlayEvent }
+- For events: usePlayContext() -> { dispatchEvent, onEvent }
 - For cursors in React: usePlayContext() → { cursors, configureCursors, getMyPlayerIdentity }
 
 DATA UPDATES:

--- a/docs/llm-prompting-guide.md
+++ b/docs/llm-prompting-guide.md
@@ -52,9 +52,11 @@ Vanilla HTML (can-play):
 React (withSharedState):
 
 - withSharedState({ defaultData: {...} }, ({ data, setData, ref }) => JSX)
+- Config can be dynamic: withSharedState((props) => ({ defaultData: ... }), component)
 - For awareness: { myDefaultAwareness: value } in config, use setMyAwareness
 - For events: usePlayContext() -> { dispatchEvent, onEvent }
 - For cursors in React: usePlayContext() → { cursors, configureCursors, getMyPlayerIdentity }
+- Built-in React components: CanMoveElement, CanToggleElement, CanSpinElement, CanGrowElement, CanDuplicateElement, CanHoverElement
 
 DATA UPDATES:
 
@@ -73,8 +75,8 @@ BUILT-IN CAPABILITIES (if they fit the use case):
 - can-spin: Rotatable element
 - can-grow: Click to scale up/down
 - can-duplicate: Click to clone element
-- can-hover: Hover to toggle on/off state
-- can-mirror: Syncs all element changes automatically
+- can-hover: Shows collaborative hover state via awareness. Sets `data-playhtml-hover` attribute when ANY user hovers, so you can style `:hover` AND `[data-playhtml-hover]` together. No persistent data — awareness only.
+- can-mirror: Syncs full DOM state (attributes, children, form values like checked/value/selectedIndex) via MutationObserver. Also tracks hover and focus awareness. Good for syncing rich content or form elements without writing custom handlers.
 - Use these instead of can-play when possible
 
 CURSOR CONFIGURATION (optional):
@@ -88,6 +90,21 @@ Enable collaborative cursors to show where other users are:
 - Get user count: window.cursors.allColors.length
 - Listen for changes: window.cursors.on('allColors', callback)
 - See docs/cursors.md for proximity detection, filtering, styling
+
+ADVANCED APIs (for when built-in capabilities and can-play aren't enough):
+
+1. **playhtml.createPageData(name, defaultValue)**: Persistent shared data NOT tied to a DOM element.
+   Returns `{ getData, setData, onUpdate, destroy }`. Use for app-level state like shared settings,
+   vote tallies, or page metadata that multiple components read/write. Call after `playhtml.init()`.
+
+2. **playhtml.createPresenceRoom(name)**: Domain-scoped presence channel independent of cursors.
+   Returns `{ presence, destroy }` where presence has `setMyPresence(channel, data)`,
+   `getPresences()`, `onPresenceChange(channel, callback)`, `getMyIdentity()`.
+   Use for cross-page awareness like "who's on which page", lobbies, or ambient social features.
+   Call after `playhtml.init()`.
+
+3. **playhtml.presence**: The built-in page-level presence API (same shape as createPresenceRoom's
+   presence). Available after init. Use for presence on the current page without creating a separate room.
 
 DATA PERFORMANCE TIPS:
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -245,6 +245,14 @@ export interface PresenceAPI {
 
 export interface PresenceRoom {
   presence: PresenceAPI;
+  /** True until the room's WebSocket has connected and synced for the first time. */
+  readonly isLoading: boolean;
+  /**
+   * Subscribe to loading-state changes. Fires when `isLoading` flips from
+   * true to false (initial sync) or vice versa (on subsequent disconnect).
+   * Returns an unsubscribe function.
+   */
+  onLoadingChange(callback: (isLoading: boolean) => void): () => void;
   dispatchEvent(type: string, payload?: unknown): void;
   onEvent(type: string, callback: (payload: unknown) => void): () => void;
   destroy: () => void;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -248,9 +248,10 @@ export interface PresenceRoom {
   /** True until the room's WebSocket has connected and synced for the first time. */
   readonly isLoading: boolean;
   /**
-   * Subscribe to loading-state changes. Fires when `isLoading` flips from
-   * true to false (initial sync) or vice versa (on subsequent disconnect).
-   * Returns an unsubscribe function.
+   * Subscribe to loading-state changes. Fires only on transitions — flipping
+   * from true to false (initial sync) or vice versa (on subsequent
+   * disconnect). Call sites that want the current value should read
+   * `room.isLoading` directly. Returns an unsubscribe function.
    */
   onLoadingChange(callback: (isLoading: boolean) => void): () => void;
   dispatchEvent(type: string, payload?: unknown): void;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -245,6 +245,8 @@ export interface PresenceAPI {
 
 export interface PresenceRoom {
   presence: PresenceAPI;
+  dispatchEvent(type: string, payload?: unknown): void;
+  onEvent(type: string, callback: (payload: unknown) => void): () => void;
   destroy: () => void;
 }
 

--- a/packages/playhtml/src/__tests__/page-events.test.ts
+++ b/packages/playhtml/src/__tests__/page-events.test.ts
@@ -4,6 +4,12 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { playhtml } from "../index";
 
+// Reach the latest FakeProvider instance (set up in vitest.setup.ts) so
+// tests can simulate inbound messages via emit("custom-message", payload).
+function latestProvider(): any {
+  return (globalThis as any).__getLatestFakeProvider();
+}
+
 beforeAll(async () => {
   await playhtml.init({});
   await new Promise((r) => setTimeout(r, 0));
@@ -40,6 +46,71 @@ describe("playhtml page-scoped events", () => {
     const unsub = playhtml.onEvent("test-double-unsub", () => {});
     unsub();
     expect(() => unsub()).not.toThrow();
+  });
+
+  describe("wire roundtrip", () => {
+    it("onEvent receives payloads from incoming custom-message frames", () => {
+      const received: unknown[] = [];
+      const unsub = playhtml.onEvent("roundtrip", (payload) => {
+        received.push(payload);
+      });
+      try {
+        latestProvider().emit(
+          "custom-message",
+          JSON.stringify({ type: "roundtrip", eventPayload: { hello: "world" } }),
+        );
+        expect(received).toEqual([{ hello: "world" }]);
+      } finally {
+        unsub();
+      }
+    });
+
+    it("unsubscribe actually stops delivery", () => {
+      const received: unknown[] = [];
+      const unsub = playhtml.onEvent("stop-delivery", (p) => received.push(p));
+      unsub();
+      latestProvider().emit(
+        "custom-message",
+        JSON.stringify({ type: "stop-delivery", eventPayload: 1 }),
+      );
+      expect(received).toEqual([]);
+    });
+
+    it("deprecated registerPlayEventListener delivers via shared wire format", () => {
+      const received: unknown[] = [];
+      const id = playhtml.registerPlayEventListener("old-api", {
+        onEvent: ({ eventPayload }) => received.push(eventPayload),
+      });
+      try {
+        latestProvider().emit(
+          "custom-message",
+          JSON.stringify({ type: "old-api", eventPayload: 42 }),
+        );
+        expect(received).toEqual([42]);
+      } finally {
+        playhtml.removePlayEventListener("old-api", id);
+      }
+    });
+
+    it("new onEvent and deprecated register fire together on same type", () => {
+      const newReceived: unknown[] = [];
+      const oldReceived: unknown[] = [];
+      const unsub = playhtml.onEvent("shared", (p) => newReceived.push(p));
+      const id = playhtml.registerPlayEventListener("shared", {
+        onEvent: ({ eventPayload }) => oldReceived.push(eventPayload),
+      });
+      try {
+        latestProvider().emit(
+          "custom-message",
+          JSON.stringify({ type: "shared", eventPayload: "both" }),
+        );
+        expect(newReceived).toEqual(["both"]);
+        expect(oldReceived).toEqual(["both"]);
+      } finally {
+        unsub();
+        playhtml.removePlayEventListener("shared", id);
+      }
+    });
   });
 });
 

--- a/packages/playhtml/src/__tests__/page-events.test.ts
+++ b/packages/playhtml/src/__tests__/page-events.test.ts
@@ -3,12 +3,7 @@
 
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { playhtml } from "../index";
-
-// Reach the latest FakeProvider instance (set up in vitest.setup.ts) so
-// tests can simulate inbound messages via emit("custom-message", payload).
-function latestProvider(): any {
-  return (globalThis as any).__getLatestFakeProvider();
-}
+import { latestFakeProvider } from "./test-utils";
 
 beforeAll(async () => {
   await playhtml.init({});
@@ -55,7 +50,7 @@ describe("playhtml page-scoped events", () => {
         received.push(payload);
       });
       try {
-        latestProvider().emit(
+        latestFakeProvider().emit(
           "custom-message",
           JSON.stringify({ type: "roundtrip", eventPayload: { hello: "world" } }),
         );
@@ -69,7 +64,7 @@ describe("playhtml page-scoped events", () => {
       const received: unknown[] = [];
       const unsub = playhtml.onEvent("stop-delivery", (p) => received.push(p));
       unsub();
-      latestProvider().emit(
+      latestFakeProvider().emit(
         "custom-message",
         JSON.stringify({ type: "stop-delivery", eventPayload: 1 }),
       );
@@ -82,7 +77,7 @@ describe("playhtml page-scoped events", () => {
         onEvent: ({ eventPayload }) => received.push(eventPayload),
       });
       try {
-        latestProvider().emit(
+        latestFakeProvider().emit(
           "custom-message",
           JSON.stringify({ type: "old-api", eventPayload: 42 }),
         );
@@ -100,7 +95,7 @@ describe("playhtml page-scoped events", () => {
         onEvent: ({ eventPayload }) => oldReceived.push(eventPayload),
       });
       try {
-        latestProvider().emit(
+        latestFakeProvider().emit(
           "custom-message",
           JSON.stringify({ type: "shared", eventPayload: "both" }),
         );

--- a/packages/playhtml/src/__tests__/page-events.test.ts
+++ b/packages/playhtml/src/__tests__/page-events.test.ts
@@ -1,0 +1,62 @@
+// ABOUTME: Tests for playhtml.dispatchEvent and playhtml.onEvent (page-scoped).
+// ABOUTME: Verifies the new event API works alongside the deprecated dispatchPlayEvent.
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { playhtml } from "../index";
+
+beforeAll(async () => {
+  await playhtml.init({});
+  await new Promise((r) => setTimeout(r, 0));
+});
+
+describe("playhtml page-scoped events", () => {
+  it("dispatchEvent is a function", () => {
+    expect(playhtml.dispatchEvent).toBeTypeOf("function");
+  });
+
+  it("onEvent is a function", () => {
+    expect(playhtml.onEvent).toBeTypeOf("function");
+  });
+
+  it("onEvent returns an unsubscribe function", () => {
+    const unsub = playhtml.onEvent("test-page-event", () => {});
+    expect(unsub).toBeTypeOf("function");
+    unsub();
+  });
+
+  it("dispatchEvent does not throw", () => {
+    const unsub = playhtml.onEvent("test-dispatch", () => {});
+    expect(() => playhtml.dispatchEvent("test-dispatch", { x: 1 })).not.toThrow();
+    unsub();
+  });
+
+  it("dispatchEvent without payload does not throw", () => {
+    const unsub = playhtml.onEvent("test-no-payload", () => {});
+    expect(() => playhtml.dispatchEvent("test-no-payload")).not.toThrow();
+    unsub();
+  });
+
+  it("unsubscribe is safe to call twice", () => {
+    const unsub = playhtml.onEvent("test-double-unsub", () => {});
+    unsub();
+    expect(() => unsub()).not.toThrow();
+  });
+});
+
+describe("playhtml page-scoped events before init", () => {
+  it("onEvent returns valid unsubscribe before init", async () => {
+    vi.resetModules();
+    delete (globalThis as any).playhtml;
+    const mod = await import("../index");
+    const unsub = mod.playhtml.onEvent("pre-init-evt", () => {});
+    expect(unsub).toBeTypeOf("function");
+    unsub();
+  });
+
+  it("dispatchEvent does not throw before init", async () => {
+    vi.resetModules();
+    delete (globalThis as any).playhtml;
+    const mod = await import("../index");
+    expect(() => mod.playhtml.dispatchEvent("pre-init-evt", {})).not.toThrow();
+  });
+});

--- a/packages/playhtml/src/__tests__/room-events.test.ts
+++ b/packages/playhtml/src/__tests__/room-events.test.ts
@@ -1,0 +1,86 @@
+// ABOUTME: Tests for PresenceRoom.dispatchEvent and PresenceRoom.onEvent.
+// ABOUTME: Verifies ephemeral event dispatch and listener lifecycle.
+
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { playhtml } from "../index";
+
+describe("PresenceRoom events", () => {
+  describe("after init", () => {
+    beforeAll(async () => {
+      await playhtml.init({});
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    it("room has dispatchEvent and onEvent methods", () => {
+      const room = playhtml.createPresenceRoom("event-shape");
+      try {
+        expect(room.dispatchEvent).toBeTypeOf("function");
+        expect(room.onEvent).toBeTypeOf("function");
+      } finally {
+        room.destroy();
+      }
+    });
+
+    it("onEvent returns an unsubscribe function", () => {
+      const room = playhtml.createPresenceRoom("event-unsub");
+      try {
+        const unsub = room.onEvent("test", () => {});
+        expect(unsub).toBeTypeOf("function");
+        unsub();
+      } finally {
+        room.destroy();
+      }
+    });
+
+    it("dispatchEvent does not throw", () => {
+      const room = playhtml.createPresenceRoom("event-dispatch");
+      try {
+        expect(() => room.dispatchEvent("test", { x: 1 })).not.toThrow();
+      } finally {
+        room.destroy();
+      }
+    });
+
+    it("dispatchEvent without payload does not throw", () => {
+      const room = playhtml.createPresenceRoom("event-no-payload");
+      try {
+        expect(() => room.dispatchEvent("ping")).not.toThrow();
+      } finally {
+        room.destroy();
+      }
+    });
+
+    it("unsubscribe is safe to call twice", () => {
+      const room = playhtml.createPresenceRoom("event-double-unsub");
+      try {
+        const unsub = room.onEvent("test", () => {});
+        unsub();
+        expect(() => unsub()).not.toThrow();
+      } finally {
+        room.destroy();
+      }
+    });
+  });
+
+  describe("before init (deferred)", () => {
+    it("onEvent returns valid unsubscribe before init", async () => {
+      vi.resetModules();
+      delete (globalThis as any).playhtml;
+      const mod = await import("../index");
+      const room = mod.playhtml.createPresenceRoom("deferred-event");
+      const unsub = room.onEvent("test", () => {});
+      expect(unsub).toBeTypeOf("function");
+      unsub();
+      room.destroy();
+    });
+
+    it("dispatchEvent does not throw before init", async () => {
+      vi.resetModules();
+      delete (globalThis as any).playhtml;
+      const mod = await import("../index");
+      const room = mod.playhtml.createPresenceRoom("deferred-dispatch");
+      expect(() => room.dispatchEvent("test", { x: 1 })).not.toThrow();
+      room.destroy();
+    });
+  });
+});

--- a/packages/playhtml/src/__tests__/room-events.test.ts
+++ b/packages/playhtml/src/__tests__/room-events.test.ts
@@ -4,6 +4,10 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { playhtml } from "../index";
 
+function latestProvider(): any {
+  return (globalThis as any).__getLatestFakeProvider();
+}
+
 describe("PresenceRoom events", () => {
   describe("after init", () => {
     beforeAll(async () => {
@@ -59,6 +63,54 @@ describe("PresenceRoom events", () => {
       } finally {
         room.destroy();
       }
+    });
+
+    describe("wire roundtrip", () => {
+      it("onEvent receives payloads from incoming custom-message frames", () => {
+        const room = playhtml.createPresenceRoom("event-roundtrip");
+        const roomProvider = latestProvider();
+        try {
+          const received: unknown[] = [];
+          room.onEvent("ping", (payload) => received.push(payload));
+          roomProvider.emit(
+            "custom-message",
+            JSON.stringify({ type: "ping", eventPayload: { count: 3 } }),
+          );
+          expect(received).toEqual([{ count: 3 }]);
+        } finally {
+          room.destroy();
+        }
+      });
+
+      it("unsubscribe stops delivery", () => {
+        const room = playhtml.createPresenceRoom("event-room-stop");
+        const roomProvider = latestProvider();
+        try {
+          const received: unknown[] = [];
+          const unsub = room.onEvent("x", (p) => received.push(p));
+          unsub();
+          roomProvider.emit(
+            "custom-message",
+            JSON.stringify({ type: "x", eventPayload: "nope" }),
+          );
+          expect(received).toEqual([]);
+        } finally {
+          room.destroy();
+        }
+      });
+
+      it("dispatchEvent calls provider.sendMessage with EventMessage JSON", () => {
+        const room = playhtml.createPresenceRoom("event-room-dispatch");
+        const roomProvider = latestProvider();
+        try {
+          room.dispatchEvent("hello", { a: 1 });
+          expect(roomProvider.sendMessage).toHaveBeenCalledWith(
+            JSON.stringify({ type: "hello", eventPayload: { a: 1 } }),
+          );
+        } finally {
+          room.destroy();
+        }
+      });
     });
   });
 

--- a/packages/playhtml/src/__tests__/room-events.test.ts
+++ b/packages/playhtml/src/__tests__/room-events.test.ts
@@ -3,10 +3,7 @@
 
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { playhtml } from "../index";
-
-function latestProvider(): any {
-  return (globalThis as any).__getLatestFakeProvider();
-}
+import { captureNextProvider } from "./test-utils";
 
 describe("PresenceRoom events", () => {
   describe("after init", () => {
@@ -67,8 +64,9 @@ describe("PresenceRoom events", () => {
 
     describe("wire roundtrip", () => {
       it("onEvent receives payloads from incoming custom-message frames", () => {
-        const room = playhtml.createPresenceRoom("event-roundtrip");
-        const roomProvider = latestProvider();
+        const { provider: roomProvider, result: room } = captureNextProvider(
+          () => playhtml.createPresenceRoom("event-roundtrip"),
+        );
         try {
           const received: unknown[] = [];
           room.onEvent("ping", (payload) => received.push(payload));
@@ -83,8 +81,9 @@ describe("PresenceRoom events", () => {
       });
 
       it("unsubscribe stops delivery", () => {
-        const room = playhtml.createPresenceRoom("event-room-stop");
-        const roomProvider = latestProvider();
+        const { provider: roomProvider, result: room } = captureNextProvider(
+          () => playhtml.createPresenceRoom("event-room-stop"),
+        );
         try {
           const received: unknown[] = [];
           const unsub = room.onEvent("x", (p) => received.push(p));
@@ -100,8 +99,9 @@ describe("PresenceRoom events", () => {
       });
 
       it("dispatchEvent calls provider.sendMessage with EventMessage JSON", () => {
-        const room = playhtml.createPresenceRoom("event-room-dispatch");
-        const roomProvider = latestProvider();
+        const { provider: roomProvider, result: room } = captureNextProvider(
+          () => playhtml.createPresenceRoom("event-room-dispatch"),
+        );
         try {
           room.dispatchEvent("hello", { a: 1 });
           expect(roomProvider.sendMessage).toHaveBeenCalledWith(

--- a/packages/playhtml/src/__tests__/room-events.test.ts
+++ b/packages/playhtml/src/__tests__/room-events.test.ts
@@ -62,25 +62,14 @@ describe("PresenceRoom events", () => {
     });
   });
 
-  describe("before init (deferred)", () => {
-    it("onEvent returns valid unsubscribe before init", async () => {
+  describe("before init", () => {
+    it("createPresenceRoom throws before init", async () => {
       vi.resetModules();
       delete (globalThis as any).playhtml;
       const mod = await import("../index");
-      const room = mod.playhtml.createPresenceRoom("deferred-event");
-      const unsub = room.onEvent("test", () => {});
-      expect(unsub).toBeTypeOf("function");
-      unsub();
-      room.destroy();
-    });
-
-    it("dispatchEvent does not throw before init", async () => {
-      vi.resetModules();
-      delete (globalThis as any).playhtml;
-      const mod = await import("../index");
-      const room = mod.playhtml.createPresenceRoom("deferred-dispatch");
-      expect(() => room.dispatchEvent("test", { x: 1 })).not.toThrow();
-      room.destroy();
+      expect(() => mod.playhtml.createPresenceRoom("pre-init")).toThrow(
+        /not available before init/,
+      );
     });
   });
 });

--- a/packages/playhtml/src/__tests__/test-utils.ts
+++ b/packages/playhtml/src/__tests__/test-utils.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Helpers for tests that need to reach into the FakeProvider mock.
+// ABOUTME: Provides typed access to the instance list set up in vitest.setup.ts.
+
+interface FakeProvider {
+  emit(event: string, ...args: unknown[]): void;
+  sendMessage: (...args: unknown[]) => void;
+  synced: boolean;
+  on(event: string, cb: (...args: unknown[]) => void): void;
+}
+
+function allFakeProviders(): FakeProvider[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return ((globalThis as any).__playhtmlFakeProviders as FakeProvider[]) ?? [];
+}
+
+/**
+ * Returns the most recently created FakeProvider. In tests that create
+ * multiple providers (e.g. a page provider and a room provider), this is
+ * the last one constructed — typically the one just created by the unit
+ * under test. For multi-provider tests, prefer captureNextProvider().
+ */
+export function latestFakeProvider(): FakeProvider {
+  const list = allFakeProviders();
+  const last = list[list.length - 1];
+  if (!last) throw new Error("No FakeProvider has been constructed yet");
+  return last;
+}
+
+/**
+ * Runs `fn`, then returns the provider that was constructed during that
+ * invocation. Use when a test creates a new provider and wants to drive
+ * it without worrying about earlier providers in the process.
+ */
+export function captureNextProvider<T>(fn: () => T): { provider: FakeProvider; result: T } {
+  const before = allFakeProviders().length;
+  const result = fn();
+  const after = allFakeProviders();
+  const provider = after[before];
+  if (!provider) throw new Error("No new FakeProvider was constructed by fn");
+  return { provider, result };
+}

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -303,6 +303,7 @@ let eventHandlers: Map<string, Array<RegisteredPlayEvent>> = new Map<
 const remoteApplyingKeys: Set<string> = new Set();
 const selectorIdsToAvailableIdx = new Map<string, number>();
 let eventCount = 0;
+const pageEventListeners = new Map<string, Set<(payload: unknown) => void>>();
 export type CursorRoom =
   | "page"
   | "domain"
@@ -430,6 +431,15 @@ function onMessage(data: string) {
     }
     // Force reload to fetch fresh state
     window.location.reload();
+    return;
+  }
+
+  // Handle new-style room events
+  if (message.type === ROOM_EVENT_TYPE) {
+    const callbacks = pageEventListeners.get(message.eventType);
+    if (callbacks) {
+      for (const cb of callbacks) cb(message.payload);
+    }
     return;
   }
 
@@ -1119,6 +1129,8 @@ export interface PlayHTMLComponents {
   dispatchPlayEvent: typeof dispatchPlayEvent;
   registerPlayEventListener: typeof registerPlayEventListener;
   removePlayEventListener: typeof removePlayEventListener;
+  dispatchEvent(type: string, payload?: unknown): void;
+  onEvent(type: string, callback: (payload: unknown) => void): () => void;
   cursorClient: CursorClientAwareness | null;
   presence: PresenceAPI;
   createPageData: typeof createPageData;
@@ -1150,6 +1162,8 @@ export const playhtml: PlayHTMLComponents = {
   dispatchPlayEvent,
   registerPlayEventListener,
   removePlayEventListener,
+  dispatchEvent: pageDispatchEvent,
+  onEvent: pageOnEvent,
   get cursorClient() {
     return cursorClient;
   },
@@ -1578,6 +1592,27 @@ function removePlayEventListener(type: string, id: string) {
   if (handlers.length === 0) {
     eventHandlers.delete(type);
   }
+}
+
+function pageDispatchEvent(type: string, payload?: unknown): void {
+  if (!yprovider?.ws) return;
+  yprovider.ws.send(JSON.stringify({
+    type: ROOM_EVENT_TYPE,
+    eventType: type,
+    payload: payload ?? null,
+  }));
+}
+
+function pageOnEvent(type: string, callback: (payload: unknown) => void): () => void {
+  if (!pageEventListeners.has(type)) pageEventListeners.set(type, new Set());
+  pageEventListeners.get(type)!.add(callback);
+  return () => {
+    const set = pageEventListeners.get(type);
+    if (set) {
+      set.delete(callback);
+      if (set.size === 0) pageEventListeners.delete(type);
+    }
+  };
 }
 
 export type {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -147,6 +147,8 @@ function normalizeRoomId(host: string, roomString: string): string {
   return encodeURIComponent(normalized);
 }
 
+const ROOM_EVENT_TYPE = "__playhtml_event__";
+
 let yprovider: YProvider;
 let cursorProvider: YProvider | null = null;
 let cursorClient: CursorClientAwareness | null = null;
@@ -1053,12 +1055,51 @@ function createPresenceRoom(name: string): PresenceRoom {
       cursorClient?.getMyPlayerIdentity() ?? generatePersistentPlayerIdentity(),
   });
 
+  const eventListeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  function handleMessage(evt: MessageEvent) {
+    if (evt.data instanceof Blob) return;
+    let parsed: any;
+    try { parsed = JSON.parse(evt.data); } catch { return; }
+    if (parsed.type !== ROOM_EVENT_TYPE) return;
+    const callbacks = eventListeners.get(parsed.eventType);
+    if (!callbacks) return;
+    for (const cb of callbacks) cb(parsed.payload);
+  }
+
+  provider.ws?.addEventListener("message", handleMessage);
+  provider.on("status", ({ status }: { status: string }) => {
+    if (status === "connected") {
+      provider.ws?.addEventListener("message", handleMessage);
+    }
+  });
+
   let destroyed = false;
   return {
     presence,
+    dispatchEvent(type: string, payload?: unknown): void {
+      if (destroyed || !provider.ws) return;
+      provider.ws.send(JSON.stringify({
+        type: ROOM_EVENT_TYPE,
+        eventType: type,
+        payload: payload ?? null,
+      }));
+    },
+    onEvent(type: string, callback: (payload: unknown) => void): () => void {
+      if (!eventListeners.has(type)) eventListeners.set(type, new Set());
+      eventListeners.get(type)!.add(callback);
+      return () => {
+        const set = eventListeners.get(type);
+        if (set) {
+          set.delete(callback);
+          if (set.size === 0) eventListeners.delete(type);
+        }
+      };
+    },
     destroy: () => {
       if (destroyed) return;
       destroyed = true;
+      eventListeners.clear();
       provider.destroy();
       roomDoc.destroy();
     },

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -572,7 +572,7 @@ async function initPlayHTML({
   // We use a microtask to ensure the provider is fully initialized.
   queueMicrotask(() => {
     if (yprovider.ws) {
-      yprovider.ws.addEventListener("message", onMessage);
+      yprovider.ws.addEventListener("message", (ev) => onMessage(ev.data));
     } else {
       console.warn(
         "[PLAYHTML] WebSocket not available in microtask, onMessage handler not attached",
@@ -583,7 +583,7 @@ async function initPlayHTML({
   // Re-attach message handler when the WebSocket reconnects (provider creates a new instance)
   yprovider.on("status", ({ status }: { status: string }) => {
     if (status === "connected") {
-      yprovider.ws?.addEventListener("message", onMessage);
+      yprovider.ws?.addEventListener("message", (ev) => onMessage(ev.data));
     }
   });
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -292,16 +292,20 @@ let elementHandlers: Map<string, Map<string, ElementHandler>> = new Map<
   string,
   Map<string, ElementHandler>
 >();
-let eventHandlers: Map<string, Array<RegisteredPlayEvent>> = new Map<
-  string,
-  Array<RegisteredPlayEvent>
->();
 // Tracks elements currently being updated due to remote SyncedStore/Yjs updates.
 // Allows us to distinguish programmatic remote-applied changes from local user writes.
 const remoteApplyingKeys: Set<string> = new Set();
 const selectorIdsToAvailableIdx = new Map<string, number>();
-let eventCount = 0;
+
+// Single source of truth for page-scoped event subscriptions.
+// Both the new dispatchEvent/onEvent API and the deprecated registerPlayEventListener
+// API route through here; the deprecated API wraps it via an id → unsubscribe map below.
 const pageEventListeners = new Map<string, Set<(payload: unknown) => void>>();
+
+// Backs the deprecated registerPlayEventListener/removePlayEventListener pair.
+// Can be deleted together with those functions when the deprecation period ends.
+let eventCount = 0;
+const deprecatedEventRegistrations = new Map<string, () => void>();
 export type CursorRoom =
   | "page"
   | "domain"
@@ -402,10 +406,6 @@ function getTagTypes(): (TagType | string)[] {
   return [TagType.CanPlay, ...Object.keys(capabilitiesToInitializer)];
 }
 
-function sendPlayEvent(eventMessage: EventMessage) {
-  yprovider.sendMessage(JSON.stringify(eventMessage));
-}
-
 function onMessage(data: string) {
   let message: any;
   try {
@@ -432,27 +432,8 @@ function onMessage(data: string) {
     return;
   }
 
-  // Handle PlayHTML events. Both the deprecated registerPlayEventListener
-  // registry (eventHandlers) and the new onEvent registry (pageEventListeners)
-  // share the same wire format; fire whichever matches the type.
-  const { type, eventPayload } = message as EventMessage;
-
-  const newListeners = pageEventListeners.get(type);
-  if (newListeners) {
-    for (const cb of newListeners) cb(eventPayload);
-  }
-
-  const maybeHandlers = eventHandlers.get(type);
-  if (maybeHandlers) {
-    for (const handler of maybeHandlers) {
-      handler.onEvent(eventPayload);
-    }
-    return;
-  }
-
-  if (newListeners) return;
-
-  // Handle internal bridge replies (only if no listeners matched above)
+  // Handle permission-bridge replies. This message shape is distinct from
+  // EventMessage (no `type`, carries `permissions`), so route it explicitly.
   if ((message as any).permissions) {
     try {
       const perms = (message as any).permissions as Record<
@@ -470,6 +451,16 @@ function onMessage(data: string) {
         }
       });
     } catch {}
+    return;
+  }
+
+  // Dispatch page-scoped events. Deprecated registerPlayEventListener
+  // adapters live in pageEventListeners too (via deprecatedEventRegistrations),
+  // so this is the single dispatch path.
+  const { type, eventPayload } = message as EventMessage;
+  const listeners = pageEventListeners.get(type);
+  if (listeners) {
+    for (const cb of listeners) cb(eventPayload);
   }
 }
 
@@ -1065,6 +1056,8 @@ function createPresenceRoom(name: string): PresenceRoom {
   });
 
   const eventListeners = new Map<string, Set<(payload: unknown) => void>>();
+  const loadingListeners = new Set<(isLoading: boolean) => void>();
+  let isLoading = !provider.synced;
 
   provider.on("custom-message", (data: string) => {
     let parsed: EventMessage;
@@ -1078,9 +1071,25 @@ function createPresenceRoom(name: string): PresenceRoom {
     for (const cb of callbacks) cb(parsed.eventPayload);
   });
 
+  provider.on("sync", (synced: boolean) => {
+    const next = !synced;
+    if (next === isLoading) return;
+    isLoading = next;
+    for (const cb of loadingListeners) cb(isLoading);
+  });
+
   let destroyed = false;
   return {
     presence,
+    get isLoading() {
+      return isLoading;
+    },
+    onLoadingChange(callback: (isLoading: boolean) => void): () => void {
+      loadingListeners.add(callback);
+      return () => {
+        loadingListeners.delete(callback);
+      };
+    },
     dispatchEvent(type: string, payload?: unknown): void {
       if (destroyed) return;
       const message: EventMessage = { type, eventPayload: payload ?? null };
@@ -1101,6 +1110,7 @@ function createPresenceRoom(name: string): PresenceRoom {
       if (destroyed) return;
       destroyed = true;
       eventListeners.clear();
+      loadingListeners.clear();
       provider.destroy();
       roomDoc.destroy();
     },
@@ -1116,6 +1126,7 @@ export interface PlayHTMLComponents {
   setupPlayElementForTag: typeof setupPlayElementForTag;
   syncedStore: (typeof store)["play"];
   elementHandlers: Map<string, Map<string, ElementHandler>>;
+  /** @deprecated Kept for type compatibility; no longer populated. Use onEvent. */
   eventHandlers: Map<string, Array<RegisteredPlayEvent>>;
   dispatchPlayEvent: typeof dispatchPlayEvent;
   registerPlayEventListener: typeof registerPlayEventListener;
@@ -1149,7 +1160,9 @@ export const playhtml: PlayHTMLComponents = {
   setupPlayElementForTag,
   syncedStore: store.play,
   elementHandlers,
-  eventHandlers,
+  // Always empty; dispatch flows through pageEventListeners. Kept for type
+  // compatibility; can be removed when the deprecated event API is removed.
+  eventHandlers: new Map<string, Array<RegisteredPlayEvent>>(),
   dispatchPlayEvent,
   registerPlayEventListener,
   removePlayEventListener,
@@ -1524,62 +1537,41 @@ function deleteElementData(tag: string, elementId: string): void {
 
 /**
  * @deprecated Use `playhtml.dispatchEvent(type, payload)` instead.
+ *
+ * If a listener is registered for the same event type via both
+ * `registerPlayEventListener` and `onEvent`, both will fire.
  */
 function dispatchPlayEvent(message: EventMessage) {
-  const { type } = message;
-  if (!eventHandlers.has(type)) {
-    console.error(`[playhtml] event "${type}" not registered.`);
-    return;
-  }
-
-  sendPlayEvent(message);
+  pageDispatchEvent(message.type, message.eventPayload);
 }
 
 /**
- * @deprecated Use `playhtml.onEvent(type, callback)` instead. Returns an unsubscribe function directly.
+ * @deprecated Use `playhtml.onEvent(type, callback)` instead. Returns an
+ * unsubscribe function directly.
+ *
+ * If a listener is registered for the same event type via both
+ * `registerPlayEventListener` and `onEvent`, both will fire.
  */
 function registerPlayEventListener(
   type: string,
   event: Omit<PlayEvent, "type">,
 ): string {
   const id = String(eventCount++);
-
-  eventHandlers.set(type, [
-    ...(eventHandlers.get(type) ?? []),
-    { type, ...event, id },
-  ]);
-
-  // NOTE: bring this back if desired to automatically listen to native DOM events of the same type
-  // document.addEventListener(type, (evt) => {
-  //   const payload: EventMessage = {
-  //     type,
-  //     // @ts-ignore
-  //     eventPayload: evt.detail,
-  //     // @ts-ignore
-  //     // element: evt.target,
-  //   };
-  //   sendPlayEvent(payload);
-  // });
+  const unsub = pageOnEvent(type, (payload) => {
+    event.onEvent({ eventPayload: payload });
+  });
+  deprecatedEventRegistrations.set(id, unsub);
   return id;
 }
 
 /**
  * @deprecated Use the unsubscribe function returned by `playhtml.onEvent()` instead.
  */
-function removePlayEventListener(type: string, id: string) {
-  const handlers = eventHandlers.get(type);
-  if (!handlers) {
-    return;
-  }
-
-  const index = handlers.findIndex((handler) => handler.id === id);
-  if (index === -1) {
-    return;
-  }
-
-  handlers.splice(index, 1);
-  if (handlers.length === 0) {
-    eventHandlers.delete(type);
+function removePlayEventListener(_type: string, id: string) {
+  const unsub = deprecatedEventRegistrations.get(id);
+  if (unsub) {
+    unsub();
+    deprecatedEventRegistrations.delete(id);
   }
 }
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1126,7 +1126,11 @@ export interface PlayHTMLComponents {
   setupPlayElementForTag: typeof setupPlayElementForTag;
   syncedStore: (typeof store)["play"];
   elementHandlers: Map<string, Map<string, ElementHandler>>;
-  /** @deprecated Kept for type compatibility; no longer populated. Use onEvent. */
+  /**
+   * @deprecated Always empty in this and later versions — handlers for the
+   * deprecated `registerPlayEventListener` API are no longer externally
+   * observable. Kept for type compatibility. Use `onEvent` instead.
+   */
   eventHandlers: Map<string, Array<RegisteredPlayEvent>>;
   dispatchPlayEvent: typeof dispatchPlayEvent;
   registerPlayEventListener: typeof registerPlayEventListener;

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -565,6 +565,29 @@ async function initPlayHTML({
     onError?.();
   });
 
+  // Register message handler immediately after provider creation to catch early messages
+  // like room-reset, which the server sends immediately upon detecting a stale client epoch.
+  // The WebSocket is created synchronously in the provider constructor,
+  // so we can access it here before any sync events fire.
+  // We use a microtask to ensure the provider is fully initialized.
+  queueMicrotask(() => {
+    if (yprovider.ws) {
+      yprovider.ws.addEventListener("message", onMessage);
+    } else {
+      console.warn(
+        "[PLAYHTML] WebSocket not available in microtask, onMessage handler not attached",
+      );
+    }
+  });
+
+  // Re-attach message handler when the WebSocket reconnects (provider creates a new instance)
+  yprovider.on("status", ({ status }: { status: string }) => {
+    if (status === "connected") {
+      yprovider.ws?.addEventListener("message", onMessage);
+    }
+  });
+
+
   // Initialize cursor tracking immediately after provider creation
   if (cursors.enabled) {
     // Generate player identity if not provided

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1531,6 +1531,9 @@ function deleteElementData(tag: string, elementId: string): void {
   }
 }
 
+/**
+ * @deprecated Use `playhtml.dispatchEvent(type, payload)` instead.
+ */
 function dispatchPlayEvent(message: EventMessage) {
   const { type } = message;
   if (!eventHandlers.has(type)) {
@@ -1542,13 +1545,8 @@ function dispatchPlayEvent(message: EventMessage) {
 }
 
 /**
- * Registers the given event listener.
- * Returns a unique ID corresponding to the listener.
+ * @deprecated Use `playhtml.onEvent(type, callback)` instead. Returns an unsubscribe function directly.
  */
-// TODO: allow duplicates or not..
-// duplicates are good for registering a lot of logic.. but why wouldn't you just put it all in one call?
-// duplicates bad when you want to handle deduping the same logic, so this would be useful to expose one helper function in the react context
-// to register a listener for a type and provide a callback and it returns you a function that triggers that event.
 function registerPlayEventListener(
   type: string,
   event: Omit<PlayEvent, "type">,
@@ -1575,7 +1573,7 @@ function registerPlayEventListener(
 }
 
 /**
- * Removes the event listener with the given type and id.
+ * @deprecated Use the unsubscribe function returned by `playhtml.onEvent()` instead.
  */
 function removePlayEventListener(type: string, id: string) {
   const handlers = eventHandlers.get(type);

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -147,8 +147,6 @@ function normalizeRoomId(host: string, roomString: string): string {
   return encodeURIComponent(normalized);
 }
 
-const ROOM_EVENT_TYPE = "__playhtml_event__";
-
 let yprovider: YProvider;
 let cursorProvider: YProvider | null = null;
 let cursorClient: CursorClientAwareness | null = null;
@@ -434,43 +432,44 @@ function onMessage(data: string) {
     return;
   }
 
-  // Handle new-style room events
-  if (message.type === ROOM_EVENT_TYPE) {
-    const callbacks = pageEventListeners.get(message.eventType);
-    if (callbacks) {
-      for (const cb of callbacks) cb(message.payload);
-    }
-    return;
-  }
-
-  // Handle regular PlayHTML events
+  // Handle PlayHTML events. Both the deprecated registerPlayEventListener
+  // registry (eventHandlers) and the new onEvent registry (pageEventListeners)
+  // share the same wire format; fire whichever matches the type.
   const { type, eventPayload } = message as EventMessage;
+
+  const newListeners = pageEventListeners.get(type);
+  if (newListeners) {
+    for (const cb of newListeners) cb(eventPayload);
+  }
+
   const maybeHandlers = eventHandlers.get(type);
-  if (!maybeHandlers) {
-    // Handle internal bridge replies
-    if ((message as any).permissions) {
-      try {
-        const perms = (message as any).permissions as Record<
-          string,
-          "read-only" | "read-write"
-        >;
-        Object.entries(perms).forEach(([elementId, mode]) => {
-          sharedPermissions.set(elementId, mode);
-          if (mode === "read-only") {
-            // Add not-allowed affordance to any matching referenced element
-            const el = document.querySelector(
-              `[data-source$="#${CSS.escape(elementId)}"]`,
-            ) as HTMLElement | null;
-            if (el) el.setAttribute("data-source-read-only", "");
-          }
-        });
-      } catch {}
+  if (maybeHandlers) {
+    for (const handler of maybeHandlers) {
+      handler.onEvent(eventPayload);
     }
     return;
   }
 
-  for (const handler of maybeHandlers) {
-    handler.onEvent(eventPayload);
+  if (newListeners) return;
+
+  // Handle internal bridge replies (only if no listeners matched above)
+  if ((message as any).permissions) {
+    try {
+      const perms = (message as any).permissions as Record<
+        string,
+        "read-only" | "read-write"
+      >;
+      Object.entries(perms).forEach(([elementId, mode]) => {
+        sharedPermissions.set(elementId, mode);
+        if (mode === "read-only") {
+          // Add not-allowed affordance to any matching referenced element
+          const el = document.querySelector(
+            `[data-source$="#${CSS.escape(elementId)}"]`,
+          ) as HTMLElement | null;
+          if (el) el.setAttribute("data-source-read-only", "");
+        }
+      });
+    } catch {}
   }
 }
 
@@ -564,29 +563,6 @@ async function initPlayHTML({
   yprovider.on("error", () => {
     onError?.();
   });
-
-  // Register message handler immediately after provider creation to catch early messages
-  // like room-reset, which the server sends immediately upon detecting a stale client epoch.
-  // The WebSocket is created synchronously in the provider constructor,
-  // so we can access it here before any sync events fire.
-  // We use a microtask to ensure the provider is fully initialized.
-  queueMicrotask(() => {
-    if (yprovider.ws) {
-      yprovider.ws.addEventListener("message", (ev) => onMessage(ev.data));
-    } else {
-      console.warn(
-        "[PLAYHTML] WebSocket not available in microtask, onMessage handler not attached",
-      );
-    }
-  });
-
-  // Re-attach message handler when the WebSocket reconnects (provider creates a new instance)
-  yprovider.on("status", ({ status }: { status: string }) => {
-    if (status === "connected") {
-      yprovider.ws?.addEventListener("message", (ev) => onMessage(ev.data));
-    }
-  });
-
 
   // Initialize cursor tracking immediately after provider creation
   if (cursors.enabled) {
@@ -1090,33 +1066,25 @@ function createPresenceRoom(name: string): PresenceRoom {
 
   const eventListeners = new Map<string, Set<(payload: unknown) => void>>();
 
-  function handleMessage(evt: MessageEvent) {
-    if (evt.data instanceof Blob) return;
-    let parsed: any;
-    try { parsed = JSON.parse(evt.data); } catch { return; }
-    if (parsed.type !== ROOM_EVENT_TYPE) return;
-    const callbacks = eventListeners.get(parsed.eventType);
-    if (!callbacks) return;
-    for (const cb of callbacks) cb(parsed.payload);
-  }
-
-  provider.ws?.addEventListener("message", handleMessage);
-  provider.on("status", ({ status }: { status: string }) => {
-    if (status === "connected") {
-      provider.ws?.addEventListener("message", handleMessage);
+  provider.on("custom-message", (data: string) => {
+    let parsed: EventMessage;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return;
     }
+    const callbacks = eventListeners.get(parsed.type);
+    if (!callbacks) return;
+    for (const cb of callbacks) cb(parsed.eventPayload);
   });
 
   let destroyed = false;
   return {
     presence,
     dispatchEvent(type: string, payload?: unknown): void {
-      if (destroyed || !provider.ws) return;
-      provider.ws.send(JSON.stringify({
-        type: ROOM_EVENT_TYPE,
-        eventType: type,
-        payload: payload ?? null,
-      }));
+      if (destroyed) return;
+      const message: EventMessage = { type, eventPayload: payload ?? null };
+      provider.sendMessage(JSON.stringify(message));
     },
     onEvent(type: string, callback: (payload: unknown) => void): () => void {
       if (!eventListeners.has(type)) eventListeners.set(type, new Set());
@@ -1616,12 +1584,9 @@ function removePlayEventListener(type: string, id: string) {
 }
 
 function pageDispatchEvent(type: string, payload?: unknown): void {
-  if (!yprovider?.ws) return;
-  yprovider.ws.send(JSON.stringify({
-    type: ROOM_EVENT_TYPE,
-    eventType: type,
-    payload: payload ?? null,
-  }));
+  if (!yprovider) return;
+  const message: EventMessage = { type, eventPayload: payload ?? null };
+  yprovider.sendMessage(JSON.stringify(message));
 }
 
 function pageOnEvent(type: string, callback: (payload: unknown) => void): () => void {

--- a/packages/playhtml/vitest.setup.ts
+++ b/packages/playhtml/vitest.setup.ts
@@ -30,6 +30,7 @@ vi.mock("y-partyserver/provider", () => {
         addEventListener: (t: string, cb: any) => void;
       };
       awareness: any;
+      sendMessage = vi.fn();
       private listeners: Record<string, Function[]> = {};
       private clientId: number = 1;
       constructor() {

--- a/packages/playhtml/vitest.setup.ts
+++ b/packages/playhtml/vitest.setup.ts
@@ -23,10 +23,10 @@ import { vi } from "vitest";
 vi.mock("y-indexeddb", () => ({ IndexeddbPersistence: class {} }));
 
 // Tracks all FakeProvider instances so tests can drive inbound messages via
-// `latestFakeProvider()` below.
-const _fakeProviderInstances: unknown[] = [];
-// @ts-ignore — attach to global so tests can reach it without importing setup
-(globalThis as any).__getLatestFakeProvider = () => _fakeProviderInstances[_fakeProviderInstances.length - 1];
+// emit("custom-message", ...). Use the helpers in ./test-utils to access.
+const fakeProviderInstances: unknown[] = [];
+// @ts-ignore — expose via a well-known symbol the test-utils module reads.
+(globalThis as any).__playhtmlFakeProviders = fakeProviderInstances;
 
 vi.mock("y-partyserver/provider", () => {
   return {
@@ -41,7 +41,7 @@ vi.mock("y-partyserver/provider", () => {
       private listeners: Record<string, Function[]> = {};
       private clientId: number = 1;
       constructor() {
-        _fakeProviderInstances.push(this);
+        fakeProviderInstances.push(this);
         this.ws = {
           send: vi.fn(),
           addEventListener: vi.fn(),

--- a/packages/playhtml/vitest.setup.ts
+++ b/packages/playhtml/vitest.setup.ts
@@ -22,6 +22,12 @@ import { vi } from "vitest";
 
 vi.mock("y-indexeddb", () => ({ IndexeddbPersistence: class {} }));
 
+// Tracks all FakeProvider instances so tests can drive inbound messages via
+// `latestFakeProvider()` below.
+const _fakeProviderInstances: unknown[] = [];
+// @ts-ignore — attach to global so tests can reach it without importing setup
+(globalThis as any).__getLatestFakeProvider = () => _fakeProviderInstances[_fakeProviderInstances.length - 1];
+
 vi.mock("y-partyserver/provider", () => {
   return {
     default: class FakeProvider {
@@ -31,9 +37,11 @@ vi.mock("y-partyserver/provider", () => {
       };
       awareness: any;
       sendMessage = vi.fn();
+      synced = false;
       private listeners: Record<string, Function[]> = {};
       private clientId: number = 1;
       constructor() {
+        _fakeProviderInstances.push(this);
         this.ws = {
           send: vi.fn(),
           addEventListener: vi.fn(),
@@ -56,12 +64,16 @@ vi.mock("y-partyserver/provider", () => {
           getStates: () => states,
           on: (t: string, cb: any) => this.on(t, cb),
         };
-        queueMicrotask(() => this.emit("sync", true));
+        queueMicrotask(() => {
+          this.synced = true;
+          this.emit("sync", true);
+        });
       }
       on(t: string, cb: any) {
         this.listeners[t] ??= [];
         this.listeners[t].push(cb);
       }
+      // Exposed publicly so tests can simulate inbound messages via emit("custom-message", payload).
       emit(t: string, ...args: any[]) {
         (this.listeners[t] || []).forEach((cb) => cb(...args));
       }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -170,30 +170,22 @@ import { useContext, useEffect } from "react";
 const ConfettiEventType = "confetti";
 
 export function useConfetti() {
-  const {
-    registerPlayEventListener,
-    removePlayEventListener,
-    dispatchPlayEvent,
-  } = useContext(PlayContext);
+  const { dispatchEvent, onEvent } = useContext(PlayContext);
 
   useEffect(() => {
-    const id = registerPlayEventListener(ConfettiEventType, {
-      onEvent: () => {
-        // requires importing <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
-        // somewhere in your app
-        window.confetti({
-          particleCount: 100,
-          spread: 70,
-          origin: { y: 0.6 },
-        });
-      },
+    return onEvent(ConfettiEventType, () => {
+      // requires importing <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js"></script>
+      // somewhere in your app
+      window.confetti({
+        particleCount: 100,
+        spread: 70,
+        origin: { y: 0.6 },
+      });
     });
-
-    return () => removePlayEventListener(ConfettiEventType, id);
-  }, []);
+  }, [onEvent]);
 
   return () => {
-    dispatchPlayEvent({ type: ConfettiEventType });
+    dispatchEvent(ConfettiEventType);
   };
 }
 

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -11,6 +11,8 @@ export interface PlayContextInfo
     | "dispatchPlayEvent"
     | "registerPlayEventListener"
     | "removePlayEventListener"
+    | "dispatchEvent"
+    | "onEvent"
     | "deleteElementData"
   > {
   /** @deprecated Use `isLoading` instead. */
@@ -47,6 +49,16 @@ export const PlayContext = createContext<PlayContextInfo>({
     );
   },
   removePlayEventListener: () => {},
+  dispatchEvent: () => {
+    throw new Error(
+      "[@playhtml/react]: PlayProvider element missing. please render it at the top-level or use the `standalone` prop"
+    );
+  },
+  onEvent: () => {
+    throw new Error(
+      "[@playhtml/react]: PlayProvider element missing. please render it at the top-level or use the `standalone` prop"
+    );
+  },
   hasSynced: false,
   isLoading: true,
   isProviderMissing: true,
@@ -206,6 +218,8 @@ export function PlayProvider({
         dispatchPlayEvent: playhtml.dispatchPlayEvent,
         registerPlayEventListener: playhtml.registerPlayEventListener,
         removePlayEventListener: playhtml.removePlayEventListener,
+        dispatchEvent: playhtml.dispatchEvent,
+        onEvent: playhtml.onEvent,
         deleteElementData: playhtml.deleteElementData,
         hasSynced,
         isLoading: !hasSynced,

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -133,12 +133,12 @@ describe("usePageData", () => {
 });
 
 describe("usePresenceRoom", () => {
-  it("returns null pre-sync, then a room post-sync", async () => {
-    const seen: Array<boolean> = [];
+  it("returns null room and isLoading=true pre-sync, then populates post-sync", async () => {
+    const seen: Array<{ hasRoom: boolean; isLoading: boolean }> = [];
 
     function TestComponent() {
-      const room = usePresenceRoom("voice");
-      seen.push(room !== null);
+      const { room, isLoading } = usePresenceRoom("voice");
+      seen.push({ hasRoom: room !== null, isLoading });
       return <div />;
     }
 
@@ -148,7 +148,11 @@ describe("usePresenceRoom", () => {
       </PlayProvider>,
     );
 
-    expect(seen[0]).toBe(false);
-    await waitFor(() => expect(seen.at(-1)).toBe(true));
+    expect(seen[0]).toEqual({ hasRoom: false, isLoading: true });
+    await waitFor(() => {
+      const last = seen.at(-1)!;
+      expect(last.hasRoom).toBe(true);
+      expect(last.isLoading).toBe(false);
+    });
   });
 });

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -69,6 +69,8 @@ const mockedPlayhtml = {
   }),
   createPresenceRoom: vi.fn((_name: string) => ({
     presence: mockedPlayhtml.presence,
+    isLoading: false,
+    onLoadingChange: vi.fn().mockReturnValue(() => {}),
     dispatchEvent: vi.fn(),
     onEvent: vi.fn().mockReturnValue(() => {}),
     destroy: vi.fn(),

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -29,6 +29,8 @@ const mockedPlayhtml = {
   dispatchPlayEvent: vi.fn(),
   registerPlayEventListener: vi.fn().mockReturnValue("mock-id"),
   removePlayEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+  onEvent: vi.fn().mockReturnValue(() => {}),
   presence: {
     setMyPresence: vi.fn((channel: string, data: unknown) => {
       mockPresences.set("me", { ...data, isMe: true, cursor: null });
@@ -67,6 +69,8 @@ const mockedPlayhtml = {
   }),
   createPresenceRoom: vi.fn((_name: string) => ({
     presence: mockedPlayhtml.presence,
+    dispatchEvent: vi.fn(),
+    onEvent: vi.fn().mockReturnValue(() => {}),
     destroy: vi.fn(),
   })),
 };

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -143,23 +143,37 @@ export function usePageData<T>(
 }
 
 /**
- * Join a presence room. Safe to call before playhtml has initialized:
- * returns `null` until sync completes. When `name` changes, briefly returns
- * `null` during the transition between rooms.
+ * Join a presence room. Safe to call before playhtml has initialized.
+ *
+ * Returns `{ room, isLoading }`:
+ * - `room` is `null` until playhtml has initialized and the room has been
+ *   created. When `name` changes, briefly returns `null` during the
+ *   transition between rooms.
+ * - `isLoading` is `true` until both playhtml has synced AND the room's
+ *   own WebSocket has connected and synced. Gate `room.dispatchEvent`
+ *   calls on `isLoading === false`.
  */
-export function usePresenceRoom(name: string): PresenceRoom | null {
-  const { isLoading } = useContext(PlayContext);
+export function usePresenceRoom(name: string): {
+  room: PresenceRoom | null;
+  isLoading: boolean;
+} {
+  const { isLoading: playhtmlLoading } = useContext(PlayContext);
   const [room, setRoom] = useState<PresenceRoom | null>(null);
+  const [roomLoading, setRoomLoading] = useState(true);
 
   useEffect(() => {
-    if (isLoading) return;
+    if (playhtmlLoading) return;
     const r = playhtml.createPresenceRoom(name);
     setRoom(r);
+    setRoomLoading(r.isLoading);
+    const unsubLoading = r.onLoadingChange(setRoomLoading);
     return () => {
+      unsubLoading();
       r.destroy();
       setRoom(null);
+      setRoomLoading(true);
     };
-  }, [isLoading, name]);
+  }, [playhtmlLoading, name]);
 
-  return room;
+  return { room, isLoading: playhtmlLoading || roomLoading };
 }

--- a/website/test/react-test.tsx
+++ b/website/test/react-test.tsx
@@ -27,6 +27,7 @@ import { SharedSlider } from "../../packages/react/examples/SharedSlider";
 import { LiveReactions } from "../../packages/react/examples/LiveReactions";
 // import { CursorOverlap } from "../../packages/react/examples/CursorOverlap";
 import { SharedSound } from "../../packages/react/examples/SharedSound";
+import { useCallback, useState } from "react";
 
 const Candle = withSharedState(
   { defaultData: { on: false } },
@@ -112,6 +113,70 @@ const WithSharedStateCanPlayWithLoading = withSharedState(
   ),
 );
 
+// Event API test: exercises both old (dispatchPlayEvent) and new (dispatchEvent/onEvent) APIs
+const EventApiTest = () => {
+  const {
+    dispatchPlayEvent,
+    registerPlayEventListener,
+    removePlayEventListener,
+    dispatchEvent,
+    onEvent,
+  } = usePlayContext();
+  const [oldApiLog, setOldApiLog] = useState<string[]>([]);
+  const [newApiLog, setNewApiLog] = useState<string[]>([]);
+
+  // Old API listener
+  React.useEffect(() => {
+    const id = registerPlayEventListener("test-old-api", {
+      onEvent: () => {
+        setOldApiLog((prev) => [...prev, `[${new Date().toLocaleTimeString()}] received via old API`]);
+      },
+    });
+    return () => removePlayEventListener("test-old-api", id);
+  }, [registerPlayEventListener, removePlayEventListener]);
+
+  // New API listener
+  React.useEffect(() => {
+    return onEvent("test-new-api", (payload: any) => {
+      setNewApiLog((prev) => [...prev, `[${new Date().toLocaleTimeString()}] received: ${JSON.stringify(payload)}`]);
+    });
+  }, [onEvent]);
+
+  const sendOld = useCallback(() => {
+    dispatchPlayEvent({ type: "test-old-api" });
+  }, [dispatchPlayEvent]);
+
+  const sendNew = useCallback(() => {
+    dispatchEvent("test-new-api", { msg: "hello", ts: Date.now() });
+  }, [dispatchEvent]);
+
+  return (
+    <div style={{ padding: "20px", border: "2px solid #4a9a8a", margin: "20px 0" }}>
+      <h3>Event API Test</h3>
+      <div style={{ display: "flex", gap: "24px" }}>
+        <div style={{ flex: 1 }}>
+          <h4>Old API (deprecated)</h4>
+          <button onClick={sendOld} style={{ padding: "8px 16px", cursor: "pointer" }}>
+            dispatchPlayEvent("test-old-api")
+          </button>
+          <pre style={{ fontSize: "12px", maxHeight: "120px", overflow: "auto", background: "#f5f0e8", padding: "8px", marginTop: "8px" }}>
+            {oldApiLog.length === 0 ? "(no events yet)" : oldApiLog.join("\n")}
+          </pre>
+        </div>
+        <div style={{ flex: 1 }}>
+          <h4>New API (dispatchEvent/onEvent)</h4>
+          <button onClick={sendNew} style={{ padding: "8px 16px", cursor: "pointer" }}>
+            dispatchEvent("test-new-api")
+          </button>
+          <pre style={{ fontSize: "12px", maxHeight: "120px", overflow: "auto", background: "#f5f0e8", padding: "8px", marginTop: "8px" }}>
+            {newApiLog.length === 0 ? "(no events yet)" : newApiLog.join("\n")}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+};
+
 ReactDOM.createRoot(
   document.getElementById("reactContent") as HTMLElement,
 ).render(
@@ -173,6 +238,7 @@ ReactDOM.createRoot(
         </div>
       </div>
 
+      <EventApiTest />
       <LoadingStateTest />
       <Candle />
       <ReactionView reaction={{ emoji: "🧡", count: 1 }} />


### PR DESCRIPTION
Add dispatchEvent/onEvent to PresenceRoom and playhtml for cleaner event API

- `room.dispatchEvent(type, payload?)` and `room.onEvent(type, callback)` for domain-scoped events via PresenceRoom
- `playhtml.dispatchEvent(type, payload?)` and `playhtml.onEvent(type, callback)` for page-scoped events
- `onEvent` returns an unsubscribe function directly (no ID tracking needed)
- Deprecate `dispatchPlayEvent`, `registerPlayEventListener`, `removePlayEventListener` (still functional, no breaking change)