### PR TITLE
Onboarding presets + movement sound fixes

### DIFF
--- a/extension/src/__tests__/keyboardRedaction.test.ts
+++ b/extension/src/__tests__/keyboardRedaction.test.ts
@@ -1,0 +1,153 @@
+// ABOUTME: Tests for keyboard legibility parsing, PII redaction, and partial redaction with stable seeding.
+// ABOUTME: Protects the migration path from legacy "abstract"/"full" string values to the numeric legibility model.
+
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_LEGIBILITY,
+  REDACTION_CHAR,
+  parseLegibility,
+  redactPII,
+  redactNonWhitespace,
+  redactWithLegibility,
+} from "../utils/keyboardRedaction";
+
+describe("parseLegibility", () => {
+  it("maps legacy 'abstract' to 0", () => {
+    expect(parseLegibility("abstract")).toBe(0);
+  });
+
+  it("maps legacy 'full' to 100", () => {
+    expect(parseLegibility("full")).toBe(100);
+  });
+
+  it("clamps numbers outside 0-100", () => {
+    expect(parseLegibility(-5)).toBe(0);
+    expect(parseLegibility(105)).toBe(100);
+  });
+
+  it("rounds fractional numbers", () => {
+    expect(parseLegibility(50.7)).toBe(51);
+    expect(parseLegibility(49.4)).toBe(49);
+  });
+
+  it("returns DEFAULT_LEGIBILITY for unknown values", () => {
+    expect(parseLegibility(null)).toBe(DEFAULT_LEGIBILITY);
+    expect(parseLegibility(undefined)).toBe(DEFAULT_LEGIBILITY);
+    expect(parseLegibility("something else")).toBe(DEFAULT_LEGIBILITY);
+    expect(parseLegibility({})).toBe(DEFAULT_LEGIBILITY);
+  });
+
+  it("passes through in-range integers", () => {
+    expect(parseLegibility(0)).toBe(0);
+    expect(parseLegibility(50)).toBe(50);
+    expect(parseLegibility(100)).toBe(100);
+  });
+
+  it("returns DEFAULT_LEGIBILITY for NaN and Infinity", () => {
+    expect(parseLegibility(NaN)).toBe(DEFAULT_LEGIBILITY);
+    expect(parseLegibility(Infinity)).toBe(DEFAULT_LEGIBILITY);
+  });
+});
+
+describe("redactPII", () => {
+  it("redacts email addresses", () => {
+    const out = redactPII("email hi@spencer.place with feedback");
+    expect(out).not.toContain("hi@spencer.place");
+    expect(out).toContain(REDACTION_CHAR.repeat("hi@spencer.place".length));
+  });
+
+  it("redacts US phone numbers", () => {
+    const out = redactPII("call me at (555) 123-4567 tomorrow");
+    expect(out).not.toContain("555");
+    expect(out).not.toContain("4567");
+  });
+
+  it("redacts SSN patterns", () => {
+    const out = redactPII("ssn 123-45-6789");
+    expect(out).not.toContain("123-45-6789");
+  });
+
+  it("leaves non-PII text intact", () => {
+    expect(redactPII("hello world")).toBe("hello world");
+  });
+});
+
+describe("redactNonWhitespace", () => {
+  it("replaces every non-whitespace character", () => {
+    expect(redactNonWhitespace("a b c")).toBe(
+      `${REDACTION_CHAR} ${REDACTION_CHAR} ${REDACTION_CHAR}`,
+    );
+  });
+
+  it("preserves whitespace", () => {
+    expect(redactNonWhitespace("  \n\t")).toBe("  \n\t");
+  });
+});
+
+describe("redactWithLegibility", () => {
+  it("at 0% redacts all non-whitespace (matches redactNonWhitespace)", () => {
+    expect(redactWithLegibility("hello world", 0, 0)).toBe(
+      redactNonWhitespace("hello world"),
+    );
+  });
+
+  it("at 100% preserves non-PII text (matches redactPII)", () => {
+    const input = "write hi@spencer.place now";
+    expect(redactWithLegibility(input, 100, 0)).toBe(redactPII(input));
+  });
+
+  it("always redacts PII regardless of legibility", () => {
+    const inputs = ["email hi@spencer.place", "call (555) 123-4567"];
+    for (const input of inputs) {
+      for (const pct of [0, 25, 50, 75, 99, 100]) {
+        const out = redactWithLegibility(input, pct, 1);
+        expect(out).not.toContain("hi@spencer.place");
+        expect(out).not.toContain("(555) 123-4567");
+      }
+    }
+  });
+
+  it("is deterministic for same (text, pct, seed)", () => {
+    const a = redactWithLegibility("the quick brown fox", 50, 42);
+    const b = redactWithLegibility("the quick brown fox", 50, 42);
+    expect(a).toBe(b);
+  });
+
+  it("differs across seeds at partial legibility", () => {
+    const a = redactWithLegibility("the quick brown fox", 50, 1);
+    const b = redactWithLegibility("the quick brown fox", 50, 99);
+    // Not guaranteed, but extremely likely for a 19-char string at 50%.
+    expect(a).not.toBe(b);
+  });
+
+  it("redacts more characters as legibility decreases", () => {
+    const text = "the quick brown fox jumps over the lazy dog";
+    const countBlocks = (s: string) =>
+      (s.match(new RegExp(REDACTION_CHAR, "g")) || []).length;
+    const hi = countBlocks(redactWithLegibility(text, 80, 7));
+    const lo = countBlocks(redactWithLegibility(text, 20, 7));
+    expect(lo).toBeGreaterThan(hi);
+  });
+
+  it("preserves whitespace at all legibility levels", () => {
+    for (const pct of [0, 25, 50, 75, 100]) {
+      const out = redactWithLegibility("a b\nc\td", pct, 3);
+      expect(out[1]).toBe(" ");
+      expect(out[3]).toBe("\n");
+      expect(out[5]).toBe("\t");
+    }
+  });
+
+  it("clamps out-of-range pct", () => {
+    expect(redactWithLegibility("abc", -50, 0)).toBe(
+      redactWithLegibility("abc", 0, 0),
+    );
+    expect(redactWithLegibility("abc", 500, 0)).toBe(
+      redactWithLegibility("abc", 100, 0),
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(redactWithLegibility("", 50, 0)).toBe("");
+  });
+});

--- a/extension/src/collectors/KeyboardCollector.ts
+++ b/extension/src/collectors/KeyboardCollector.ts
@@ -6,30 +6,31 @@ import type { KeyboardEventData, TypingAction } from './types';
 import { normalizePosition, getElementSelector } from './types';
 import browser from 'webextension-polyfill';
 import { VERBOSE } from '../config';
+import {
+  LEGIBILITY_KEY,
+  REDACTION_CHAR,
+  parseLegibility,
+  redactWithLegibility,
+} from '../utils/keyboardRedaction';
 
-const PRIVACY_LEVEL_KEY = 'collection_keyboard_privacy_level';
+const PRIVACY_LEVEL_KEY = LEGIBILITY_KEY;
 const FILTER_SUBSTRINGS_KEY = 'collection_keyboard_filter_substrings';
-const REDACTION_CHAR = '█'; // U+2588, full block
 const DEBOUNCE_DELAY = 5000; // 5 seconds - longer to handle gaps between typing sessions
 
-// PII detection patterns
-const PII_PATTERNS = {
-  email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/gi,
-  phone: /\b(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b/g,
-  ssn: /\b\d{3}-\d{2}-\d{4}\b/g,
-};
-
 /**
- * KeyboardCollector captures typing behavior with dual privacy levels:
- * - Abstract: Typing frequency, text length, location (no actual text)
- * - Full: Actual text content + location + typing sequence (PII redacted)
+ * KeyboardCollector captures typing behavior with a legibility percent (0–100):
+ *   0   → cadence only (all non-whitespace redacted)
+ *   100 → full text (PII always redacted)
+ * Intermediate values redact a proportional share of random characters.
  */
 export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
   readonly type = 'keyboard' as const;
   readonly description = 'Captures typing in any editable element (inputs, textareas, contenteditable)';
 
-  // Privacy level (cached in memory)
-  private privacyLevel: 'abstract' | 'full' = 'abstract';
+  // Legibility percent, 0–100 (cached in memory)
+  private legibilityPct: number = 0;
+  // Seed for deterministic per-session redaction patterns
+  private redactionSeed: number = Math.floor(Math.random() * 0xffffffff);
 
   // Filter substrings (cached in memory)
   private filterSubstrings: string[] = [];
@@ -74,10 +75,7 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
     browser.storage.onChanged.addListener((changes, areaName) => {
       if (areaName === 'local') {
         if (changes[PRIVACY_LEVEL_KEY]) {
-          const newLevel = changes[PRIVACY_LEVEL_KEY].newValue;
-          if (newLevel === 'abstract' || newLevel === 'full') {
-            this.privacyLevel = newLevel;
-          }
+          this.legibilityPct = parseLegibility(changes[PRIVACY_LEVEL_KEY].newValue);
         }
         if (changes[FILTER_SUBSTRINGS_KEY]) {
           const newList = changes[FILTER_SUBSTRINGS_KEY].newValue;
@@ -208,21 +206,20 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
   }
 
   /**
-   * Initialize privacy level from storage (read once, cache in memory)
+   * Initialize legibility percent from storage (read once, cache in memory).
+   * Migrates legacy "abstract" | "full" values to the numeric range.
    */
   private async initPrivacyLevel(): Promise<void> {
     try {
       const result = await browser.storage.local.get([PRIVACY_LEVEL_KEY]);
-      const level = result[PRIVACY_LEVEL_KEY];
-      if (level === 'abstract' || level === 'full') {
-        this.privacyLevel = level;
-      } else {
-        // Default to abstract
-        this.privacyLevel = 'abstract';
-        await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: 'abstract' });
+      const raw = result[PRIVACY_LEVEL_KEY];
+      this.legibilityPct = parseLegibility(raw);
+      // Persist migrated/default value so legacy strings don't keep re-parsing.
+      if (typeof raw !== 'number') {
+        await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: this.legibilityPct });
       }
     } catch (error) {
-      this.privacyLevel = 'abstract'; // Default on error
+      this.legibilityPct = 0;
     }
   }
 
@@ -541,28 +538,18 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
         if (action.text) {
           redacted.text = REDACTION_CHAR.repeat(action.text.length);
         }
-        // deletedCount is just a number, no redaction needed
-        return redacted;
-      });
-    } else if (this.privacyLevel === 'full') {
-      // Redact PII in sequence actions
-      sequence = this.sequence.map(action => {
-        const redacted: TypingAction = { ...action };
-        if (action.text) {
-          redacted.text = this.redactPII(action.text);
-        }
-        // deletedCount is just a number, no redaction needed
         return redacted;
       });
     } else {
-      // Abstract level: redact all non-whitespace characters but preserve whitespace
-      // This preserves cadence (timestamps) while hiding actual content
-      sequence = this.sequence.map(action => {
+      sequence = this.sequence.map((action, idx) => {
         const redacted: TypingAction = { ...action };
         if (action.text) {
-          redacted.text = this.redactNonWhitespace(action.text);
+          redacted.text = redactWithLegibility(
+            action.text,
+            this.legibilityPct,
+            this.redactionSeed + idx,
+          );
         }
-        // deletedCount is just a number, no redaction needed
         return redacted;
       });
     }
@@ -625,34 +612,6 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
       case 'double': return 4;
       default: return 0; // none, hidden, or other
     }
-  }
-
-  /**
-   * Redact PII patterns in text
-   */
-  private redactPII(text: string): string {
-    let redacted = text;
-
-    // Apply each PII pattern
-    for (const pattern of Object.values(PII_PATTERNS)) {
-      redacted = redacted.replace(pattern, (match) => {
-        return REDACTION_CHAR.repeat(match.length);
-      });
-    }
-
-    return redacted;
-  }
-
-  /**
-   * Redact all non-whitespace characters while preserving whitespace
-   * Used for abstract privacy level to preserve cadence while hiding content
-   */
-  private redactNonWhitespace(text: string): string {
-    // Replace each character: keep whitespace, redact everything else
-    return text.replace(/./g, (char) => {
-      // Check if character is whitespace (space, tab, newline, etc.)
-      return /\s/.test(char) ? char : REDACTION_CHAR;
-    });
   }
 
   /**

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -412,6 +412,51 @@
     cursor: pointer;
   }
 
+  &__legibility-slider {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    input[type="range"] {
+      width: 100%;
+      accent-color: $accent-teal;
+      cursor: pointer;
+    }
+  }
+
+  &__legibility-stops {
+    display: flex;
+    justify-content: space-between;
+    gap: 6px;
+  }
+
+  &__legibility-stop {
+    @include btn-base;
+    flex: 1;
+    padding: 4px 6px;
+    font-size: 10px;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    font-family: 'Martian Mono', monospace;
+    background: transparent;
+    color: $text-muted;
+    border: 1px solid $border;
+    border-radius: 4px;
+
+    &--active {
+      background: $accent-teal;
+      color: white;
+      border-color: $accent-teal;
+    }
+
+    &:not(&--active):hover {
+      background: $surface-hover;
+      color: $text;
+      filter: none;
+    }
+  }
+
   &__privacy-preview {
     margin-top: 10px;
     padding: 8px 10px;

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -1,19 +1,25 @@
 // ABOUTME: Data collection settings screen for managing collector modes (off/local/shared)
 // ABOUTME: Also handles keyboard privacy level and filter substring settings
 
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import browser from "webextension-polyfill";
 import type { CollectorStatus } from "../collectors/types";
 import { getValidEventTypes } from "../shared/types";
 import { CollectorIcon } from "./icons";
 import { triggerDownload } from "../utils/portraitExport";
+import {
+  LEGIBILITY_KEY,
+  DEFAULT_LEGIBILITY,
+  parseLegibility,
+  redactWithLegibility,
+} from "../utils/keyboardRedaction";
 import "./Collections.scss";
 
 interface CollectionsProps {
   onBack: () => void;
 }
 
-const PRIVACY_LEVEL_KEY = "collection_keyboard_privacy_level";
+const PRIVACY_LEVEL_KEY = LEGIBILITY_KEY;
 const FILTER_SUBSTRINGS_KEY = "collection_keyboard_filter_substrings";
 const DEV_MODE_KEY = "dev_mode";
 
@@ -47,8 +53,8 @@ function formatAge(ts: number): string {
 export interface CollectorListProps {
   modes: Record<string, "off" | "local" | "shared">;
   onModeChange: (type: string, mode: "off" | "local" | "shared") => void;
-  keyboardPrivacyLevel: "abstract" | "full";
-  onKeyboardPrivacyChange: (level: "abstract" | "full") => void;
+  keyboardLegibilityPct: number;
+  onKeyboardLegibilityChange: (pct: number) => void;
 }
 
 const COLLECTOR_DESCRIPTIONS: Record<string, string> = {
@@ -58,36 +64,35 @@ const COLLECTOR_DESCRIPTIONS: Record<string, string> = {
   navigation: "Captures page navigation and session timing",
 };
 
-// ── Keyboard privacy preview ─────────────────────────────────────────────────
-// Shows a before/after so users can see what "abstract" vs "full" actually
-// records. The sample contains an email so the PII redaction in full mode
-// is visible, not just abstract's opaque solid blocks.
+// ── Keyboard legibility preview ──────────────────────────────────────────────
+// Shows a before/after so users can see how legibility % maps to recorded text.
+// The sample contains an email so the always-on PII redaction stays visible.
 
 const SAMPLE_TYPED_TEXT = "email hi@spencer.place with feedback!";
-const REDACTION_CHAR = "\u2588"; // U+2588 FULL BLOCK — matches KeyboardCollector
 
-const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
-const PHONE_RE =
-  /\b(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b/g;
-const SSN_RE = /\b\d{3}-\d{2}-\d{4}\b/g;
+const LEGIBILITY_STOPS = [
+  { value: 0, label: "Cadence only" },
+  { value: 50, label: "Partial" },
+  { value: 100, label: "Full text" },
+] as const;
 
-function redactPII(text: string): string {
-  let out = text;
-  for (const re of [EMAIL_RE, PHONE_RE, SSN_RE]) {
-    out = out.replace(re, (m) => REDACTION_CHAR.repeat(m.length));
-  }
-  return out;
+function legibilityLabel(pct: number): string {
+  if (pct <= 0) return "Cadence only";
+  if (pct >= 100) return "Full text";
+  if (pct === 50) return "Partial";
+  return `${pct}% legible`;
 }
 
-function redactNonWhitespace(text: string): string {
-  return text.replace(/\S/g, REDACTION_CHAR);
+function legibilityDescription(pct: number): string {
+  if (pct <= 0) return "Typing frequency and location only (no text)";
+  if (pct >= 100) return "Typed text recorded (emails, phones, SSNs redacted)";
+  return `About ${pct}% of characters kept; the rest redacted (PII always redacted)`;
 }
 
-function KeyboardPrivacyPreview({ level }: { level: "abstract" | "full" }) {
-  const output =
-    level === "abstract"
-      ? redactNonWhitespace(SAMPLE_TYPED_TEXT)
-      : redactPII(SAMPLE_TYPED_TEXT);
+function KeyboardLegibilityPreview({ pct }: { pct: number }) {
+  // Seed stays stable across renders for a given preview so the pattern
+  // doesn't flicker while the user drags the slider.
+  const output = useMemo(() => redactWithLegibility(SAMPLE_TYPED_TEXT, pct, 1), [pct]);
   return (
     <div className="collector-card__privacy-preview">
       <div className="collector-card__privacy-preview-row">
@@ -109,8 +114,8 @@ function KeyboardPrivacyPreview({ level }: { level: "abstract" | "full" }) {
 export function CollectorList({
   modes,
   onModeChange,
-  keyboardPrivacyLevel,
-  onKeyboardPrivacyChange,
+  keyboardLegibilityPct,
+  onKeyboardLegibilityChange,
 }: CollectorListProps) {
   const types = getValidEventTypes();
   return (
@@ -159,28 +164,50 @@ export function CollectorList({
                 <div className="collector-card__privacy-header">
                   <div>
                     <label className="collector-card__privacy-label">
-                      Privacy Level
+                      Keyboard legibility — {legibilityLabel(keyboardLegibilityPct)}
                     </label>
                     <p className="collector-card__privacy-desc">
-                      {keyboardPrivacyLevel === "abstract"
-                        ? "Abstract: Typing frequency and location only (no text)"
-                        : "Full: Text content with PII redaction"}
+                      {legibilityDescription(keyboardLegibilityPct)}
                     </p>
                   </div>
-                  <select
-                    value={keyboardPrivacyLevel}
-                    onChange={(e) =>
-                      onKeyboardPrivacyChange(
-                        e.target.value as "abstract" | "full",
-                      )
-                    }
-                    className="collector-card__privacy-select"
-                  >
-                    <option value="abstract">Abstract</option>
-                    <option value="full">Full</option>
-                  </select>
                 </div>
-                <KeyboardPrivacyPreview level={keyboardPrivacyLevel} />
+                <div className="collector-card__legibility-slider">
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={5}
+                    value={keyboardLegibilityPct}
+                    onChange={(e) =>
+                      onKeyboardLegibilityChange(Number(e.target.value))
+                    }
+                    list="legibility-stops"
+                    aria-label="Keyboard legibility"
+                  />
+                  <datalist id="legibility-stops">
+                    {LEGIBILITY_STOPS.map((s) => (
+                      <option key={s.value} value={s.value} label={s.label} />
+                    ))}
+                  </datalist>
+                  <div className="collector-card__legibility-stops">
+                    {LEGIBILITY_STOPS.map((s) => (
+                      <button
+                        key={s.value}
+                        type="button"
+                        className={
+                          "collector-card__legibility-stop" +
+                          (keyboardLegibilityPct === s.value
+                            ? " collector-card__legibility-stop--active"
+                            : "")
+                        }
+                        onClick={() => onKeyboardLegibilityChange(s.value)}
+                      >
+                        {s.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <KeyboardLegibilityPreview pct={keyboardLegibilityPct} />
               </div>
             )}
           </div>
@@ -194,9 +221,9 @@ export function Collections({ onBack }: CollectionsProps) {
   const [collectors, setCollectors] = useState<CollectorStatus[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [keyboardPrivacyLevel, setKeyboardPrivacyLevel] = useState<
-    "abstract" | "full"
-  >("abstract");
+  const [keyboardLegibilityPct, setKeyboardLegibilityPct] = useState<number>(
+    DEFAULT_LEGIBILITY,
+  );
   const [filterSubstrings, setFilterSubstrings] = useState<string[]>([]);
   const [newFilterSubstring, setNewFilterSubstring] = useState("");
   const [modes, setModes] = useState<
@@ -326,29 +353,27 @@ export function Collections({ onBack }: CollectionsProps) {
   const loadPrivacyLevel = async () => {
     try {
       const result = await browser.storage.local.get([PRIVACY_LEVEL_KEY]);
-      const level = result[PRIVACY_LEVEL_KEY];
-      if (level === "abstract" || level === "full") {
-        setKeyboardPrivacyLevel(level);
-      } else {
-        // Default to abstract if not set
-        setKeyboardPrivacyLevel("abstract");
-        await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: "abstract" });
+      const raw = result[PRIVACY_LEVEL_KEY];
+      const pct = parseLegibility(raw);
+      setKeyboardLegibilityPct(pct);
+      if (typeof raw !== "number") {
+        await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: pct });
       }
     } catch (error) {
-      console.error("Failed to load privacy level:", error);
-      setKeyboardPrivacyLevel("abstract");
+      console.error("Failed to load keyboard legibility:", error);
+      setKeyboardLegibilityPct(DEFAULT_LEGIBILITY);
     }
   };
 
-  const updatePrivacyLevel = async (level: "abstract" | "full") => {
+  const updatePrivacyLevel = async (pct: number) => {
     try {
-      await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: level });
-      setKeyboardPrivacyLevel(level);
-      // Reload collectors to ensure the change is reflected
+      const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+      await browser.storage.local.set({ [PRIVACY_LEVEL_KEY]: clamped });
+      setKeyboardLegibilityPct(clamped);
       await loadCollectors();
     } catch (error) {
-      console.error("Failed to update privacy level:", error);
-      alert("Failed to update privacy level. Please try again.");
+      console.error("Failed to update keyboard legibility:", error);
+      alert("Failed to update keyboard legibility. Please try again.");
     }
   };
 
@@ -672,13 +697,13 @@ export function Collections({ onBack }: CollectionsProps) {
         <CollectorList
           modes={modes}
           onModeChange={updateMode}
-          keyboardPrivacyLevel={keyboardPrivacyLevel}
-          onKeyboardPrivacyChange={updatePrivacyLevel}
+          keyboardLegibilityPct={keyboardLegibilityPct}
+          onKeyboardLegibilityChange={updatePrivacyLevel}
         />
 
-        {/* Filter substrings — only when keyboard is active and full fidelity */}
+        {/* Filter substrings — only when keyboard is active and any text is legible */}
         {(modes["keyboard"] ?? "local") !== "off" &&
-          keyboardPrivacyLevel === "full" && (
+          keyboardLegibilityPct > 0 && (
             <div className="collector-card__filter-section">
               <label className="collector-card__filter-label">
                 Filter Sensitive Text
@@ -719,11 +744,12 @@ export function Collections({ onBack }: CollectionsProps) {
           )}
 
         <div className="collections__privacy-notice">
-          {keyboardPrivacyLevel === "full" &&
+          {keyboardLegibilityPct > 0 &&
           (modes["keyboard"] ?? "local") !== "off" ? (
             <>
-              Keyboard full-fidelity mode records typed text. Use filters above
-              to redact sensitive content. All other data is anonymous.{" "}
+              Keyboard legibility is above 0, so some typed text is recorded.
+              Use filters above to redact sensitive content. All other data is
+              anonymous.{" "}
               <a href="mailto:hi@spencer.place">hi@spencer.place</a>
             </>
           ) : (

--- a/extension/src/components/SetupPage.scss
+++ b/extension/src/components/SetupPage.scss
@@ -43,6 +43,17 @@
     margin-bottom: 16px;
   }
 
+  &__heading-link {
+    color: $accent-teal;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 3px;
+
+    &:hover {
+      text-decoration-thickness: 2px;
+    }
+  }
+
   &__subheading {
     @include heading;
     font-size: 15px;
@@ -76,40 +87,99 @@
     max-width: 280px;
   }
 
-  // ── Sharing tabs ────────────────────────────────────────────────────────────
+  // ── Preset tabs ─────────────────────────────────────────────────────────────
 
-  &__tabs {
-    display: inline-flex;
-    background: $surface;
-    border: 1px solid $border-strong;
-    border-radius: 24px;
-    padding: 3px;
-    gap: 2px;
-    margin-bottom: 20px;
+  &__preset-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-bottom: 12px;
   }
 
-  &__tab {
+  &__preset-tab {
     @include btn-base;
-    padding: 7px 16px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: 12px 14px;
     font-size: 13px;
     font-weight: 500;
-    border-radius: 20px;
-    background: transparent;
+    text-align: left;
+    border-radius: 10px;
+    background: $surface;
+    border: 1px solid $border;
     color: $text-muted;
-    border: none;
-
-    &--active {
-      background: $accent-teal;
-      color: white;
-
-      &:hover { filter: brightness(0.97); }
-    }
+    transition: border-color 0.15s, background 0.15s, color 0.15s;
 
     &:not(&--active):hover {
       background: $surface-hover;
       color: $text;
+      border-color: $border-strong;
       filter: none;
     }
+
+    &--active {
+      background: $accent-teal;
+      color: white;
+      border-color: $accent-teal;
+
+      .setup-step__preset-subhead { color: rgba(255, 255, 255, 0.85); }
+      .setup-step__preset-chip {
+        background: rgba(255, 255, 255, 0.2);
+        color: white;
+      }
+    }
+  }
+
+  &__preset-label {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+  }
+
+  &__preset-subhead {
+    font-size: 11px;
+    color: $text-muted;
+    font-weight: 400;
+  }
+
+  &__preset-chip {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: 10px;
+    background: $accent-teal;
+    color: white;
+  }
+
+  &__preset-description {
+    font-size: 13px;
+    line-height: 1.55;
+    color: $text;
+    margin: 8px 0 12px;
+  }
+
+  &__preset-customized {
+    color: $text-muted;
+    font-style: italic;
+  }
+
+  &__trust {
+    font-size: 12px;
+    line-height: 1.5;
+    color: $text-muted;
+    padding: 10px 12px;
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+    margin-bottom: 16px;
   }
 
   // ── Collector list (reuses Collections card styles) ─────────────────────────

--- a/extension/src/components/SetupPage.tsx
+++ b/extension/src/components/SetupPage.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Full-page setup wizard for first-time extension configuration
-// ABOUTME: Handles data sharing consent and cursor color customization
+// ABOUTME: Handles data-sharing preset choice and cursor color customization
 import React, { useEffect, useRef, useState } from "react";
 import browser from "webextension-polyfill";
 import { getValidEventTypes } from "../shared/types";
@@ -8,39 +8,83 @@ import { CollectorList } from "./Collections";
 import { TrailsHero } from "./TrailsHero";
 import { syncParticipantColor } from "../storage/sync";
 import { getParticipantId } from "../storage/participant";
+import { LEGIBILITY_KEY } from "../utils/keyboardRedaction";
 import "./SetupPage.scss";
 import { hslToHex } from "../utils/color";
 import { MilestoneToastPreview } from "./MilestoneToastPreview";
 
 type Step = "welcome" | "configure" | "done";
-type SharingMode = "local" | "shared";
+type Preset = "abstain" | "participate" | "allIn";
 type CollectorMode = "off" | "local" | "shared";
-type KeyboardFidelity = "abstract" | "full";
+
+interface PresetConfig {
+  label: string;
+  subhead: string;
+  description: string;
+  modes: Record<string, CollectorMode>;
+  legibilityPct: number;
+  recommended?: boolean;
+}
 
 function randomPrimaryColor(): string {
   const hue = Math.floor(Math.random() * 360);
   return hslToHex(hue, 70, 60);
 }
 
-function defaultModesFor(mode: SharingMode): Record<string, CollectorMode> {
+function presetConfigs(): Record<Preset, PresetConfig> {
   const types = getValidEventTypes();
-  const result: Record<string, CollectorMode> = {};
-  for (const t of types) result[t] = mode;
-  return result;
+  const allLocal = (): Record<string, CollectorMode> => {
+    const r: Record<string, CollectorMode> = {};
+    for (const t of types) r[t] = "local";
+    return r;
+  };
+  const allShared = (): Record<string, CollectorMode> => {
+    const r: Record<string, CollectorMode> = {};
+    for (const t of types) r[t] = "shared";
+    return r;
+  };
+  return {
+    abstain: {
+      label: "Abstain",
+      subhead: "Share nothing",
+      description:
+        "Nothing leaves this browser. Your portrait stays entirely local — a private record of your own wandering, including your full typing. You can change your mind anytime.",
+      modes: allLocal(),
+      legibilityPct: 100,
+    },
+    participate: {
+      label: "Participate",
+      subhead: "Share how I move",
+      description:
+        "Your full browsing movement joins the collective portrait — cursor trails, scroll rhythm, pages visited, and typing cadence. Typed text is partially redacted by default; you can make it more or less legible below.",
+      modes: allShared(),
+      legibilityPct: 50,
+      recommended: true,
+    },
+    allIn: {
+      label: "All-In",
+      subhead: "Share everything",
+      description:
+        "Everything Participate shares, plus your typed text is fully legible (emails, phone numbers, and SSNs are still automatically redacted). You can tune legibility below.",
+      modes: allShared(),
+      legibilityPct: 100,
+    },
+  };
 }
 
 export default function SetupPage() {
   const [step, setStep] = useState<Step>("welcome");
   const [email, setEmail] = useState("");
   const [color, setColor] = useState<string>("");
-  const [sharingMode, setSharingMode] = useState<SharingMode>("local");
+  const presets = presetConfigs();
+  const [preset, setPreset] = useState<Preset>("participate");
   const [collectorModes, setCollectorModes] = useState<
     Record<string, CollectorMode>
-  >(defaultModesFor("local"));
-  const [keyboardFidelity, setKeyboardFidelity] =
-    useState<KeyboardFidelity>("full");
-  const [keyboardFidelityOverridden, setKeyboardFidelityOverridden] =
-    useState(false);
+  >(presets.participate.modes);
+  const [legibilityPct, setLegibilityPct] = useState<number>(
+    presets.participate.legibilityPct,
+  );
+  const [customized, setCustomized] = useState(false);
   const [busy, setBusy] = useState(false);
   const colorInputRef = useRef<HTMLInputElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
@@ -76,31 +120,31 @@ export default function SetupPage() {
     })();
   }, []);
 
-  const handleSharingTabChange = (mode: SharingMode) => {
-    setSharingMode(mode);
-    setCollectorModes(defaultModesFor(mode));
-    if (!keyboardFidelityOverridden) {
-      setKeyboardFidelity(mode === "local" ? "full" : "abstract");
-    }
+  const handlePresetChange = (next: Preset) => {
+    setPreset(next);
+    setCollectorModes(presets[next].modes);
+    setLegibilityPct(presets[next].legibilityPct);
+    setCustomized(false);
   };
 
   const handleCollectorModeChange = (type: string, mode: CollectorMode) => {
     setCollectorModes((prev) => ({ ...prev, [type]: mode }));
+    setCustomized(true);
   };
 
-  const handleKeyboardFidelityChange = (fidelity: KeyboardFidelity) => {
-    setKeyboardFidelity(fidelity);
-    setKeyboardFidelityOverridden(true);
+  const handleLegibilityChange = (pct: number) => {
+    setLegibilityPct(Math.max(0, Math.min(100, Math.round(pct))));
+    setCustomized(true);
   };
 
   const applyConsent = async () => {
     setBusy(true);
     try {
       const types = getValidEventTypes();
-      const toSet: Record<string, string> = {};
+      const toSet: Record<string, unknown> = {};
       for (const t of types)
-        toSet[`collection_mode_${t}`] = collectorModes[t] || sharingMode;
-      toSet["keyboard_display_mode"] = keyboardFidelity;
+        toSet[`collection_mode_${t}`] = collectorModes[t] || "local";
+      toSet[LEGIBILITY_KEY] = legibilityPct;
       toSet["onboarding_complete"] = "true";
       if (email.trim()) {
         toSet["setup_email"] = email.trim();
@@ -146,6 +190,8 @@ export default function SetupPage() {
       setBusy(false);
     }
   };
+
+  const presetOrder: Preset[] = ["abstain", "participate", "allIn"];
 
   return (
     <div className="setup-page">
@@ -220,33 +266,66 @@ export default function SetupPage() {
             </div>
 
             <h2 className="setup-step__heading">
-              Choose how your data is collected
+              Do you want to participate in{" "}
+              <a
+                href="https://spencer.place/creation/internet-movement"
+                target="_blank"
+                rel="noreferrer"
+                className="setup-step__heading-link"
+              >
+                Internet Movement
+              </a>
+              , a living, collective Internet portrait?
             </h2>
-            <div className="setup-step__tabs">
-              <button
-                className={`setup-step__tab${
-                  sharingMode === "local" ? " setup-step__tab--active" : ""
-                }`}
-                onClick={() => handleSharingTabChange("local")}
-              >
-                Keep local
-              </button>
-              <button
-                className={`setup-step__tab${
-                  sharingMode === "shared" ? " setup-step__tab--active" : ""
-                }`}
-                onClick={() => handleSharingTabChange("shared")}
-              >
-                Share anonymously
-              </button>
+
+            <p className="setup-step__trust">
+              Your data is anonymously collected, stewarded by Spencer, and
+              will never be sold or shared for any other purpose without your
+              permission.
+            </p>
+
+            <div className="setup-step__preset-tabs">
+              {presetOrder.map((key) => {
+                const p = presets[key];
+                return (
+                  <button
+                    key={key}
+                    className={
+                      "setup-step__preset-tab" +
+                      (preset === key ? " setup-step__preset-tab--active" : "")
+                    }
+                    onClick={() => handlePresetChange(key)}
+                  >
+                    <span className="setup-step__preset-label">{p.label}</span>
+                    <span className="setup-step__preset-subhead">
+                      {p.subhead}
+                    </span>
+                    {p.recommended && (
+                      <span className="setup-step__preset-chip">
+                        Recommended
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
 
-            {/* Reuse the same collector card UI from the settings page */}
+            <p className="setup-step__preset-description">
+              {presets[preset].description}
+              {customized && (
+                <span className="setup-step__preset-customized">
+                  {" "}
+                  (customized)
+                </span>
+              )}
+            </p>
+
+            {/* Reuse the collector card UI from the settings page */}
             <CollectorList
               modes={collectorModes}
               onModeChange={handleCollectorModeChange}
-              keyboardPrivacyLevel={keyboardFidelity}
-              onKeyboardPrivacyChange={handleKeyboardFidelityChange}
+              keyboardLegibilityPct={legibilityPct}
+              onKeyboardLegibilityChange={handleLegibilityChange}
             />
 
             <div className="setup-step__actions">

--- a/extension/src/utils/keyboardRedaction.ts
+++ b/extension/src/utils/keyboardRedaction.ts
@@ -1,0 +1,84 @@
+// ABOUTME: Shared keyboard-text redaction helpers used by KeyboardCollector and Collections UI
+// ABOUTME: Exposes PII redaction and a legibility-percent control (0 = cadence only, 100 = full text)
+
+export const REDACTION_CHAR = "\u2588"; // U+2588 FULL BLOCK
+export const LEGIBILITY_KEY = "collection_keyboard_privacy_level";
+export const DEFAULT_LEGIBILITY = 0;
+
+const EMAIL_RE = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+const PHONE_RE =
+  /\b(?:\+?1[-.\s]?)?\(?([0-9]{3})\)?[-.\s]?([0-9]{3})[-.\s]?([0-9]{4})\b/g;
+const SSN_RE = /\b\d{3}-\d{2}-\d{4}\b/g;
+
+const PII_PATTERNS = [EMAIL_RE, PHONE_RE, SSN_RE];
+
+export function redactPII(text: string): string {
+  let out = text;
+  for (const re of PII_PATTERNS) {
+    out = out.replace(re, (m) => REDACTION_CHAR.repeat(m.length));
+  }
+  return out;
+}
+
+export function redactNonWhitespace(text: string): string {
+  return text.replace(/\S/g, REDACTION_CHAR);
+}
+
+// Deterministic 32-bit hash so the same (seed, position) always redacts the
+// same character within a typing session — avoids preview flicker on re-render.
+function hash(seed: number, i: number): number {
+  let x = (seed ^ (i * 0x9e3779b1)) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x7feb352d) >>> 0;
+  x = Math.imul(x ^ (x >>> 15), 0x846ca68b) >>> 0;
+  return (x ^ (x >>> 16)) >>> 0;
+}
+
+/**
+ * Redact text according to a legibility percent (0–100).
+ *
+ *   0   → every non-whitespace char replaced (old "abstract" mode)
+ *   100 → PII-only redaction (old "full" mode)
+ *   50  → roughly half of non-PII characters replaced, stable per seed
+ *
+ * PII is always redacted regardless of legibility. The seed keeps the random
+ * pattern stable for a given (text, session) so the preview and the stored
+ * event don't flicker on re-render.
+ */
+export function redactWithLegibility(
+  text: string,
+  legibilityPct: number,
+  seed: number = 0,
+): string {
+  const pct = Math.max(0, Math.min(100, legibilityPct));
+
+  if (pct >= 100) return redactPII(text);
+  if (pct <= 0) return redactNonWhitespace(text);
+
+  const piiRedacted = redactPII(text);
+  const hideThreshold = (100 - pct) / 100;
+
+  let out = "";
+  for (let i = 0; i < piiRedacted.length; i++) {
+    const ch = piiRedacted[i];
+    if (/\s/.test(ch) || ch === REDACTION_CHAR) {
+      out += ch;
+      continue;
+    }
+    const r = hash(seed, i) / 0xffffffff;
+    out += r < hideThreshold ? REDACTION_CHAR : ch;
+  }
+  return out;
+}
+
+/**
+ * Normalize stored values. The key previously held `"abstract" | "full"`;
+ * migrate those to the new numeric range so old installs Just Work.
+ */
+export function parseLegibility(raw: unknown): number {
+  if (typeof raw === "number" && Number.isFinite(raw)) {
+    return Math.max(0, Math.min(100, Math.round(raw)));
+  }
+  if (raw === "abstract") return 0;
+  if (raw === "full") return 100;
+  return DEFAULT_LEGIBILITY;
+}

--- a/website/internet-series/movement/components/MovementCanvas.tsx
+++ b/website/internet-series/movement/components/MovementCanvas.tsx
@@ -239,6 +239,18 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     setDayPlaybackMode((m) => (m === "cycle" ? "loop" : "cycle"));
   }, []);
 
+  const handleToggleSound = useCallback(() => {
+    setSoundEnabled((prev) => {
+      const next = !prev;
+      if (next) {
+        // Resume an existing engine's AudioContext from within the gesture so
+        // sound starts immediately. First-time init() handles its own resume.
+        soundEngineRef.current?.resume();
+      }
+      return next;
+    });
+  }, []);
+
   const handleCapture = useCallback(async () => {
     if (!containerRef.current) return;
     const html2canvas = (await import("html2canvas")).default;
@@ -668,7 +680,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       )}
 
       <button
-        onClick={() => setSoundEnabled((prev) => !prev)}
+        onClick={handleToggleSound}
         title={soundEnabled ? "Mute" : "Play sound"}
         style={{
           position: "absolute",

--- a/website/internet-series/movement/sound/SoundEngine.ts
+++ b/website/internet-series/movement/sound/SoundEngine.ts
@@ -95,6 +95,20 @@ export class SoundEngine {
     this.convolver.connect(this.ctx.destination);
 
     this.enabled = true;
+
+    // init() is triggered by a user gesture (sound-toggle click), so resuming
+    // here satisfies the browser autoplay policy. Without this, the context
+    // stays suspended until tick() happens to fire from AnimatedTrails' rAF
+    // loop, which can delay audible sound by seconds.
+    if (this.ctx.state === "suspended") {
+      await this.ctx.resume();
+    }
+  }
+
+  async resume(): Promise<void> {
+    if (this.ctx && this.ctx.state === "suspended") {
+      await this.ctx.resume();
+    }
   }
 
   private createReverbImpulse(
@@ -605,8 +619,23 @@ export class SoundEngine {
   }
 
   reset(): void {
+    // Fast-cut fade (30ms) — releaseVoice uses a 500ms ramp that audibly
+    // overlaps with newly-created voices on data changes like day swaps.
+    const now = this.ctx?.currentTime ?? 0;
     for (const [, voice] of this.voices) {
-      this.releaseVoice(voice);
+      if (this.ctx) {
+        voice.gainNode.gain.cancelScheduledValues(now);
+        voice.gainNode.gain.linearRampToValueAtTime(0, now + 0.03);
+      }
+      if (voice.oscillator) {
+        try { voice.oscillator.stop(now + 0.04); } catch { /* already stopped */ }
+        voice.oscillator = null;
+      }
+      if (voice.fifthOscillator) {
+        try { voice.fifthOscillator.stop(now + 0.04); } catch { /* already stopped */ }
+        voice.fifthOscillator = null;
+      }
+      voice.active = false;
     }
     this.voices.clear();
     this.prevPositions.clear();


### PR DESCRIPTION
## Summary

Two unrelated-but-bundled fixes (extension onboarding + movement sound):

### Extension onboarding

Replaces the binary "Keep local / Share anonymously" tabs with three presets framed around contributing to Internet Movement:

- **Abstain** — Share nothing. Everything stays local, including full typing.
- **Participate** (default, recommended) — All four collectors shared with keyboard legibility at 50%.
- **All-In** — Same collectors shared, but keyboard at 100% legibility (PII still redacted).

Heading now reads "Do you want to participate in Internet Movement, a living, collective Internet portrait?" with a link to spencer.place. Trust statement placed directly under the heading.

Replaces the keyboard abstract/full select with a **legibility slider** (0-100 with snap-stops: Cadence only / Partial / Full text). The old values migrate transparently (`"abstract"` → 0, `"full"` → 100). PII redaction stays always-on; the slider controls additional random-character masking with a deterministic seed so the preview doesn't flicker.

Fixes an existing bug: SetupPage was writing to `keyboard_display_mode` but the runtime reads `collection_keyboard_privacy_level` — the SetupPage keyboard choice was being silently ignored.

### Movement sound

Two bugs in the sound toggle/swap flow:

1. Clicking sound-on had a delay of several seconds because the AudioContext only resumed inside the rAF `tick()` loop. Now `init()` resumes within the gesture's promise chain (satisfying autoplay policy) and a `resume()` method handles toggling on an already-initialized engine.

2. Swapping days produced a loud mix of the previous day's voices bleeding into the new day's. `SoundEngine.reset()` was fading voices over 500ms, long enough to audibly overlap with newly-created voices. Now uses a 30ms fast-cut fade — brief silence, then clean new sounds.

### Notable design decision

Participate is now the default instead of Abstain (previous default was `"local"`). Called out because this changes the new-user data posture — mitigated by the three tabs being explicit and the trust statement sitting directly under the heading.

<img width="794" height="1160" alt="image" src="https://github.com/user-attachments/assets/d638c42b-f724-406e-a7e5-54bc64fc94f1" />


## Test plan

- [ ] Fresh install onboarding → land on setup, Participate pre-selected
- [ ] Click each preset → collector radios + legibility slider update
- [ ] Let's go → storage has four `collection_mode_*` and `collection_keyboard_privacy_level=50` (for Participate)
- [x] Collections settings page → slider shows current legibility with live preview
- [x] Old profile with `keyboard_display_mode: "abstract"` in storage → migrates to `0`
- [ ] Movement page: click sound-on → audio within ~1 frame
- [ ] Movement page: swap days with sound on → no loud overlap, brief silence then new day's sounds