### PR TITLE
presence: populate playerIdentity on non-cursor rooms

### DIFF
--- a/.changeset/presence-identity-all-rooms.md
+++ b/.changeset/presence-identity-all-rooms.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+presence: ensure `playerIdentity` is populated on all presence rooms, not only the cursor room. Previously `PresenceView.playerIdentity` was read exclusively from the cursor client's awareness field, so remote peers in any presence room created via `playhtml.createPresenceRoom()` arrived with `playerIdentity: undefined`. Each presence API instance now writes its own identity into a dedicated `__playhtml_identity__` awareness field; `buildViewFromState` falls back to it when the cursor field is absent.

--- a/packages/playhtml/src/__tests__/presence-identity.test.ts
+++ b/packages/playhtml/src/__tests__/presence-identity.test.ts
@@ -118,4 +118,44 @@ describe("createPresenceAPI identity propagation", () => {
     api.getPresences();
     expect(calls).toBe(1);
   });
+
+  it("re-arms the identity write after the awareness provider is rebuilt", () => {
+    // Regression: SPA navigation rebuilds the cursor/main provider, which
+    // creates a fresh awareness object with no identity field. The presence
+    // API must write identity into the new awareness on next use.
+    let awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_local");
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => identity,
+    });
+
+    api.getPresences();
+    expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toEqual(identity);
+
+    // Simulate provider rebind on navigation: brand-new awareness instance.
+    awareness = makeAwareness(2);
+    expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toBeUndefined();
+
+    api.getPresences();
+    expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toEqual(identity);
+  });
+
+  it("returns playerIdentity undefined for peers with no identity at all", () => {
+    // Pin the contract: missing both cursor field and identity field should
+    // not throw; playerIdentity is simply undefined on the view.
+    const awareness = makeAwareness(1);
+    awareness.states.set(2, { __presence__: { tab: { id: "x" } } });
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => makeIdentity("pk_local"),
+    });
+
+    const presences = api.getPresences();
+    const remote = Array.from(presences.values()).find((p) => !p.isMe);
+    expect(remote).toBeDefined();
+    expect(remote!.playerIdentity).toBeUndefined();
+  });
 });

