### PR TITLE
fix: consolidate init lifecycle, split PlayProvider into init-owning vs context-only

### DIFF
--- a/.changeset/init-lifecycle-consolidation.md
+++ b/.changeset/init-lifecycle-consolidation.md
@@ -1,0 +1,28 @@
+---
+"playhtml": minor
+"@playhtml/react": minor
+---
+
+Consolidate the init lifecycle around a single `isLoading` boolean and a `playhtml.ready` promise, and split `<PlayProvider>` into init-owning and context-only modes.
+
+**Core (`playhtml`):**
+
+- Adds `playhtml.isLoading` (true until init's setup wiring completes, false thereafter) and `playhtml.ready: Promise<void>` (resolves once when isLoading flips false; concurrent `init()` callers all await the same promise).
+- Removes the internal `firstSetup` flag entirely; renames the bistable `hasSynced` (which is reset during `handleNavigation`) to `mainRoomSynced` since the public-facing meaning is now `isLoading`.
+- `createPresenceRoom` now gates on `isLoading` instead of the bistable `hasSynced`. Presence rooms have their own provider independent of the main room, so they no longer race with `handleNavigation`.
+- `init()` is fully idempotent and dedupes concurrent in-process callers via a shared `_ready` promise.
+- Adds a 10s safety timeout on the main-room sync await — if the WebSocket never connects, init still resolves with a warning so consumers aren't stuck on `playhtml.ready` forever.
+
+**React (`@playhtml/react`):**
+
+- `<PlayProvider>` now has two explicit modes:
+  - **Init-owning**: rendered with `initOptions`. Calls `playhtml.init()` on mount. Use once at your app root.
+  - **Context-only**: rendered without `initOptions`. Does not call init — relays state from the global playhtml singleton. Use in additional React roots (e.g. Astro islands).
+- Multiple init-owning providers log a one-time warning, since `playhtml.init()` is idempotent and silently drops late options.
+- Drops the previous behavior of flipping `hasSynced=true` on `init()` rejection — `playhtml.ready` either resolves cleanly or stays pending. UI stays in loading state on transient failures.
+- Context still exposes both `isLoading` (canonical) and `hasSynced` (deprecated alias = `!isLoading`).
+
+This fixes intermittent `playhtml.createPresenceRoom is not available before init()` errors that surfaced when:
+- Multiple `<PlayProvider>` instances mounted concurrently (Astro islands pattern) and one early-returned from `init()` while another was still bootstrapping.
+- `handleNavigation()` cleared the internal sync flag mid-flight.
+- `init()` failed transiently and the React provider unblocked downstream hooks anyway.

--- a/packages/playhtml/src/__tests__/init-readiness.test.ts
+++ b/packages/playhtml/src/__tests__/init-readiness.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Tests the playhtml.isLoading + playhtml.ready public lifecycle API.
+// ABOUTME: Covers concurrent init dedup, idempotence, and resetPlayHTML semantics.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { playhtml, resetPlayHTML } from "../index";
+
+describe("playhtml lifecycle (isLoading + ready)", () => {
+  beforeEach(async () => {
+    try {
+      await resetPlayHTML();
+    } catch {}
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+    document.body.innerHTML = "";
+  });
+
+  it("starts with isLoading=true and a pending ready promise", () => {
+    expect(playhtml.isLoading).toBe(true);
+    expect(playhtml.ready).toBeInstanceOf(Promise);
+  });
+
+  it("ready resolves and isLoading flips false after init()", async () => {
+    await playhtml.init({});
+    expect(playhtml.isLoading).toBe(false);
+    await expect(playhtml.ready).resolves.toBeUndefined();
+  });
+
+  it("concurrent init() calls share the same ready promise", async () => {
+    const a = playhtml.init({});
+    const b = playhtml.init({});
+    const c = playhtml.init({});
+    // All three resolve together once setup completes.
+    await Promise.all([a, b, c]);
+    expect(playhtml.isLoading).toBe(false);
+    // All concurrent calls received the same underlying readiness signal —
+    // verify by checking they all resolve to the canonical ready promise.
+    await expect(playhtml.ready).resolves.toBeUndefined();
+  });
+
+  it("init() called after readiness returns the resolved ready promise", async () => {
+    await playhtml.init({});
+    const second = playhtml.init({});
+    await expect(second).resolves.toBeUndefined();
+    expect(playhtml.isLoading).toBe(false);
+  });
+
+  it("createPresenceRoom does not throw after awaiting ready", async () => {
+    playhtml.init({});
+    await playhtml.ready;
+    expect(() => {
+      const room = playhtml.createPresenceRoom("ready-test");
+      room.destroy();
+    }).not.toThrow();
+  });
+
+  it("createPageData does not throw after awaiting ready", async () => {
+    playhtml.init({});
+    await playhtml.ready;
+    expect(() => {
+      const channel = playhtml.createPageData("ready-test", { count: 0 });
+      channel.destroy();
+    }).not.toThrow();
+  });
+
+  it("resetPlayHTML resets isLoading and gives a fresh ready promise", async () => {
+    await playhtml.init({});
+    const firstReady = playhtml.ready;
+    expect(playhtml.isLoading).toBe(false);
+
+    await resetPlayHTML();
+    expect(playhtml.isLoading).toBe(true);
+    // New ready is a different, pending promise.
+    expect(playhtml.ready).not.toBe(firstReady);
+
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+    await playhtml.init({});
+    expect(playhtml.isLoading).toBe(false);
+  });
+});

--- a/packages/playhtml/src/__tests__/presence-room.test.ts
+++ b/packages/playhtml/src/__tests__/presence-room.test.ts
@@ -100,5 +100,45 @@ describe("createPresenceRoom", () => {
         roomB.destroy();
       }
     });
