### PR TITLE
docs: cross-site nav between docs and /play

### DIFF
--- a/apps/docs/src/components/CrossSiteNav.astro
+++ b/apps/docs/src/components/CrossSiteNav.astro
@@ -1,25 +1,14 @@
 ---
 // ABOUTME: Cross-site link cluster (home / docs / /play) used in the docs
-// ABOUTME: SiteTitle slot and the /play page header. Active state is parent-passed.
+// ABOUTME: SiteTitle slot. Active state is parent-passed.
+import { crossSiteLinks, type SurfaceKey } from "./cross-site-links";
 
 interface Props {
-  active: "home" | "docs" | "play";
+  active: SurfaceKey;
 }
 
 const { active } = Astro.props;
-
-// Link targets follow the production layout (set by Astro's `base: "/docs"`
-// + the website build serving `/`):
-//   home  → `/`              (the website Vite build's root)
-//   docs  → `/docs/`         (Starlight base)
-//   /play → `/docs/play`     (Astro page emitted under the docs base)
-// The label "/play" is the friendly name Spencer uses; the href is the
-// real built path.
-const links: Array<{ key: Props["active"]; label: string; href: string }> = [
-  { key: "home", label: "home", href: "/" },
-  { key: "docs", label: "docs", href: "/docs/" },
-  { key: "play", label: "/play", href: "/docs/play" },
-];
+const links = crossSiteLinks;
 ---
 
 <nav class="ph-crossnav" aria-label="playhtml sites">

--- a/apps/docs/src/components/CrossSiteNav.astro
+++ b/apps/docs/src/components/CrossSiteNav.astro
@@ -1,0 +1,74 @@
+---
+// ABOUTME: Cross-site link cluster (home / docs / /play) used in the docs
+// ABOUTME: SiteTitle slot and the /play page header. Active state is parent-passed.
+
+interface Props {
+  active: "home" | "docs" | "play";
+}
+
+const { active } = Astro.props;
+
+// Link targets follow the production layout (set by Astro's `base: "/docs"`
+// + the website build serving `/`):
+//   home  → `/`              (the website Vite build's root)
+//   docs  → `/docs/`         (Starlight base)
+//   /play → `/docs/play`     (Astro page emitted under the docs base)
+// The label "/play" is the friendly name Spencer uses; the href is the
+// real built path.
+const links: Array<{ key: Props["active"]; label: string; href: string }> = [
+  { key: "home", label: "home", href: "/" },
+  { key: "docs", label: "docs", href: "/docs/" },
+  { key: "play", label: "/play", href: "/docs/play" },
+];
+---
+
+<nav class="ph-crossnav" aria-label="playhtml sites">
+  {
+    links.map((link) => (
+      <a
+        href={link.href}
+        class:list={["ph-crossnav__link", { "is-active": link.key === active }]}
+        aria-current={link.key === active ? "page" : undefined}
+      >
+        {link.label}
+      </a>
+    ))
+  }
+</nav>
+
+<style>
+  .ph-crossnav {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 14px;
+    margin-left: 18px;
+    padding-left: 18px;
+    border-left: 1px solid var(--ph-hairline);
+    font-family: var(--ph-font-body);
+    font-size: 0.875rem;
+    line-height: 1;
+  }
+  .ph-crossnav__link {
+    color: var(--ph-ink-2);
+    text-decoration: none;
+    padding: 2px 0;
+    transition: color var(--ph-motion-fast);
+    border-bottom: 1px solid transparent;
+  }
+  .ph-crossnav__link:hover {
+    color: var(--ph-ultramarine-deep);
+  }
+  .ph-crossnav__link.is-active {
+    color: var(--ph-ink);
+    border-bottom-color: var(--ph-ultramarine);
+  }
+
+  /* Hide on narrow widths — docs already collapses to a hamburger,
+     /play is desktop-first. Keeps the wordmark + right-side icons
+     legible on phones without the link cluster fighting for space. */
+  @media (max-width: 600px) {
+    .ph-crossnav {
+      display: none;
+    }
+  }
+</style>

