### PR TITLE
Optimize animated trail rendering

### DIFF
--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
     environment: "jsdom",
     exclude: ["node_modules/**", "dist/**", ".output/**"],
     setupFiles: [setupFile],
-    include: ["src/__tests__/**/*.test.ts"],
+    include: [
+      "src/__tests__/**/*.test.ts",
+      "website/shared/**/*.test.ts",
+      "website/shared/**/*.test.tsx",
+    ],
   },
 });

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -17,7 +17,12 @@ import {
 import { RippleEffect } from "./ClickRipple";
 import type { SoundEngine } from "../sound/SoundEngine";
 import type { TrailSoundFrame } from "../sound/types";
-import { getTrailRenderer, TRAIL_RENDERERS, type TrailRenderer } from "../styles/trailRenderers";
+import { getTrailRenderer, type TrailRenderer } from "../styles/trailRenderers";
+import {
+  buildStraightPathSegment,
+  getFinishedTrailRenderRange,
+  type FinishedTrailOrderEntry,
+} from "../utils/trailAnimation";
 
 // How many ms to spend fading a trail out when evicted by windowSize
 const EVICTION_FADE_MS = 3000;
@@ -32,61 +37,11 @@ const HIDDEN_TAB_TICK_MS = 100;
 // How many points to show behind the cursor while drawing
 const TAIL_LENGTH = 1000;
 
-// Path generation from varied points, with LRU cache
-function createPathGenerator() {
-  const cache = new Map<string, string>();
-
-  return (points: Array<{ x: number; y: number }>, style: string): string => {
-    if (points.length < 2) return "";
-
-    const cacheKey = `${style}-${points.length}-${points[0].x.toFixed(
-      0,
-    )}-${points[0].y.toFixed(0)}-${points[points.length - 1].x.toFixed(
-      0,
-    )}-${points[points.length - 1].y.toFixed(0)}`;
-    const cached = cache.get(cacheKey);
-    if (cached) return cached;
-
-    let path = `M ${points[0].x} ${points[0].y}`;
-
-    if (style === "straight") {
-      for (let i = 1; i < points.length; i++) {
-        path += ` L ${points[i].x} ${points[i].y}`;
-      }
-    } else {
-      for (let i = 0; i < points.length - 1; i++) {
-        const p1 = points[i];
-        const p2 = points[i + 1];
-        path += ` Q ${p1.x} ${p1.y} ${(p1.x + p2.x) / 2} ${(p1.y + p2.y) / 2}`;
-      }
-
-      if (points.length > 1) {
-        const lastPoint = points[points.length - 1];
-        const secondLast = points[points.length - 2];
-        path += ` Q ${secondLast.x} ${secondLast.y} ${lastPoint.x} ${lastPoint.y}`;
-      }
-    }
-
-    cache.set(cacheKey, path);
-
-    if (cache.size > 500) {
-      const firstKey = cache.keys().next().value!;
-      cache.delete(firstKey);
-    }
-
-    return path;
-  };
-}
-
 // Compute visible points and path data for a trail at a given elapsed time.
-function computeTrailFrame(
-  trailState: TrailState,
-  elapsedTimeMs: number,
-  generatePath: (pts: Array<{ x: number; y: number }>, style: string) => string,
-) {
+function computeTrailFrame(trailState: TrailState, elapsedTimeMs: number) {
   const { trail, startOffsetMs, durationMs, variedPoints } = trailState;
 
-  if (trail.points.length < 2) return null;
+  if (trail.points.length < 2 || variedPoints.length < 2) return null;
 
   const trailElapsedMs = elapsedTimeMs - startOffsetMs;
   if (trailElapsedMs < 0) return null;
@@ -104,27 +59,28 @@ function computeTrailFrame(
     : Math.max(0, headIndex - TAIL_LENGTH + 1);
   const tailEnd = Math.min(headIndex, totalVariedPoints - 1);
 
-  const pointsToDraw: Array<{ x: number; y: number }> = [];
-  for (let i = tailStart; i <= tailEnd; i++) {
-    pointsToDraw.push(variedPoints[i]);
-  }
-
+  let interpolatedHead: { x: number; y: number } | undefined;
   if (!isFinished && headIndex < totalVariedPoints - 1 && headFraction > 0) {
     const p1 = variedPoints[headIndex];
     const p2 = variedPoints[headIndex + 1];
-    pointsToDraw.push({
+    interpolatedHead = {
       x: p1.x + (p2.x - p1.x) * headFraction,
       y: p1.y + (p2.y - p1.y) * headFraction,
-    });
+    };
   }
 
-  const cursorPosition =
-    pointsToDraw.length > 0
-      ? pointsToDraw[pointsToDraw.length - 1]
-      : variedPoints[0] || { x: 0, y: 0 };
+  const cursorPosition = interpolatedHead ?? variedPoints[tailEnd];
 
+  const pointCount = tailEnd - tailStart + 1 + (interpolatedHead ? 1 : 0);
   const pathData =
-    pointsToDraw.length >= 2 ? generatePath(pointsToDraw, "straight") : "";
+    pointCount >= 2
+      ? buildStraightPathSegment(
+          variedPoints,
+          tailStart,
+          tailEnd,
+          interpolatedHead,
+        )
+      : "";
 
   const currentPointIndex = Math.min(
     Math.floor((trail.points.length - 1) * trailProgress),
@@ -152,78 +108,129 @@ interface ImperativeTrailHandle {
     evictionFade: number,
   ): { trailProgress: number; cursorPosition: { x: number; y: number } } | null;
   getGroup(): SVGGElement | null;
+  hide(): void;
 }
 
 interface TrailPathProps {
   trailState: TrailState;
-  trailIndex: number;
   fixedMonoStrokeWidth: number;
   renderer: TrailRenderer;
-  generatePath: (
-    points: Array<{ x: number; y: number }>,
-    style: string,
-  ) => string;
 }
 
 // Renders only the trail path (no cursor). The parent rAF loop drives updates
 // via the imperative handle.
 const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>(
-  ({ trailState, trailIndex, fixedMonoStrokeWidth, renderer, generatePath }, ref) => {
+  ({ trailState, fixedMonoStrokeWidth, renderer }, ref) => {
     const groupRef = useRef<SVGGElement>(null);
     const pathRef = useRef<SVGPathElement>(null);
     const haloRef = useRef<SVGPathElement>(null);
+    const lastGroupOpacityRef = useRef("");
+    const lastPathDataRef = useRef("");
+    const lastRendererIdRef = useRef("");
+    const lastTrailOpacityRef = useRef<number | null>(null);
+    const lastStrokeWidthRef = useRef<number | null>(null);
+    const lastCursorTypeRef = useRef<string | undefined>(undefined);
+    const lastTrailColorRef = useRef("");
+    const finishedFrameRef = useRef<ReturnType<typeof computeTrailFrame>>(null);
 
-    React.useImperativeHandle(ref, () => ({
-      update(elapsedTimeMs, trailOpacity, strokeWidth, evictionFade) {
-        const group = groupRef.current;
-        if (!group) return null;
+    useEffect(() => {
+      finishedFrameRef.current = null;
+      lastPathDataRef.current = "";
+      lastRendererIdRef.current = "";
+      lastTrailOpacityRef.current = null;
+      lastStrokeWidthRef.current = null;
+      lastCursorTypeRef.current = undefined;
+      lastTrailColorRef.current = "";
+    }, [trailState]);
 
-        if (evictionFade <= 0) {
-          group.setAttribute("opacity", "0");
-          return null;
-        }
+    const hideTrail = useCallback(() => {
+      const group = groupRef.current;
+      if (group && lastGroupOpacityRef.current !== "0") {
+        group.setAttribute("opacity", "0");
+        lastGroupOpacityRef.current = "0";
+      }
+    }, []);
 
-        const frame = computeTrailFrame(
-          trailState,
-          elapsedTimeMs,
-          generatePath,
-        );
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        hide: hideTrail,
+        getGroup() {
+          return groupRef.current;
+        },
+        update(elapsedTimeMs, trailOpacity, strokeWidth, evictionFade) {
+          const group = groupRef.current;
+          if (!group) return null;
 
-        if (!frame) {
-          group.setAttribute("opacity", "0");
-          return null;
-        }
-
-        group.setAttribute("opacity", String(evictionFade));
-
-        const { pathData, trailProgress, cursorPosition } = frame;
-
-        const pathEl = pathRef.current;
-        if (pathEl) {
-          if (pathData) {
-            renderer.updatePath({
-              pathEl,
-              haloEl: haloRef.current,
-              pathData,
-              trailOpacity,
-              strokeWidth,
-              cursorType: frame.cursorType,
-              trailProgress,
-              trailColor: trailState.trail.color,
-              fixedMonoStrokeWidth,
-            });
-          } else {
-            pathEl.style.display = "none";
-            if (haloRef.current) haloRef.current.style.display = "none";
+          if (evictionFade <= 0) {
+            hideTrail();
+            return null;
           }
-        }
 
-        return { trailProgress, cursorPosition };
-      },
-      getGroup() {
-        return groupRef.current;
-      },
-    }));
+          const isPastEnd =
+            elapsedTimeMs - trailState.startOffsetMs >= trailState.durationMs;
+          let frame = isPastEnd ? finishedFrameRef.current : null;
+          if (!frame) {
+            frame = computeTrailFrame(trailState, elapsedTimeMs);
+            if (isPastEnd) {
+              finishedFrameRef.current = frame;
+            }
+          }
+
+          if (!frame) {
+            hideTrail();
+            return null;
+          }
+
+          const groupOpacity = String(evictionFade);
+          if (lastGroupOpacityRef.current !== groupOpacity) {
+            group.setAttribute("opacity", groupOpacity);
+            lastGroupOpacityRef.current = groupOpacity;
+          }
+
+          const { pathData, trailProgress, cursorPosition } = frame;
+
+          const pathEl = pathRef.current;
+          if (pathEl) {
+            if (pathData) {
+              if (
+                lastPathDataRef.current !== pathData ||
+                lastRendererIdRef.current !== renderer.id ||
+                lastTrailOpacityRef.current !== trailOpacity ||
+                lastStrokeWidthRef.current !== strokeWidth ||
+                lastCursorTypeRef.current !== frame.cursorType ||
+                lastTrailColorRef.current !== trailState.trail.color
+              ) {
+                renderer.updatePath({
+                  pathEl,
+                  haloEl: haloRef.current,
+                  pathData,
+                  trailOpacity,
+                  strokeWidth,
+                  cursorType: frame.cursorType,
+                  trailProgress,
+                  trailColor: trailState.trail.color,
+                  fixedMonoStrokeWidth,
+                });
+                lastPathDataRef.current = pathData;
+                lastRendererIdRef.current = renderer.id;
+                lastTrailOpacityRef.current = trailOpacity;
+                lastStrokeWidthRef.current = strokeWidth;
+                lastCursorTypeRef.current = frame.cursorType;
+                lastTrailColorRef.current = trailState.trail.color;
+              }
+            } else {
+              pathEl.style.display = "none";
+              if (haloRef.current) haloRef.current.style.display = "none";
+              lastPathDataRef.current = "";
+            }
+          }
+
+          return { trailProgress, cursorPosition };
+        },
+      }),
+      [fixedMonoStrokeWidth, hideTrail, renderer, trailState],
+    );
 
     const color = trailState.trail.color;
 
@@ -251,7 +258,6 @@ const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>(
 
 interface TrailCursorProps {
   trailState: TrailState;
-  trailIndex: number;
   renderer: TrailRenderer;
 }
 
@@ -265,11 +271,14 @@ interface ImperativeTrailCursorHandle {
     trailProgress: number,
     evictionFade: number,
   ): void;
+  hide(): void;
 }
 
 const TrailCursor = React.forwardRef<ImperativeTrailCursorHandle, TrailCursorProps>(
   ({ trailState, renderer }, ref) => {
     const cursorGroupRef = useRef<SVGGElement>(null);
+    const cursorVisibleRef = useRef(false);
+    const lastTransformRef = useRef("");
 
     const [cursorType, setCursorType] = useState<string | undefined>(
       trailState.trail.points[0]?.cursor,
@@ -277,27 +286,41 @@ const TrailCursor = React.forwardRef<ImperativeTrailCursorHandle, TrailCursorPro
     const CursorComponent = getCursorComponent(cursorType);
     const cursorSize = 32;
 
+    const hideCursor = useCallback(() => {
+      const cursorGroup = cursorGroupRef.current;
+      if (cursorGroup && cursorVisibleRef.current) {
+        cursorGroup.style.display = "none";
+        cursorVisibleRef.current = false;
+      }
+    }, []);
+
     React.useImperativeHandle(ref, () => ({
+      hide: hideCursor,
       update(cursorPosition, newCursorType, isFinished, trailProgress, evictionFade) {
         const cursorGroup = cursorGroupRef.current;
         if (!cursorGroup) return;
 
         if (evictionFade <= 0 || isFinished || trailProgress <= 0) {
-          cursorGroup.style.display = "none";
+          hideCursor();
           return;
         }
 
-        cursorGroup.style.display = "";
-        cursorGroup.setAttribute(
-          "transform",
-          `translate(${cursorPosition.x}, ${cursorPosition.y})`,
-        );
+        if (!cursorVisibleRef.current) {
+          cursorGroup.style.display = "";
+          cursorVisibleRef.current = true;
+        }
+
+        const transform = `translate(${cursorPosition.x}, ${cursorPosition.y})`;
+        if (lastTransformRef.current !== transform) {
+          cursorGroup.setAttribute("transform", transform);
+          lastTransformRef.current = transform;
+        }
 
         if (newCursorType !== cursorType) {
           setCursorType(newCursorType);
         }
       },
-    }));
+    }), [cursorType, hideCursor]);
 
     const color = renderer.getCursorColor(trailState.trail.color, cursorType);
 
@@ -321,59 +344,38 @@ const TrailCursor = React.forwardRef<ImperativeTrailCursorHandle, TrailCursorPro
   },
 );
 
-// Compute eviction fade for each trail index at a given time.
-function computeEvictionFades(
-  trailStates: TrailState[],
-  sortedFinishOrder: Array<{ originalIndex: number; finishedAtMs: number }>,
+function computeTrailFade(
+  trailState: TrailState,
+  finishPosition: number,
+  sortedFinishOrder: FinishedTrailOrderEntry[],
   elapsedTimeMs: number,
   windowSize: number,
-): Float64Array {
-  // Returns an array indexed by originalIndex with eviction fade values.
-  // 0 = hidden (not started or fully evicted), >0 = visible.
-  const fades = new Float64Array(trailStates.length);
+  finishedCount: number,
+): number {
+  const trailElapsedMs = elapsedTimeMs - trailState.startOffsetMs;
+  if (trailElapsedMs < 0) return 0;
 
-  const finished: Array<{ originalIndex: number; finishedAtMs: number }> = [];
+  const trailProgress = Math.min(1, trailElapsedMs / trailState.durationMs);
+  if (trailProgress < 1) return 1;
 
-  for (const entry of sortedFinishOrder) {
-    const ts = trailStates[entry.originalIndex];
-    const trailElapsedMs = elapsedTimeMs - ts.startOffsetMs;
-    if (trailElapsedMs < 0) continue; // not started
-
-    const trailProgress = Math.min(1, trailElapsedMs / ts.durationMs);
-    if (trailProgress < 1) {
-      fades[entry.originalIndex] = 1; // active
-    } else {
-      finished.push(entry);
-    }
+  const excessCount = Math.max(0, finishedCount - windowSize);
+  if (finishPosition < excessCount) {
+    const displacerIndex = finishPosition + windowSize;
+    const evictedAtMs =
+      displacerIndex < finishedCount
+        ? sortedFinishOrder[displacerIndex].finishedAtMs
+        : elapsedTimeMs;
+    const timeSinceEvicted = elapsedTimeMs - evictedAtMs;
+    return Math.max(
+      0,
+      COMPLETED_OPACITY * (1 - timeSinceEvicted / EVICTION_FADE_MS),
+    );
   }
 
-  const excessCount = Math.max(0, finished.length - windowSize);
-  for (let i = 0; i < finished.length; i++) {
-    const f = finished[i];
-    if (i < excessCount) {
-      // Fade based on when this trail was pushed out of the window, not when
-      // it finished. The trail at index windowSize is the one that displaced
-      // trail i — so use its finishedAtMs as the eviction trigger time.
-      const displacerIndex = i + windowSize;
-      const evictedAtMs =
-        displacerIndex < finished.length
-          ? finished[displacerIndex].finishedAtMs
-          : elapsedTimeMs;
-      const timeSinceEvicted = elapsedTimeMs - evictedAtMs;
-      // Fade from COMPLETED_OPACITY (not full opacity) to avoid a brightness jump
-      fades[f.originalIndex] = Math.max(
-        0,
-        COMPLETED_OPACITY * (1 - timeSinceEvicted / EVICTION_FADE_MS),
-      );
-    } else {
-      // Dim finished trails so active ones are visually prominent
-      const timeSinceFinished = elapsedTimeMs - f.finishedAtMs;
-      const fadeFraction = Math.min(1, timeSinceFinished / COMPLETION_FADE_MS);
-      fades[f.originalIndex] = 1 - fadeFraction * (1 - COMPLETED_OPACITY);
-    }
-  }
-
-  return fades;
+  const finishedAtMs = trailState.startOffsetMs + trailState.durationMs;
+  const timeSinceFinished = elapsedTimeMs - finishedAtMs;
+  const fadeFraction = Math.min(1, timeSinceFinished / COMPLETION_FADE_MS);
+  return 1 - fadeFraction * (1 - COMPLETED_OPACITY);
 }
 
 interface AnimatedTrailsProps {
@@ -422,13 +424,11 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
       [],
     );
 
-    const animationRef = useRef<number>();
-    const timeoutRef = useRef<number>();
-    const spawnedClicksRef = useRef<Map<string, Set<number>>>(new Map());
+    const animationRef = useRef<number | undefined>(undefined);
+    const timeoutRef = useRef<number | undefined>(undefined);
     const svgRef = useRef<SVGSVGElement>(null);
     const pathLayerRef = useRef<SVGGElement>(null);
 
-    const generatePath = useRef(createPathGenerator()).current;
     const renderer = getTrailRenderer(settings.trailVisualStyle ?? "color");
     const rendererRef = useRef(renderer);
     useEffect(() => { rendererRef.current = renderer; }, [renderer]);
@@ -452,6 +452,24 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
           finishedAtMs: ts.startOffsetMs + ts.durationMs,
         }))
         .sort((a, b) => a.finishedAtMs - b.finishedAtMs);
+    }, [trailStates]);
+
+    const finishPositionByTrail = useMemo(() => {
+      const positions = new Int32Array(trailStates.length);
+      sortedFinishOrder.forEach((entry, position) => {
+        positions[entry.originalIndex] = position;
+      });
+      return positions;
+    }, [sortedFinishOrder, trailStates.length]);
+
+    const sortedStartOrder = useMemo(() => {
+      return trailStates
+        .map((ts, i) => ({
+          originalIndex: i,
+          startOffsetMs: ts.startOffsetMs,
+          finishedAtMs: ts.startOffsetMs + ts.durationMs,
+        }))
+        .sort((a, b) => a.startOffsetMs - b.startOffsetMs);
     }, [trailStates]);
 
     // Store one ref handle per trail index for paths and cursors separately.
