### PR TITLE
Fix movement audio progression when tab is hidden

### DIFF
--- a/website/internet-series/movement/components/AnimatedTrails.tsx
+++ b/website/internet-series/movement/components/AnimatedTrails.tsx
@@ -21,6 +21,8 @@ const EVICTION_FADE_MS = 3000;
 // Finished trails dim to this opacity over COMPLETION_FADE_MS
 const COMPLETED_OPACITY = 0.5;
 const COMPLETION_FADE_MS = 3000;
+// Hidden tabs heavily throttle rAF; 100ms (~10fps) keeps audio/time progression
+// alive without spending too much background CPU.
 const HIDDEN_TAB_TICK_MS = 100;
 
 // How many points to show behind the cursor while drawing

--- a/website/internet-series/movement/components/AnimatedTrails.tsx
+++ b/website/internet-series/movement/components/AnimatedTrails.tsx
@@ -21,6 +21,7 @@ const EVICTION_FADE_MS = 3000;
 // Finished trails dim to this opacity over COMPLETION_FADE_MS
 const COMPLETED_OPACITY = 0.5;
 const COMPLETION_FADE_MS = 3000;
+const HIDDEN_TAB_TICK_MS = 100;
 
 // How many points to show behind the cursor while drawing
 const TAIL_LENGTH = 1000;
@@ -405,6 +406,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     );
 
     const animationRef = useRef<number>();
+    const timeoutRef = useRef<number>();
     const spawnedClicksRef = useRef<Map<string, Set<number>>>(new Map());
     const svgRef = useRef<SVGSVGElement>(null);
 
@@ -543,6 +545,29 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
       soundEngineRef.current?.reset();
 
       let startTime: number | null = null;
+
+      const clearScheduledFrame = () => {
+        if (animationRef.current !== undefined) {
+          cancelAnimationFrame(animationRef.current);
+          animationRef.current = undefined;
+        }
+        if (timeoutRef.current !== undefined) {
+          window.clearTimeout(timeoutRef.current);
+          timeoutRef.current = undefined;
+        }
+      };
+
+      const scheduleNextFrame = () => {
+        clearScheduledFrame();
+        if (document.visibilityState === "hidden") {
+          timeoutRef.current = window.setTimeout(
+            () => animate(performance.now()),
+            HIDDEN_TAB_TICK_MS,
+          );
+          return;
+        }
+        animationRef.current = requestAnimationFrame(animate);
+      };
 
       const animate = (timestamp: number) => {
         if (startTime === null) startTime = timestamp;
@@ -704,15 +729,23 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         // Prune ripples for trails that became invisible
         scheduleRipplePrune();
 
-        animationRef.current = requestAnimationFrame(animate);
+        scheduleNextFrame();
       };
 
-      animationRef.current = requestAnimationFrame(animate);
+      // Hidden tabs throttle rAF heavily; switch scheduler mode immediately
+      // when visibility changes so audio progression does not get stuck.
+      const handleVisibilityChange = () => {
+        if (startTime !== null) {
+          scheduleNextFrame();
+        }
+      };
+
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+      scheduleNextFrame();
 
       return () => {
-        if (animationRef.current) {
-          cancelAnimationFrame(animationRef.current);
-        }
+        document.removeEventListener("visibilitychange", handleVisibilityChange);
+        clearScheduledFrame();
       };
     }, [trailStates, timeRange.duration, frozen]);
 