--- a/apps/docs/src/components/SiteTitle.astro
+++ b/apps/docs/src/components/SiteTitle.astro
@@ -3,13 +3,25 @@
 // link, while each letter in "html" is a vanilla `can-toggle` element. State is
 // page-local (each docs URL is its own room) which is fine for a navigational
 // flourish — the point is to prove the library works everywhere in the docs.
+import CrossSiteNav from "./CrossSiteNav.astro";
 const { siteTitleHref } = Astro.locals.starlightRoute;
 ---
-<div class="ph-wordmark" translate="no">
-  <a href={siteTitleHref} class="ph-wordmark__home" aria-label="playhtml docs home"
-    ><span class="ph-wordmark__stem">play</span></a
-  ><span id="ph-wordmark-h" can-toggle class="ph-wordmark__letter">h</span
-  ><span id="ph-wordmark-t" can-toggle class="ph-wordmark__letter">t</span
-  ><span id="ph-wordmark-m" can-toggle class="ph-wordmark__letter">m</span
-  ><span id="ph-wordmark-l" can-toggle class="ph-wordmark__letter">l</span>
+<div class="ph-sitetitle">
+  <div class="ph-wordmark" translate="no">
+    <a href={siteTitleHref} class="ph-wordmark__home" aria-label="playhtml docs home"
+      ><span class="ph-wordmark__stem">play</span></a
+    ><span id="ph-wordmark-h" can-toggle class="ph-wordmark__letter">h</span
+    ><span id="ph-wordmark-t" can-toggle class="ph-wordmark__letter">t</span
+    ><span id="ph-wordmark-m" can-toggle class="ph-wordmark__letter">m</span
+    ><span id="ph-wordmark-l" can-toggle class="ph-wordmark__letter">l</span>
+  </div>
+  <CrossSiteNav active="docs" />
 </div>
+
+<style>
+  .ph-sitetitle {
+    display: inline-flex;
+    align-items: baseline;
+    min-width: 0;
+  }
+</style>

--- a/apps/docs/src/components/cross-site-links.ts
+++ b/apps/docs/src/components/cross-site-links.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Single source of truth for the cross-site nav link list.
+// ABOUTME: Imported by CrossSiteNav.astro and by Playground.tsx (the React playground shell).
+
+export type SurfaceKey = "home" | "docs" | "play";
+
+export interface CrossSiteLink {
+  key: SurfaceKey;
+  label: string;
+  href: string;
+}
+
+// Link targets follow the production layout (Astro `base: "/docs"` + the website
+// Vite build serving `/`):
+//   home  → `/`              (the website Vite build's root)
+//   docs  → `/docs/`         (Starlight base)
+//   /play → `/docs/play`     (Astro page emitted under the docs base)
+// The label "/play" is the friendly name; the href is the real built path.
+export const crossSiteLinks: CrossSiteLink[] = [
+  { key: "home", label: "home", href: "/" },
+  { key: "docs", label: "docs", href: "/docs/" },
+  { key: "play", label: "/play", href: "/docs/play" },
+];

--- a/apps/docs/src/components/playground/Playground.tsx
+++ b/apps/docs/src/components/playground/Playground.tsx
@@ -12,6 +12,7 @@ import {
   discardDraft,
   pruneStaleDrafts,
 } from "./recipe-loader";