@@ -484,6 +502,8 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     // Refs the rAF loop reads (kept current via effects)
     const trailStatesRef = useRef(trailStates);
     const sortedFinishOrderRef = useRef(sortedFinishOrder);
+    const finishPositionByTrailRef = useRef(finishPositionByTrail);
+    const sortedStartOrderRef = useRef(sortedStartOrder);
     const windowSizeRef = useRef(windowSize);
     const showClickRipplesRef = useRef(showClickRipples);
     const documentSpaceRef = useRef(documentSpace);
@@ -499,6 +519,12 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
       sortedFinishOrderRef.current = sortedFinishOrder;
     }, [sortedFinishOrder]);
     useEffect(() => {
+      finishPositionByTrailRef.current = finishPositionByTrail;
+    }, [finishPositionByTrail]);
+    useEffect(() => {
+      sortedStartOrderRef.current = sortedStartOrder;
+    }, [sortedStartOrder]);
+    useEffect(() => {
       windowSizeRef.current = windowSize;
     }, [windowSize]);
     useEffect(() => {
@@ -512,6 +538,27 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     // Updated from rAF loop but only triggers a React re-render for ripple cleanup.
     const visibleSetRef = useRef<Set<number>>(new Set());
     const ripplePruneScheduled = useRef(false);
+    const activeTrailIndicesRef = useRef<number[]>([]);
+    const nextStartOrderIndexRef = useRef(0);
+    const visibleMarksRef = useRef(new Uint32Array(trailStates.length));
+    const visibleFrameIdRef = useRef(1);
+    const visibleIndicesScratchRef = useRef<number[]>([]);
+    const previousVisibleIndicesRef = useRef<number[]>([]);
+    const nextClickIndexByTrailRef = useRef(new Int32Array(trailStates.length));
+    const soundFramesRef = useRef<TrailSoundFrame[]>([]);
+    const activePaintOrderIndicesRef = useRef<number[]>([]);
+    const previousActivePaintOrderIndicesRef = useRef<number[]>([]);
+
+    useEffect(() => {
+      visibleMarksRef.current = new Uint32Array(trailStates.length);
+      nextClickIndexByTrailRef.current = new Int32Array(trailStates.length);
+      activeTrailIndicesRef.current = [];
+      visibleIndicesScratchRef.current = [];
+      previousVisibleIndicesRef.current = [];
+      activePaintOrderIndicesRef.current = [];
+      previousActivePaintOrderIndicesRef.current = [];
+      nextStartOrderIndexRef.current = 0;
+    }, [trailStates]);
 
     const scheduleRipplePrune = useCallback(() => {
       if (ripplePruneScheduled.current) return;
@@ -558,11 +605,19 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
       // Reset per-loop state so stale prevElapsed from a previous loop doesn't
       // look like a wrap and trigger a mass re-spawn of all clicks at once.
       prevElapsedRef.current = 0;
-      spawnedClicksRef.current.clear();
+      nextClickIndexByTrailRef.current.fill(0);
+      activeTrailIndicesRef.current = [];
+      nextStartOrderIndexRef.current = 0;
       setActiveClickEffects([]);
       soundEngineRef.current?.reset();
 
       let startTime: number | null = null;
+
+      const resetPlaybackTrackers = () => {
+        activeTrailIndicesRef.current = [];
+        nextStartOrderIndexRef.current = 0;
+        nextClickIndexByTrailRef.current.fill(0);
+      };
 
       const clearScheduledFrame = () => {
         if (animationRef.current !== undefined) {
@@ -610,7 +665,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
 
         // Detect loop wrap
         if (loopedElapsed < prevElapsedRef.current) {
-          spawnedClicksRef.current.clear();
+          resetPlaybackTrackers();
           setActiveClickEffects([]);
           soundEngineRef.current?.reset();
         }
@@ -620,33 +675,95 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         const trailOpacity = trailOpacityRef.current;
         const strokeWidth = strokeWidthRef.current;
 
-        // Compute per-trail eviction fades
-        const fades = computeEvictionFades(
-          currentTrailStates,
-          sortedFinishOrderRef.current,
+        const frameId = visibleFrameIdRef.current++;
+        if (visibleFrameIdRef.current === Number.MAX_SAFE_INTEGER) {
+          visibleMarksRef.current.fill(0);
+          visibleFrameIdRef.current = 1;
+        }
+
+        const visibleMarks = visibleMarksRef.current;
+        const visibleIndices = visibleIndicesScratchRef.current;
+        visibleIndices.length = 0;
+
+        const markVisible = (trailIndex: number) => {
+          if (visibleMarks[trailIndex] === frameId) return;
+          visibleMarks[trailIndex] = frameId;
+          visibleIndices.push(trailIndex);
+        };
+
+        const sortedStartOrder = sortedStartOrderRef.current;
+        while (
+          nextStartOrderIndexRef.current < sortedStartOrder.length &&
+          sortedStartOrder[nextStartOrderIndexRef.current].startOffsetMs <=
+            loopedElapsed
+        ) {
+          const entry = sortedStartOrder[nextStartOrderIndexRef.current];
+          if (entry.finishedAtMs > loopedElapsed) {
+            activeTrailIndicesRef.current.push(entry.originalIndex);
+          }
+          nextStartOrderIndexRef.current++;
+        }
+
+        const activeTrailIndices = activeTrailIndicesRef.current;
+        let activeWriteIndex = 0;
+        for (let i = 0; i < activeTrailIndices.length; i++) {
+          const trailIndex = activeTrailIndices[i];
+          const trailState = currentTrailStates[trailIndex];
+          const finishedAtMs = trailState.startOffsetMs + trailState.durationMs;
+          if (
+            trailState.startOffsetMs <= loopedElapsed &&
+            finishedAtMs > loopedElapsed
+          ) {
+            activeTrailIndices[activeWriteIndex] = trailIndex;
+            activeWriteIndex++;
+            markVisible(trailIndex);
+          }
+        }
+        activeTrailIndices.length = activeWriteIndex;
+
+        const sortedFinishOrder = sortedFinishOrderRef.current;
+        const finishedRange = getFinishedTrailRenderRange(
+          sortedFinishOrder,
           loopedElapsed,
           windowSizeRef.current,
+          EVICTION_FADE_MS,
         );
+        for (let i = finishedRange.start; i < finishedRange.end; i++) {
+          markVisible(sortedFinishOrder[i].originalIndex);
+        }
 
-        // Track which trails are visible this frame for ripple pruning
-        const newVisible = new Set<number>();
+        let visibilityChanged =
+          previousVisibleIndicesRef.current.length !== visibleIndices.length;
+        for (const trailIndex of previousVisibleIndicesRef.current) {
+          if (visibleMarks[trailIndex] !== frameId) {
+            trailHandles.current[trailIndex]?.hide();
+            cursorHandles.current[trailIndex]?.hide();
+            visibilityChanged = true;
+          }
+        }
 
-        // Collect trail frame results for sound engine
-        const soundFrames: TrailSoundFrame[] = [];
+        const soundEngine = soundEngineRef.current;
+        const soundEnabled = soundEngine?.isEnabled() ?? false;
+        const soundFrames = soundFramesRef.current;
+        soundFrames.length = 0;
+        const activePaintOrderIndices = activePaintOrderIndicesRef.current;
+        activePaintOrderIndices.length = 0;
 
-        // Track currently-drawing trails so we can reorder their <g> to the
-        // end of the path layer, ensuring active heads paint on top of any
-        // earlier-rendered (older) trail body that overlaps them in SVG paint
-        // order. Sorted by startOffsetMs so the most recently started trail
-        // ends up last.
-        const activeIndices: number[] = [];
-
-        // Update all trail paths and cursors imperatively
-        for (let idx = 0; idx < currentTrailStates.length; idx++) {
+        // Update visible trail paths and cursors imperatively
+        for (const idx of visibleIndices) {
           const handle = trailHandles.current[idx];
           if (!handle) continue;
 
-          const fade = fades[idx];
+          const fade = computeTrailFade(
+            currentTrailStates[idx],
+            finishPositionByTrailRef.current[idx],
+            sortedFinishOrder,
+            loopedElapsed,
+            windowSizeRef.current,
+            finishedRange.finishedCount,
+          );
+          if (fade <= 0) continue;
+
           const result = handle.update(
             loopedElapsed,
             trailOpacity,
@@ -654,10 +771,8 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
             fade,
           );
 
-          if (fade > 0) newVisible.add(idx);
-
           if (result && fade > 0 && result.trailProgress < 1) {
-            activeIndices.push(idx);
+            activePaintOrderIndices.push(idx);
           }
 
           // Update cursor icon in the separate cursor layer
@@ -684,7 +799,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
           }
 
           // Collect frame data for sound engine
-          if (result && fade > 0 && soundEngineRef.current?.isEnabled()) {
+          if (result && fade > 0 && soundEnabled) {
             const cpIdx = Math.min(
               Math.floor(
                 (ts.trail.points.length - 1) * result.trailProgress,
@@ -707,69 +822,89 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
           // Spawn clicks
           if (result && showClickRipplesRef.current) {
             const ts = currentTrailStates[idx];
-            const trailKey = `trail-${idx}`;
-            if (!spawnedClicksRef.current.has(trailKey)) {
-              spawnedClicksRef.current.set(trailKey, new Set());
+            let clickIdx = nextClickIndexByTrailRef.current[idx];
+            while (
+              clickIdx < ts.clicksWithProgress.length &&
+              result.trailProgress >= ts.clicksWithProgress[clickIdx].progress
+            ) {
+              const click = ts.clicksWithProgress[clickIdx];
+
+              soundEngine?.triggerClick({
+                x: result.cursorPosition.x,
+                y: result.cursorPosition.y,
+                holdDuration: click.duration,
+              });
+
+              pendingClicks.current.push({
+                id: `${idx}-${clickIdx}-${Date.now()}`,
+                x: result.cursorPosition.x,
+                y: result.cursorPosition.y,
+                color: rendererRef.current.getClickColor(ts.trail.color),
+                radiusFactor: Math.random(),
+                durationFactor: Math.random(),
+                startTime: Date.now(),
+                trailIndex: idx,
+                holdDuration: click.duration,
+              });
+
+              clickIdx++;
             }
-            const spawnedSet = spawnedClicksRef.current.get(trailKey)!;
-
-            ts.clicksWithProgress.forEach((click, clickIdx) => {
-              if (
-                result.trailProgress >= click.progress &&
-                !spawnedSet.has(clickIdx)
-              ) {
-                spawnedSet.add(clickIdx);
-
-                // Trigger click sound
-                soundEngineRef.current?.triggerClick({
-                  x: result.cursorPosition.x,
-                  y: result.cursorPosition.y,
-                  holdDuration: click.duration,
-                });
-
-                pendingClicks.current.push({
-                  id: `${idx}-${clickIdx}-${Date.now()}`,
-                  x: result.cursorPosition.x,
-                  y: result.cursorPosition.y,
-                  color: rendererRef.current.getClickColor(ts.trail.color),
-                  radiusFactor: Math.random(),
-                  durationFactor: Math.random(),
-                  startTime: Date.now(),
-                  trailIndex: idx,
-                  holdDuration: click.duration,
-                });
-              }
-            });
+            nextClickIndexByTrailRef.current[idx] = clickIdx;
           }
         }
 
-        // Reorder active trail groups so they paint on top of finished /
-        // earlier-started trails. Sort by startOffsetMs ascending — the
-        // latest-started active trail ends up last in DOM order, so its head
-        // paints over any other active trail's body it crosses. appendChild
-        // on an existing node moves it within the parent.
         const pathLayer = pathLayerRef.current;
-        if (pathLayer && activeIndices.length > 0) {
-          activeIndices.sort(
-            (a, b) =>
-              currentTrailStates[a].startOffsetMs -
-              currentTrailStates[b].startOffsetMs,
-          );
-          for (let i = 0; i < activeIndices.length; i++) {
-            const handle = trailHandles.current[activeIndices[i]];
-            const group = handle?.getGroup();
-            if (group && group.parentNode === pathLayer) {
-              pathLayer.appendChild(group);
+        if (pathLayer && activePaintOrderIndices.length > 0) {
+          const previousActivePaintOrder =
+            previousActivePaintOrderIndicesRef.current;
+          let activePaintOrderChanged =
+            previousActivePaintOrder.length !== activePaintOrderIndices.length;
+
+          if (!activePaintOrderChanged) {
+            for (let i = 0; i < activePaintOrderIndices.length; i++) {
+              if (previousActivePaintOrder[i] !== activePaintOrderIndices[i]) {
+                activePaintOrderChanged = true;
+                break;
+              }
             }
           }
+
+          if (activePaintOrderChanged) {
+            // Active heads paint over earlier or finished bodies.
+            activePaintOrderIndices.sort(
+              (a, b) =>
+                currentTrailStates[a].startOffsetMs -
+                currentTrailStates[b].startOffsetMs,
+            );
+
+            for (const idx of activePaintOrderIndices) {
+              const group = trailHandles.current[idx]?.getGroup();
+              if (group && group.parentNode === pathLayer) {
+                pathLayer.appendChild(group);
+              }
+            }
+            previousActivePaintOrder.length = activePaintOrderIndices.length;
+            for (let i = 0; i < activePaintOrderIndices.length; i++) {
+              previousActivePaintOrder[i] = activePaintOrderIndices[i];
+            }
+          }
+        } else {
+          previousActivePaintOrderIndicesRef.current.length = 0;
         }
 
         // Feed sound engine with collected trail frames
-        if (soundFrames.length > 0) {
-          soundEngineRef.current?.tick(loopedElapsed, soundFrames);
+        if (soundFrames.length > 0 && soundEngine) {
+          soundEngine.tick(loopedElapsed, soundFrames);
         }
 
-        visibleSetRef.current = newVisible;
+        if (visibilityChanged) {
+          const visibleSet = visibleSetRef.current;
+          visibleSet.clear();
+          for (const trailIndex of visibleIndices) {
+            visibleSet.add(trailIndex);
+          }
+          previousVisibleIndicesRef.current = [...visibleIndices];
+        }
 
         // Flush pending clicks
         if (pendingClicks.current.length > 0) {
@@ -777,7 +912,9 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         }
 
         // Prune ripples for trails that became invisible
-        scheduleRipplePrune();
+        if (visibilityChanged) {
+          scheduleRipplePrune();
+        }
 
         scheduleNextFrame();
       };
@@ -849,10 +986,8 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
                 trailHandles.current[idx] = handle;
               }}
               trailState={ts}
-              trailIndex={idx}
               fixedMonoStrokeWidth={1 + ((idx * 7 + 3) % 5)}
               renderer={renderer}
-              generatePath={generatePath}
             />
           ))}
         </g>
@@ -866,7 +1001,6 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
               cursorHandles.current[idx] = handle;
             }}
             trailState={ts}
-            trailIndex={idx}
             renderer={renderer}
           />
         ))}
@@ -882,6 +1016,12 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
       prevProps.windowSize === nextProps.windowSize &&
       prevProps.documentSpace === nextProps.documentSpace &&
       prevProps.soundEngine === nextProps.soundEngine &&
+      prevProps.settings.strokeWidth === nextProps.settings.strokeWidth &&
+      prevProps.settings.trailOpacity === nextProps.settings.trailOpacity &&
+      prevProps.settings.animationSpeed ===
+        nextProps.settings.animationSpeed &&
+      prevProps.settings.trailVisualStyle ===
+        nextProps.settings.trailVisualStyle &&
       prevProps.settings.clickMinRadius === nextProps.settings.clickMinRadius &&
       prevProps.settings.clickMaxRadius === nextProps.settings.clickMaxRadius &&
       prevProps.settings.clickCoreRadius === nextProps.settings.clickCoreRadius &&

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -766,6 +766,43 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     ],
   );
 
+  const trailAnimationSettings = useMemo(
+    () => ({
+      strokeWidth: settings.strokeWidth,
+      trailOpacity: settings.trailOpacity,
+      animationSpeed: settings.animationSpeed,
+      clickMinRadius: settings.clickMinRadius,
+      clickMaxRadius: settings.clickMaxRadius,
+      clickCoreRadius: settings.clickCoreRadius,
+      clickMinDuration: settings.clickMinDuration,
+      clickMaxDuration: settings.clickMaxDuration,
+      clickExpansionDuration: settings.clickExpansionDuration,
+      clickStrokeWidth: settings.clickStrokeWidth,
+      clickOpacity: settings.clickOpacity,
+      clickNumRings: settings.clickNumRings,
+      clickRingDelayMs: settings.clickRingDelayMs,
+      clickAnimationStopPoint: settings.clickAnimationStopPoint,
+      trailVisualStyle: settings.trailVisualStyle,
+    }),
+    [
+      settings.strokeWidth,
+      settings.trailOpacity,
+      settings.animationSpeed,
+      settings.clickMinRadius,
+      settings.clickMaxRadius,
+      settings.clickCoreRadius,
+      settings.clickMinDuration,
+      settings.clickMaxDuration,
+      settings.clickExpansionDuration,
+      settings.clickStrokeWidth,
+      settings.clickOpacity,
+      settings.clickNumRings,
+      settings.clickRingDelayMs,
+      settings.clickAnimationStopPoint,
+      settings.trailVisualStyle,
+    ],
+  );
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -953,23 +990,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             showClickRipples={!showClicks}
             windowSize={settings.maxConcurrentTrails * 2}
             soundEngine={soundEnabled ? soundEngineReady : null}
-            settings={{
-              strokeWidth: settings.strokeWidth,
-              trailOpacity: settings.trailOpacity,
-              animationSpeed: settings.animationSpeed,
-              clickMinRadius: settings.clickMinRadius,
-              clickMaxRadius: settings.clickMaxRadius,
-              clickCoreRadius: settings.clickCoreRadius,
-              clickMinDuration: settings.clickMinDuration,
-              clickMaxDuration: settings.clickMaxDuration,
-              clickExpansionDuration: settings.clickExpansionDuration,
-              clickStrokeWidth: settings.clickStrokeWidth,
-              clickOpacity: settings.clickOpacity,
-              clickNumRings: settings.clickNumRings,
-              clickRingDelayMs: settings.clickRingDelayMs,
-              clickAnimationStopPoint: settings.clickAnimationStopPoint,
-              trailVisualStyle: settings.trailVisualStyle,
-            }}
+            settings={trailAnimationSettings}
           />
         )}
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -505,7 +505,6 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
   const cursorSettings = useMemo(
     () => ({
-      trailOpacity: settings.trailOpacity,
       randomizeColors: settings.randomizeColors,
       domainFilter: settings.domainFilter,
       eventFilter: settings.eventFilter,
@@ -518,7 +517,6 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       documentSpace: settings.documentSpace,
     }),
     [
-      settings.trailOpacity,
       settings.randomizeColors,
       settings.domainFilter,
       settings.eventFilter,

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -25,7 +25,6 @@ import {
 
 // Settings interface for cursor trails
 export interface CursorTrailSettings {
-  trailOpacity: number;
   randomizeColors: boolean;
   domainFilter: string;
   eventFilter: {
@@ -190,10 +189,6 @@ export function useCursorTrails(
         duration?: number;
       }> = [];
       let lastTimestamp = 0;
-      // Track last viewport-relative position (normalized 0-1) to detect
-      // scroll-only samples where the cursor hasn't actually moved.
-      let lastNormX = -1;
-      let lastNormY = -1;
 
       groupEvents.forEach((event) => {
         const eventType = event.data.event || "move";
@@ -207,24 +202,6 @@ export function useCursorTrails(
           !settings.eventFilter.cursor_change
         )
           return;
-
-        // In document space mode, skip move events that are scroll-induced:
-        // the cursor barely moved in viewport-relative terms between samples.
-        // Threshold is 5% of viewport — small enough to catch a stationary
-        // cursor while scrolling, large enough to keep real cursor movement.
-        // Clicks and holds always pass through.
-        // if (
-        //   settings.documentSpace &&
-        //   eventType === "move" &&
-        //   lastNormX >= 0 &&
-        //   Math.abs(event.data.x - lastNormX) < 0.05 &&
-        //   Math.abs(event.data.y - lastNormY) < 0.05
-        // ) {
-        //   lastTimestamp = event.ts;
-        //   lastNormX = event.data.x;
-        //   lastNormY = event.data.y;
-        //   return;
-        // }
 
         // Convert normalized coordinates (0-1) to pixel coordinates.
         // In document space mode: reconstruct the absolute document position using
@@ -270,7 +247,7 @@ export function useCursorTrails(
             trails.push({
               points: [...currentTrail],
               color: getTrailColor(startTime),
-              opacity: settings.trailOpacity,
+              opacity: 1,
               startTime,
               endTime,
               clicks: [...currentClicks],
@@ -317,8 +294,6 @@ export function useCursorTrails(
         }
 
         lastTimestamp = event.ts;
-        lastNormX = event.data.x;
-        lastNormY = event.data.y;
       });
 
       // Don't forget the last trail
@@ -329,7 +304,7 @@ export function useCursorTrails(
         trails.push({
           points: currentTrail,
           color: getTrailColor(startTime),
-          opacity: settings.trailOpacity,
+          opacity: 1,
           startTime,
           endTime,
           clicks: [...currentClicks],
@@ -348,7 +323,6 @@ export function useCursorTrails(
     settings.randomizeColors,
     settings.domainFilter,
     settings.eventFilter,
-    settings.trailOpacity,
     settings.documentSpace,
     viewportSize,
   ]);

--- a/extension/website/shared/styles/__tests__/trailRenderers.test.ts
+++ b/extension/website/shared/styles/__tests__/trailRenderers.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Tests trail renderer DOM mutation caching.
+// ABOUTME: Guards hot-path SVG attribute updates against redundant writes.
+
+import { describe, expect, it, vi } from "vitest";
+import { colorRenderer } from "../trailRenderers";
+
+describe("colorRenderer", () => {
+  it("does not reapply unchanged SVG path attributes", () => {
+    const pathEl = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "path",
+    );
+    const setAttribute = vi.spyOn(pathEl, "setAttribute");
+
+    const params = {
+      pathEl,
+      pathData: "M 0 0 L 10 10",
+      trailOpacity: 0.7,
+      strokeWidth: 5,
+      cursorType: "default",
+      trailProgress: 0.5,
+      trailColor: "#7c3aed",
+      fixedMonoStrokeWidth: 3,
+    };
+
+    colorRenderer.updatePath(params);
+    const firstCallCount = setAttribute.mock.calls.length;
+
+    colorRenderer.updatePath(params);
+
+    expect(firstCallCount).toBeGreaterThan(0);
+    expect(setAttribute.mock.calls).toHaveLength(firstCallCount);
+  });
+});

--- a/extension/website/shared/styles/trailRenderers.ts
+++ b/extension/website/shared/styles/trailRenderers.ts
@@ -148,6 +148,48 @@ interface MonochromeStyle {
   opacity: number;
 }
 
+interface AppliedAttributes {
+  d?: string;
+  filter?: string;
+  opacity?: string;
+  stroke?: string;
+  strokeWidth?: string;
+}
+
+const appliedAttributesByPath = new WeakMap<SVGPathElement, AppliedAttributes>();
+
+function setPathAttribute(
+  pathEl: SVGPathElement,
+  attributeName: keyof AppliedAttributes,
+  value: string,
+): void {
+  let applied = appliedAttributesByPath.get(pathEl);
+  if (!applied) {
+    applied = {};
+    appliedAttributesByPath.set(pathEl, applied);
+  }
+
+  if (applied[attributeName] === value) return;
+
+  const svgAttributeName =
+    attributeName === "strokeWidth" ? "stroke-width" : attributeName;
+  pathEl.setAttribute(svgAttributeName, value);
+  applied[attributeName] = value;
+}
+
+function removePathAttribute(
+  pathEl: SVGPathElement,
+  attributeName: keyof AppliedAttributes,
+): void {
+  const applied = appliedAttributesByPath.get(pathEl);
+  if (applied?.[attributeName] === undefined) return;
+
+  const svgAttributeName =
+    attributeName === "strokeWidth" ? "stroke-width" : attributeName;
+  pathEl.removeAttribute(svgAttributeName);
+  applied[attributeName] = undefined;
+}
+
 function getMonochromeStyle(cursorType: string | undefined): MonochromeStyle {
   switch (cursorType) {
     case "pointer":
@@ -172,11 +214,11 @@ export const colorRenderer: TrailRenderer = {
   id: "color",
   name: "Color",
   updatePath({ pathEl, haloEl, pathData, trailOpacity, strokeWidth, trailColor }) {
-    pathEl.setAttribute("d", pathData);
-    pathEl.setAttribute("stroke", trailColor);
-    pathEl.setAttribute("opacity", String(trailOpacity));
-    pathEl.setAttribute("stroke-width", String(strokeWidth));
-    pathEl.removeAttribute("filter");
+    setPathAttribute(pathEl, "d", pathData);
+    setPathAttribute(pathEl, "stroke", trailColor);
+    setPathAttribute(pathEl, "opacity", String(trailOpacity));
+    setPathAttribute(pathEl, "strokeWidth", String(strokeWidth));
+    removePathAttribute(pathEl, "filter");
     pathEl.style.display = "";
 
     if (haloEl) {
@@ -186,14 +228,16 @@ export const colorRenderer: TrailRenderer = {
           ? getPlateColor(trailColor, distance)
           : null;
       if (plateColor) {
-        haloEl.setAttribute("d", pathData);
-        haloEl.setAttribute("stroke", plateColor);
-        haloEl.setAttribute(
+        setPathAttribute(haloEl, "d", pathData);
+        setPathAttribute(haloEl, "stroke", plateColor);
+        setPathAttribute(
+          haloEl,
           "opacity",
           String(trailOpacity * PLATE_OPACITY_FACTOR),
         );
-        haloEl.setAttribute(
-          "stroke-width",
+        setPathAttribute(
+          haloEl,
+          "strokeWidth",
           String(strokeWidth * PLATE_STROKE_MULTIPLIER),
         );
         haloEl.style.display = "";
@@ -218,11 +262,11 @@ export const monochromeRenderer: TrailRenderer = {
     <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G" />
   </filter>`,
   updatePath({ pathEl, haloEl, pathData, trailOpacity, fixedMonoStrokeWidth }) {
-    pathEl.setAttribute("d", pathData);
-    pathEl.setAttribute("stroke", "#000");
-    pathEl.setAttribute("opacity", String(0.8 * trailOpacity));
-    pathEl.setAttribute("stroke-width", String(fixedMonoStrokeWidth));
-    pathEl.setAttribute("filter", "url(#ink-texture)");
+    setPathAttribute(pathEl, "d", pathData);
+    setPathAttribute(pathEl, "stroke", "#000");
+    setPathAttribute(pathEl, "opacity", String(0.8 * trailOpacity));
+    setPathAttribute(pathEl, "strokeWidth", String(fixedMonoStrokeWidth));
+    setPathAttribute(pathEl, "filter", "url(#ink-texture)");
     pathEl.style.display = "";
     if (haloEl) haloEl.style.display = "none";
   },

--- a/extension/website/shared/utils/__tests__/trailAnimation.test.ts
+++ b/extension/website/shared/utils/__tests__/trailAnimation.test.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Tests performance-oriented trail animation planning helpers.
+// ABOUTME: Verifies optimized frame selection preserves existing visual timing.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildStraightPathSegment,
+  getFinishedTrailRenderRange,
+} from "../trailAnimation";
+
+describe("buildStraightPathSegment", () => {
+  it("builds the same straight path shape with an interpolated head point", () => {
+    const path = buildStraightPathSegment(
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 20, y: 10 },
+      ],
+      0,
+      2,
+      { x: 25, y: 15 },
+    );
+
+    expect(path).toBe("M 0 0 L 10 0 L 20 10 L 25 15");
+  });
+});
+
+describe("getFinishedTrailRenderRange", () => {
+  const sortedFinishOrder = [
+    { originalIndex: 0, finishedAtMs: 100 },
+    { originalIndex: 1, finishedAtMs: 200 },
+    { originalIndex: 2, finishedAtMs: 300 },
+    { originalIndex: 3, finishedAtMs: 400 },
+    { originalIndex: 4, finishedAtMs: 500 },
+  ];
+
+  it("keeps the visible finished window plus trails still fading after eviction", () => {
+    expect(getFinishedTrailRenderRange(sortedFinishOrder, 550, 2, 3000)).toEqual(
+      {
+        start: 0,
+        end: 5,
+        finishedCount: 5,
+      },
+    );
+  });
+
+  it("skips finished trails whose eviction fade has completed", () => {
+    expect(
+      getFinishedTrailRenderRange(sortedFinishOrder, 3500, 2, 3000),
+    ).toEqual({
+      start: 3,
+      end: 5,
+      finishedCount: 5,
+    });
+  });
+});

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Pure helpers for planning and drawing animated cursor trail frames.
+// ABOUTME: Keeps hot animation-loop calculations testable and allocation-light.
+
+export interface FinishedTrailOrderEntry {
+  originalIndex: number;
+  finishedAtMs: number;
+}
+
+export interface FinishedTrailRenderRange {
+  start: number;
+  end: number;
+  finishedCount: number;
+}
+
+export function buildStraightPathSegment(
+  points: Array<{ x: number; y: number }>,
+  startIndex: number,
+  endIndex: number,
+  interpolatedHead?: { x: number; y: number },
+): string {
+  if (points.length === 0 || startIndex > endIndex) return "";
+
+  let path = `M ${points[startIndex].x} ${points[startIndex].y}`;
+  for (let i = startIndex + 1; i <= endIndex; i++) {
+    path += ` L ${points[i].x} ${points[i].y}`;
+  }
+
+  if (interpolatedHead) {
+    path += ` L ${interpolatedHead.x} ${interpolatedHead.y}`;
+  }
+
+  return path;
+}
+
+export function getFinishedTrailRenderRange(
+  sortedFinishOrder: FinishedTrailOrderEntry[],
+  elapsedTimeMs: number,
+  windowSize: number,
+  evictionFadeMs: number,
+): FinishedTrailRenderRange {
+  const finishedCount = getFinishedCount(sortedFinishOrder, elapsedTimeMs);
+  if (finishedCount === 0) {
+    return { start: 0, end: 0, finishedCount };
+  }
+
+  const excessCount = Math.max(0, finishedCount - windowSize);
+  if (excessCount === 0) {
+    return { start: 0, end: finishedCount, finishedCount };
+  }
+
+  const evictionCutoffMs = elapsedTimeMs - evictionFadeMs;
+  let start = 0;
+  while (
+    start < excessCount &&
+    sortedFinishOrder[start + windowSize].finishedAtMs <= evictionCutoffMs
+  ) {
+    start++;
+  }
+
+  return { start, end: finishedCount, finishedCount };
+}
+
+function getFinishedCount(
+  sortedFinishOrder: FinishedTrailOrderEntry[],
+  elapsedTimeMs: number,
+): number {
+  let low = 0;
+  let high = sortedFinishOrder.length;
+
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (sortedFinishOrder[mid].finishedAtMs <= elapsedTimeMs) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return low;
+}


### PR DESCRIPTION
## Summary

- Reduces per-frame work in the animated trails hot path by caching finished trail frames, avoiding redundant SVG/path mutations, and reusing frame scratch collections.
- Preserves the newer trail overlap behavior by layering active path groups so active heads paint over earlier or finished trail bodies.
- Memoizes movement canvas trail settings and keeps the trail visual style comparator current.

## Validation

- `git diff --check`
- `bun --bun run vitest run website/shared/utils/__tests__/trailAnimation.test.ts website/shared/styles/__tests__/trailRenderers.test.ts`
- `bun --bun run vitest run` in `extension` (117 tests passing)
- `bun --bun run build` in `extension/website`

## Notes

The website build still emits pre-existing Sass deprecation warnings. The extension tests still emit the existing participant fallback stderr logs.