+
+    it("works mid-navigation while main room is re-syncing", async () => {
+      // Regression: handleNavigation() clears the internal main-room sync
+      // flag while the new room re-syncs. createPresenceRoom must not
+      // throw during this window — presence rooms have their own provider
+      // independent of the main room's sync state.
+      const navPromise = playhtml.handleNavigation();
+      let room: ReturnType<typeof playhtml.createPresenceRoom> | undefined;
+      expect(() => {
+        room = playhtml.createPresenceRoom("mid-nav-room");
+      }).not.toThrow();
+      try {
+        expect(room?.presence).toBeDefined();
+      } finally {
+        room?.destroy();
+      }
+      await navPromise;
+    });
+  });
+
+  describe("concurrent init", () => {
+    it("multiple init() calls share playhtml.ready and createPresenceRoom is safe after", async () => {
+      // Regression: when multiple React PlayProviders mount in parallel
+      // both call playhtml.init(). Before the lifecycle consolidation, the
+      // early-return path resolved immediately while playhtml's internal
+      // setup wasn't complete, so a downstream usePresenceRoom effect
+      // could fire createPresenceRoom() and throw "not available before
+      // init()". Now concurrent callers all await playhtml.ready.
+      const { resetPlayHTML, playhtml: ph } = await import("../index");
+      await resetPlayHTML();
+      delete (window as any).playhtml;
+      delete document.documentElement.dataset.playhtml;
+
+      await Promise.all([ph.init({}), ph.init({}), ph.init({})]);
+      expect(ph.isLoading).toBe(false);
+      expect(() => {
+        const room = ph.createPresenceRoom("concurrent-init-room");
+        room.destroy();
+      }).not.toThrow();
+    });
   });
 });

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -482,8 +482,25 @@ function onMessage(data: string) {
   }
 }
 