+import { crossSiteLinks } from "../cross-site-links";
 import "./playground.css";
 
 export function Playground() {
@@ -192,10 +193,43 @@ export function Playground() {
   return (
     <div className="ph-play-root">
       <div className="ph-play-topbar">
+        {/* Wordmark visually mirrors the docs SiteTitle (Carter One, 1.55rem,
+            "play" stem links home). The live `can-toggle` letter behavior
+            from docs is intentionally NOT replicated here — playhtml runs
+            inside the preview iframe, not on the /play host page, and adding
+            a second playhtml room just to animate the chrome wordmark would
+            cost a connection without meaningfully changing the surface. The
+            preview iframe owns the live-demo affordance on /play. */}
+        <span className="ph-play-wordmark" translate="no">
+          <a href="/" className="ph-play-wordmark__home" aria-label="playhtml home">
+            <span className="ph-play-wordmark__stem">play</span>
+          </a>
+          <span className="ph-play-wordmark__letter">h</span>
+          <span className="ph-play-wordmark__letter">t</span>
+          <span className="ph-play-wordmark__letter">m</span>
+          <span className="ph-play-wordmark__letter">l</span>
+        </span>
+        <nav className="ph-play-crossnav" aria-label="playhtml sites">
+          {crossSiteLinks.map((link) => (
+            <a
+              key={link.key}
+              href={link.href}
+              className={
+                "ph-play-crossnav__link" +
+                (link.key === "play" ? " is-active" : "")
+              }
+              aria-current={link.key === "play" ? "page" : undefined}
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+        <span className="ph-play-topbar-divider" aria-hidden="true" />
         <span className="ph-play-title">
-          playhtml playground
-          {recipeId !== "_starter" && (
-            <span className="ph-play-title-recipe"> · {recipeId}</span>
+          {recipeId !== "_starter" ? (
+            <span className="ph-play-title-recipe">{recipeId}</span>
+          ) : (
+            <span className="ph-play-title-recipe">starter</span>
           )}
           {isEdited && <span className="ph-play-title-edited"> · edited</span>}
         </span>

--- a/apps/docs/src/components/playground/playground.css
+++ b/apps/docs/src/components/playground/playground.css
@@ -71,7 +71,7 @@ body { background: var(--ph-paper); }
    topbar → pane headers → editor/iframe interior. */
 .ph-play-topbar {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 12px;
   padding: 10px 18px;
   background: var(--ph-sage);
@@ -79,12 +79,94 @@ body { background: var(--ph-paper); }
   flex-shrink: 0;
   font-size: 14px;
 }
+
+/* Wordmark — mirrors the docs SiteTitle exactly so the two surfaces feel
+   like one site. Carter One, ink color, 1.55rem; "play" stem is the home
+   link, each letter in "html" is a `can-toggle`. Mustard glow on toggled
+   letters matches docs. */
+.ph-play-wordmark {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  font-family: "Carter One", var(--ph-font-display);
+  font-size: 1.55rem;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--ph-ink);
+  user-select: none;
+}
+.ph-play-wordmark__home {
+  color: inherit;
+  text-decoration: none;
+  transition: color var(--ph-motion-fast);
+}
+.ph-play-wordmark__home:hover .ph-play-wordmark__stem {
+  color: var(--ph-ultramarine-deep);
+}
+/* Static letters — no can-toggle behavior on /play (see Playground.tsx).
+   Kept as separate spans so the visual rhythm matches the docs wordmark
+   exactly even though they don't animate. */
+.ph-play-wordmark__letter {
+  display: inline-block;
+  color: var(--ph-ink);
+}
+
+/* Cross-site nav. Sits inside the sage topbar between the wordmark and the
+   recipe/edited title. Hairline divider on the right separates nav from
+   the editor's own title content. */
+.ph-play-crossnav {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-left: 14px;
+  padding-left: 14px;
+  border-left: 1px solid var(--ph-hairline);
+  font-family: var(--ph-font-body);
+  font-size: 13px;
+  line-height: 1;
+}
+.ph-play-crossnav__link {
+  color: var(--ph-ink-2);
+  text-decoration: none;
+  padding: 2px 0;
+  border-bottom: 1px solid transparent;
+  transition: color var(--ph-motion-fast);
+}
+.ph-play-crossnav__link:hover {
+  color: var(--ph-ultramarine-deep);
+}
+.ph-play-crossnav__link.is-active {
+  color: var(--ph-ink);
+  border-bottom-color: var(--ph-ultramarine);
+}
+
+/* Vertical hairline between the nav cluster and the recipe/edited indicator.
+   Renders as a 1px ink-tone bar so it reads as a separator without adding
+   visual weight to the sage band. */
+.ph-play-topbar-divider {
+  display: inline-block;
+  width: 1px;
+  height: 18px;
+  background: var(--ph-hairline);
+  margin: 0 4px;
+  align-self: center;
+}
+
 .ph-play-title {
   font-family: var(--ph-font-display);
   font-weight: 700;
   letter-spacing: -0.015em;
   color: var(--ph-ink);
-  font-size: 16px;
+  font-size: 14px;
+}
+
+/* On narrow widths, hide the nav cluster — desktop-first editor.
+   Wordmark + recipe/edited indicator + reset button stay visible. */
+@media (max-width: 600px) {
+  .ph-play-crossnav,
+  .ph-play-topbar-divider {
+    display: none;
+  }
 }
 .ph-play-title-recipe {
   color: var(--ph-ink-3);

--- a/apps/docs/src/pages/play.astro
+++ b/apps/docs/src/pages/play.astro
@@ -1,6 +1,7 @@
 ---
 // ABOUTME: /play route — the live editor + preview playground.
 import { Playground } from "../components/playground/Playground";
+import CrossSiteNav from "../components/CrossSiteNav.astro";
 ---
 <!doctype html>
 <html lang="en">
@@ -22,6 +23,48 @@ import { Playground } from "../components/playground/Playground";
     -->
   </head>
   <body>
+    <header class="ph-play-header">
+      <a href="/" class="ph-play-header__wordmark" aria-label="playhtml home">
+        <span class="ph-play-header__stem">play</span><span class="ph-play-header__letters">html</span>
+      </a>
+      <CrossSiteNav active="play" />
+    </header>
     <Playground client:only="react" />
+
+    <style is:global>
+      .ph-play-header {
+        display: flex;
+        align-items: baseline;
+        gap: 0;
+        padding: 8px 18px;
+        background: var(--ph-paper);
+        border-bottom: 1px solid var(--ph-hairline);
+        flex-shrink: 0;
+        font-family: var(--ph-font-body);
+      }
+      .ph-play-header__wordmark {
+        font-family: var(--ph-font-wordmark, "Carter One", system-ui);
+        font-size: 1.4rem;
+        line-height: 1;
+        color: var(--ph-ink);
+        text-decoration: none;
+        letter-spacing: -0.01em;
+        transition: color var(--ph-motion-fast);
+      }
+      .ph-play-header__wordmark:hover {
+        color: var(--ph-ultramarine-deep);
+      }
+      .ph-play-header__stem,
+      .ph-play-header__letters {
+        display: inline;
+      }
+      /* Account for the new header in the playground's full-viewport layout —
+         .ph-play-root assumes 100vh, which would push the editor below the
+         fold once we add chrome above it. Use dynamic viewport units so
+         mobile browsers' chrome doesn't double-count. */
+      .ph-play-root {
+        height: calc(100dvh - var(--ph-play-header-height, 41px)) !important;
+      }
+    </style>
   </body>
 </html>

--- a/apps/docs/src/pages/play.astro
+++ b/apps/docs/src/pages/play.astro
@@ -1,7 +1,6 @@
 ---
 // ABOUTME: /play route — the live editor + preview playground.
 import { Playground } from "../components/playground/Playground";
-import CrossSiteNav from "../components/CrossSiteNav.astro";
 ---
 <!doctype html>
 <html lang="en">
@@ -23,48 +22,6 @@ import CrossSiteNav from "../components/CrossSiteNav.astro";
     -->
   </head>
   <body>
-    <header class="ph-play-header">
-      <a href="/" class="ph-play-header__wordmark" aria-label="playhtml home">
-        <span class="ph-play-header__stem">play</span><span class="ph-play-header__letters">html</span>
-      </a>
-      <CrossSiteNav active="play" />
-    </header>
     <Playground client:only="react" />
-
-    <style is:global>
-      .ph-play-header {
-        display: flex;
-        align-items: baseline;
-        gap: 0;
-        padding: 8px 18px;
-        background: var(--ph-paper);
-        border-bottom: 1px solid var(--ph-hairline);
-        flex-shrink: 0;
-        font-family: var(--ph-font-body);
-      }
-      .ph-play-header__wordmark {
-        font-family: var(--ph-font-wordmark, "Carter One", system-ui);
-        font-size: 1.4rem;
-        line-height: 1;
-        color: var(--ph-ink);
-        text-decoration: none;
-        letter-spacing: -0.01em;
-        transition: color var(--ph-motion-fast);
-      }
-      .ph-play-header__wordmark:hover {
-        color: var(--ph-ultramarine-deep);
-      }
-      .ph-play-header__stem,
-      .ph-play-header__letters {
-        display: inline;
-      }
-      /* Account for the new header in the playground's full-viewport layout —
-         .ph-play-root assumes 100vh, which would push the editor below the
-         fold once we add chrome above it. Use dynamic viewport units so
-         mobile browsers' chrome doesn't double-count. */
-      .ph-play-root {
-        height: calc(100dvh - var(--ph-play-header-height, 41px)) !important;
-      }
-    </style>
   </body>
 </html>

--- a/apps/docs/src/pages/play.astro
+++ b/apps/docs/src/pages/play.astro
@@ -11,7 +11,7 @@ import { Playground } from "../components/playground/Playground";
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;600;700;800&family=Play:wght@400;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@400;600;700;800&family=Play:wght@400;700&family=IBM+Plex+Mono:wght@400;500;600&family=Carter+One&display=swap"
       rel="stylesheet"
     />
     <!--


### PR DESCRIPTION
## Summary

- Adds a small `home / docs / /play` link cluster to the docs Starlight header (next to the existing live `can-toggle` wordmark).
- Adds a server-rendered header on `/play` with the same link cluster, so the editor surface points back to docs and home.
- Single shared component (`CrossSiteNav.astro`) — one source of truth for the link list and active-state styling.

Home page (`website/index.html`) is intentionally out of scope this round.

The existing `ph-play-topbar` (title, edited indicator, Reset to starter) is untouched and now sits as a tool-row below the new header.

## Files

- `apps/docs/src/components/CrossSiteNav.astro` (new)
- `apps/docs/src/components/SiteTitle.astro` — wraps existing wordmark + adds `<CrossSiteNav active="docs" />`
- `apps/docs/src/pages/play.astro` — adds `<header>` above the React playground mount; adjusts `.ph-play-root` height so the editor stays full-viewport

No changes to `Playground.tsx` or to Starlight's `Header.astro` override map. Search, sidebar, socials, theme toggle, and mobile menu remain exactly as Starlight ships them.

## Notes

- Link `href="/docs/play"` matches the production build path (Astro `base: "/docs"`); the visible label is `/play`.
- Cross-nav hides below 600px on `/play` (desktop-first editor); docs continues to use Starlight's hamburger collapse.

Spec: `internal-docs/specs/2026-04-29-cross-site-nav-design.md` (gitignored).

## Test plan

- [ ] `/docs/getting-started/` renders with `home  docs  /play` cluster next to the wordmark; `docs` is the active link (ultramarine underline)
- [ ] Live `can-toggle` letters in the docs wordmark still toggle
- [ ] `/docs/play` renders the new header above the existing sage topbar; `/play` is the active link
- [ ] Editor and live preview still mount and function in the playground
- [ ] Cross-nav is hidden at viewport < 600px on `/play`
- [ ] No new console errors on either surface