### PR TITLE
ci: regression + smoke tests for the built site

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -29,12 +29,35 @@ jobs:
     - name: Build packages
       run: bun build-packages
 
-    - name: Run tests
+    - name: Run core tests
       run: cd packages/playhtml && bun run test
+
+    - name: Run react tests
+      # 2 pre-existing pathname-prop failures (mock-restore quirk) are
+      # tracked separately. Reports failures but does not block merge.
+      run: cd packages/react && bun run test
+      continue-on-error: true
 
     - name: Lint
       run: bun run lint
       continue-on-error: true  # Report lint results but do not block merge
-      
+
     - name: Build site
       run: bun build-site
+
+    - name: Install Playwright browsers
+      run: bunx playwright install --with-deps chromium
+      working-directory: smoke-tests
+
+    - name: Run smoke tests
+      run: bun smoke
+
+    - name: Upload smoke test report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: smoke-test-report
+        path: |
+          smoke-tests/playwright-report
+          smoke-tests/test-results
+        retention-days: 7

--- a/bun.lock
+++ b/bun.lock
@@ -165,6 +165,13 @@
         "react-dom": "^16.8.0  || ^17.0.0 || ^18.2.0 || ^19.0.0",
       },
     },
+    "smoke-tests": {
+      "name": "playhtml-smoke-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0",
+      },
+    },
   },
   "overrides": {
     "yjs": "13.6.18",
@@ -553,6 +560,8 @@
     "@playhtml/extension": ["@playhtml/extension@workspace:extension"],
 
     "@playhtml/react": ["@playhtml/react@workspace:packages/react"],
+
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@pnpm/config.env-replace": ["@pnpm/config.env-replace@1.1.0", "", {}, "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="],
 
@@ -1784,6 +1793,12 @@
 
     "playhtml": ["playhtml@workspace:packages/playhtml"],
 
+    "playhtml-smoke-tests": ["playhtml-smoke-tests@workspace:smoke-tests"],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
@@ -2537,6 +2552,8 @@
     "playhtml/jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
     "playhtml/vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "packages/common",
     "apps/docs",
     "extension",
-    "extension/website"
+    "extension/website",
+    "smoke-tests"
   ],
   "scripts": {
     "dev": "vite --config vite.config.site.mts",
@@ -29,6 +30,7 @@
     "lint": "bunx tsc -p partykit && cd website && bunx tsc && cd .. && for dir in packages/*; do (cd \"$dir\" && bunx tsc); done && cd extension && bunx tsc",
     "load-test": "bun load-test/src/runner.ts",
     "load-test:full": "bun load-test/src/runner.ts --config full-suite",
+    "smoke": "cd smoke-tests && bun run test",
     "generate-types": "bunx wrangler types --include-runtime=false"
   },
   "overrides": {

--- a/packages/react/src/__tests__/PlayProvider.regression.test.tsx
+++ b/packages/react/src/__tests__/PlayProvider.regression.test.tsx
@@ -1,0 +1,46 @@
+// ABOUTME: Regression tests locking in PlayProvider's bootstrap contract.
+// ABOUTME: Catches breakages where bare <PlayProvider> stops initializing playhtml.
+
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { PlayProvider } from "../index";
+
+const mockedPlayhtml = (globalThis as any).MOCKED_PLAYHTML as {
+  init: ReturnType<typeof vi.fn>;
+};
+
+describe("PlayProvider bootstrap contract", () => {
+  beforeEach(() => {
+    mockedPlayhtml.init.mockClear();
+  });
+
+  it("bare <PlayProvider> (no initOptions) bootstraps playhtml", async () => {
+    // Regression for the breakage shipped in PR #102 and reverted: the
+    // experiments site (e.g. /experiments/4/) renders <PlayProvider> with no
+    // initOptions and relies on it to call playhtml.init(). If the provider
+    // ever stops bootstrapping in this case, all bare-provider sites break
+    // with "Element X does not have proper info to initial a playhtml element".
+    render(
+      <PlayProvider>
+        <div data-testid="child" />
+      </PlayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockedPlayhtml.init).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("<PlayProvider initOptions={{}}> bootstraps playhtml", async () => {
+    render(
+      <PlayProvider initOptions={{}}>
+        <div data-testid="child" />
+      </PlayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockedPlayhtml.init).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/smoke-tests/.gitignore
+++ b/smoke-tests/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+playwright-report
+test-results

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -1,0 +1,38 @@
+# smoke-tests
+
+Headless browser checks against the prebuilt site. Catches regressions that
+unit tests miss because they only show up when real bundled JS runs in a real
+browser — e.g. the April 2026 PR #102 incident, where bare `<PlayProvider>`
+stopped bootstrapping playhtml and every experiment page broke in production.
+
+## Running locally
+
+```bash
+# From repo root
+bun build-site
+bun run -C smoke-tests install-browsers   # one-time
+bun smoke
+```
+
+## What it checks
+
+For each page in `smoke.spec.ts`'s `PAGES` list:
+
+- HTTP status < 400.
+- No uncaught `pageerror` (rendering threw).
+- No fatal `console.error` matching `FATAL_CONSOLE_PATTERNS` (playhtml runtime
+  errors, missing PlayProvider, etc.).
+- No same-origin asset 4xx/5xx (a renamed JS chunk would surface here).
+
+Cross-origin failures (PartyKit WebSocket, Google Fonts) are deliberately
+ignored — this is a build-output smoke test, not a backend integration test.
+
+## Adding a new page
+
+Add its URL path to `PAGES`. Add new error patterns to
+`FATAL_CONSOLE_PATTERNS` when a new class of regression is found.
+
+## CI
+
+The `smoke` job in `.github/workflows/pr-validation.yml` builds the site,
+installs Chromium, and runs this suite on every PR.

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "playhtml-smoke-tests",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "install-browsers": "playwright install chromium --with-deps"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/smoke-tests/playwright.config.ts
+++ b/smoke-tests/playwright.config.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Playwright config for the smoke test suite.
+// ABOUTME: Spins up a static server over the prebuilt site-dist/ output.
+
+import { defineConfig } from "@playwright/test";
+
+const PORT = Number(process.env.SMOKE_PORT ?? 4173);
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    // Serve the prebuilt site. Tests assume `bun build-site` has already run.
+    command: `bunx serve -l ${PORT} --no-clipboard ../site-dist`,
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/smoke-tests/smoke.spec.ts
+++ b/smoke-tests/smoke.spec.ts
@@ -1,0 +1,155 @@
+// ABOUTME: Loads each public page from the built site and asserts no playhtml
+// ABOUTME: errors, no uncaught exceptions, and no same-origin asset 404s.
+
+import { test, expect, type ConsoleMessage, type Page } from "@playwright/test";
+
+// Pages we ship and expect to load cleanly. Keep this list in sync with the
+// vite build glob in vite.config.site.mts (any *.html under website/, excluding
+// `test/`).
+const PAGES: { path: string; skip?: string }[] = [
+  { path: "/" },
+  { path: "/candles" },
+  { path: "/story" },
+  { path: "/fridge" },
+  { path: "/admin" },
+  { path: "/experiments/" },
+  { path: "/experiments/3/" },
+  { path: "/experiments/4/" },
+  { path: "/experiments/5/" },
+  { path: "/experiments/6/" },
+  { path: "/experiments/7/" },
+  { path: "/experiments/8/" },
+  { path: "/experiments/9/" },
+  { path: "/experiments/one/" },
+  { path: "/experiments/two/" },
+  { path: "/events/gathering/" },
+  { path: "/events/gray-area/" },
+  { path: "/events/if-then/" },
+  { path: "/events/walking-together/" },
+  { path: "/docs/" },
+];
+
+// Console messages matching any of these are surfaced as test failures. The
+// list is the load-bearing part of this suite — additions here lock in
+// previously-broken classes of regression.
+const FATAL_CONSOLE_PATTERNS: RegExp[] = [
+  // The April 2026 PR #102 regression — bare <PlayProvider> stopped calling
+  // playhtml.init(), so withSharedState elements failed to register.
+  /does not have proper info to initial a playhtml element/i,
+  // Generic playhtml runtime errors. The library prefixes these consistently.
+  /\[playhtml\]/i,
+  /\[PLAYHTML\]/,
+  // React's "uncaught error inside a render" path.
+  /Uncaught .*Error/,
+  // PlayProvider missing — would mean a page lost its provider entirely.
+  /PlayProvider element missing/i,
+];
+
+// Console errors matching these are EXPECTED (network-dependent, third party,
+// etc.) and should not fail the smoke test. Keep the list narrow — broad
+// excludes hide regressions.
+const IGNORED_CONSOLE_PATTERNS: RegExp[] = [
+  // PartyKit / yjs WebSocket attempts may fail in offline CI environments.
+  // The library handles this gracefully (10s sync timeout) and pages still
+  // render; we only care that the page itself doesn't error out.
+  /Issue connecting to yjs/i,
+  /WebSocket/i,
+  /partykit/i,
+  // Google Fonts and other third-party font CDNs can blip without affecting
+  // page functionality.
+  /fonts\.(googleapis|gstatic)\.com/i,
+  // Favicon misses are noisy and irrelevant.
+  /favicon/i,
+];
+
+function isFatal(text: string): boolean {
+  if (IGNORED_CONSOLE_PATTERNS.some((re) => re.test(text))) return false;
+  return FATAL_CONSOLE_PATTERNS.some((re) => re.test(text));
+}
+
+async function collectErrors(page: Page) {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const sameOriginFailures: string[] = [];
+
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (isFatal(text)) consoleErrors.push(text);
+  });
+
+  page.on("pageerror", (err) => {
+    pageErrors.push(`${err.name}: ${err.message}`);
+  });
+
+  page.on("requestfailed", (req) => {
+    const url = req.url();
+    // Only flag failures for assets served from our own origin. Cross-origin
+    // network errors (partykit, fonts) are out of scope for a smoke test.
+    if (!url.startsWith("http://localhost")) return;
+    sameOriginFailures.push(`${req.failure()?.errorText ?? "failed"}: ${url}`);
+  });
+
+  page.on("response", (resp) => {
+    const url = resp.url();
+    if (!url.startsWith("http://localhost")) return;
+    if (resp.status() >= 400) {
+      sameOriginFailures.push(`${resp.status()}: ${url}`);
+    }
+  });
+
+  return { consoleErrors, pageErrors, sameOriginFailures };
+}
+
+for (const { path, skip } of PAGES) {
+  const runner = skip ? test.skip : test;
+  runner(`smoke: ${path}${skip ? ` (skipped: ${skip})` : ""}`, async ({ page }) => {
+    const errors = await collectErrors(page);
+
+    const response = await page.goto(path, { waitUntil: "domcontentloaded" });
+    expect(response, `no response for ${path}`).not.toBeNull();
+    expect(response!.status(), `bad status for ${path}`).toBeLessThan(400);
+
+    // Give playhtml a moment to register and any synchronous render errors to
+    // surface. The library's 10s yjs sync timeout means we don't need to wait
+    // for full sync — registration happens earlier.
+    await page.waitForTimeout(2_000);
+
+    // Page must have rendered *something*. Catches silent failures where a
+    // React island throws and an error boundary leaves a blank document.
+    const bodyText = (await page.locator("body").innerText()).trim();
+    expect(bodyText.length, `${path} rendered an empty body`).toBeGreaterThan(0);
+
+    // Title must be present. Catches HTML emit / template breakage.
+    const title = await page.title();
+    expect(title.length, `${path} has no <title>`).toBeGreaterThan(0);
+
+    expect.soft(errors.pageErrors, `uncaught page errors on ${path}`).toEqual([]);
+    expect
+      .soft(errors.consoleErrors, `fatal console errors on ${path}`)
+      .toEqual([]);
+    expect
+      .soft(errors.sameOriginFailures, `same-origin asset failures on ${path}`)
+      .toEqual([]);
+
+    // Surface the soft assertions if any tripped.
+    if (
+      errors.pageErrors.length ||
+      errors.consoleErrors.length ||
+      errors.sameOriginFailures.length
+    ) {
+      throw new Error(
+        `Smoke check failed for ${path}:\n` +
+          (errors.pageErrors.length
+            ? `  page errors: ${errors.pageErrors.join(" | ")}\n`
+            : "") +
+          (errors.consoleErrors.length
+            ? `  console: ${errors.consoleErrors.join(" | ")}\n`
+            : "") +
+          (errors.sameOriginFailures.length
+            ? `  assets: ${errors.sameOriginFailures.join(" | ")}\n`
+            : ""),
+      );
+    }
+  });
+}

--- a/website/candles.html
+++ b/website/candles.html
@@ -67,7 +67,7 @@
 
     <script type="module" src="./story.ts"></script>
     <script type="module">
-      import "https://unpkg.com/playhtml@latest";
+      import { playhtml } from "https://unpkg.com/playhtml@latest";
       playhtml.init({
         room: window.location.pathname,
         cursors: { enabled: true },

--- a/website/story.html
+++ b/website/story.html
@@ -235,7 +235,7 @@
 
     <script type="module" src="./story.ts"></script>
     <script type="module">
-      import "https://unpkg.com/playhtml@latest";
+      import { playhtml } from "https://unpkg.com/playhtml@latest";
       playhtml.init({ room: window.location.pathname });
     </script>
     <!-- import cursor chat -->


### PR DESCRIPTION
## Summary

Two layers of regression coverage prompted by the PR #102 incident, where bare `<PlayProvider>` stopped bootstrapping playhtml and shipped to prod with a broken `/experiments/4/` (and friends) before anyone noticed.

- **Tier 1 — unit regression test.** `packages/react/.../PlayProvider.regression.test.tsx` asserts `<PlayProvider>` calls `playhtml.init()` whether or not `initOptions` is provided. This is the exact contract PR #102 violated. Verified by simulating the broken behavior locally — the test fails under it and passes against the current implementation.
- **Tier 2 — Playwright smoke suite.** `smoke-tests/` loads each public page (home, experiments 3/4/5/6/7/8/9/one/two, events, fridge/admin/candles/story, docs) from the prebuilt `site-dist/` over a local static server and asserts:
  - HTTP status < 400
  - No uncaught `pageerror`
  - No fatal `console.error` matching playhtml runtime patterns (`does not have proper info...`, `[playhtml]`, `[PLAYHTML]`, "PlayProvider element missing", uncaught error)
  - No same-origin asset 4xx/5xx
  - Body has rendered text and a non-empty `<title>` (catches blank-page silent failures)

  Cross-origin failures (PartyKit WebSocket, Google Fonts) are deliberately ignored — this is build-output smoke, not a backend integration test. The `FATAL_CONSOLE_PATTERNS` list in `smoke.spec.ts` is the load-bearing part — additions there are how new classes of regression get locked in.

- **CI:** `pr-validation.yml` now runs the `packages/react` tests (continue-on-error for two pre-existing pathname-prop failures, tracked separately) and the smoke suite, with a Chromium install step and a failure-only artifact upload of the playwright report.

## Bonus catches

The smoke suite immediately surfaced two pages that throw `ReferenceError: playhtml is not defined` on load: `/candles` and `/story`. They imported `playhtml` from unpkg as a global, but the published ESM build doesn't expose it that way. Fixed by switching to a named import. Co-developed with another agent in a separate session — landing here so the smoke suite runs against working pages.

## Honest limits

The smoke suite would have caught the *exact text* of the PR #102 error if it appeared, but the actual production bug had subtler timing dynamics. Locking in the bootstrap contract via the unit test is the more direct guardrail. Smoke catches the broader category — page throws on load, missing assets, blank renders — and is cheap enough to run on every PR.

## Test plan

- [x] `bun run -C packages/react test src/__tests__/PlayProvider.regression.test.tsx` → 2/2 pass
- [x] Verified the regression test fails when `<PlayProvider>` is conditionally skipping init for bare usage (simulating PR #102 behavior)
- [x] `bun build-site && bun smoke` → 20/20 pages pass
- [x] Smoke suite catches `ReferenceError: playhtml is not defined` (validated by reverting the candles/story fix)
- [ ] CI run on the PR