-let hasSynced = false;
-let firstSetup = true;
+// Tracks main-room sync state. Bistable: flips true after first sync, then
+// flips back to false during handleNavigation while the new room re-syncs.
+// Internal — used by setupElements per-tag work, awareness fingerprinting,
+// and runHandleNavigation.
+let mainRoomSynced = false;
+// Public lifecycle signal. Inverse of "init's one-time wiring has run".
+// Flips true → false once, after the first init() completes its setup hooks
+// (awareness binding, navigation controller). Stays false until
+// resetPlayHTML(). This is the single signal API consumers should gate on
+// for "is playhtml ready for API calls?".
+let isLoading = true;
+let readyResolve: () => void = () => {};
+let _ready: Promise<void> = new Promise<void>((resolve) => {
+  readyResolve = resolve;
+});
+// Flips true the moment init() begins its synchronous work. Distinct from
+// `isLoading` (which doesn't flip until setup has fully completed). Used
+// to dedupe concurrent in-process callers so they share `_ready`.
+let initStarted = false;
 /** Last fingerprint of element-awareness only; skip handler updates when unchanged (e.g. cursor-only moves). */
 let lastElementAwarenessFingerprint: string | null = null;
 let isDevelopmentMode = false;
@@ -662,8 +679,8 @@ function buildCursors(args: {
 }
 
 async function runHandleNavigation(): Promise<void> {
-  // firstSetup is true before init and after resetPlayHTML — skip nav in both.
-  if (firstSetup) return;
+  // isLoading is true before init and after resetPlayHTML — skip nav in both.
+  if (isLoading) return;
 
   const nextRoomInput =
     explicitRoomOption ?? getDefaultRoom(cachedDefaultRoomOptions);
@@ -699,7 +716,7 @@ async function runHandleNavigation(): Promise<void> {
 
   if (mainRoomChanged) {
     teardownMainProvider();
-    hasSynced = false;
+    mainRoomSynced = false;
     lastElementAwarenessFingerprint = null;
     buildMainProvider({
       room: newMainRoom,
@@ -732,14 +749,14 @@ async function runHandleNavigation(): Promise<void> {
 
   if (mainRoomChanged) {
     await new Promise<void>((resolve) => {
-      if (hasSynced) {
+      if (mainRoomSynced) {
         resolve();
         return;
       }
       yprovider.on("sync", (connected: boolean) => {
         if (!connected) console.error("Issue connecting to yjs...");
-        if (hasSynced) return;
-        hasSynced = true;
+        if (mainRoomSynced) return;
+        mainRoomSynced = true;
         resolve();
       });
     });
@@ -764,11 +781,19 @@ async function initPlayHTML({
   onError,
   developmentMode = false,
   cursors = {},
-}: InitOptions = {}) {
-  if (!firstSetup || "playhtml" in window) {
+}: InitOptions = {}): Promise<void> {
+  // Concurrent callers (e.g. multiple React PlayProviders mounting in
+  // parallel) all await the same _ready promise. `initStarted` flips true
+  // synchronously on the first call so subsequent calls in the same tick
+  // (or any later) skip the setup body entirely and just return _ready.
+  if (initStarted) return _ready;
+  if ("playhtml" in window) {
+    // Something external (e.g., a browser extension) set window.playhtml
+    // before our init started. Don't try to init again.
     console.error("playhtml already set up! ignoring");
-    return;
+    return _ready;
   }
+  initStarted = true;
   explicitRoomOption = explicitRoom;
   cachedDefaultRoomOptions = defaultRoomOptions;
   const inputRoom = explicitRoom ?? getDefaultRoom(defaultRoomOptions);
@@ -884,43 +909,55 @@ async function initPlayHTML({
   // Mark all discovered playhtml elements as loading before sync
   markAllElementsAsLoading();
 
-  // await until yprovider is synced
-  await new Promise((resolve) => {
-    if (hasSynced) {
-      resolve(true);
+  // await until yprovider is synced, with a safety timeout so a stuck
+  // WebSocket doesn't leave consumers waiting on `playhtml.ready` forever.
+  // After the timeout we run setupElements anyway so APIs become callable;
+  // writes will queue locally and flush when sync eventually completes.
+  await new Promise<void>((resolve) => {
+    if (mainRoomSynced) {
+      resolve();
+      return;
     }
+
+    let resolved = false;
+    const finish = (reason: "sync" | "timeout") => {
+      if (resolved) return;
+      resolved = true;
+      if (!mainRoomSynced) {
+        if (reason === "timeout") {
+          console.warn(
+            "[PLAYHTML] yjs sync timed out after 10s — proceeding without sync. Reads/writes will queue until the WebSocket connects.",
+          );
+        }
+        mainRoomSynced = true;
+        console.log("[PLAYHTML]: Setting up elements... Time to have some fun 🛝");
+        setupElements();
+        markAllElementsAsReady();
+
+        if (sharedReferences.length > 0) {
+          try {
+            const elementIds = sharedReferences.map((r) => r.elementId);
+            yprovider.sendMessage(
+              JSON.stringify({ type: "export-permissions", elementIds }),
+            );
+          } catch (error) {
+            console.error("[PLAYHTML] Error during post-sync setup:", error);
+          }
+        }
+      }
+      resolve();
+    };
+
+    const timeoutId = window.setTimeout(() => finish("timeout"), 10_000);
+
     yprovider.on("sync", (connected: boolean) => {
       if (!connected) {
         console.error("Issue connecting to yjs...");
       }
-      if (hasSynced) {
-        return;
-      }
-      hasSynced = true;
-      console.log("[PLAYHTML]: Setting up elements... Time to have some fun 🛝");
-
-      setupElements();
-
-      // Mark all elements as ready after sync completes and elements are set up
-      markAllElementsAsReady();
-
-      // Fetch simple permissions for referenced shared elements so clients can block writes locally
-      if (sharedReferences.length > 0) {
-        try {
-          const elementIds = sharedReferences.map((r) => r.elementId);
-          yprovider.sendMessage(
-            JSON.stringify({ type: "export-permissions", elementIds })
-          );
-        } catch (error) {
-          console.error("[PLAYHTML] Error during post-sync setup:", error);
-        }
-      }
-
-      resolve(true);
+      window.clearTimeout(timeoutId);
+      finish("sync");
     });
   });
-
-  return yprovider;
 }
 
 function getElementAwareness(tagType: TagType, elementId: string) {
@@ -1210,7 +1247,7 @@ function onChangeAwareness() {
  * on the `playhtml` object on `window`.
  */
 function setupElements(): void {
-  if (!hasSynced) {
+  if (!mainRoomSynced) {
     return;
   }
 
@@ -1231,7 +1268,7 @@ function setupElements(): void {
     );
   }
 
-  if (!firstSetup) {
+  if (!isLoading) {
     return;
   }
 
@@ -1248,11 +1285,16 @@ function setupElements(): void {
   });
   detachNavListeners = attachNavigationListeners(navigationController);
 
-  firstSetup = false;
+  isLoading = false;
+  readyResolve();
 }
 
 function createPageData<T>(name: string, defaultValue: T): PageDataChannel<T> {
-  if (!hasSynced) {
+  // Page data uses module-level `doc` and `store.play` which survive
+  // navigation, so we only need init to have completed wiring — not for the
+  // main room to currently be synced. Mid-navigation calls return a channel
+  // pointing at the same doc; writes flush once the new provider connects.
+  if (isLoading) {
     throw new Error("playhtml.createPageData is not available before init()");
   }
   return createPageDataChannel(name, defaultValue, {
@@ -1268,7 +1310,12 @@ function createPageData<T>(name: string, defaultValue: T): PageDataChannel<T> {
 }
 
 function createPresenceRoom(name: string): PresenceRoom {
-  if (!hasSynced) {
+  // Presence rooms have their own YProvider independent of the main room, so
+  // they only require init() to have completed once — not for the main room
+  // to be currently synced. Using `mainRoomSynced` here would race with
+  // handleNavigation(), which clears `mainRoomSynced` mid-flight while the
+  // main room re-syncs. `isLoading` is the durable "init has run" signal.
+  if (isLoading) {
     throw new Error("playhtml.createPresenceRoom is not available before init()");
   }
 
@@ -1296,6 +1343,20 @@ function createPresenceRoom(name: string): PresenceRoom {
 
 export interface PlayHTMLComponents {
   init: typeof initPlayHTML;
+  /**
+   * True until init() has finished its one-time setup wiring (awareness
+   * binding, navigation controller). Stays false until resetPlayHTML().
+   * Gate API calls (createPresenceRoom, createPageData, presence.*) on
+   * isLoading === false. After resolution `ready` resolves.
+   */
+  readonly isLoading: boolean;
+  /**
+   * Resolves once when init has finished setup wiring. Multiple concurrent
+   * init() calls all await the same promise. Never rejects — sync failures
+   * are logged but don't block readiness so APIs remain callable. After
+   * resetPlayHTML() this becomes a fresh pending promise.
+   */
+  readonly ready: Promise<void>;
   handleNavigation: () => Promise<void>;
   setupPlayElements: typeof setupElements;
   setupPlayElement: typeof setupPlayElement;
@@ -1332,7 +1393,8 @@ export interface PlayHTMLComponents {
  * isolation (beforeEach resets) only.
  */
 export async function resetPlayHTML(): Promise<void> {
-  if (firstSetup) return;
+  // Idempotent: nothing to reset if init has never been called.
+  if (!initStarted) return;
 
   try {
     if (navigationController) {
@@ -1390,9 +1452,13 @@ export async function resetPlayHTML(): Promise<void> {
     delete (window as any).playhtml;
     delete document.documentElement.dataset.playhtml;
 
-    hasSynced = false;
+    mainRoomSynced = false;
     lastElementAwarenessFingerprint = null;
-    firstSetup = true;
+    isLoading = true;
+    initStarted = false;
+    _ready = new Promise<void>((resolve) => {
+      readyResolve = resolve;
+    });
     __currentRoomId = "";
     __currentHost = "";
     presenceAPI = null;
@@ -1401,14 +1467,20 @@ export async function resetPlayHTML(): Promise<void> {
     cursorOptionsCache = undefined;
     cachedOnError = undefined;
   } finally {
-    // firstSetup = true (set above) is the canonical "not initialized"
-    // flag — runHandleNavigation checks it to skip nav after reset.
+    // isLoading=true (set above) is the canonical "not initialized" flag —
+    // runHandleNavigation checks it to skip nav after reset.
   }
 }
 
 // Expose big variables to the window object for debugging purposes.
 export const playhtml: PlayHTMLComponents = {
   init: initPlayHTML,
+  get isLoading() {
+    return isLoading;
+  },
+  get ready() {
+    return _ready;
+  },
   handleNavigation: async function handleNavigation(): Promise<void> {
     if (!navigationController) return;
     await navigationController.trigger();
@@ -1457,7 +1529,9 @@ function maybeSetupTag(tag: TagType | string): void {
     return;
   }
 
-  if (!hasSynced) {
+  // Wait for first main-room sync before initializing the per-tag store —
+  // creating the entry before sync would race with the initial state load.
+  if (!mainRoomSynced) {
     return;
   }
 
@@ -1500,7 +1574,10 @@ async function setupPlayElementForTag<T extends TagType | string>(
     return;
   }
 
-  if (!hasSynced) {
+  // Reads initial state from the synced main-room doc to hydrate the
+  // element. Skip until first sync; subsequent navs leave already-set-up
+  // elements alone.
+  if (!mainRoomSynced) {
     return;
   }
 
@@ -1678,7 +1755,7 @@ function setupPlayElement(
   );
 
   if (hasPlayhtmlAttributes) {
-    if (hasSynced) {
+    if (mainRoomSynced) {
       // If already synced, element will be ready immediately
       markElementAsReady(element);
     } else {
@@ -1729,7 +1806,7 @@ function removePlayElement(element: Element | null) {
  * @param elementId - The element ID
  */
 function deleteElementData(tag: string, elementId: string): void {
-  if (!hasSynced) {
+  if (!mainRoomSynced) {
     console.warn(
       `[PLAYHTML] Cannot remove element data before sync: ${tag}:${elementId}`,
     );

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -127,6 +127,49 @@ interface Props {
   pathname?: string;
 }
 
+// Flips true the first time any PlayProvider with initOptions calls init().
+// Used to detect and warn about a second init-owning PlayProvider mounting
+// later (whose options would be silently ignored by playhtml.init()).
+let hasInitOwner = false;
+let hasWarnedConflictingInit = false;
+
+/**
+ * Test-only: reset the module-level init-owner tracking between tests.
+ * Not part of the public API. The harness mocks playhtml itself, so this
+ * just clears React's local bookkeeping that pairs with the mock reset.
+ */
+export function __resetInitOwnerForTests(): void {
+  hasInitOwner = false;
+  hasWarnedConflictingInit = false;
+}
+
+/**
+ * PlayProvider has two modes:
+ *
+ * 1. Init-owning: render with `initOptions`. Calls `playhtml.init()` on
+ *    mount. Use this once at your app root.
+ *
+ *    ```tsx
+ *    <PlayProvider initOptions={{ cursors: { enabled: true } }}>
+ *      <App />
+ *    </PlayProvider>
+ *    ```
+ *
+ * 2. Context-only: render bare (no `initOptions`). Does NOT call init —
+ *    just relays context from the global playhtml singleton. Use this in
+ *    additional React roots (e.g. Astro islands) that need
+ *    `useCursorPresences`, `usePresenceRoom`, etc.
+ *
+ *    ```tsx
+ *    <PlayProvider>
+ *      <NestedIsland />
+ *    </PlayProvider>
+ *    ```
+ *
+ * The app must have either an init-owning provider OR call
+ * `playhtml.init()` directly somewhere — context-only providers don't
+ * trigger init.
+ */
 export function PlayProvider({
   children,
   initOptions,
@@ -152,10 +195,13 @@ export function PlayProvider({
     playhtml.setupPlayElements();
   }, [pathname, search]);
 
-  const [hasSynced, setHasSynced] = useState(false);
+  // Subscribe to playhtml's module-level isLoading. Multiple PlayProviders
+  // mounted concurrently all observe the same `playhtml.ready` promise, so
+  // they flip together once init's setup wiring completes.
+  const [isLoading, setIsLoading] = useState(playhtml.isLoading);
 
   const processedInitOptions = useMemo<InitOptions | undefined>(() => {
-    if (!initOptions) return initOptions as InitOptions | undefined;
+    if (!initOptions) return undefined;
     if (!initOptions.cursors) return initOptions as InitOptions;
     return {
       ...initOptions,
@@ -167,15 +213,38 @@ export function PlayProvider({
   }, [initOptions]);
 
   useEffect(() => {
-    playhtml.init(processedInitOptions).then(
-      () => {
-        setHasSynced(true);
-      },
-      (err) => {
-        console.error(err);
-        setHasSynced(true);
+    // PlayProvider has two modes:
+    //   1. init-owning: rendered with `initOptions`. Calls playhtml.init().
+    //      Only one such provider per app. A second init-owning provider
+    //      logs a warning — playhtml.init() is idempotent, so the late
+    //      options are silently dropped and would otherwise be invisible.
+    //   2. context-only: rendered without `initOptions` (typical for
+    //      nested Astro islands). Does NOT call init — relays context
+    //      from the global playhtml singleton. The app must have an
+    //      init-owning provider somewhere, or call playhtml.init() directly.
+    let cancelled = false;
+    if (processedInitOptions) {
+      if (hasInitOwner && !hasWarnedConflictingInit) {
+        hasWarnedConflictingInit = true;
+        console.warn(
+          "[@playhtml/react] Multiple <PlayProvider> instances passed `initOptions`. " +
+            "Only the first init-owning provider's options take effect; later options are " +
+            "silently ignored. Pass `initOptions` to exactly one PlayProvider (typically " +
+            "your app root) and render bare <PlayProvider> elsewhere for context-only mode.",
+        );
       }
-    );
+      hasInitOwner = true;
+      playhtml.init(processedInitOptions).catch((err) => console.error(err));
+    }
+
+    // Whether or not we triggered init, wait for readiness so context
+    // accurately reflects the global state.
+    playhtml.ready.then(() => {
+      if (!cancelled) setIsLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const configureCursors = (options: Partial<CursorOptions>) => {
@@ -259,7 +328,7 @@ export function PlayProvider({
       client.off("name", handleName);
       unsubPresences();
     };
-  }, [hasSynced]);
+  }, [isLoading]);
 
   return (
     <PlayContext.Provider
@@ -269,8 +338,8 @@ export function PlayProvider({
         registerPlayEventListener: playhtml.registerPlayEventListener,
         removePlayEventListener: playhtml.removePlayEventListener,
         deleteElementData: playhtml.deleteElementData,
-        hasSynced,
-        isLoading: !hasSynced,
+        hasSynced: !isLoading,
+        isLoading,
         isProviderMissing: false,
         configureCursors,
         getMyPlayerIdentity,

--- a/packages/react/src/__tests__/PlayProvider.dual.test.tsx
+++ b/packages/react/src/__tests__/PlayProvider.dual.test.tsx
@@ -1,0 +1,68 @@
+// ABOUTME: Tests dual-PlayProvider mounting in Pattern A: one init-owning,
+// ABOUTME: one or more context-only siblings (Astro islands pattern).
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import "@testing-library/dom";
+import { PlayProvider, PlayContext, usePresenceRoom } from "../index";
+
+function StatusReporter({ id }: { id: string }) {
+  const ctx = React.useContext(PlayContext);
+  const room = usePresenceRoom("dual-test");
+  return (
+    <div data-testid={id}>
+      {ctx.isLoading ? "loading" : room ? "ready+room" : "ready"}
+    </div>
+  );
+}
+
+describe("dual PlayProvider mounted concurrently", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("init-owning + context-only siblings both reach isLoading=false", async () => {
+    // Pattern A: one init-owning provider, one context-only sibling. The
+    // context-only provider does NOT call init — it relays state from the
+    // global playhtml singleton. Both contexts flip to isLoading=false
+    // once the init-owning provider's ready promise resolves.
+    const { getByTestId } = render(
+      <>
+        <PlayProvider initOptions={{}}>
+          <StatusReporter id="a" />
+        </PlayProvider>
+        <PlayProvider>
+          <StatusReporter id="b" />
+        </PlayProvider>
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("a").textContent).not.toBe("loading");
+      expect(getByTestId("b").textContent).not.toBe("loading");
+    });
+  });
+
+  it("warns when a second init-owning PlayProvider mounts", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <>
+        <PlayProvider initOptions={{}}>
+          <div />
+        </PlayProvider>
+        <PlayProvider initOptions={{}}>
+          <div />
+        </PlayProvider>
+      </>,
+    );
+
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes("Multiple <PlayProvider> instances passed `initOptions`"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/react/src/__tests__/PlayProvider.test.tsx
+++ b/packages/react/src/__tests__/PlayProvider.test.tsx
@@ -21,7 +21,7 @@ describe("PlayProvider", () => {
     };
 
     const { getByTestId } = render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>
     );

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -22,7 +22,7 @@ describe("usePresence", () => {
     }
 
     render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>,
     );
@@ -46,7 +46,7 @@ describe("usePresence", () => {
     }
 
     render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>,
     );
@@ -89,7 +89,7 @@ describe("usePageData", () => {
     }
 
     const { getByText } = render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>,
     );
@@ -108,7 +108,7 @@ describe("usePageData", () => {
     }
 
     const { getByText } = render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>,
     );
@@ -143,7 +143,7 @@ describe("usePresenceRoom", () => {
     }
 
     render(
-      <PlayProvider>
+      <PlayProvider initOptions={{}}>
         <TestComponent />
       </PlayProvider>,
     );

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -6,19 +6,38 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 expect.extend(matchers);
 
 // Runs a cleanup after each test case (e.g. clearing jsdom)
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  mockedPlayhtml.isInitialized = false;
+  mockedPlayhtml.isLoading = true;
+  mockReady = new Promise<void>((resolve) => {
+    mockReadyResolve = resolve;
+  });
+  // Lazy-import after vi.mock has been hoisted and applied.
+  const { __resetInitOwnerForTests } = await import("../PlayProvider");
+  __resetInitOwnerForTests();
 });
 
 // Create a mock playhtml instance
 const presenceListeners = new Map<string, Set<(presences: Map<string, unknown>) => void>>();
 const mockPresences = new Map<string, unknown>();
 
+let mockReadyResolve: () => void = () => {};
+let mockReady: Promise<void> = new Promise<void>((resolve) => {
+  mockReadyResolve = resolve;
+});
+
 const mockedPlayhtml = {
   isInitialized: false,
+  isLoading: true,
+  get ready() {
+    return mockReady;
+  },
   init: vi.fn().mockImplementation(() => {
     mockedPlayhtml.isInitialized = true;
-    return Promise.resolve();
+    mockedPlayhtml.isLoading = false;
+    mockReadyResolve();
+    return mockReady;
   }),
   setupPlayElements: vi.fn(),
   setupPlayElement: vi.fn(),


### PR DESCRIPTION
## Summary

Fixes intermittent `playhtml.createPresenceRoom is not available before init()` errors and the broader class of init-lifecycle races. The root cause was three overlapping flags (`firstSetup`, `hasSynced`, plus React-context `hasSynced`) encoding subtly different lifecycle phases — most call sites gated on the wrong one.

## Core changes (`playhtml`)

- **Single public lifecycle signal:** `playhtml.isLoading` (boolean, monotonic) + `playhtml.ready: Promise<void>`. Replaces `firstSetup` entirely. Concurrent `init()` callers all await the same `_ready` promise.
- **Internal flag rename:** the bistable "main room currently in sync" flag is now `mainRoomSynced` (was `hasSynced`). Used only where the semantic actually requires current sync state (per-tag setup, awareness fingerprinting, runHandleNavigation).
- **`createPresenceRoom` gates on `isLoading`**, not `mainRoomSynced`. Presence rooms have their own provider, so they don't race with `handleNavigation()` clearing the main-room flag mid-flight.
- **10s safety timeout** on the yjs sync await. A stuck WebSocket can no longer leave consumers waiting on `playhtml.ready` forever.

## React changes (`@playhtml/react`)

`<PlayProvider>` now has two explicit modes:

- **Init-owning:** rendered with `initOptions`. Calls `playhtml.init()` on mount. Use once at the app root.
- **Context-only:** rendered without `initOptions` (typical for nested Astro islands). Does NOT call init — relays context from the global singleton.

Multiple init-owning providers log a one-time warning, since `playhtml.init()` is idempotent and silently drops late options.

Drops the previous behavior of flipping `hasSynced=true` on `init()` rejection — `playhtml.ready` either resolves cleanly or stays pending. UI stays in loading state on transient failures.

Context still exposes both `isLoading` (canonical) and `hasSynced` (deprecated alias = `!isLoading`).

## Why this fixes the bug

The original error showed up when:
1. **Multiple `<PlayProvider>` instances mounted concurrently.** Whichever called `init()` first won; the other early-returned and signaled \`hasSynced=true\` to its subtree even though the global flag wasn't yet flipped. Downstream `usePresenceRoom` then fired `createPresenceRoom()` and threw.
2. **`handleNavigation()` cleared `hasSynced` mid-flight** while the new room re-synced. Calls to `createPresenceRoom()` during that window threw, even though presence rooms don't depend on the main room.
3. **`init()` rejected transiently** (network blip) and the React provider unblocked downstream hooks anyway via `setHasSynced(true)` in the rejection handler.

All three are addressed by the consolidated lifecycle.

## Test plan

- [x] All existing tests pass (157 playhtml tests, 19 react tests; 2 pre-existing pathname-prop failures on main are not related)
- [x] New regression tests:
  - `init-readiness.test.ts` — 7 tests covering `isLoading`/`ready` semantics, concurrent init, resetPlayHTML
  - `presence-room.test.ts` — concurrent init + mid-navigation safety
  - `PlayProvider.dual.test.tsx` — init-owning + context-only siblings, and the warning when both are init-owning
- [x] Verified locally on spencer.place — the original `createPresenceRoom is not available` error no longer reproduces, cursors and chat presence work regardless of which Astro island hydrates first