### PR TITLE
extension: fix Firefox collector failures from missing randomUUID/session storage

### DIFF
--- a/extension/src/__tests__/participant.test.ts
+++ b/extension/src/__tests__/participant.test.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Verifies participant/session identity fallbacks for Firefox API gaps.
+// ABOUTME: Covers missing crypto.randomUUID and missing browser.storage.session.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalCrypto = globalThis.crypto;
+
+function installCryptoWithoutRandomUuid(): void {
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      getRandomValues: (bytes: Uint8Array) => {
+        for (let i = 0; i < bytes.length; i++) {
+          bytes[i] = (i * 17 + 11) % 256;
+        }
+        return bytes;
+      },
+    } as Pick<Crypto, "getRandomValues">,
+  });
+}
+
+describe("participant storage fallbacks", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: originalCrypto,
+    });
+  });
+
+  it("uses a stable in-memory sid when browser.storage.session is unavailable", async () => {
+    installCryptoWithoutRandomUuid();
+    vi.doMock("webextension-polyfill", () => ({
+      default: {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({}),
+          },
+        },
+      },
+    }));
+
+    const { getSessionId } = await import("../storage/participant");
+    const first = await getSessionId();
+    const second = await getSessionId();
+
+    expect(first.startsWith("sid_")).toBe(true);
+    expect(first).toBe(second);
+  });
+
+  it("falls back to generated participant id without crypto.randomUUID", async () => {
+    installCryptoWithoutRandomUuid();
+    vi.doMock("webextension-polyfill", () => ({
+      default: {
+        storage: {
+          local: {
+            get: vi.fn().mockRejectedValue(new Error("storage unavailable")),
+          },
+        },
+      },
+    }));
+
+    const { getParticipantId } = await import("../storage/participant");
+    const pid = await getParticipantId();
+
+    expect(pid.startsWith("pk_temp_")).toBe(true);
+    expect(pid.length).toBeGreaterThan("pk_temp_".length + 8);
+  });
+});

--- a/extension/src/storage/participant.ts
+++ b/extension/src/storage/participant.ts
@@ -3,6 +3,31 @@
 
 import browser from 'webextension-polyfill';
 
+let fallbackSessionId: string | null = null;
+let warnedAboutMissingSessionStorage = false;
+
+function createUuidLikeId(): string {
+  if (typeof crypto?.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  if (typeof crypto?.getRandomValues === 'function') {
+    // RFC4122 v4-compatible fallback for browsers missing crypto.randomUUID.
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  // Last-resort fallback for unusual runtimes without Web Crypto.
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function createPrefixedId(prefix: string): string {
+  return `${prefix}${createUuidLikeId()}`;
+}
+
 /**
  * Get participant ID (the ECDSA public key from playerIdentity).
  * Falls back to generating a temporary random ID if identity isn't initialized yet.
@@ -17,10 +42,10 @@ export async function getParticipantId(): Promise<string> {
     // Identity not yet initialized — generate temporary ID.
     // This should only happen in a race condition before background.ts runs.
     console.warn('[Participant] playerIdentity not found, using temporary ID');
-    return 'pk_temp_' + crypto.randomUUID();
+    return createPrefixedId('pk_temp_');
   } catch (error) {
     console.error('Failed to get participant ID:', error);
-    return 'pk_temp_' + crypto.randomUUID();
+    return createPrefixedId('pk_temp_');
   }
 }
 
@@ -31,19 +56,39 @@ const SESSION_ID_KEY = 'collection_session_id';
  * Uses browser.storage.session so it resets when the browser closes.
  */
 export async function getSessionId(): Promise<string> {
+  const sessionStorage = (browser.storage as { session?: typeof browser.storage.local }).session;
+  const supportsSessionStorage =
+    typeof sessionStorage?.get === 'function' && typeof sessionStorage?.set === 'function';
+
+  if (!supportsSessionStorage) {
+    // Firefox can omit storage.session in content scripts. Keep one in-memory
+    // fallback ID so event creation keeps working instead of failing per emit.
+    if (!fallbackSessionId) {
+      fallbackSessionId = createPrefixedId('sid_');
+    }
+    if (!warnedAboutMissingSessionStorage) {
+      warnedAboutMissingSessionStorage = true;
+      console.warn('[Participant] browser.storage.session unavailable; using in-memory session id');
+    }
+    return fallbackSessionId;
+  }
+
   try {
-    const result = await browser.storage.session.get([SESSION_ID_KEY]);
+    const result = await sessionStorage.get([SESSION_ID_KEY]);
 
     if (result[SESSION_ID_KEY]) {
       return result[SESSION_ID_KEY];
     }
 
-    const sessionId = 'sid_' + crypto.randomUUID();
-    await browser.storage.session.set({ [SESSION_ID_KEY]: sessionId });
+    const sessionId = createPrefixedId('sid_');
+    await sessionStorage.set({ [SESSION_ID_KEY]: sessionId });
     return sessionId;
   } catch (error) {
     console.error('Failed to get session ID:', error);
-    return 'sid_' + crypto.randomUUID();
+    if (!fallbackSessionId) {
+      fallbackSessionId = createPrefixedId('sid_');
+    }
+    return fallbackSessionId;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a UUID fallback in `participant.ts` for runtimes where `crypto.randomUUID` is unavailable
- harden session ID creation when `browser.storage.session` is missing in content scripts (Firefox) by using a stable in-memory fallback
- add regression tests for both Firefox-specific API gaps

## Root cause
In Firefox content script context, `browser.storage.session` may be unavailable and `crypto.randomUUID` may not exist. The previous error paths still called `crypto.randomUUID`, so collector event creation failed repeatedly on mouse movement.

## Validation
- `bunx vitest run src/__tests__/participant.test.ts`
- `bunx vitest run src/__tests__/collectors.integration.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a54dded4-fcf5-44de-ba41-5bca5bc3b6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a54dded4-fcf5-44de-ba41-5bca5bc3b6fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