--- a/website/internet-series/movement/sound/SoundEngine.ts
+++ b/website/internet-series/movement/sound/SoundEngine.ts
@@ -259,12 +259,8 @@ export class SoundEngine {
           const now = this.ctx.currentTime;
           const pluckGain = gain * instrument.gain;
           // Sharp attack, quick decay — percussive envelope
-          voice.gainNode.gain.cancelScheduledValues(now);
-          // Start from current gain and ramp up quickly to avoid step-clicks.
-          voice.gainNode.gain.setValueAtTime(
-            Math.max(0.0001, voice.gainNode.gain.value),
-            now,
-          );
+          this.holdParam(voice.gainNode.gain, now);
+          // Hold the current automation value, then ramp up quickly.
           voice.gainNode.gain.linearRampToValueAtTime(pluckGain, now + 0.005);
           voice.gainNode.gain.exponentialRampToValueAtTime(
             0.001,
@@ -630,10 +626,22 @@ export class SoundEngine {
   ): void {
     if (!this.ctx) return;
     const now = this.ctx.currentTime;
-    const currentValue = param.value;
-    param.cancelScheduledValues(now);
-    param.setValueAtTime(currentValue, now);
+    this.holdParam(param, now);
     param.linearRampToValueAtTime(targetValue, now + durationSeconds);
+  }
+
+  private holdParam(param: AudioParam, time: number): void {
+    // cancelAndHoldAtTime preserves the instantaneous computed value and avoids
+    // discontinuities ("pops") from jumping to AudioParam.value mid-envelope.
+    const hold = (param as AudioParam & {
+      cancelAndHoldAtTime?: (time: number) => void;
+    }).cancelAndHoldAtTime;
+    if (hold) {
+      hold.call(param, time);
+      return;
+    }
+    // Fallback for older browsers lacking cancelAndHoldAtTime.
+    param.cancelScheduledValues(time);
   }
 
   dispose(): void {

--- a/website/internet-series/movement/sound/SoundEngine.ts
+++ b/website/internet-series/movement/sound/SoundEngine.ts
@@ -25,6 +25,8 @@ const CROSSING_DISTANCE_THRESHOLD = 15;
 
 /** Minimum time between crossing triggers for the same pair (ms) */
 const CROSSING_COOLDOWN_MS = 500;
+const DEFAULT_MASTER_VOLUME = 0.5;
+const MIN_POLYPHONY_GAIN_SCALE = 0.35;
 
 /** Configurable sound modes */
 export interface SoundConfig {
@@ -65,9 +67,12 @@ export class SoundEngine {
   private masterGain: GainNode | null = null;
   private reverbGain: GainNode | null = null;
   private convolver: ConvolverNode | null = null;
+  private compressor: DynamicsCompressorNode | null = null;
   private voices: Map<number, Voice> = new Map();
   private canvasWidth: number = 0;
   private enabled: boolean = false;
+  private baseVolume: number = DEFAULT_MASTER_VOLUME;
+  private lastActiveTrailCount: number = 0;
   private prevPositions: Map<number, { x: number; y: number }> = new Map();
   /** Accumulated path history per trail for crossing detection */
   private trailPaths: Map<number, Array<{ x: number; y: number }>> = new Map();
@@ -81,7 +86,7 @@ export class SoundEngine {
     this.ctx = new AudioContext();
 
     this.masterGain = this.ctx.createGain();
-    this.masterGain.gain.value = 0.5;
+    this.masterGain.gain.value = this.baseVolume;
 
     this.convolver = this.ctx.createConvolver();
     this.convolver.buffer = this.createReverbImpulse(this.ctx, 3.0, 2.0);
@@ -89,10 +94,18 @@ export class SoundEngine {
     this.reverbGain = this.ctx.createGain();
     this.reverbGain.gain.value = 0.3;
 
-    this.masterGain.connect(this.ctx.destination);
+    this.compressor = this.ctx.createDynamicsCompressor();
+    this.compressor.threshold.value = -24;
+    this.compressor.knee.value = 24;
+    this.compressor.ratio.value = 12;
+    this.compressor.attack.value = 0.003;
+    this.compressor.release.value = 0.2;
+
+    this.masterGain.connect(this.compressor);
     this.masterGain.connect(this.reverbGain);
     this.reverbGain.connect(this.convolver);
-    this.convolver.connect(this.ctx.destination);
+    this.convolver.connect(this.compressor);
+    this.compressor.connect(this.ctx.destination);
 
     this.enabled = true;
 
@@ -160,6 +173,8 @@ export class SoundEngine {
     }
 
     const activeIndices = new Set(activeTrails.map((t) => t.trailIndex));
+    this.lastActiveTrailCount = activeTrails.length;
+    this.updateMasterGainForPolyphony(activeTrails.length);
 
     for (const [idx, voice] of this.voices) {
       if (!activeIndices.has(idx) && voice.active) {
@@ -245,23 +260,22 @@ export class SoundEngine {
           const pluckGain = gain * instrument.gain;
           // Sharp attack, quick decay — percussive envelope
           voice.gainNode.gain.cancelScheduledValues(now);
-          voice.gainNode.gain.setValueAtTime(pluckGain, now);
+          // Start from current gain and ramp up quickly to avoid step-clicks.
+          voice.gainNode.gain.setValueAtTime(
+            Math.max(0.0001, voice.gainNode.gain.value),
+            now,
+          );
+          voice.gainNode.gain.linearRampToValueAtTime(pluckGain, now + 0.005);
           voice.gainNode.gain.exponentialRampToValueAtTime(
             0.001,
-            now + instrument.attack + instrument.decay + instrument.release,
+            now + 0.005 + instrument.attack + instrument.decay + instrument.release,
           );
         }
       } else {
-        voice.gainNode.gain.linearRampToValueAtTime(
-          gain * instrument.gain,
-          this.ctx.currentTime + 0.05,
-        );
+        this.rampParam(voice.gainNode.gain, gain * instrument.gain, 0.05);
       }
 
-      voice.panNode.pan.linearRampToValueAtTime(
-        pan,
-        this.ctx.currentTime + 0.05,
-      );
+      this.rampParam(voice.panNode.pan, pan, 0.05);
 
       voice.active = true;
     }
@@ -591,11 +605,35 @@ export class SoundEngine {
   }
 
   setVolume(volume: number): void {
+    this.baseVolume = Math.max(0, Math.min(1, volume));
+    this.updateMasterGainForPolyphony(this.lastActiveTrailCount);
+  }
+
+  private updateMasterGainForPolyphony(activeTrailCount: number): void {
     if (!this.masterGain || !this.ctx) return;
-    this.masterGain.gain.linearRampToValueAtTime(
-      volume,
-      this.ctx.currentTime + 0.05,
+    // When many trails overlap, reduce total output energy to avoid clipping artifacts.
+    const polyphonyScale = Math.max(
+      MIN_POLYPHONY_GAIN_SCALE,
+      1 / Math.sqrt(Math.max(1, activeTrailCount / 3)),
     );
+    this.rampParam(
+      this.masterGain.gain,
+      this.baseVolume * polyphonyScale,
+      0.08,
+    );
+  }
+
+  private rampParam(
+    param: AudioParam,
+    targetValue: number,
+    durationSeconds: number,
+  ): void {
+    if (!this.ctx) return;
+    const now = this.ctx.currentTime;
+    const currentValue = param.value;
+    param.cancelScheduledValues(now);
+    param.setValueAtTime(currentValue, now);
+    param.linearRampToValueAtTime(targetValue, now + durationSeconds);
   }
 
   dispose(): void {

--- a/website/internet-series/movement/sound/SoundEngine.ts
+++ b/website/internet-series/movement/sound/SoundEngine.ts
@@ -25,7 +25,12 @@ const CROSSING_DISTANCE_THRESHOLD = 15;
 
 /** Minimum time between crossing triggers for the same pair (ms) */
 const CROSSING_COOLDOWN_MS = 500;
+/** Default user-facing volume when sound is enabled. */
 const DEFAULT_MASTER_VOLUME = 0.5;
+/**
+ * Lower bound for overlap normalization so dense scenes stay audible while
+ * preventing clipping/crackle when many trails stack at once.
+ */
 const MIN_POLYPHONY_GAIN_SCALE = 0.35;
 
 /** Configurable sound modes */
@@ -641,6 +646,8 @@ export class SoundEngine {
       return;
     }
     // Fallback for older browsers lacking cancelAndHoldAtTime.
+    // We intentionally avoid noisy compatibility logs in the audio hot path;
+    // this degrades safely by cancelling future automation only.
     param.cancelScheduledValues(time);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switched `AnimatedTrails` from a pure `requestAnimationFrame` loop to a visibility-aware scheduler
- keep normal `requestAnimationFrame` when visible, but use a timeout fallback when `document.visibilityState === "hidden"`
- added visibility-change rescheduling so the loop transitions cleanly between visible and hidden states without duplicate or stale callbacks
- ensured scheduled frame cleanup cancels both pending rAF and timeout handles
- added overlap-safe audio output handling in `SoundEngine` to reduce click artifacts under high trail polyphony:
  - route output through a dynamics compressor/limiter stage
  - apply polyphony-aware master gain scaling (energy normalization as active trails rise)
  - replace abrupt gain/pan updates with shared smoothed ramps
- fixed cursor-onset pop regression introduced by param smoothing:
  - use `cancelAndHoldAtTime` (with fallback) before new ramps so we preserve the instantaneous computed value
  - avoid stepping from stale `.value` at the moment a new cursor/voice appears
- addressed review feedback with in-code rationale comments for key tuning constants and fallback behavior

## Why
Three root causes were addressed:
1. Hidden tabs throttle/pause `requestAnimationFrame`, so audio updates could stall and leave a sustained note.
2. At specific overlap densities, aggregate output and abrupt envelope transitions could create transient clicks/crackles.
3. New cursor appearance could pop due to discontinuous AudioParam scheduling when replacing ramps.

The scheduler now keeps progression running in background tabs, dense overlap is stabilized by output dynamics + gain scaling, and new voices no longer jump at onset.

## Validation
- attempted type-check for website code path
- could not run project TypeScript checks in this environment because `bun`/`bunx` is unavailable and local TypeScript dependencies are not installed (`node_modules/typescript` missing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6a31021-14f3-4d8b-9553-4d74c5d7bcaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6a31021-14f3-4d8b-9553-4d74c5d7bcaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

