### PR TITLE
fix(partykit): broadcast room-reset via sendCustomMessage

### DIFF
--- a/.changeset/room-reset-send-custom-message.md
+++ b/.changeset/room-reset-send-custom-message.md
@@ -1,4 +1,0 @@
----
----
-
-fix(partykit): broadcast the `room-reset` message to stale clients via `sendCustomMessage` so it carries partyserver's `__YPS:` prefix. Without the prefix, the client-side `provider.on("custom-message", ...)` handler silently dropped the signal, leaving stale clients unable to receive the reset and reload.

--- a/.changeset/room-reset-send-custom-message.md
+++ b/.changeset/room-reset-send-custom-message.md
@@ -1,0 +1,4 @@
+---
+---
+
+fix(partykit): broadcast the `room-reset` message to stale clients via `sendCustomMessage` so it carries partyserver's `__YPS:` prefix. Without the prefix, the client-side `provider.on("custom-message", ...)` handler silently dropped the signal, leaving stale clients unable to receive the reset and reload.

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -631,7 +631,7 @@ export class PartyServer extends YServer {
         timestamp: serverResetEpoch,
         resetEpoch: serverResetEpoch,
       });
-      connection.send(resetMessage);
+      this.sendCustomMessage(connection, resetMessage);
       console.log(
         `[PartyServer] Sent room-reset message to connectionId=${connectionId}, returning early (no Y.js sync). Client will reload and reconnect.`
       );

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,12 @@
   "compatibility_date": "2024-09-23",
   "workers_dev": true,
   "preview_urls": false,
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true
+    }
+  },
   "secrets": {
     "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
   },
@@ -28,6 +34,12 @@
       "name": "playhtml-staging",
       "workers_dev": true,
       "preview_urls": false,
+      "observability": {
+        "logs": {
+          "enabled": true,
+          "invocation_logs": true
+        }
+      },
       "secrets": {
         "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
       },


### PR DESCRIPTION
The partyserver migration left one call site using raw connection.send() for the room-reset message. Partyserver's custom-message protocol requires a __YPS: prefix (added by sendCustomMessage/broadcastCustomMessage) — raw send bypasses this and the client-side provider.on("custom-message", ...) handler silently drops non-prefixed messages.

Stale clients were therefore not receiving their reset signal and not reloading. Switching to sendCustomMessage fixes it.