### PR TITLE
extension: dismiss milestone toasts with × button

### DIFF
--- a/extension/src/components/MilestoneToast.tsx
+++ b/extension/src/components/MilestoneToast.tsx
@@ -242,6 +242,14 @@ export function MilestoneToast({
 
   return (
     <div ref={toastRef} className={cls}>
+      <button
+        type="button"
+        className="wwo-toast-close"
+        onClick={dismiss}
+        aria-label="Dismiss milestone"
+      >
+        ×
+      </button>
       <div className="wwo-toast-wordmark">wwo</div>
       <div className="wwo-toast-body">
         <div className="wwo-toast-accent">

--- a/extension/src/components/MilestoneToastPreview.tsx
+++ b/extension/src/components/MilestoneToastPreview.tsx
@@ -65,6 +65,7 @@ const CYCLE_MS = 3500;
 
 export function MilestoneToastPreview() {
   const [index, setIndex] = useState(0);
+  const [mountKey, setMountKey] = useState(0);
 
   useEffect(() => {
     const t = setInterval(() => {
@@ -76,9 +77,10 @@ export function MilestoneToastPreview() {
   return (
     <div className="setup-step__milestone-preview">
       <MilestoneToast
-        key={index}
+        key={`${index}-${mountKey}`}
         milestone={SAMPLES[index]}
         static={false}
+        onDismiss={() => setMountKey((k) => k + 1)}
       />
     </div>
   );

--- a/extension/src/entrypoints/content/milestone-toast-styles.ts
+++ b/extension/src/entrypoints/content/milestone-toast-styles.ts
@@ -32,10 +32,42 @@ export const MILESTONE_TOAST_CSS = `
   transform: translateY(4px);
 }
 
+.wwo-toast-close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 2;
+  width: 26px;
+  height: 26px;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: rgba(61, 56, 51, 0.45);
+  font-family: 'Atkinson Hyperlegible', -apple-system, sans-serif;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wwo-toast-close:hover {
+  background: rgba(61, 56, 51, 0.06);
+  color: rgba(61, 56, 51, 0.75);
+}
+
+.wwo-toast-close:focus-visible {
+  outline: 2px solid rgba(74, 154, 138, 0.55);
+  outline-offset: 1px;
+}
+
 .wwo-toast-wordmark {
   position: absolute;
   top: 9px;
-  right: 12px;
+  right: 38px;
   font-family: 'Source Serif 4', 'Lora', Georgia, serif;
   font-style: italic;
   font-weight: 300;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an explicit dismiss control (×) to milestone toast notifications in the extension. Clicking it runs the same dismiss path as the CTA and auto-hide timer, which removes the shadow-root host for injected toasts.

## Details

- **MilestoneToast**: Top-right close button with `aria-label="Dismiss milestone"`.
- **milestone-toast-styles**: Styles for the close control; **wwo** wordmark shifted left (`right: 38px`) so it does not sit under the ×.
- **MilestoneToastPreview** (setup page): `onDismiss` increments a mount key so closing the preview remounts the toast instead of leaving an empty preview until the next cycle.

## Testing

- `bunx vitest run` in `extension/` — all 111 tests passed.
- `bun run build` in `extension/` after `bun run build-packages` at repo root — succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a11189ab-a6b0-4846-86c1-7c6e551f31f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a11189ab-a6b0-4846-86c1-7c6e551f31f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

