### PR TITLE
Enable Durable Object hibernation

### DIFF
--- a/.changeset/partyserver-hibernation.md
+++ b/.changeset/partyserver-hibernation.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Update the y-partyserver provider dependency used by playhtml.

--- a/bun.lock
+++ b/bun.lock
@@ -8,17 +8,17 @@
         "@supabase/supabase-js": "^2.57.4",
         "canvas-confetti": "^1.9.2",
         "html2canvas": "^1.4.1",
-        "partyserver": "^0.1.0",
+        "partyserver": "^0.5.5",
         "profane-words": "^1.5.11",
         "randomcolor": "^0.6.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "y-partyserver": "^1.0.0",
+        "y-partyserver": "^2.2.0",
         "yjs": "13.6.18",
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.9",
-        "@cloudflare/workers-types": "^4.20230518.0",
+        "@cloudflare/workers-types": "^4.20260424.1",
         "@types/canvas-confetti": "^1.6.4",
         "@types/node": "^20.3.3",
         "@types/randomcolor": "^0.5.9",
@@ -133,7 +133,7 @@
       "dependencies": {
         "@playhtml/common": "workspace:^",
         "@syncedstore/core": "^0.6.0",
-        "y-partyserver": "^1.0.0",
+        "y-partyserver": "^2.2.0",
         "yjs": "13.6.18",
       },
       "devDependencies": {
@@ -312,7 +312,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260409.1", "", { "os": "win32", "cpu": "x64" }, "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260118.0", "", {}, "sha512-t+2Q421kAQqwBzMUDvgg2flp8zFVxOpiAyZPbyNcnPxMDHf0z3B7LqBIVQawwI6ntZinbk9f4oUmaA5bGeYwlg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260505.1", "", {}, "sha512-Uz9D2hcwB4/pdnmCU7RsgknY8TQ5st0cQMMN6h/hvWt1TCt99GUkbi6dMgWdP7jXfIfh+S/EI5zQugI9RZn4Bw=="],
 
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
 
@@ -1704,7 +1704,7 @@
 
     "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
-    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
@@ -1794,7 +1794,7 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
-    "partyserver": ["partyserver@0.1.5", "", { "dependencies": { "nanoid": "^5.1.6" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20240729.0" } }, "sha512-kaE3GYaYWFc70EJQDQEhyYbO2Wczz/NgsFXerfjRo0t2s7ZxL1XggWT+HkMrdEyqbZOv3b66CV93WG0Lcg/ThQ=="],
+    "partyserver": ["partyserver@0.5.5", "", { "dependencies": { "nanoid": "^5.1.9" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260424.1" } }, "sha512-7zub8oV8Od9dY2aXGrgzhX5GLceaWOg7xB5VWXtDcqt2BWVDIOCAgaF0AmBMSu3AXhJHsFdzPnA8SSZdybXMbQ=="],
 
     "path": ["path@0.12.7", "", { "dependencies": { "process": "^0.11.1", "util": "^0.10.3" } }, "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q=="],
 
@@ -2322,7 +2322,7 @@
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
-    "y-partyserver": ["y-partyserver@1.0.0", "", { "dependencies": { "lib0": "^0.2.115", "lodash.debounce": "^4.0.8", "nanoid": "^5.1.6", "y-protocols": "^1.0.7" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20240729.0", "partyserver": "^0.1.0", "yjs": "^13.6.14" } }, "sha512-AeQvBTC1NNwyB7/JmilmSwfD9gdQIm8hRQxO9xmm0JjYFYEZRIzZtM7h3qHD/NVPVjb4N7b7m+A2ARRSPO1mfw=="],
+    "y-partyserver": ["y-partyserver@2.2.0", "", { "dependencies": { "lib0": "^0.2.117", "lodash.debounce": "^4.0.8", "nanoid": "^5.1.9", "y-protocols": "^1.0.7" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260424.1", "partyserver": ">=0.2.0 <1.0.0", "yjs": "^13.6.14" } }, "sha512-AIsTEZ3jPicBe3VHO5c/VdSGSaFr0J9cAGj6+sgRL/RnXLTNSkP3oQXyXf1y8hQNeXv/j9zYDT5NnRv2k1eMGA=="],
 
     "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -179,6 +179,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@playwright/test": "^1.48.0",
+        "ws": "^8.19.0",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.9",
-    "@cloudflare/workers-types": "^4.20230518.0",
+    "@cloudflare/workers-types": "^4.20260424.1",
     "@types/canvas-confetti": "^1.6.4",
     "@types/node": "^20.3.3",
     "@types/randomcolor": "^0.5.9",
@@ -57,12 +57,12 @@
     "@supabase/supabase-js": "^2.57.4",
     "canvas-confetti": "^1.9.2",
     "html2canvas": "^1.4.1",
-    "partyserver": "^0.1.0",
+    "partyserver": "^0.5.5",
     "profane-words": "^1.5.11",
     "randomcolor": "^0.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "y-partyserver": "^1.0.0",
+    "y-partyserver": "^2.2.0",
     "yjs": "13.6.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "smoke:partykit": "cd smoke-tests && bun run test:partykit",
     "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",
     "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",
+    "smoke:partykit:emergency": "cd smoke-tests && bun run test:partykit:emergency",
     "generate-types": "bunx wrangler types --config partykit/wrangler.jsonc --include-runtime=false"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "load-test": "bun load-test/src/runner.ts",
     "load-test:full": "bun load-test/src/runner.ts --config full-suite",
     "smoke": "cd smoke-tests && bun run test",
+    "smoke:partykit": "cd smoke-tests && bun run test:partykit",
+    "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",
+    "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",
     "generate-types": "bunx wrangler types --config partykit/wrangler.jsonc --include-runtime=false"
   },
   "overrides": {

--- a/packages/playhtml/package.json
+++ b/packages/playhtml/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@playhtml/common": "workspace:^",
     "@syncedstore/core": "^0.6.0",
-    "y-partyserver": "^1.0.0",
+    "y-partyserver": "^2.2.0",
     "yjs": "13.6.18"
   }
 }

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   getNextAlarmTime,
+  isCompactionAutosave,
   shouldStoreCompactedDocument,
 } from "../compactionPolicy";
 
@@ -11,6 +12,14 @@ describe("shouldStoreCompactedDocument", () => {
     expect(shouldStoreCompactedDocument(100, 99)).toBe(true);
     expect(shouldStoreCompactedDocument(100, 100)).toBe(false);
     expect(shouldStoreCompactedDocument(100, 101)).toBe(false);
+  });
+});
+
+describe("isCompactionAutosave", () => {
+  it("matches only the compacted snapshot autosave", () => {
+    expect(isCompactionAutosave("snapshot-a", "snapshot-a")).toBe(true);
+    expect(isCompactionAutosave("snapshot-b", "snapshot-a")).toBe(false);
+    expect(isCompactionAutosave("snapshot-a", null)).toBe(false);
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "bun:test";
 import {
   getNextAlarmTime,
   isCompactionAutosave,
+  shouldCheckEmergencyCompaction,
+  shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "../compactionPolicy";
 
@@ -20,6 +22,82 @@ describe("isCompactionAutosave", () => {
     expect(isCompactionAutosave("snapshot-a", "snapshot-a")).toBe(true);
     expect(isCompactionAutosave("snapshot-b", "snapshot-a")).toBe(false);
     expect(isCompactionAutosave("snapshot-a", null)).toBe(false);
+  });
+});
+
+describe("shouldCheckEmergencyCompaction", () => {
+  it("only runs the expensive check after the size threshold and cooldown", () => {
+    expect(
+      shouldCheckEmergencyCompaction({
+        documentSize: 999,
+        thresholdBytes: 1_000,
+        nextCheckAt: null,
+        now: 5_000,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldCheckEmergencyCompaction({
+        documentSize: 1_000,
+        thresholdBytes: 1_000,
+        nextCheckAt: 6_000,
+        now: 5_000,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldCheckEmergencyCompaction({
+        documentSize: 1_000,
+        thresholdBytes: 1_000,
+        nextCheckAt: 5_000,
+        now: 5_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldCheckEmergencyCompaction({
+        documentSize: 1_000,
+        thresholdBytes: 1_000,
+        nextCheckAt: null,
+        now: 5_000,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("shouldUseEmergencyCompactedDocument", () => {
+  it("requires compaction to move a large room below threshold or save meaningful space", () => {
+    expect(
+      shouldUseEmergencyCompactedDocument({
+        beforeSize: 1_200,
+        afterSize: 900,
+        thresholdBytes: 1_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldUseEmergencyCompactedDocument({
+        beforeSize: 2_000,
+        afterSize: 1_700,
+        thresholdBytes: 1_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldUseEmergencyCompactedDocument({
+        beforeSize: 2_000,
+        afterSize: 1_900,
+        thresholdBytes: 1_000,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldUseEmergencyCompactedDocument({
+        beforeSize: 2_000,
+        afterSize: 2_000,
+        thresholdBytes: 1_000,
+      })
+    ).toBe(false);
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -1,0 +1,70 @@
+// ABOUTME: Verifies pure scheduling and snapshot decisions for PartyServer compaction.
+// ABOUTME: Keeps hibernation-safe compaction rules testable outside Cloudflare runtime.
+import { describe, expect, it } from "bun:test";
+import {
+  getNextAlarmTime,
+  shouldStoreCompactedDocument,
+} from "../compactionPolicy";
+
+describe("shouldStoreCompactedDocument", () => {
+  it("only stores compacted snapshots that reduce document size", () => {
+    expect(shouldStoreCompactedDocument(100, 99)).toBe(true);
+    expect(shouldStoreCompactedDocument(100, 100)).toBe(false);
+    expect(shouldStoreCompactedDocument(100, 101)).toBe(false);
+  });
+});
+
+describe("getNextAlarmTime", () => {
+  it("returns null when no compaction or bridge lease work is pending", () => {
+    expect(
+      getNextAlarmTime({
+        compactAfter: null,
+        hasBridgeLeases: false,
+        now: 1_000,
+        pruneIntervalMs: 10_000,
+      })
+    ).toBe(null);
+  });
+
+  it("uses the pending compaction time when only compaction is pending", () => {
+    expect(
+      getNextAlarmTime({
+        compactAfter: 5_000,
+        hasBridgeLeases: false,
+        now: 1_000,
+        pruneIntervalMs: 10_000,
+      })
+    ).toBe(5_000);
+  });
+
+  it("uses the next prune time when only bridge lease work is pending", () => {
+    expect(
+      getNextAlarmTime({
+        compactAfter: null,
+        hasBridgeLeases: true,
+        now: 1_000,
+        pruneIntervalMs: 10_000,
+      })
+    ).toBe(11_000);
+  });
+
+  it("uses the earliest time when compaction and bridge lease work are both pending", () => {
+    expect(
+      getNextAlarmTime({
+        compactAfter: 5_000,
+        hasBridgeLeases: true,
+        now: 1_000,
+        pruneIntervalMs: 10_000,
+      })
+    ).toBe(5_000);
+
+    expect(
+      getNextAlarmTime({
+        compactAfter: 20_000,
+        hasBridgeLeases: true,
+        now: 1_000,
+        pruneIntervalMs: 10_000,
+      })
+    ).toBe(11_000);
+  });
+});

--- a/partykit/__tests__/resetEpochPolicy.test.ts
+++ b/partykit/__tests__/resetEpochPolicy.test.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Verifies reset-epoch parsing and stale-boundary decisions for PartyServer.
+// ABOUTME: Covers malformed client epochs that must not bypass room reset enforcement.
+import { describe, expect, it } from "bun:test";
+import { isResetEpochStale, parseClientResetEpoch } from "../resetEpochPolicy";
+
+describe("parseClientResetEpoch", () => {
+  it("parses finite numeric epoch params", () => {
+    expect(parseClientResetEpoch("1710000000000")).toBe(1710000000000);
+    expect(parseClientResetEpoch("0")).toBe(0);
+  });
+
+  it("treats missing or malformed params as absent", () => {
+    expect(parseClientResetEpoch(null)).toBe(null);
+    expect(parseClientResetEpoch("")).toBe(null);
+    expect(parseClientResetEpoch("bad")).toBe(null);
+    expect(parseClientResetEpoch("123bad")).toBe(null);
+    expect(parseClientResetEpoch("Infinity")).toBe(null);
+  });
+});
+
+describe("isResetEpochStale", () => {
+  it("requires a current client epoch once the room has a reset epoch", () => {
+    expect(isResetEpochStale(null, null)).toBe(false);
+    expect(isResetEpochStale(null, 100)).toBe(true);
+    expect(isResetEpochStale(99, 100)).toBe(true);
+    expect(isResetEpochStale(100, 100)).toBe(false);
+    expect(isResetEpochStale(101, 100)).toBe(false);
+  });
+});

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -7,6 +7,16 @@ export function shouldStoreCompactedDocument(
   return afterSize < beforeSize;
 }
 
+export function isCompactionAutosave(
+  documentBase64: string,
+  compactionSnapshotBase64: string | null
+): boolean {
+  return (
+    compactionSnapshotBase64 !== null &&
+    documentBase64 === compactionSnapshotBase64
+  );
+}
+
 export function getNextAlarmTime({
   compactAfter,
   hasBridgeLeases,

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -17,6 +17,54 @@ export function isCompactionAutosave(
   );
 }
 
+// Emergency compaction protects rooms that stay continuously connected and
+// therefore never reach the empty-room compaction path. The check is split in
+// two parts: this cheap predicate runs on every autosave using the encoded
+// size we already computed, and only lets the expensive Y.Doc rebuild happen
+// after the high-watermark threshold and cooldown allow it.
+export function shouldCheckEmergencyCompaction({
+  documentSize,
+  thresholdBytes,
+  nextCheckAt,
+  now,
+}: {
+  documentSize: number;
+  thresholdBytes: number;
+  nextCheckAt: number | null;
+  now: number;
+}): boolean {
+  if (documentSize < thresholdBytes) {
+    return false;
+  }
+
+  return nextCheckAt === null || nextCheckAt <= now;
+}
+
+// A connected-room emergency reset is disruptive because clients must reload
+// into a fresh Yjs history. Do it only when the compacted snapshot either gets
+// back under the high-watermark threshold or saves at least 25% of that
+// threshold. The percentage is derived from the threshold so staging can lower
+// one setting for smoke tests without needing a separate reduction constant.
+export function shouldUseEmergencyCompactedDocument({
+  beforeSize,
+  afterSize,
+  thresholdBytes,
+}: {
+  beforeSize: number;
+  afterSize: number;
+  thresholdBytes: number;
+}): boolean {
+  if (!shouldStoreCompactedDocument(beforeSize, afterSize)) {
+    return false;
+  }
+
+  if (afterSize < thresholdBytes) {
+    return true;
+  }
+
+  return beforeSize - afterSize >= thresholdBytes / 4;
+}
+
 export function getNextAlarmTime({
   compactAfter,
   hasBridgeLeases,

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Provides pure policy helpers for PartyServer document compaction.
+// ABOUTME: Keeps alarm selection and compaction commit decisions deterministic and testable.
+export function shouldStoreCompactedDocument(
+  beforeSize: number,
+  afterSize: number
+): boolean {
+  return afterSize < beforeSize;
+}
+
+export function getNextAlarmTime({
+  compactAfter,
+  hasBridgeLeases,
+  now,
+  pruneIntervalMs,
+}: {
+  compactAfter: number | null;
+  hasBridgeLeases: boolean;
+  now: number;
+  pruneIntervalMs: number;
+}): number | null {
+  const candidates: number[] = [];
+
+  if (compactAfter !== null) {
+    candidates.push(compactAfter);
+  }
+
+  if (hasBridgeLeases) {
+    candidates.push(now + pruneIntervalMs);
+  }
+
+  if (!candidates.length) {
+    return null;
+  }
+
+  return Math.min(...candidates);
+}

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -11,6 +11,9 @@ export const STORAGE_KEYS = {
   resetEpoch: "resetEpoch",
   // Stores a timestamp after which an empty room can compact its Y.Doc history
   emptyRoomCompactAfter: "emptyRoomCompactAfter",
+  // Stores the next time a connected large room should pay the expensive
+  // compactability check
+  emergencyCompactCheckAfter: "emergencyCompactCheckAfter",
 };
 // Subscriber lease configuration (default 12 hours)
 export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
@@ -24,6 +27,15 @@ export const DEFAULT_PRUNE_INTERVAL_MS = (() => {
 // Empty-room compaction waits so transient reconnects do not trigger reloads.
 export const DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS = (() => {
   return 60 * 1000 * 5;
+})();
+// Connected rooms compact only as a high-watermark safety valve. The size check
+// itself is cheap because autosave already has the encoded document, but the
+// compactability check walks and rebuilds the Y.Doc, so it is rate-limited.
+export const DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES = (() => {
+  return 1024 * 1024 * 16;
+})();
+export const DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS = (() => {
+  return 60 * 60 * 1000;
 })();
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Defines storage keys, timing constants, and shared bridge types for PartyServer.
+// ABOUTME: Keeps Durable Object room metadata and lease timing consistent across modules.
 // Storage key constants for consistency
 export const STORAGE_KEYS = {
   // Stores consumer room ids and the elementIds they are interested in
@@ -7,6 +9,8 @@ export const STORAGE_KEYS = {
   sharedPermissions: "sharedPermissions",
   // Stores the reset epoch timestamp to detect when a room was reset
   resetEpoch: "resetEpoch",
+  // Stores a timestamp after which an empty room can compact its Y.Doc history
+  emptyRoomCompactAfter: "emptyRoomCompactAfter",
 };
 // Subscriber lease configuration (default 12 hours)
 export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
@@ -16,6 +20,10 @@ export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
 // https://docs.partykit.io/guides/scheduling-tasks-with-alarms/
 export const DEFAULT_PRUNE_INTERVAL_MS = (() => {
   return 60 * 60 * 1000 * 4;
+})();
+// Empty-room compaction waits so transient reconnects do not trigger reloads.
+export const DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS = (() => {
+  return 60 * 1000 * 5;
 })();
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -21,6 +21,8 @@ import {
 import {
   STORAGE_KEYS,
   DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
+  DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
+  DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
   ORIGIN_S2C,
@@ -48,6 +50,8 @@ import {
 import {
   getNextAlarmTime,
   isCompactionAutosave,
+  shouldCheckEmergencyCompaction,
+  shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
 
@@ -61,6 +65,23 @@ function internalRequest(path: string, body: unknown): Request {
   });
 }
 
+function readPositiveNumberEnv(name: string, fallback: number): number {
+  const value = (env as unknown as Record<string, string | undefined>)[name];
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  console.warn(
+    `[PartyServer] Ignoring invalid numeric env ${name}=${value}; using ${fallback}`
+  );
+  return fallback;
+}
+
 export class PartyServer extends YServer {
   static options = {
     hibernate: true,
@@ -71,7 +92,7 @@ export class PartyServer extends YServer {
   // in-memory state while we are performing a reset.
   public isSkippingSave = false;
   private emptyRoomCompactionPromise: Promise<void> | null = null;
-  private emptyRoomCompactionAutosaveSnapshot: string | null = null;
+  private compactionAutosaveSnapshot: string | null = null;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -164,6 +185,36 @@ export class PartyServer extends YServer {
     await this.ctx.storage.delete(STORAGE_KEYS.emptyRoomCompactAfter);
   }
 
+  private async getEmergencyCompactCheckAfter(): Promise<number | null> {
+    const value = await this.ctx.storage.get(
+      STORAGE_KEYS.emergencyCompactCheckAfter
+    );
+    return typeof value === "number" ? value : null;
+  }
+
+  private async setEmergencyCompactCheckAfter(
+    timestamp: number
+  ): Promise<void> {
+    await this.ctx.storage.put(
+      STORAGE_KEYS.emergencyCompactCheckAfter,
+      timestamp
+    );
+  }
+
+  private getEmergencyCompactCheckBytes(): number {
+    return readPositiveNumberEnv(
+      "EMERGENCY_COMPACT_CHECK_BYTES",
+      DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES
+    );
+  }
+
+  private getEmergencyCompactRecheckDelayMs(): number {
+    return readPositiveNumberEnv(
+      "EMERGENCY_COMPACT_RECHECK_DELAY_MS",
+      DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS
+    );
+  }
+
   private async waitForEmptyRoomCompaction(): Promise<void> {
     const pending = this.emptyRoomCompactionPromise;
     if (pending) {
@@ -171,9 +222,9 @@ export class PartyServer extends YServer {
     }
   }
 
-  private consumeEmptyRoomCompactionAutosave(documentBase64: string): boolean {
-    const compactionSnapshot = this.emptyRoomCompactionAutosaveSnapshot;
-    this.emptyRoomCompactionAutosaveSnapshot = null;
+  private consumeCompactionAutosave(documentBase64: string): boolean {
+    const compactionSnapshot = this.compactionAutosaveSnapshot;
+    this.compactionAutosaveSnapshot = null;
     return isCompactionAutosave(documentBase64, compactionSnapshot);
   }
 
@@ -710,11 +761,13 @@ export class PartyServer extends YServer {
         resetEpoch: serverResetEpoch,
       });
       this.sendCustomMessage(connection, resetMessage);
+      // The WebSocket has already been accepted by PartyServer, so closing it
+      // is part of enforcing the reset boundary.
+      connection.close(4000, "Room Reset");
       console.log(
-        `[PartyServer] Sent room-reset message to connectionId=${connectionId}, returning early (no Y.js sync). Client will reload and reconnect.`
+        `[PartyServer] Sent room-reset message to connectionId=${connectionId} and closed stale connection. Client will reload and reconnect.`
       );
       // Don't proceed with normal Y.js connection setup
-      // Client will reload after receiving the message, closing the connection naturally
       return;
     }
 
@@ -880,15 +933,147 @@ export class PartyServer extends YServer {
       console.log(`[PartyServer] Autosave succeeded for room ${this.name}`);
     }
 
-    if (!error && activeConnectionCount === 0) {
-      if (this.consumeEmptyRoomCompactionAutosave(documentBase64)) {
+    if (!error) {
+      if (this.consumeCompactionAutosave(documentBase64)) {
         console.log(
-          `[PartyServer] Empty-room compaction autosave completed: room=${this.name}`
+          `[PartyServer] Compaction autosave completed: room=${this.name}`
         );
         return;
       }
+    }
 
+    if (!error && activeConnectionCount > 0) {
+      const compacted = await this.maybeCompactLargeConnectedRoom({
+        documentSize,
+        now: Date.now(),
+      });
+      if (compacted) {
+        return;
+      }
+    }
+
+    if (!error && activeConnectionCount === 0) {
       await this.scheduleEmptyRoomCompaction();
+    }
+  }
+
+  private async maybeCompactLargeConnectedRoom({
+    documentSize,
+    now,
+  }: {
+    documentSize: number;
+    now: number;
+  }): Promise<boolean> {
+    const thresholdBytes = this.getEmergencyCompactCheckBytes();
+    const nextCheckAt = await this.getEmergencyCompactCheckAfter();
+
+    if (
+      !shouldCheckEmergencyCompaction({
+        documentSize,
+        thresholdBytes,
+        nextCheckAt,
+        now,
+      })
+    ) {
+      return false;
+    }
+
+    const recheckAfter = now + this.getEmergencyCompactRecheckDelayMs();
+
+    // Connected rooms normally keep raw Yjs history so hibernated clients can
+    // resume without merging against a rewritten snapshot. This path is the
+    // exception: once a never-empty room crosses the high-watermark threshold,
+    // the server pays the expensive docToJson/jsonToDoc/encode check at most
+    // once per cooldown window. If compaction is useful, it is enforced as a
+    // reset boundary by broadcasting room-reset and closing active sockets.
+    // That disruption is intentional because silently replacing Yjs history
+    // while clients are connected can merge stale client history back into the
+    // room. If compaction is not useful, the cooldown prevents every later
+    // autosave of a naturally large document from rebuilding the whole Y.Doc.
+    const liveYDoc = this.document;
+    const currentPlayData = docToJson(liveYDoc);
+    if (!currentPlayData) {
+      await this.setEmergencyCompactCheckAfter(recheckAfter);
+      return false;
+    }
+
+    const resetEpoch = Date.now();
+    const compactDoc = jsonToDoc(currentPlayData);
+    setDocResetEpoch(compactDoc, resetEpoch);
+    const compactBase64 = encodeDocToBase64(compactDoc);
+    const compactSize = compactBase64.length;
+
+    if (
+      !shouldUseEmergencyCompactedDocument({
+        beforeSize: documentSize,
+        afterSize: compactSize,
+        thresholdBytes,
+      })
+    ) {
+      await this.setEmergencyCompactCheckAfter(recheckAfter);
+      console.log(
+        `[PartyServer] Emergency compaction skipped: room=${this.name}, ${documentSize} -> ${compactSize} bytes, nextCheckAt=${recheckAfter}`
+      );
+      return false;
+    }
+
+    this.isSkippingSave = true;
+    const rollbackResetEpoch = await this.getResetEpoch();
+    let compactedDocumentSaved = false;
+
+    try {
+      await this.setResetEpoch(resetEpoch);
+
+      const { error } = await supabase.from("documents").upsert(
+        {
+          name: this.name,
+          document: compactBase64,
+        },
+        { onConflict: "name" }
+      );
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      compactedDocumentSaved = true;
+      this.compactionAutosaveSnapshot = compactBase64;
+      replaceDocFromSnapshot(liveYDoc, compactBase64);
+      await this.setEmergencyCompactCheckAfter(recheckAfter);
+      await this.clearEmptyRoomCompactAfter();
+
+      const resetMessage = JSON.stringify({
+        type: "room-reset",
+        timestamp: resetEpoch,
+        resetEpoch,
+      });
+      this.broadcastCustomMessage(resetMessage);
+
+      const connections = [...this.getConnections()];
+      connections.forEach((conn) => {
+        try {
+          conn.close(4000, "Room Compacted");
+        } catch (error) {
+          console.error("[PartyServer] Failed to close connection:", error);
+        }
+      });
+
+      console.log(
+        `[PartyServer] Emergency compacted connected room: room=${this.name}, ${documentSize} -> ${compactSize} bytes (${((1 - compactSize / documentSize) * 100).toFixed(1)}% reduction), resetEpoch=${resetEpoch}, closed=${connections.length}`
+      );
+      return true;
+    } catch (error) {
+      if (!compactedDocumentSaved) {
+        if (rollbackResetEpoch === null) {
+          await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
+        } else {
+          await this.setResetEpoch(rollbackResetEpoch);
+        }
+      }
+      this.compactionAutosaveSnapshot = null;
+      throw error;
+    } finally {
+      this.isSkippingSave = false;
     }
   }
 
@@ -1390,7 +1575,7 @@ export class PartyServer extends YServer {
         }
 
         compactedDocumentSaved = true;
-        this.emptyRoomCompactionAutosaveSnapshot = compactBase64;
+        this.compactionAutosaveSnapshot = compactBase64;
         replaceDocFromSnapshot(liveYDoc, compactBase64);
         await this.clearEmptyRoomCompactAfter();
 
@@ -1405,7 +1590,7 @@ export class PartyServer extends YServer {
             await this.setResetEpoch(rollbackResetEpoch);
           }
         }
-        this.emptyRoomCompactionAutosaveSnapshot = null;
+        this.compactionAutosaveSnapshot = null;
         throw error;
       } finally {
         this.isSkippingSave = false;

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -804,7 +804,7 @@ export class PartyServer extends YServer {
       `[PartyServer] Autosave: room=${this.name}, size=${documentSize} bytes (${(documentSize / 1024 / 1024).toFixed(2)} MB), resetEpoch=${docResetEpoch ?? serverResetEpoch ?? "none"}`
     );
 
-    // Save the compacted document to the database
+    // Save the document to the database
     const { data: _data, error } = await supabase.from("documents").upsert(
       {
         name: this.name,

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -772,32 +772,32 @@ export class PartyServer extends YServer {
       return;
     }
 
-    // Compact the doc before saving: rebuild from current JSON state to
-    // strip CRDT history and tombstones. This keeps the stored doc minimal
-    // so that cold-loading it on DO restart never exceeds the 128MB memory limit.
+    // Active WebSockets can survive hibernation with their existing Yjs history.
+    // Persist that same history while connections are present so wake-up sync
+    // merges against an equivalent base document.
     const rawSize = Y.encodeStateAsUpdate(doc).byteLength;
+    const activeConnectionCount = Array.from(this.getConnections()).length;
     const currentPlayData = docToJson(doc);
-    let compactedBase64: string;
+    let documentBase64: string;
 
-    if (currentPlayData) {
+    if (currentPlayData && activeConnectionCount === 0) {
       const compactDoc = jsonToDoc(currentPlayData);
       setDocResetEpoch(
         compactDoc,
         docResetEpoch ?? serverResetEpoch ?? Date.now()
       );
-      compactedBase64 = encodeDocToBase64(compactDoc);
-      const compactedSize = Math.ceil((compactedBase64.length * 3) / 4);
+      documentBase64 = encodeDocToBase64(compactDoc);
+      const compactedSize = Math.ceil((documentBase64.length * 3) / 4);
       if (compactedSize < rawSize) {
         console.log(
           `[PartyServer] Compacted: room=${this.name}, ${rawSize} -> ${compactedSize} bytes (${((1 - compactedSize / rawSize) * 100).toFixed(1)}% reduction)`
         );
       }
     } else {
-      // Doc is empty — just encode as-is
-      compactedBase64 = encodeDocToBase64(doc);
+      documentBase64 = encodeDocToBase64(doc);
     }
 
-    const documentSize = compactedBase64.length;
+    const documentSize = documentBase64.length;
 
     // Log structured information about the save
     console.log(
@@ -808,7 +808,7 @@ export class PartyServer extends YServer {
     const { data: _data, error } = await supabase.from("documents").upsert(
       {
         name: this.name,
-        document: compactedBase64,
+        document: documentBase64,
       },
       { onConflict: "name" }
     );

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -54,6 +54,13 @@ import {
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
+import { isResetEpochStale, parseClientResetEpoch } from "./resetEpochPolicy";
+
+const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
+
+type ResetEpochConnectionState = Record<string, unknown> & {
+  [ACCEPTED_RESET_EPOCH_STATE_KEY]?: number | null;
+};
 
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
 // The URL is synthetic — the target server's onRequest reads the body, not the path.
@@ -93,6 +100,7 @@ export class PartyServer extends YServer {
   public isSkippingSave = false;
   private emptyRoomCompactionPromise: Promise<void> | null = null;
   private compactionAutosaveSnapshot: string | null = null;
+  private cachedResetEpoch: number | null | undefined;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -229,11 +237,74 @@ export class PartyServer extends YServer {
   }
 
   async getResetEpoch(): Promise<number | null> {
-    return (await this.ctx.storage.get(STORAGE_KEYS.resetEpoch)) || null;
+    if (this.cachedResetEpoch !== undefined) {
+      return this.cachedResetEpoch;
+    }
+
+    const value = await this.ctx.storage.get(STORAGE_KEYS.resetEpoch);
+    this.cachedResetEpoch = typeof value === "number" ? value : null;
+    return this.cachedResetEpoch;
   }
 
   async setResetEpoch(epoch: number): Promise<void> {
-    await this.ctx.storage.put(STORAGE_KEYS.resetEpoch, epoch);
+    this.cachedResetEpoch = epoch;
+    try {
+      await this.ctx.storage.put(STORAGE_KEYS.resetEpoch, epoch);
+    } catch (error) {
+      this.cachedResetEpoch = undefined;
+      throw error;
+    }
+  }
+
+  private async clearResetEpoch(): Promise<void> {
+    this.cachedResetEpoch = null;
+    try {
+      await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
+    } catch (error) {
+      this.cachedResetEpoch = undefined;
+      throw error;
+    }
+  }
+
+  private setConnectionAcceptedResetEpoch(
+    connection: Party.Connection,
+    resetEpoch: number | null
+  ): void {
+    const resetConnection =
+      connection as Party.Connection<ResetEpochConnectionState>;
+    resetConnection.setState((previousState) => {
+      const state =
+        previousState && typeof previousState === "object" ? previousState : {};
+      return {
+        ...(state as Record<string, unknown>),
+        [ACCEPTED_RESET_EPOCH_STATE_KEY]: resetEpoch,
+      };
+    });
+  }
+
+  private getConnectionAcceptedResetEpoch(
+    connection: Party.Connection
+  ): number | null {
+    const state = (connection as Party.Connection<ResetEpochConnectionState>)
+      .state;
+    const value = state?.[ACCEPTED_RESET_EPOCH_STATE_KEY];
+    return typeof value === "number" && Number.isFinite(value) ? value : null;
+  }
+
+  private sendRoomResetAndClose(
+    connection: Party.Connection,
+    resetEpoch: number,
+    reason: string
+  ): void {
+    this.sendCustomMessage(
+      connection,
+      JSON.stringify({
+        type: "room-reset",
+        timestamp: resetEpoch,
+        resetEpoch,
+      })
+    );
+    connection.close(4000, reason);
   }
 
   /**
@@ -252,10 +323,7 @@ export class PartyServer extends YServer {
     candidateEpoch: number | null,
     serverEpoch: number | null
   ): boolean {
-    return (
-      serverEpoch !== null &&
-      (candidateEpoch === null || candidateEpoch < serverEpoch)
-    );
+    return isResetEpochStale(candidateEpoch, serverEpoch);
   }
 
   /**
@@ -715,10 +783,7 @@ export class PartyServer extends YServer {
     let serverResetEpoch: number | null = null;
     try {
       const clientResetEpochParam = url.searchParams.get("clientResetEpoch");
-      const clientResetEpoch =
-        clientResetEpochParam !== null
-          ? parseInt(clientResetEpochParam, 10)
-          : null;
+      const clientResetEpoch = parseClientResetEpoch(clientResetEpochParam);
 
       serverResetEpoch = await this.getResetEpoch();
 
@@ -755,21 +820,17 @@ export class PartyServer extends YServer {
       console.log(
         `[PartyServer] Rejecting stale client connection (connectionId=${connectionId}), sending room-reset message with epoch=${serverResetEpoch}`
       );
-      const resetMessage = JSON.stringify({
-        type: "room-reset",
-        timestamp: serverResetEpoch,
-        resetEpoch: serverResetEpoch,
-      });
-      this.sendCustomMessage(connection, resetMessage);
       // The WebSocket has already been accepted by PartyServer, so closing it
       // is part of enforcing the reset boundary.
-      connection.close(4000, "Room Reset");
+      this.sendRoomResetAndClose(connection, serverResetEpoch, "Room Reset");
       console.log(
         `[PartyServer] Sent room-reset message to connectionId=${connectionId} and closed stale connection. Client will reload and reconnect.`
       );
       // Don't proceed with normal Y.js connection setup
       return;
     }
+
+    this.setConnectionAcceptedResetEpoch(connection, serverResetEpoch);
 
     console.log(
       `[PartyServer] Proceeding with normal Y.js connection setup for connectionId=${connectionId}`
@@ -809,6 +870,31 @@ export class PartyServer extends YServer {
     }
 
     await super.onConnect(connection, ctx);
+  }
+
+  override async onMessage(
+    connection: Party.Connection,
+    message: Party.WSMessage
+  ): Promise<void> {
+    const serverResetEpoch = await this.getResetEpoch();
+    const connectionResetEpoch =
+      this.getConnectionAcceptedResetEpoch(connection);
+
+    // A reset can happen while an accepted socket is still closing. Reject
+    // messages from sockets accepted under earlier history before y-partyserver
+    // can merge them into the compacted Y.Doc.
+    if (
+      serverResetEpoch !== null &&
+      this.isEpochStale(connectionResetEpoch, serverResetEpoch)
+    ) {
+      console.warn(
+        `[PartyServer] Closing stale socket message: connectionId=${connection.id}, client=${connectionResetEpoch}, server=${serverResetEpoch}`
+      );
+      this.sendRoomResetAndClose(connection, serverResetEpoch, "Room Reset");
+      return;
+    }
+
+    await super.onMessage(connection, message);
   }
 
   override async onClose(
@@ -1065,7 +1151,7 @@ export class PartyServer extends YServer {
     } catch (error) {
       if (!compactedDocumentSaved) {
         if (rollbackResetEpoch === null) {
-          await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
+          await this.clearResetEpoch();
         } else {
           await this.setResetEpoch(rollbackResetEpoch);
         }
@@ -1585,7 +1671,7 @@ export class PartyServer extends YServer {
       } catch (error) {
         if (!compactedDocumentSaved) {
           if (rollbackResetEpoch === null) {
-            await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
+            await this.clearResetEpoch();
           } else {
             await this.setResetEpoch(rollbackResetEpoch);
           }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -47,6 +47,7 @@ import {
 } from "./sharing";
 import {
   getNextAlarmTime,
+  isCompactionAutosave,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
 
@@ -70,6 +71,7 @@ export class PartyServer extends YServer {
   // in-memory state while we are performing a reset.
   public isSkippingSave = false;
   private emptyRoomCompactionPromise: Promise<void> | null = null;
+  private emptyRoomCompactionAutosaveSnapshot: string | null = null;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -167,6 +169,12 @@ export class PartyServer extends YServer {
     if (pending) {
       await pending;
     }
+  }
+
+  private consumeEmptyRoomCompactionAutosave(documentBase64: string): boolean {
+    const compactionSnapshot = this.emptyRoomCompactionAutosaveSnapshot;
+    this.emptyRoomCompactionAutosaveSnapshot = null;
+    return isCompactionAutosave(documentBase64, compactionSnapshot);
   }
 
   async getResetEpoch(): Promise<number | null> {
@@ -873,6 +881,13 @@ export class PartyServer extends YServer {
     }
 
     if (!error && activeConnectionCount === 0) {
+      if (this.consumeEmptyRoomCompactionAutosave(documentBase64)) {
+        console.log(
+          `[PartyServer] Empty-room compaction autosave completed: room=${this.name}`
+        );
+        return;
+      }
+
       await this.scheduleEmptyRoomCompaction();
     }
   }
@@ -1375,8 +1390,8 @@ export class PartyServer extends YServer {
         }
 
         compactedDocumentSaved = true;
+        this.emptyRoomCompactionAutosaveSnapshot = compactBase64;
         replaceDocFromSnapshot(liveYDoc, compactBase64);
-        setDocResetEpoch(liveYDoc, resetEpoch);
         await this.clearEmptyRoomCompactAfter();
 
         console.log(
@@ -1390,6 +1405,7 @@ export class PartyServer extends YServer {
             await this.setResetEpoch(rollbackResetEpoch);
           }
         }
+        this.emptyRoomCompactionAutosaveSnapshot = null;
         throw error;
       } finally {
         this.isSkippingSave = false;

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -62,6 +62,19 @@ type ResetEpochConnectionState = Record<string, unknown> & {
   [ACCEPTED_RESET_EPOCH_STATE_KEY]?: number | null;
 };
 
+type CompactedDocument = {
+  base64: string;
+  beforeSize: number;
+  afterSize: number;
+  resetEpoch: number;
+};
+
+type CommitCompactedDocumentOptions = {
+  compactedDocument: CompactedDocument;
+  beforeCommit?: () => Promise<boolean>;
+  afterReplace?: () => Promise<void>;
+};
+
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
 // The URL is synthetic — the target server's onRequest reads the body, not the path.
 function internalRequest(path: string, body: unknown): Request {
@@ -236,6 +249,79 @@ export class PartyServer extends YServer {
     return isCompactionAutosave(documentBase64, compactionSnapshot);
   }
 
+  private buildCompactedDocument(doc: Y.Doc): CompactedDocument | null {
+    const currentPlayData = docToJson(doc);
+    if (!currentPlayData) {
+      return null;
+    }
+
+    const beforeSize = encodeDocToBase64(doc).length;
+    const resetEpoch = Date.now();
+    const compactDoc = jsonToDoc(currentPlayData);
+    setDocResetEpoch(compactDoc, resetEpoch);
+    const base64 = encodeDocToBase64(compactDoc);
+
+    return {
+      base64,
+      beforeSize,
+      afterSize: base64.length,
+      resetEpoch,
+    };
+  }
+
+  private async restoreResetEpoch(resetEpoch: number | null): Promise<void> {
+    if (resetEpoch === null) {
+      await this.clearResetEpoch();
+      return;
+    }
+
+    await this.setResetEpoch(resetEpoch);
+  }
+
+  private async commitCompactedDocument({
+    compactedDocument,
+    beforeCommit,
+    afterReplace,
+  }: CommitCompactedDocumentOptions): Promise<boolean> {
+    this.isSkippingSave = true;
+    const rollbackResetEpoch = await this.getResetEpoch();
+    let documentSaved = false;
+
+    try {
+      if (beforeCommit && !(await beforeCommit())) {
+        return false;
+      }
+
+      await this.setResetEpoch(compactedDocument.resetEpoch);
+
+      const { error } = await supabase.from("documents").upsert(
+        {
+          name: this.name,
+          document: compactedDocument.base64,
+        },
+        { onConflict: "name" }
+      );
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      documentSaved = true;
+      this.compactionAutosaveSnapshot = compactedDocument.base64;
+      replaceDocFromSnapshot(this.document, compactedDocument.base64);
+      await afterReplace?.();
+      return true;
+    } catch (error) {
+      if (!documentSaved) {
+        await this.restoreResetEpoch(rollbackResetEpoch);
+      }
+      this.compactionAutosaveSnapshot = null;
+      throw error;
+    } finally {
+      this.isSkippingSave = false;
+    }
+  }
+
   async getResetEpoch(): Promise<number | null> {
     if (this.cachedResetEpoch !== undefined) {
       return this.cachedResetEpoch;
@@ -291,20 +377,33 @@ export class PartyServer extends YServer {
     return typeof value === "number" && Number.isFinite(value) ? value : null;
   }
 
+  private getRoomResetMessage(resetEpoch: number): string {
+    return JSON.stringify({
+      type: "room-reset",
+      timestamp: resetEpoch,
+      resetEpoch,
+    });
+  }
+
   private sendRoomResetAndClose(
     connection: Party.Connection,
     resetEpoch: number,
     reason: string
   ): void {
-    this.sendCustomMessage(
-      connection,
-      JSON.stringify({
-        type: "room-reset",
-        timestamp: resetEpoch,
-        resetEpoch,
-      })
-    );
+    this.sendCustomMessage(connection, this.getRoomResetMessage(resetEpoch));
     connection.close(4000, reason);
+  }
+
+  private closeConnections(reason: string): number {
+    const connections = [...this.getConnections()];
+    connections.forEach((conn) => {
+      try {
+        conn.close(4000, reason);
+      } catch (error) {
+        console.error("[PartyServer] Failed to close connection:", error);
+      }
+    });
+    return connections.length;
   }
 
   /**
@@ -407,28 +506,15 @@ export class PartyServer extends YServer {
       console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
 
       // Broadcast a "room-reset" message to all connected clients
-      this.broadcastCustomMessage(
-        JSON.stringify({
-          type: "room-reset",
-          timestamp: resetEpoch,
-          resetEpoch: resetEpoch,
-        })
-      );
+      this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
       console.log(
         `[Restore Snapshot] Broadcasted room-reset signal to all clients`
       );
 
       // FORCE DISCONNECT: Close all connections
-      const connections = [...this.getConnections()];
-      connections.forEach((conn) => {
-        try {
-          conn.close(4000, "Room Restored by Admin");
-        } catch (e) {
-          console.error("[Restore Snapshot] Failed to close connection:", e);
-        }
-      });
+      const closedCount = this.closeConnections("Room Restored by Admin");
       console.log(
-        `[Restore Snapshot] Closed ${connections.length} connections`
+        `[Restore Snapshot] Closed ${closedCount} connections`
       );
 
       console.log(
@@ -778,45 +864,29 @@ export class PartyServer extends YServer {
       `[PartyServer] onConnect: connectionId=${connectionId}, room=${this.name}`
     );
 
-    // Check reset epoch from client params and enforce if stale
-    let shouldForceReset = false;
-    let serverResetEpoch: number | null = null;
+    const clientResetEpoch = parseClientResetEpoch(
+      url.searchParams.get("clientResetEpoch")
+    );
+    let serverResetEpoch: number | null;
+
     try {
-      const clientResetEpochParam = url.searchParams.get("clientResetEpoch");
-      const clientResetEpoch = parseClientResetEpoch(clientResetEpochParam);
-
       serverResetEpoch = await this.getResetEpoch();
-
-      console.log(
-        `[PartyServer] Epoch check: client=${clientResetEpoch}, server=${serverResetEpoch}, connectionId=${connectionId}`
-      );
-
-      // If server has a reset epoch and client's is stale (or missing), mark for reset
-      if (this.isEpochStale(clientResetEpoch, serverResetEpoch)) {
-        console.log(
-          `[PartyServer] Client reset epoch (${clientResetEpoch}) is stale compared to server (${serverResetEpoch}). Will force reload. connectionId=${connectionId}`
-        );
-        shouldForceReset = true;
-      } else if (clientResetEpoch !== null && serverResetEpoch !== null) {
-        console.log(
-          `[PartyServer] Client reset epoch (${clientResetEpoch}) matches server (${serverResetEpoch}). Connection allowed. connectionId=${connectionId}`
-        );
-      } else {
-        console.log(
-          `[PartyServer] No epoch validation needed (server=${serverResetEpoch}). Connection allowed. connectionId=${connectionId}`
-        );
-      }
     } catch (error) {
-      // If epoch check fails, log but don't block connection (fail open for backwards compatibility)
       console.warn(
         `[PartyServer] Failed to check reset epoch on connect (connectionId=${connectionId}):`,
         error
       );
+      serverResetEpoch = null;
     }
 
-    // If client epoch is stale, immediately send reset message and return early
-    // Do NOT attempt Y.js sync with stale clients as it may fail or sync incorrect state
-    if (shouldForceReset && serverResetEpoch !== null) {
+    console.log(
+      `[PartyServer] Epoch check: client=${clientResetEpoch}, server=${serverResetEpoch}, connectionId=${connectionId}`
+    );
+
+    if (
+      serverResetEpoch !== null &&
+      this.isEpochStale(clientResetEpoch, serverResetEpoch)
+    ) {
       console.log(
         `[PartyServer] Rejecting stale client connection (connectionId=${connectionId}), sending room-reset message with epoch=${serverResetEpoch}`
       );
@@ -1076,91 +1146,42 @@ export class PartyServer extends YServer {
     // while clients are connected can merge stale client history back into the
     // room. If compaction is not useful, the cooldown prevents every later
     // autosave of a naturally large document from rebuilding the whole Y.Doc.
-    const liveYDoc = this.document;
-    const currentPlayData = docToJson(liveYDoc);
-    if (!currentPlayData) {
+    const compactedDocument = this.buildCompactedDocument(this.document);
+    if (compactedDocument === null) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
       return false;
     }
 
-    const resetEpoch = Date.now();
-    const compactDoc = jsonToDoc(currentPlayData);
-    setDocResetEpoch(compactDoc, resetEpoch);
-    const compactBase64 = encodeDocToBase64(compactDoc);
-    const compactSize = compactBase64.length;
-
     if (
       !shouldUseEmergencyCompactedDocument({
         beforeSize: documentSize,
-        afterSize: compactSize,
+        afterSize: compactedDocument.afterSize,
         thresholdBytes,
       })
     ) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
       console.log(
-        `[PartyServer] Emergency compaction skipped: room=${this.name}, ${documentSize} -> ${compactSize} bytes, nextCheckAt=${recheckAfter}`
+        `[PartyServer] Emergency compaction skipped: room=${this.name}, ${documentSize} -> ${compactedDocument.afterSize} bytes, nextCheckAt=${recheckAfter}`
       );
       return false;
     }
 
-    this.isSkippingSave = true;
-    const rollbackResetEpoch = await this.getResetEpoch();
-    let compactedDocumentSaved = false;
+    await this.commitCompactedDocument({
+      compactedDocument,
+      afterReplace: async () => {
+        await this.setEmergencyCompactCheckAfter(recheckAfter);
+        await this.clearEmptyRoomCompactAfter();
+        this.broadcastCustomMessage(
+          this.getRoomResetMessage(compactedDocument.resetEpoch)
+        );
 
-    try {
-      await this.setResetEpoch(resetEpoch);
-
-      const { error } = await supabase.from("documents").upsert(
-        {
-          name: this.name,
-          document: compactBase64,
-        },
-        { onConflict: "name" }
-      );
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      compactedDocumentSaved = true;
-      this.compactionAutosaveSnapshot = compactBase64;
-      replaceDocFromSnapshot(liveYDoc, compactBase64);
-      await this.setEmergencyCompactCheckAfter(recheckAfter);
-      await this.clearEmptyRoomCompactAfter();
-
-      const resetMessage = JSON.stringify({
-        type: "room-reset",
-        timestamp: resetEpoch,
-        resetEpoch,
-      });
-      this.broadcastCustomMessage(resetMessage);
-
-      const connections = [...this.getConnections()];
-      connections.forEach((conn) => {
-        try {
-          conn.close(4000, "Room Compacted");
-        } catch (error) {
-          console.error("[PartyServer] Failed to close connection:", error);
-        }
-      });
-
-      console.log(
-        `[PartyServer] Emergency compacted connected room: room=${this.name}, ${documentSize} -> ${compactSize} bytes (${((1 - compactSize / documentSize) * 100).toFixed(1)}% reduction), resetEpoch=${resetEpoch}, closed=${connections.length}`
-      );
-      return true;
-    } catch (error) {
-      if (!compactedDocumentSaved) {
-        if (rollbackResetEpoch === null) {
-          await this.clearResetEpoch();
-        } else {
-          await this.setResetEpoch(rollbackResetEpoch);
-        }
-      }
-      this.compactionAutosaveSnapshot = null;
-      throw error;
-    } finally {
-      this.isSkippingSave = false;
-    }
+        const closedCount = this.closeConnections("Room Compacted");
+        console.log(
+          `[PartyServer] Emergency compacted connected room: room=${this.name}, ${documentSize} -> ${compactedDocument.afterSize} bytes (${((1 - compactedDocument.afterSize / documentSize) * 100).toFixed(1)}% reduction), resetEpoch=${compactedDocument.resetEpoch}, closed=${closedCount}`
+        );
+      },
+    });
+    return true;
   }
 
   override async onRequest(request: Request): Promise<Response> {
@@ -1543,26 +1564,13 @@ export class PartyServer extends YServer {
       console.log(`[Hard Reset] Set resetEpoch: ${resetEpoch}`);
 
       // Broadcast a "room-reset" message to all connected clients
-      this.broadcastCustomMessage(
-        JSON.stringify({
-          type: "room-reset",
-          timestamp: resetEpoch,
-          resetEpoch: resetEpoch,
-        })
-      );
+      this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
       console.log(`[Hard Reset] Broadcasted room-reset signal to all clients`);
 
       // FORCE DISCONNECT: Close all connections to ensure no lingering clients
       // push their old state back to the server
-      const connections = [...this.getConnections()];
-      connections.forEach((conn) => {
-        try {
-          conn.close(4000, "Room Reset by Admin");
-        } catch (e) {
-          console.error("[Hard Reset] Failed to close connection:", e);
-        }
-      });
-      console.log(`[Hard Reset] Closed ${connections.length} connections`);
+      const closedCount = this.closeConnections("Room Reset by Admin");
+      console.log(`[Hard Reset] Closed ${closedCount} connections`);
 
       const sizeReduction = beforeSize - afterSize;
       const sizeReductionPercent = ((sizeReduction / beforeSize) * 100).toFixed(
@@ -1614,72 +1622,42 @@ export class PartyServer extends YServer {
     if (this.getOpenConnectionCount() !== 0) return;
 
     const run = async () => {
-      const liveYDoc = this.document;
-      const currentPlayData = docToJson(liveYDoc);
-      if (!currentPlayData) {
+      const compactedDocument = this.buildCompactedDocument(this.document);
+      if (compactedDocument === null) {
         await this.clearEmptyRoomCompactAfter();
         return;
       }
 
-      const beforeSize = encodeDocToBase64(liveYDoc).length;
-      const resetEpoch = Date.now();
-      const compactDoc = jsonToDoc(currentPlayData);
-      setDocResetEpoch(compactDoc, resetEpoch);
-      const compactBase64 = encodeDocToBase64(compactDoc);
-      const afterSize = compactBase64.length;
-
-      if (!shouldStoreCompactedDocument(beforeSize, afterSize)) {
+      if (
+        !shouldStoreCompactedDocument(
+          compactedDocument.beforeSize,
+          compactedDocument.afterSize
+        )
+      ) {
         await this.clearEmptyRoomCompactAfter();
         console.log(
-          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${beforeSize} -> ${afterSize} bytes`
+          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes`
         );
         return;
       }
 
-      this.isSkippingSave = true;
-      const rollbackResetEpoch = await this.getResetEpoch();
-      let compactedDocumentSaved = false;
-
-      try {
-        if (this.getOpenConnectionCount() !== 0) {
-          await this.clearEmptyRoomCompactAfter();
-          return;
-        }
-
-        await this.setResetEpoch(resetEpoch);
-
-        const { error } = await supabase.from("documents").upsert(
-          {
-            name: this.name,
-            document: compactBase64,
-          },
-          { onConflict: "name" }
-        );
-
-        if (error) {
-          throw new Error(error.message);
-        }
-
-        compactedDocumentSaved = true;
-        this.compactionAutosaveSnapshot = compactBase64;
-        replaceDocFromSnapshot(liveYDoc, compactBase64);
-        await this.clearEmptyRoomCompactAfter();
-
-        console.log(
-          `[PartyServer] Empty-room compacted: room=${this.name}, ${beforeSize} -> ${afterSize} bytes (${((1 - afterSize / beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${resetEpoch}`
-        );
-      } catch (error) {
-        if (!compactedDocumentSaved) {
-          if (rollbackResetEpoch === null) {
-            await this.clearResetEpoch();
-          } else {
-            await this.setResetEpoch(rollbackResetEpoch);
+      const committed = await this.commitCompactedDocument({
+        compactedDocument,
+        beforeCommit: async () => {
+          if (this.getOpenConnectionCount() === 0) {
+            return true;
           }
-        }
-        this.compactionAutosaveSnapshot = null;
-        throw error;
-      } finally {
-        this.isSkippingSave = false;
+          await this.clearEmptyRoomCompactAfter();
+          return false;
+        },
+        afterReplace: async () => {
+          await this.clearEmptyRoomCompactAfter();
+        },
+      });
+      if (committed) {
+        console.log(
+          `[PartyServer] Empty-room compacted: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes (${((1 - compactedDocument.afterSize / compactedDocument.beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${compactedDocument.resetEpoch}`
+        );
       }
     };
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Hosts the playhtml PartyServer Durable Object for Yjs sync and room-to-room sharing.
+// ABOUTME: Persists room documents, coordinates shared element bridges, and handles admin operations.
 import type * as Party from "partyserver";
 import { getServerByName, routePartykitRequest } from "partyserver";
 import { YServer } from "y-partyserver";
@@ -54,6 +56,10 @@ function internalRequest(path: string, body: unknown): Request {
 }
 
 export class PartyServer extends YServer {
+  static options = {
+    hibernate: true,
+  };
+
   // Public flag to pause autosave during administrative resets
   // This prevents the server from overwriting the clean DB state with
   // in-memory state while we are performing a reset.
@@ -78,6 +84,11 @@ export class PartyServer extends YServer {
 
   private observersAttached = false;
   private adminHandler = new AdminHandler(this);
+
+  override async onStart(): Promise<void> {
+    await super.onStart();
+    await this.attachImmediateBridgeObservers();
+  }
 
   async getSubscribers(): Promise<Subscriber[]> {
     if (this.cachedSubscribers !== null) return this.cachedSubscribers;
@@ -676,9 +687,6 @@ export class PartyServer extends YServer {
     }
 
     await super.onConnect(connection, ctx);
-
-    // Attach immediate-update observers once
-    await this.attachImmediateBridgeObservers();
   }
 
   // Benign disconnect errors thrown by the Cloudflare runtime when a client's

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -20,6 +20,7 @@ import {
 } from "./docUtils";
 import {
   STORAGE_KEYS,
+  DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
   ORIGIN_S2C,
@@ -44,6 +45,10 @@ import {
   parseSharedReferencesFromUrl,
   SharedElementPermissions,
 } from "./sharing";
+import {
+  getNextAlarmTime,
+  shouldStoreCompactedDocument,
+} from "./compactionPolicy";
 
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
 // The URL is synthetic — the target server's onRequest reads the body, not the path.
@@ -64,6 +69,7 @@ export class PartyServer extends YServer {
   // This prevents the server from overwriting the clean DB state with
   // in-memory state while we are performing a reset.
   public isSkippingSave = false;
+  private emptyRoomCompactionPromise: Promise<void> | null = null;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -137,6 +143,30 @@ export class PartyServer extends YServer {
   ): Promise<void> {
     this.cachedSharedPerms = permissions;
     await this.ctx.storage.put(STORAGE_KEYS.sharedPermissions, permissions);
+  }
+
+  private getOpenConnectionCount(): number {
+    return Array.from(this.getConnections()).length;
+  }
+
+  private async getEmptyRoomCompactAfter(): Promise<number | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.emptyRoomCompactAfter);
+    return typeof value === "number" ? value : null;
+  }
+
+  private async setEmptyRoomCompactAfter(timestamp: number): Promise<void> {
+    await this.ctx.storage.put(STORAGE_KEYS.emptyRoomCompactAfter, timestamp);
+  }
+
+  private async clearEmptyRoomCompactAfter(): Promise<void> {
+    await this.ctx.storage.delete(STORAGE_KEYS.emptyRoomCompactAfter);
+  }
+
+  private async waitForEmptyRoomCompaction(): Promise<void> {
+    const pending = this.emptyRoomCompactionPromise;
+    if (pending) {
+      await pending;
+    }
   }
 
   async getResetEpoch(): Promise<number | null> {
@@ -306,12 +336,26 @@ export class PartyServer extends YServer {
     }
   }
 
-  // Ensure an alarm is set if subscribers exist; avoids rescheduling if one is set sooner
-  private async ensureAlarmIfSubscribersPresent(): Promise<void> {
+  // Ensure an alarm is set for bridge lease pruning or empty-room compaction.
+  private async ensureAlarmScheduled(): Promise<void> {
+    await this.scheduleNextAlarm();
+  }
+
+  private async scheduleNextAlarm(): Promise<void> {
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
-    if (!subs.length && !refs.length) return;
-    const nextAlarm = Date.now() + DEFAULT_PRUNE_INTERVAL_MS;
+    const nextAlarm = getNextAlarmTime({
+      compactAfter: await this.getEmptyRoomCompactAfter(),
+      hasBridgeLeases: Boolean(subs.length || refs.length),
+      now: Date.now(),
+      pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS,
+    });
+
+    if (nextAlarm === null) {
+      await this.ctx.storage.deleteAlarm?.();
+      return;
+    }
+
     const previousAlarm = await this.ctx.storage.getAlarm?.();
     if (
       previousAlarm === null ||
@@ -320,6 +364,19 @@ export class PartyServer extends YServer {
     ) {
       await this.ctx.storage.setAlarm?.(nextAlarm);
     }
+  }
+
+  private async scheduleEmptyRoomCompaction(): Promise<void> {
+    if (this.isSkippingSave) return;
+    if (this.getOpenConnectionCount() !== 0) return;
+
+    const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
+    await this.setEmptyRoomCompactAfter(compactAfter);
+    await this.scheduleNextAlarm();
+
+    console.log(
+      `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
+    );
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -586,6 +643,8 @@ export class PartyServer extends YServer {
     connection: Party.Connection,
     ctx: Party.ConnectionContext
   ) {
+    await this.waitForEmptyRoomCompaction();
+
     const url = new URL(ctx.request.url);
     const connectionId = connection.id;
     console.log(
@@ -655,8 +714,10 @@ export class PartyServer extends YServer {
       `[PartyServer] Proceeding with normal Y.js connection setup for connectionId=${connectionId}`
     );
 
-    // Opportunistically schedule an alarm if subscribers exist
-    await this.ensureAlarmIfSubscribersPresent();
+    await this.clearEmptyRoomCompactAfter();
+
+    // Opportunistically schedule an alarm if bridge leases or compaction need one
+    await this.ensureAlarmScheduled();
 
     // Parse shared references from the connecting client (for consumer rooms)
     // Parse from the WebSocket request URL
@@ -687,6 +748,16 @@ export class PartyServer extends YServer {
     }
 
     await super.onConnect(connection, ctx);
+  }
+
+  override async onClose(
+    connection: Party.Connection,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<void> {
+    await super.onClose(connection, code, reason, wasClean);
+    await this.scheduleEmptyRoomCompaction();
   }
 
   // Benign disconnect errors thrown by the Cloudflare runtime when a client's
@@ -772,32 +843,11 @@ export class PartyServer extends YServer {
       return;
     }
 
-    // Active WebSockets can survive hibernation with their existing Yjs history.
-    // Persist that same history while connections are present so wake-up sync
-    // merges against an equivalent base document.
-    const rawSize = Y.encodeStateAsUpdate(doc).byteLength;
-    const activeConnectionCount = Array.from(this.getConnections()).length;
-    const currentPlayData = docToJson(doc);
-    let documentBase64: string;
-
-    if (currentPlayData && activeConnectionCount === 0) {
-      const compactDoc = jsonToDoc(currentPlayData);
-      setDocResetEpoch(
-        compactDoc,
-        docResetEpoch ?? serverResetEpoch ?? Date.now()
-      );
-      documentBase64 = encodeDocToBase64(compactDoc);
-      const compactedSize = Math.ceil((documentBase64.length * 3) / 4);
-      if (compactedSize < rawSize) {
-        console.log(
-          `[PartyServer] Compacted: room=${this.name}, ${rawSize} -> ${compactedSize} bytes (${((1 - compactedSize / rawSize) * 100).toFixed(1)}% reduction)`
-        );
-      }
-    } else {
-      documentBase64 = encodeDocToBase64(doc);
-    }
-
+    // Ordinary autosave preserves Yjs history so reconnecting clients can merge
+    // safely. Empty-room compaction is handled as a reset boundary by alarms.
+    const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
+    const activeConnectionCount = this.getOpenConnectionCount();
 
     // Log structured information about the save
     console.log(
@@ -820,6 +870,10 @@ export class PartyServer extends YServer {
       );
     } else {
       console.log(`[PartyServer] Autosave succeeded for room ${this.name}`);
+    }
+
+    if (!error && activeConnectionCount === 0) {
+      await this.scheduleEmptyRoomCompaction();
     }
   }
 
@@ -1264,9 +1318,104 @@ export class PartyServer extends YServer {
     }
   }
 
+  private async compactEmptyRoomDocument(): Promise<void> {
+    if (this.emptyRoomCompactionPromise) {
+      await this.emptyRoomCompactionPromise;
+      return;
+    }
+
+    if (this.isSkippingSave) return;
+    if (this.getOpenConnectionCount() !== 0) return;
+
+    const run = async () => {
+      const liveYDoc = this.document;
+      const currentPlayData = docToJson(liveYDoc);
+      if (!currentPlayData) {
+        await this.clearEmptyRoomCompactAfter();
+        return;
+      }
+
+      const beforeSize = encodeDocToBase64(liveYDoc).length;
+      const resetEpoch = Date.now();
+      const compactDoc = jsonToDoc(currentPlayData);
+      setDocResetEpoch(compactDoc, resetEpoch);
+      const compactBase64 = encodeDocToBase64(compactDoc);
+      const afterSize = compactBase64.length;
+
+      if (!shouldStoreCompactedDocument(beforeSize, afterSize)) {
+        await this.clearEmptyRoomCompactAfter();
+        console.log(
+          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${beforeSize} -> ${afterSize} bytes`
+        );
+        return;
+      }
+
+      this.isSkippingSave = true;
+      const rollbackResetEpoch = await this.getResetEpoch();
+      let compactedDocumentSaved = false;
+
+      try {
+        if (this.getOpenConnectionCount() !== 0) {
+          await this.clearEmptyRoomCompactAfter();
+          return;
+        }
+
+        await this.setResetEpoch(resetEpoch);
+
+        const { error } = await supabase.from("documents").upsert(
+          {
+            name: this.name,
+            document: compactBase64,
+          },
+          { onConflict: "name" }
+        );
+
+        if (error) {
+          throw new Error(error.message);
+        }
+
+        compactedDocumentSaved = true;
+        replaceDocFromSnapshot(liveYDoc, compactBase64);
+        setDocResetEpoch(liveYDoc, resetEpoch);
+        await this.clearEmptyRoomCompactAfter();
+
+        console.log(
+          `[PartyServer] Empty-room compacted: room=${this.name}, ${beforeSize} -> ${afterSize} bytes (${((1 - afterSize / beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${resetEpoch}`
+        );
+      } catch (error) {
+        if (!compactedDocumentSaved) {
+          if (rollbackResetEpoch === null) {
+            await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
+          } else {
+            await this.setResetEpoch(rollbackResetEpoch);
+          }
+        }
+        throw error;
+      } finally {
+        this.isSkippingSave = false;
+      }
+    };
+
+    this.emptyRoomCompactionPromise = run();
+    try {
+      await this.emptyRoomCompactionPromise;
+    } finally {
+      this.emptyRoomCompactionPromise = null;
+    }
+  }
+
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
     try {
+      const compactAfter = await this.getEmptyRoomCompactAfter();
+      if (compactAfter !== null && compactAfter <= Date.now()) {
+        if (this.getOpenConnectionCount() === 0) {
+          await this.compactEmptyRoomDocument();
+        } else {
+          await this.clearEmptyRoomCompactAfter();
+        }
+      }
+
       const subscribers = await this.getSubscribers();
 
       if (subscribers.length) {
@@ -1301,14 +1450,7 @@ export class PartyServer extends YServer {
         }
       }
     } finally {
-      // Reschedule the next alarm only if there are subscribers or refs remaining
-      const subs = await this.getSubscribers();
-      const refs = await this.getSharedReferences();
-      if (subs.length || refs.length) {
-        await this.ctx.storage.setAlarm?.(
-          Date.now() + DEFAULT_PRUNE_INTERVAL_MS
-        );
-      }
+      await this.scheduleNextAlarm();
     }
   }
 

--- a/partykit/resetEpochPolicy.ts
+++ b/partykit/resetEpochPolicy.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Provides pure reset-epoch parsing and staleness helpers for PartyServer.
+// ABOUTME: Keeps reset boundary decisions consistent for client, bridge, and socket checks.
+export function parseClientResetEpoch(value: string | null): number | null {
+  if (value === null || value === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function isResetEpochStale(
+  candidateEpoch: number | null,
+  serverEpoch: number | null
+): boolean {
+  return (
+    serverEpoch !== null &&
+    (candidateEpoch === null || candidateEpoch < serverEpoch)
+  );
+}

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -40,8 +40,23 @@ bun smoke:partykit:hibernation
 # Verifies empty-room compaction, reset rejection, and fresh reconnect.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:compaction
 
-# Runs both checks.
+# Verifies connected-room high-watermark compaction.
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:emergency
+
+# Runs the standard PartyKit checks.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit
+```
+
+The emergency smoke expects the deployed Worker to use a low threshold, so it
+can exercise the reset path without sending a production-sized document. One
+staging workflow is:
+
+```bash
+bunx wrangler deploy --config partykit/wrangler.jsonc --env staging \
+  --var EMERGENCY_COMPACT_CHECK_BYTES:60000 \
+  --var EMERGENCY_COMPACT_RECHECK_DELAY_MS:1000
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:emergency
+bunx wrangler deploy --config partykit/wrangler.jsonc --env staging
 ```
 
 Config:
@@ -52,6 +67,9 @@ Config:
 - `PARTYKIT_HIBERNATION_WAIT_MS`: idle wait for the hibernation smoke. Defaults to `90000`.
 - `PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS`: expected server empty-room compaction delay. Defaults to `300000`.
 - `PARTYKIT_SKIP_COMPACTION_SETTLE_CHECK=1`: skips the extra no-op alarm wait after reconnect.
+- `PARTYKIT_EMERGENCY_TARGET_RAW_BYTES`: target local raw Y.Doc size for the emergency smoke. Defaults to `120000`.
+- `PARTYKIT_EMERGENCY_BATCH_SIZE`: temp entry batch size while building the emergency smoke doc. Defaults to `2000`.
+- `PARTYKIT_EMERGENCY_RESET_TIMEOUT_MS`: timeout while waiting for emergency reset. Defaults to `180000`.
 
 ## Adding a new page
 

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -27,6 +27,32 @@ For each page in `smoke.spec.ts`'s `PAGES` list:
 Cross-origin failures (PartyKit WebSocket, Google Fonts) are deliberately
 ignored — this is a build-output smoke test, not a backend integration test.
 
+## PartyKit staging smoke tests
+
+The PartyKit smoke scripts run against a real deployed Worker and Supabase.
+They are manual because they take several minutes, wait for real Durable Object
+alarms, and need staging secrets.
+
+```bash
+# Verifies bridge observers reattach after Durable Object hibernation.
+bun smoke:partykit:hibernation
+
+# Verifies empty-room compaction, reset rejection, and fresh reconnect.
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:compaction
+
+# Runs both checks.
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit
+```
+
+Config:
+
+- `PARTYKIT_HOST`: Worker host. Defaults to `playhtml-staging.spencerc99.workers.dev`.
+- `SMOKE_ENV_FILE`: optional `.dev.vars` or `.env` file to load before the script reads `ADMIN_TOKEN`.
+- `ADMIN_TOKEN`: required for `test:partykit:compaction`.
+- `PARTYKIT_HIBERNATION_WAIT_MS`: idle wait for the hibernation smoke. Defaults to `90000`.
+- `PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS`: expected server empty-room compaction delay. Defaults to `300000`.
+- `PARTYKIT_SKIP_COMPACTION_SETTLE_CHECK=1`: skips the extra no-op alarm wait after reconnect.
+
 ## Adding a new page
 
 Add its URL path to `PAGES`. Add new error patterns to

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "playwright test",
     "test:headed": "playwright test --headed",
+    "test:partykit": "bun run test:partykit:hibernation && bun run test:partykit:compaction",
+    "test:partykit:hibernation": "node partykit/hibernation-bridge-smoke.mjs",
+    "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",
     "install-browsers": "playwright install chromium --with-deps"
   },
   "devDependencies": {

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -9,6 +9,7 @@
     "test:partykit": "bun run test:partykit:hibernation && bun run test:partykit:compaction",
     "test:partykit:hibernation": "node partykit/hibernation-bridge-smoke.mjs",
     "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",
+    "test:partykit:emergency": "node partykit/emergency-compaction-smoke.mjs",
     "install-browsers": "playwright install chromium --with-deps"
   },
   "devDependencies": {

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -13,6 +13,7 @@
     "install-browsers": "playwright install chromium --with-deps"
   },
   "devDependencies": {
-    "@playwright/test": "^1.48.0"
+    "@playwright/test": "^1.48.0",
+    "ws": "^8.19.0"
   }
 }

--- a/smoke-tests/partykit/emergency-compaction-smoke.mjs
+++ b/smoke-tests/partykit/emergency-compaction-smoke.mjs
@@ -1,0 +1,139 @@
+// ABOUTME: Verifies connected-room emergency compaction resets bloated active rooms.
+// ABOUTME: Exercises real WebSocket sync, high-watermark compaction, reset close, and fresh reconnect.
+import {
+  Y,
+  connectRoom,
+  createStore,
+  getHost,
+  getNumberEnv,
+  inspectRoom,
+  loadSmokeEnv,
+  waitForProviderStatus,
+  waitForRoomReset,
+  waitForSync,
+} from "./shared.mjs";
+
+const loadedEnvFile = loadSmokeEnv();
+const host = getHost();
+const adminToken = process.env.ADMIN_TOKEN;
+const room = `codex-emergency-compaction-${Date.now()}`;
+const elementId = "shared";
+const targetRawBytes = getNumberEnv(
+  "PARTYKIT_EMERGENCY_TARGET_RAW_BYTES",
+  120_000
+);
+const batchSize = getNumberEnv("PARTYKIT_EMERGENCY_BATCH_SIZE", 2_000);
+const resetTimeoutMs = getNumberEnv(
+  "PARTYKIT_EMERGENCY_RESET_TIMEOUT_MS",
+  3 * 60 * 1000
+);
+
+if (!adminToken) {
+  throw new Error(
+    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file."
+  );
+}
+
+function encodedBase64Size(doc) {
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64").length;
+}
+
+function connectSmokeRoom(doc, params = {}) {
+  return connectRoom(host, room, doc, params);
+}
+
+async function inspectSmokeRoom() {
+  return inspectRoom({ host, room, adminToken });
+}
+
+function buildBloat({ doc, store }) {
+  store.play.canMove = {};
+  store.play.canMove[elementId] = { x: 0, y: 1 };
+
+  let created = 0;
+  let rawSize = encodedBase64Size(doc);
+
+  while (rawSize < targetRawBytes) {
+    doc.transact(() => {
+      for (let i = 1; i <= batchSize; i += 1) {
+        const id = created + i;
+        store.play.canMove[`temp-${id}`] = { x: id, y: id };
+      }
+      for (let i = 1; i <= batchSize; i += 1) {
+        const id = created + i;
+        delete store.play.canMove[`temp-${id}`];
+      }
+    });
+    created += batchSize;
+    rawSize = encodedBase64Size(doc);
+    console.log(`built local bloat: entries=${created}, rawSize=${rawSize}`);
+  }
+
+  store.play.canMove[elementId].x = created;
+  return {
+    created,
+    rawSize: encodedBase64Size(doc),
+  };
+}
+
+console.log(`host=${host}`);
+console.log(`env=${loadedEnvFile ?? "process.env"}`);
+console.log(`room=${room}`);
+console.log(`targetRawBytes=${targetRawBytes}`);
+const doc = new Y.Doc();
+const store = createStore(doc);
+const provider = connectSmokeRoom(doc);
+await waitForSync(provider, "initial", 60_000);
+
+const resetEpochPromise = waitForRoomReset(provider, resetTimeoutMs);
+const disconnectedPromise = waitForProviderStatus(
+  provider,
+  "disconnected",
+  resetTimeoutMs
+);
+
+const { created, rawSize } = buildBloat({ doc, store });
+console.log(`sent bloated connected doc: entries=${created}, rawSize=${rawSize}`);
+
+const resetEpoch = await resetEpochPromise;
+console.log(`emergency compaction received room-reset resetEpoch=${resetEpoch}`);
+await disconnectedPromise;
+console.log("emergency compaction disconnected active client");
+provider.destroy();
+
+const compacted = await inspectSmokeRoom();
+console.log(
+  `after emergency compaction: size=${compacted.documentSize}, resetEpoch=${compacted.resetEpoch}, x=${compacted.ydoc.play.canMove[elementId].x}`
+);
+
+if (compacted.resetEpoch !== resetEpoch) {
+  throw new Error(
+    `expected inspect resetEpoch ${resetEpoch}, got ${compacted.resetEpoch}`
+  );
+}
+if (compacted.documentSize >= rawSize) {
+  throw new Error(
+    `expected compacted size below raw size: before=${rawSize}, after=${compacted.documentSize}`
+  );
+}
+
+const freshDoc = new Y.Doc();
+const freshStore = createStore(freshDoc);
+const freshProvider = connectSmokeRoom(freshDoc, {
+  clientResetEpoch: String(resetEpoch),
+});
+
+try {
+  await waitForSync(freshProvider, "fresh", 60_000);
+  const x = freshStore.play.canMove?.[elementId]?.x;
+  console.log(`fresh reconnect observed x=${x}`);
+  if (x !== store.play.canMove[elementId].x) {
+    throw new Error(
+      `expected fresh reconnect to observe x=${store.play.canMove[elementId].x}, got ${x}`
+    );
+  }
+} finally {
+  freshProvider.destroy();
+}
+
+console.log("emergency compaction smoke passed");

--- a/smoke-tests/partykit/emergency-compaction-smoke.mjs
+++ b/smoke-tests/partykit/emergency-compaction-smoke.mjs
@@ -97,6 +97,8 @@ console.log(`sent bloated connected doc: entries=${created}, rawSize=${rawSize}`
 
 const resetEpoch = await resetEpochPromise;
 console.log(`emergency compaction received room-reset resetEpoch=${resetEpoch}`);
+store.play.canMove[elementId].x = -1;
+console.log("attempted stale update after reset signal");
 await disconnectedPromise;
 console.log("emergency compaction disconnected active client");
 provider.destroy();
@@ -116,6 +118,11 @@ if (compacted.documentSize >= rawSize) {
     `expected compacted size below raw size: before=${rawSize}, after=${compacted.documentSize}`
   );
 }
+if (compacted.ydoc.play.canMove[elementId].x !== created) {
+  throw new Error(
+    `expected compacted doc to keep x=${created}, got ${compacted.ydoc.play.canMove[elementId].x}`
+  );
+}
 
 const freshDoc = new Y.Doc();
 const freshStore = createStore(freshDoc);
@@ -127,9 +134,9 @@ try {
   await waitForSync(freshProvider, "fresh", 60_000);
   const x = freshStore.play.canMove?.[elementId]?.x;
   console.log(`fresh reconnect observed x=${x}`);
-  if (x !== store.play.canMove[elementId].x) {
+  if (x !== created) {
     throw new Error(
-      `expected fresh reconnect to observe x=${store.play.canMove[elementId].x}, got ${x}`
+      `expected fresh reconnect to observe x=${created}, got ${x}`
     );
   }
 } finally {

--- a/smoke-tests/partykit/empty-room-compaction-smoke.mjs
+++ b/smoke-tests/partykit/empty-room-compaction-smoke.mjs
@@ -6,8 +6,10 @@ import {
   createStore,
   getHost,
   getNumberEnv,
+  inspectRoom as inspectPartyRoom,
   loadSmokeEnv,
   sleep,
+  waitForProviderStatus,
   waitForRoomReset,
   waitForSync,
 } from "./shared.mjs";
@@ -35,23 +37,7 @@ function connectSmokeRoom(doc, params = {}) {
 }
 
 async function inspectRoom() {
-  const response = await fetch(
-    `https://${host}/parties/main/${encodeURIComponent(room)}/admin/inspect`,
-    {
-      headers: { Authorization: `Bearer ${adminToken}` },
-    }
-  );
-  const text = await response.text();
-  let body;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    throw new Error(`inspect returned non-JSON ${response.status}: ${text}`);
-  }
-  if (!response.ok) {
-    throw new Error(`inspect failed ${response.status}: ${text}`);
-  }
-  return body;
+  return inspectPartyRoom({ host, room, adminToken });
 }
 
 async function waitForCompaction(beforeResetEpoch, timeoutMs = 2 * 60 * 1000) {
@@ -127,6 +113,8 @@ if (after.documentSize >= before.documentSize) {
 const staleProvider = connectSmokeRoom(doc);
 const staleResetEpoch = await waitForRoomReset(staleProvider);
 console.log(`stale reconnect received room-reset resetEpoch=${staleResetEpoch}`);
+await waitForProviderStatus(staleProvider, "disconnected");
+console.log("stale reconnect was disconnected");
 staleProvider.destroy();
 
 const freshDoc = new Y.Doc();

--- a/smoke-tests/partykit/empty-room-compaction-smoke.mjs
+++ b/smoke-tests/partykit/empty-room-compaction-smoke.mjs
@@ -1,0 +1,172 @@
+// ABOUTME: Verifies empty-room compaction creates a reset boundary on staging.
+// ABOUTME: Exercises real WebSocket clients, delayed alarms, admin inspect, and reconnects.
+import {
+  Y,
+  connectRoom,
+  createStore,
+  getHost,
+  getNumberEnv,
+  loadSmokeEnv,
+  sleep,
+  waitForRoomReset,
+  waitForSync,
+} from "./shared.mjs";
+
+const loadedEnvFile = loadSmokeEnv();
+const host = getHost();
+const adminToken = process.env.ADMIN_TOKEN;
+const room = `codex-empty-compaction-${Date.now()}`;
+const elementId = "shared";
+const compactDelayMs = getNumberEnv(
+  "PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS",
+  5 * 60 * 1000
+);
+const shouldVerifyNoopAlarm =
+  process.env.PARTYKIT_SKIP_COMPACTION_SETTLE_CHECK !== "1";
+
+if (!adminToken) {
+  throw new Error(
+    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file."
+  );
+}
+
+function connectSmokeRoom(doc, params = {}) {
+  return connectRoom(host, room, doc, params);
+}
+
+async function inspectRoom() {
+  const response = await fetch(
+    `https://${host}/parties/main/${encodeURIComponent(room)}/admin/inspect`,
+    {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    }
+  );
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`inspect returned non-JSON ${response.status}: ${text}`);
+  }
+  if (!response.ok) {
+    throw new Error(`inspect failed ${response.status}: ${text}`);
+  }
+  return body;
+}
+
+async function waitForCompaction(beforeResetEpoch, timeoutMs = 2 * 60 * 1000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const inspected = await inspectRoom();
+    if (
+      inspected.resetEpoch !== null &&
+      inspected.resetEpoch !== beforeResetEpoch
+    ) {
+      return inspected;
+    }
+    console.log(
+      `waiting for compaction: size=${inspected.documentSize}, resetEpoch=${inspected.resetEpoch}`
+    );
+    await sleep(10_000);
+  }
+  throw new Error("timed out waiting for empty-room compaction");
+}
+
+console.log(`host=${host}`);
+console.log(`env=${loadedEnvFile ?? "process.env"}`);
+console.log(`room=${room}`);
+
+const doc = new Y.Doc();
+const store = createStore(doc);
+const provider = connectSmokeRoom(doc);
+await waitForSync(provider, "initial");
+
+doc.transact(() => {
+  store.play.canMove = {};
+  store.play.canMove[elementId] = { x: 0, y: 1 };
+  for (let i = 1; i <= 2_000; i += 1) {
+    store.play.canMove[`temp-${i}`] = { x: i, y: i };
+  }
+});
+
+for (let i = 1; i <= 2_000; i += 1) {
+  delete store.play.canMove[`temp-${i}`];
+}
+store.play.canMove[elementId].x = 2_000;
+
+console.log("waiting for connected raw autosave");
+await sleep(20_000);
+const before = await inspectRoom();
+console.log(
+  `before disconnect: size=${before.documentSize}, resetEpoch=${before.resetEpoch}, x=${before.ydoc.play.canMove[elementId].x}`
+);
+
+provider.destroy();
+console.log(`waiting ${compactDelayMs / 1000}s for empty-room compact alarm`);
+await sleep(compactDelayMs + 20_000);
+
+const after = await waitForCompaction(before.resetEpoch);
+console.log(
+  `after compaction: size=${after.documentSize}, resetEpoch=${after.resetEpoch}, x=${after.ydoc.play.canMove[elementId].x}`
+);
+
+if (after.connections !== 0) {
+  throw new Error(
+    `expected zero connections after compaction, got ${after.connections}`
+  );
+}
+if (after.resetEpoch === null) {
+  throw new Error("expected resetEpoch after compaction");
+}
+if (after.documentSize >= before.documentSize) {
+  throw new Error(
+    `expected compacted size below raw size: before=${before.documentSize}, after=${after.documentSize}`
+  );
+}
+
+const staleProvider = connectSmokeRoom(doc);
+const staleResetEpoch = await waitForRoomReset(staleProvider);
+console.log(`stale reconnect received room-reset resetEpoch=${staleResetEpoch}`);
+staleProvider.destroy();
+
+const freshDoc = new Y.Doc();
+const freshStore = createStore(freshDoc);
+const freshProvider = connectSmokeRoom(freshDoc, {
+  clientResetEpoch: String(after.resetEpoch),
+});
+
+try {
+  await waitForSync(freshProvider, "fresh");
+  const x = freshStore.play.canMove?.[elementId]?.x;
+  console.log(`fresh reconnect observed x=${x}`);
+  if (x !== 2_000) {
+    throw new Error(`expected fresh reconnect to observe x=2000, got ${x}`);
+  }
+} finally {
+  freshProvider.destroy();
+}
+
+if (shouldVerifyNoopAlarm) {
+  console.log(
+    `waiting ${compactDelayMs / 1000}s for post-reconnect no-op compact alarm`
+  );
+  await sleep(compactDelayMs + 20_000);
+
+  const settled = await inspectRoom();
+  console.log(
+    `after no-op alarm window: size=${settled.documentSize}, resetEpoch=${settled.resetEpoch}`
+  );
+
+  if (settled.resetEpoch !== after.resetEpoch) {
+    throw new Error(
+      `expected resetEpoch to remain ${after.resetEpoch}, got ${settled.resetEpoch}`
+    );
+  }
+  if (settled.documentSize !== after.documentSize) {
+    throw new Error(
+      `expected document size to remain ${after.documentSize}, got ${settled.documentSize}`
+    );
+  }
+}
+
+console.log("empty-room compaction smoke passed");

--- a/smoke-tests/partykit/hibernation-bridge-smoke.mjs
+++ b/smoke-tests/partykit/hibernation-bridge-smoke.mjs
@@ -1,0 +1,169 @@
+// ABOUTME: Exercises shared-element sync across a Durable Object hibernation window.
+// ABOUTME: Verifies live and reconnecting consumers receive bridge updates after wake.
+import {
+  Y,
+  connectRoom,
+  createStore,
+  deriveRoomId,
+  getHost,
+  getNumberEnv,
+  sleep,
+  waitForSync,
+} from "./shared.mjs";
+
+const host = getHost();
+const domain =
+  process.env.PARTYKIT_SMOKE_DOMAIN ?? "codex-bridge-hibernation.test";
+const stamp = Date.now();
+const elementId = "shared";
+const idleWaitMs = getNumberEnv("PARTYKIT_HIBERNATION_WAIT_MS", 90_000);
+
+function setSharedPosition(store, x, y) {
+  if (!store.play.canMove) {
+    store.play.canMove = {};
+  }
+  store.play.canMove[elementId] = { x, y };
+}
+
+function readSharedPosition(store) {
+  return store.play.canMove?.[elementId] ?? null;
+}
+
+async function waitForPosition(store, expectedX, label, timeoutMs = 20_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const position = readSharedPosition(store);
+    if (position?.x === expectedX) {
+      console.log(`${label}: observed x=${expectedX}`);
+      return position;
+    }
+    await sleep(100);
+  }
+
+  throw new Error(
+    `${label} did not observe x=${expectedX}; last=${JSON.stringify(
+      readSharedPosition(store)
+    )}`
+  );
+}
+
+async function runLiveConsumerCase() {
+  const sourcePath = `/source-live-${stamp}`;
+  const consumerPath = `/consumer-live-${stamp}`;
+  const sourceRoom = deriveRoomId(domain, sourcePath);
+  const consumerRoom = deriveRoomId(domain, consumerPath);
+
+  const sourceDoc = new Y.Doc();
+  const consumerDoc = new Y.Doc();
+  const sourceStore = createStore(sourceDoc);
+  const consumerStore = createStore(consumerDoc);
+
+  const sourceProvider = connectRoom(host, sourceRoom, sourceDoc, {
+    sharedElements: JSON.stringify([{ elementId, permissions: "read-write" }]),
+  });
+  const consumerProvider = connectRoom(host, consumerRoom, consumerDoc, {
+    sharedReferences: JSON.stringify([{ domain, path: sourcePath, elementId }]),
+  });
+
+  try {
+    await Promise.all([
+      waitForSync(sourceProvider, "live source"),
+      waitForSync(consumerProvider, "live consumer"),
+    ]);
+
+    setSharedPosition(sourceStore, 1, 1);
+    await waitForPosition(consumerStore, 1, "live consumer initial");
+
+    console.log(
+      `live consumer: waiting ${idleWaitMs / 1000}s for hibernation window`
+    );
+    await sleep(idleWaitMs);
+
+    setSharedPosition(sourceStore, 2, 1);
+    await waitForPosition(consumerStore, 2, "live consumer post-idle");
+  } finally {
+    sourceProvider.destroy();
+    consumerProvider.destroy();
+  }
+}
+
+async function runObserverOnlyCase() {
+  const sourcePath = `/source-observer-${stamp}`;
+  const consumerPath = `/consumer-observer-${stamp}`;
+  const sourceRoom = deriveRoomId(domain, sourcePath);
+  const consumerRoom = deriveRoomId(domain, consumerPath);
+
+  const sourceDoc = new Y.Doc();
+  const firstConsumerDoc = new Y.Doc();
+  const sourceStore = createStore(sourceDoc);
+  const firstConsumerStore = createStore(firstConsumerDoc);
+
+  const sourceProvider = connectRoom(host, sourceRoom, sourceDoc, {
+    sharedElements: JSON.stringify([{ elementId, permissions: "read-write" }]),
+  });
+  const firstConsumerProvider = connectRoom(
+    host,
+    consumerRoom,
+    firstConsumerDoc,
+    {
+      sharedReferences: JSON.stringify([
+        { domain, path: sourcePath, elementId },
+      ]),
+    }
+  );
+
+  try {
+    await Promise.all([
+      waitForSync(sourceProvider, "observer source"),
+      waitForSync(firstConsumerProvider, "observer consumer"),
+    ]);
+
+    setSharedPosition(sourceStore, 1, 1);
+    await waitForPosition(
+      firstConsumerStore,
+      1,
+      "observer initial consumer"
+    );
+    firstConsumerProvider.destroy();
+
+    console.log(
+      `observer source: waiting ${idleWaitMs / 1000}s for hibernation window`
+    );
+    await sleep(idleWaitMs);
+
+    setSharedPosition(sourceStore, 2, 1);
+    await sleep(3_000);
+
+    const secondConsumerDoc = new Y.Doc();
+    const secondConsumerStore = createStore(secondConsumerDoc);
+    const secondConsumerProvider = connectRoom(
+      host,
+      consumerRoom,
+      secondConsumerDoc,
+      {
+        sharedReferences: JSON.stringify([
+          { domain, path: sourcePath, elementId },
+        ]),
+      }
+    );
+
+    try {
+      await waitForSync(secondConsumerProvider, "observer reconnect consumer");
+      await waitForPosition(
+        secondConsumerStore,
+        2,
+        "observer reconnect consumer post-idle"
+      );
+    } finally {
+      secondConsumerProvider.destroy();
+    }
+  } finally {
+    sourceProvider.destroy();
+  }
+}
+
+console.log(`host=${host}`);
+console.log(`stamp=${stamp}`);
+await runLiveConsumerCase();
+await runObserverOnlyCase();
+console.log("hibernation bridge smoke passed");

--- a/smoke-tests/partykit/shared.mjs
+++ b/smoke-tests/partykit/shared.mjs
@@ -120,6 +120,58 @@ export function waitForRoomReset(provider, timeoutMs = 20_000) {
   });
 }
 
+export function waitForProviderStatus(
+  provider,
+  expectedStatus,
+  timeoutMs = 20_000
+) {
+  return new Promise((resolveStatus, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `provider did not report status=${expectedStatus} within ${timeoutMs}ms`
+        )
+      );
+    }, timeoutMs);
+
+    const onStatus = (event) => {
+      console.log(`provider status=${event.status}`);
+      if (event.status === expectedStatus) {
+        cleanup();
+        resolveStatus();
+      }
+    };
+
+    function cleanup() {
+      clearTimeout(timer);
+      provider.off("status", onStatus);
+    }
+
+    provider.on("status", onStatus);
+  });
+}
+
+export async function inspectRoom({ host, room, adminToken }) {
+  const response = await fetch(
+    `https://${host}/parties/main/${encodeURIComponent(room)}/admin/inspect`,
+    {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    }
+  );
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`inspect returned non-JSON ${response.status}: ${text}`);
+  }
+  if (!response.ok) {
+    throw new Error(`inspect failed ${response.status}: ${text}`);
+  }
+  return body;
+}
+
 export function loadSmokeEnv() {
   const candidates = process.env.SMOKE_ENV_FILE
     ? [resolve(process.env.SMOKE_ENV_FILE)]

--- a/smoke-tests/partykit/shared.mjs
+++ b/smoke-tests/partykit/shared.mjs
@@ -1,0 +1,167 @@
+// ABOUTME: Provides shared helpers for PartyKit staging smoke tests.
+// ABOUTME: Connects real Yjs clients and loads optional local smoke-test env files.
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(resolve(repoRoot, "package.json"));
+
+export const Y = require("yjs");
+export const { syncedStore } = require("@syncedstore/core");
+const YProviderModule = require("y-partyserver/provider");
+const WebSocket = require("ws");
+const YProvider = YProviderModule.default ?? YProviderModule;
+
+export const defaultHost = "playhtml-staging.spencerc99.workers.dev";
+
+export function getHost() {
+  return process.env.PARTYKIT_HOST ?? defaultHost;
+}
+
+export function getNumberEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number, got ${raw}`);
+  }
+  return parsed;
+}
+
+export function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+export function deriveRoomId(host, inputRoom) {
+  const normalizedHost = host ? host.replace(/^www\./i, "") : "LOCAL";
+  const normalizedPath = inputRoom
+    ? inputRoom.replace(/\.[^/.]+$/, "")
+    : "/";
+  const path = normalizedPath.startsWith("/")
+    ? normalizedPath
+    : `/${normalizedPath}`;
+  return encodeURIComponent(`${normalizedHost}-${path}`);
+}
+
+export function createStore(doc) {
+  return syncedStore({ play: {} }, doc);
+}
+
+export function connectRoom(host, room, doc, params = {}) {
+  return new YProvider(host, room, doc, {
+    party: "main",
+    WebSocketPolyfill: WebSocket,
+    disableBc: true,
+    params,
+  });
+}
+
+export function waitForSync(provider, label, timeoutMs = 20_000) {
+  return new Promise((resolveSync, reject) => {
+    if (provider.synced) {
+      resolveSync();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} did not sync within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onSync = (synced) => {
+      console.log(`${label}: sync=${synced}`);
+      if (synced) {
+        cleanup();
+        resolveSync();
+      }
+    };
+
+    const onStatus = (event) => {
+      console.log(`${label}: status=${event.status}`);
+    };
+
+    function cleanup() {
+      clearTimeout(timer);
+      provider.off("sync", onSync);
+      provider.off("status", onStatus);
+    }
+
+    provider.on("sync", onSync);
+    provider.on("status", onStatus);
+  });
+}
+
+export function waitForRoomReset(provider, timeoutMs = 20_000) {
+  return new Promise((resolveReset, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("stale reconnect did not receive room-reset"));
+    }, timeoutMs);
+
+    const onMessage = (data) => {
+      const message = JSON.parse(data);
+      if (message.type === "room-reset") {
+        cleanup();
+        resolveReset(message.resetEpoch);
+      }
+    };
+
+    function cleanup() {
+      clearTimeout(timer);
+      provider.off("custom-message", onMessage);
+    }
+
+    provider.on("custom-message", onMessage);
+  });
+}
+
+export function loadSmokeEnv() {
+  const candidates = process.env.SMOKE_ENV_FILE
+    ? [resolve(process.env.SMOKE_ENV_FILE)]
+    : [resolve(repoRoot, ".dev.vars"), resolve(repoRoot, ".env")];
+
+  for (const filePath of candidates) {
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    const content = readFileSync(filePath, "utf8");
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) {
+        continue;
+      }
+
+      const withoutExport = trimmed.startsWith("export ")
+        ? trimmed.slice("export ".length).trim()
+        : trimmed;
+      const separatorIndex = withoutExport.indexOf("=");
+      if (separatorIndex === -1) {
+        continue;
+      }
+
+      const key = withoutExport.slice(0, separatorIndex).trim();
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || process.env[key]) {
+        continue;
+      }
+
+      let value = withoutExport.slice(separatorIndex + 1).trim();
+      const quote = value[0];
+      if (
+        (quote === "\"" || quote === "'") &&
+        value[value.length - 1] === quote
+      ) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+    return filePath;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- update `partyserver`, `y-partyserver`, and Workers type dependencies to hibernation-capable versions
- enable hibernation on the PartyServer Durable Object
- move bridge observer attachment to `onStart()` so observers are reattached when a hibernated object wakes
- add a patch changeset for the playhtml provider dependency update

## Why

Cloudflare Durable Object billing showed high Billable Duration compared with actual request wall time, which points to idle WebSocket connections keeping objects billable. `y-partyserver@2.2.0` supports Durable Object hibernation, and enabling it should let idle Yjs rooms stop accruing duration while sockets remain connected at the edge.

## Validation

- `bunx tsc -p partykit` passed
- `bun run --bun --cwd packages/playhtml test` passed: 18 files, 154 tests
- local Wrangler/Yjs WebSocket smoke passed against two clients in the same throwaway room; both clients connected and a `Y.Map` update replicated

## Notes

- The playhtml test suite still emits existing duplicate-target stderr from `main.nested-data.test.ts`, so the output is not pristine even though the suite exits 0.
- Full `bun run lint` is currently blocked by unrelated existing `website/` TypeScript errors in `FeaturesGrid.tsx`, `Permissions.tsx`, `fridge.tsx`, and `index.tsx`.
- Actual billing impact needs to be confirmed after staging/production deployment through Cloudflare Durable Object metrics, especially Billable Duration and hibernatable WebSocket message counters.