--- a/packages/playhtml/src/__tests__/presence-identity.test.ts
+++ b/packages/playhtml/src/__tests__/presence-identity.test.ts
@@ -1,0 +1,121 @@
+// ABOUTME: Tests that createPresenceAPI populates playerIdentity for remote peers
+// ABOUTME: in rooms where no cursor client is running (regression for non-cursor rooms).
+
+import { describe, it, expect } from "vitest";
+import { createPresenceAPI } from "../presence";
+import type { PlayerIdentity } from "@playhtml/common";
+
+const IDENTITY_FIELD = "__playhtml_identity__";
+
+interface MockAwareness {
+  clientID: number;
+  states: Map<number, Record<string, unknown>>;
+  getStates(): Map<number, Record<string, unknown>>;
+  getLocalState(): Record<string, unknown> | null;
+  setLocalStateField(field: string, value: unknown): void;
+  on(event: string, cb: (...args: unknown[]) => void): void;
+}
+
+function makeAwareness(clientID: number): MockAwareness {
+  const states = new Map<number, Record<string, unknown>>();
+  states.set(clientID, {});
+  return {
+    clientID,
+    states,
+    getStates: () => states,
+    getLocalState: () => states.get(clientID) ?? null,
+    setLocalStateField(field, value) {
+      const cur = states.get(clientID) ?? {};
+      states.set(clientID, { ...cur, [field]: value });
+    },
+    on() {},
+  };
+}
+
+function makeIdentity(publicKey: string): PlayerIdentity {
+  return {
+    publicKey,
+    playerStyle: { colorPalette: ["#000"] },
+  } as PlayerIdentity;
+}
+
+describe("createPresenceAPI identity propagation", () => {
+  it("writes local identity into __playhtml_identity__ on first use", () => {
+    const awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_local");
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => identity,
+    });
+
+    // Identity not written yet (lazy)
+    expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toBeUndefined();
+
+    api.getPresences();
+    expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toEqual(identity);
+  });
+
+  it("resolves remote peer playerIdentity from __playhtml_identity__ when no cursor field", () => {
+    const awareness = makeAwareness(1);
+    const localIdentity = makeIdentity("pk_local");
+
+    // Simulate a remote peer in a non-cursor room: they wrote IDENTITY_FIELD
+    // but never wrote __playhtml_cursors__.
+    const remoteIdentity = makeIdentity("pk_remote");
+    awareness.states.set(2, { [IDENTITY_FIELD]: remoteIdentity });
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => localIdentity,
+    });
+
+    const presences = api.getPresences();
+    const remote = Array.from(presences.values()).find((p) => !p.isMe);
+    expect(remote).toBeDefined();
+    expect(remote!.playerIdentity).toEqual(remoteIdentity);
+  });
+
+  it("prefers cursor-field identity over __playhtml_identity__ for backwards compat", () => {
+    const awareness = makeAwareness(1);
+    const localIdentity = makeIdentity("pk_local");
+
+    const cursorIdentity = makeIdentity("pk_from_cursor");
+    const fallbackIdentity = makeIdentity("pk_from_fallback");
+    awareness.states.set(2, {
+      __playhtml_cursors__: { playerIdentity: cursorIdentity },
+      [IDENTITY_FIELD]: fallbackIdentity,
+    });
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => localIdentity,
+    });
+
+    const presences = api.getPresences();
+    const remote = Array.from(presences.values()).find((p) => !p.isMe);
+    expect(remote!.playerIdentity).toEqual(cursorIdentity);
+  });
+
+  it("identity write is idempotent across multiple API calls", () => {
+    const awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_local");
+    let calls = 0;
+    const wrappedAwareness = {
+      ...awareness,
+      setLocalStateField(field: string, value: unknown) {
+        if (field === IDENTITY_FIELD) calls++;
+        awareness.setLocalStateField(field, value);
+      },
+    };
+
+    const api = createPresenceAPI({
+      getAwareness: () => wrappedAwareness,
+      getPlayerIdentity: () => identity,
+    });
+
+    api.getPresences();
+    api.setMyPresence("page", { url: "/" });
+    api.getPresences();
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/playhtml/src/presence.ts
+++ b/packages/playhtml/src/presence.ts
@@ -7,12 +7,7 @@ import { getStableIdForAwareness } from "./awareness-utils";
 const PRESENCE_FIELD = "__presence__";
 const CURSOR_FIELD = "__playhtml_cursors__";
 const IDENTITY_FIELD = "__playhtml_identity__";
-const SYSTEM_FIELDS = new Set([
-  "playerIdentity",
-  "cursor",
-  "isMe",
-  IDENTITY_FIELD,
-]);
+const SYSTEM_FIELDS = new Set(["playerIdentity", "cursor", "isMe"]);
 
 /** Minimal awareness interface matching YPartyKitProvider.awareness */
 interface AwarenessLike {
@@ -37,7 +32,6 @@ interface ChannelListener {
 export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
   const listeners = new Map<string, ChannelListener>();
   let awarenessListenerAttached = false;
-  let identityWritten = false;
   let nextListenerId = 0;
 
   function getAwareness(): AwarenessLike {
@@ -46,10 +40,13 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
 
   // Write our identity into a dedicated awareness field so remote peers can
   // resolve playerIdentity even on rooms where no cursor client is running.
+  // Idempotency keyed on the current awareness's local state (not a closure
+  // boolean) so SPA navigation that rebuilds the provider — and with it the
+  // awareness object — re-arms the write on the new awareness.
   function ensureIdentityWritten(): void {
-    if (identityWritten) return;
-    identityWritten = true;
-    getAwareness().setLocalStateField(IDENTITY_FIELD, deps.getPlayerIdentity());
+    const awareness = getAwareness();
+    if (awareness.getLocalState()?.[IDENTITY_FIELD]) return;
+    awareness.setLocalStateField(IDENTITY_FIELD, deps.getPlayerIdentity());
   }
 
   function channelFingerprint(

--- a/packages/playhtml/src/presence.ts
+++ b/packages/playhtml/src/presence.ts
@@ -6,7 +6,13 @@ import { getStableIdForAwareness } from "./awareness-utils";
 
 const PRESENCE_FIELD = "__presence__";
 const CURSOR_FIELD = "__playhtml_cursors__";
-const SYSTEM_FIELDS = new Set(["playerIdentity", "cursor", "isMe"]);
+const IDENTITY_FIELD = "__playhtml_identity__";
+const SYSTEM_FIELDS = new Set([
+  "playerIdentity",
+  "cursor",
+  "isMe",
+  IDENTITY_FIELD,
+]);
 
 /** Minimal awareness interface matching YPartyKitProvider.awareness */
 interface AwarenessLike {
@@ -31,10 +37,19 @@ interface ChannelListener {
 export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
   const listeners = new Map<string, ChannelListener>();
   let awarenessListenerAttached = false;
+  let identityWritten = false;
   let nextListenerId = 0;
 
   function getAwareness(): AwarenessLike {
     return deps.getAwareness();
+  }
+
+  // Write our identity into a dedicated awareness field so remote peers can
+  // resolve playerIdentity even on rooms where no cursor client is running.
+  function ensureIdentityWritten(): void {
+    if (identityWritten) return;
+    identityWritten = true;
+    getAwareness().setLocalStateField(IDENTITY_FIELD, deps.getPlayerIdentity());
   }
 
   function channelFingerprint(
@@ -99,7 +114,9 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
       | { cursor?: Cursor | null; playerIdentity?: PlayerIdentity; zone?: unknown }
       | undefined;
 
-    const playerIdentity = cursorState?.playerIdentity;
+    const playerIdentity =
+      cursorState?.playerIdentity ??
+      (state[IDENTITY_FIELD] as PlayerIdentity | undefined);
     const cursor = cursorState?.cursor ?? null;
     const customChannels = (state[PRESENCE_FIELD] as Record<string, unknown>) ?? {};
 
@@ -158,6 +175,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
 
   return {
     setMyPresence(channel: string, data: unknown): void {
+      ensureIdentityWritten();
       const awareness = getAwareness();
       const currentState = awareness.getLocalState() ?? {};
       const currentPresence = (currentState[PRESENCE_FIELD] as Record<string, unknown>) ?? {};
@@ -174,6 +192,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
     },
 
     getPresences(): Map<string, PresenceView> {
+      ensureIdentityWritten();
       return buildPresences();
     },
 
@@ -181,6 +200,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
       channel: string,
       callback: (presences: Map<string, PresenceView>) => void,
     ): () => void {
+      ensureIdentityWritten();
       const id = String(nextListenerId++);
       listeners.set(id, { channel, callback, lastFingerprint: "" });
       attachAwarenessListener();

--- a/packages/react/examples/UniquePeoplePill.tsx
+++ b/packages/react/examples/UniquePeoplePill.tsx
@@ -1,0 +1,122 @@
+// ABOUTME: Ambient pill showing how many unique people (deduped by playerIdentity)
+// ABOUTME: are present in a non-cursor presence room across all of their open tabs.
+
+import React, { useEffect, useState } from "react";
+import { usePresenceRoom } from "@playhtml/react";
+import type { PresenceView } from "@playhtml/common";
+
+interface Props {
+  roomName?: string;
+  label?: string;
+}
+
+interface Stats {
+  uniquePeople: number;
+  totalTabs: number;
+  swatches: string[];
+}
+
+function computeStats(presences: Map<string, PresenceView>): Stats {
+  const byPublicKey = new Map<string, { tabs: number; color: string }>();
+  let totalTabs = 0;
+
+  for (const view of presences.values()) {
+    totalTabs++;
+    const pk = view.playerIdentity?.publicKey;
+    if (!pk) continue;
+    const existing = byPublicKey.get(pk);
+    if (existing) {
+      existing.tabs++;
+    } else {
+      const color = view.playerIdentity?.playerStyle?.colorPalette?.[0] ?? "#888";
+      byPublicKey.set(pk, { tabs: 1, color });
+    }
+  }
+
+  return {
+    uniquePeople: byPublicKey.size,
+    totalTabs,
+    swatches: Array.from(byPublicKey.values()).map((v) => v.color),
+  };
+}
+
+export const UniquePeoplePill: React.FC<Props> = ({
+  roomName = "unique-people-demo",
+  label = "people here",
+}) => {
+  const room = usePresenceRoom(roomName);
+  const [stats, setStats] = useState<Stats>({
+    uniquePeople: 0,
+    totalTabs: 0,
+    swatches: [],
+  });
+
+  useEffect(() => {
+    if (!room) return;
+    // Each tab announces itself with a tab-id payload so the room actually has
+    // a presence channel populated. The dedupe relies entirely on playerIdentity.
+    const tabId = Math.random().toString(36).slice(2, 10);
+    room.presence.setMyPresence("tab", { tabId, openedAt: Date.now() });
+
+    const update = () => setStats(computeStats(room.presence.getPresences()));
+    update();
+    const unsub = room.presence.onPresenceChange("tab", update);
+    return unsub;
+  }, [room]);
+
+  const ready = room !== null;
+  const dedupedTabs = stats.totalTabs - stats.uniquePeople;
+
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "8px 14px",
+        borderRadius: 999,
+        background: "#f5f0e8",
+        border: "1px solid #d8d0c4",
+        color: "#3d3833",
+        fontFamily: "system-ui, sans-serif",
+        fontSize: 14,
+      }}
+    >
+      <span style={{ display: "inline-flex", gap: 4 }}>
+        {stats.swatches.length === 0 ? (
+          <span
+            style={{
+              width: 10,
+              height: 10,
+              borderRadius: "50%",
+              background: "#c4c0b8",
+            }}
+          />
+        ) : (
+          stats.swatches.map((color, i) => (
+            <span
+              key={i}
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                background: color,
+                border: "1px solid rgba(0,0,0,0.1)",
+              }}
+            />
+          ))
+        )}
+      </span>
+      <span>
+        <strong>{stats.uniquePeople}</strong> {label}
+      </span>
+      <span style={{ color: "#8a8279", fontSize: 12 }}>
+        {ready
+          ? `${stats.totalTabs} tab${stats.totalTabs === 1 ? "" : "s"}${
+              dedupedTabs > 0 ? ` · ${dedupedTabs} deduped` : ""
+            }`
+          : "connecting…"}
+      </span>
+    </div>
+  );
+};

--- a/website/test/react-test.tsx
+++ b/website/test/react-test.tsx
@@ -27,6 +27,7 @@ import { SharedSlider } from "../../packages/react/examples/SharedSlider";
 import { LiveReactions } from "../../packages/react/examples/LiveReactions";
 // import { CursorOverlap } from "../../packages/react/examples/CursorOverlap";
 import { SharedSound } from "../../packages/react/examples/SharedSound";
+import { UniquePeoplePill } from "../../packages/react/examples/UniquePeoplePill";
 
 const Candle = withSharedState(
   { defaultData: { on: false } },
@@ -174,6 +175,15 @@ ReactDOM.createRoot(
       </div>
 
       <LoadingStateTest />
+      <div style={{ padding: "20px", border: "2px solid #333", margin: "20px 0" }}>
+        <h3>Unique People Pill (presence-room dedupe)</h3>
+        <p style={{ marginBottom: "12px", color: "#666" }}>
+          Open this page in multiple tabs as the same browser/user — "people" stays at 1 while "tabs" climbs.
+          Open in another browser or incognito → "people" goes to 2. Regression check for the
+          presence-identity-on-non-cursor-rooms fix.
+        </p>
+        <UniquePeoplePill />
+      </div>
       <Candle />
       <ReactionView reaction={{ emoji: "🧡", count: 1 }} />
       <SharedLamp />


### PR DESCRIPTION
## Summary

- Fix: `PresenceView.playerIdentity` was undefined for remote peers in any presence room created via `playhtml.createPresenceRoom()` other than the cursor room. Identity was sourced exclusively from `state[__playhtml_cursors__].playerIdentity`, which is only ever written by the cursor client — so dedupe-by-publicKey across tabs broke in lobby/non-cursor rooms.
- Each `createPresenceAPI` instance now writes its own identity into a dedicated `__playhtml_identity__` awareness field on first use. `buildViewFromState` reads cursor-field first (backwards compat) and falls back to the new field.
- Adds `UniquePeoplePill` React example that demonstrates and visually verifies the fix (renders unique-people count deduped by `playerIdentity.publicKey` plus a "deduped" delta).

## Why

Without this fix, opening multiple tabs of the same user in a non-cursor presence room shows N people instead of 1 — every tab looks like a separate user because their `playerIdentity` is `undefined` to remote peers.

## Implementation notes

- Idempotency for the identity write is keyed on the current awareness's local state, **not** a closure boolean. SPA navigation rebuilds the cursor/main provider (see `index.ts:744`) and creates a fresh awareness object — a closure boolean would have re-introduced the bug on any post-navigation room. There's a regression test for exactly this.
- Cursor client is **not** modified. It still writes identity into the cursor field; the new field is purely additive. Cursor-room consumers see no behavioral change.
- `channelFingerprint` only inspects `__playhtml_cursors__.cursor` and `__presence__[channel]`, so writes to `__playhtml_identity__` do not trigger spurious `onPresenceChange` notifications.

## Tests

- 6 new unit tests in `packages/playhtml/src/__tests__/presence-identity.test.ts`:
  - Lazy local-identity write
  - Remote peer with only `__playhtml_identity__` resolves correctly (the original bug)
  - Cursor-field precedence (backwards compat)
  - Idempotency across multiple API calls
  - **Re-arms identity write after awareness provider rebind** (regression for the navigation case)
  - Peer with neither field returns `playerIdentity: undefined` rather than throwing
- Verified the rebind regression test fails against the pre-fix code: swapping the old `presence.ts` back in produces exactly one failure, on the rebind assertion.
- 163/163 tests pass in `packages/playhtml`. `bunx tsc` clean for `packages/playhtml` and `packages/react`.

## Test plan

- [ ] `bun run -C packages/playhtml test` (or `cd packages/playhtml && bun run test`)
- [ ] Open `/test/react-test.html` in the dev server. The "Unique People Pill" section should show `1 people · 1 tab`.
- [ ] Open the same page in a second tab of the same browser → `1 people · 2 tabs · 1 deduped`.
- [ ] Open in a third tab → `1 people · 3 tabs · 2 deduped`.
- [ ] Open in another browser or incognito → `2 people · …`.

## Changeset

`.changeset/presence-identity-all-rooms.md` — `playhtml` patch.