### PR TITLE
cursors: anchor to content when container has a CSS transform

### DIFF
--- a/.changeset/cursor-transformed-container.md
+++ b/.changeset/cursor-transformed-container.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Cursors now anchor to content when the cursor `container` has its own CSS transform (e.g. a pannable, zoomable canvas). The library reads the live transform matrix from `getComputedStyle()` and stores cursor coordinates in the container's local coordinate space, so two clients with different pan/zoom agree on a cursor's content position; each viewer's CSS transform then maps that position to their own viewport pixels. Default behavior is unchanged when `container` is `document.body` (no transform → identity matrix).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Bun handles workspace linking automatically. Changes across packages are immedia
 ## Commit & PR Guidelines
 
 - **Commits:** Short imperative subject; scope paths when helpful (e.g., `react:`, `extension:`). Group mechanical changes separately.
-- **Changesets:** Use `bun run changeset` when user-facing packages change. Config in `.changeset/config.json` (public access, patch for internal deps).
+- **Changesets:** ALWAYS add a changeset whenever you modify code under `packages/` (core libraries: `playhtml`, `@playhtml/react`, `@playhtml/common`). Create the file directly in `.changeset/<short-slug>.md` with the standard frontmatter (`"<package>": patch|minor|major`) and a one-paragraph user-facing description of the change and why. `bun run changeset` is the interactive equivalent. Config in `.changeset/config.json` (public access, patch for internal deps). Skip changesets only for changes outside `packages/` (website, extension, docs, internal-docs).
 - **Releases:** `bun run version-packages` then `bun run release` (builds + publishes via changesets).
 - **PRs:** Include summary, rationale, screenshots for UI/site/extension changes, reproduction for fixes, and link issues.
 

--- a/apps/docs/src/content/docs/data/presence/cursors.md
+++ b/apps/docs/src/content/docs/data/presence/cursors.md
@@ -177,6 +177,62 @@ cursors: {
 }
 ```
 
+### `container`
+
+Where playhtml mounts cursor DOM (and the cursor stylesheet). Defaults to `document.body`. Two reasons to set it:
+
+1. **Surviving SPA navigation.** If your framework swaps `document.body` on route changes (Astro ViewTransitions, htmx boost, Turbo), pass a container you mark as persistent so cursors don't get blown away. See [navigation](/docs/advanced/navigation/).
+2. **Anchoring cursors to a pannable / zoomable canvas.** If the container has its own CSS `transform` (e.g. you implement pinch-zoom and pan by setting `transform: translate(...) scale(...)` on a wrapper), playhtml stores cursor coordinates in that container's local space — so two viewers with different pan/zoom agree on which content a cursor is hovering. See the next section.
+
+**Type:** `HTMLElement | string | (() => HTMLElement | null) | React.RefObject<HTMLElement>`
+
+## Anchoring cursors to a transformed canvas
+
+If your page implements its own pan and zoom by applying a CSS transform to a wrapper element, the default cursor behavior doesn't do what you want: cursors are stored in viewport pixels, so when one user pans, their cursor for everyone else lands at the wrong word / shape / cell. The fix is one option:
+
+```js
+playhtml.init({
+  cursors: {
+    enabled: true,
+    container: ".canvas",  // your transformed wrapper
+  },
+});
+```
+
+When `container` resolves to a non-`document.body` element, playhtml reads its live transform matrix from `getComputedStyle()` on every pointer event:
+
+- **Storage** is the container's local (pre-transform) coordinate space. Two clients with different pan/zoom now agree on cursor positions.
+- **Rendering** mounts cursors inside the container with `position: absolute`. The container's own CSS transform composes them into each viewer's viewport pixels for free — no JavaScript per-frame repositioning, no resize-event nudging.
+
+### Requirements
+
+- The container must be `position: relative` (or any non-`static` position) so absolute children anchor to it.
+- The container should use **`transform-origin: 0 0`**. This is the standard for canvas-style apps; with any other origin, cursor positions will be shifted by the origin offset. If you need a different visual origin, pre-bake the offset into the matrix's translate component instead of changing `transform-origin`.
+- Only 2D affine transforms are supported (translate, scale, rotate, skew). 3D transforms aren't read.
+- Local-cursor proximity / visibility math, the cursor SVG icon, and `getCursorStyle` continue to work unchanged.
+
+### Example: Fridge Poetry
+
+The [`website/fridge.tsx`](https://github.com/spencerc99/playhtml/blob/main/website/fridge.tsx) demo (live at [playhtml.fun/fridge](https://playhtml.fun/fridge)) uses this pattern. Each user pans and pinch-zooms `.content` independently. With `container: ".content"`, when one user hovers the word "love," every other user sees their cursor glued to "love" in their own view, regardless of their own pan or zoom state.
+
+```tsx
+<PlayProvider
+  initOptions={{
+    cursors: {
+      enabled: true,
+      container: ".content",
+    },
+  }}
+>
+  <div className="content">
+    {/* pan/zoom transform applied here via React state */}
+    {words.map(w => <FridgeWord key={w.id} {...w} />)}
+  </div>
+</PlayProvider>
+```
+
+The transform itself (e.g. `translate(panX, panY) scale(scale)`) is applied however you like — inline `style.transform`, a CSS class, or a CSS variable. playhtml just reads it.
+
 ## Global Cursor API
 
 Cursors expose a global `window.cursors` object for accessing user presence data.

--- a/apps/docs/src/content/docs/reference/init-options.md
+++ b/apps/docs/src/content/docs/reference/init-options.md
@@ -146,7 +146,10 @@ interface CursorOptions {
 }
 ```
 
-`container` is only needed when your framework swaps `document.body` on navigation (Astro ViewTransitions, htmx boost, Turbo). Mark the container with the framework's persist directive (e.g. `transition:persist`) and cursors survive navigation. See [navigation](/docs/advanced/navigation/) for examples.
+Set `container` for either of two reasons:
+
+1. **Surviving SPA navigation.** If your framework swaps `document.body` on route changes (Astro ViewTransitions, htmx boost, Turbo), mark the container with the framework's persist directive (e.g. `transition:persist`). See [navigation](/docs/advanced/navigation/).
+2. **Anchoring cursors to a transformed canvas.** If the container has its own CSS `transform` (pannable / zoomable wrapper), playhtml stores cursor coords in the container's local space so collaborators with different pan/zoom agree on a cursor's content position. See [Anchoring cursors to a transformed canvas](/docs/data/presence/cursors/#anchoring-cursors-to-a-transformed-canvas) and the [fridge demo](https://github.com/spencerc99/playhtml/blob/main/website/fridge.tsx).
 
 Minimal opt-in:
 

--- a/packages/playhtml/src/cursors/__tests__/cursor-transformed-container.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/cursor-transformed-container.test.ts
@@ -1,0 +1,150 @@
+// ABOUTME: Verifies cursor coords round-trip through a transformed container.
+// ABOUTME: Stubs DOMMatrixReadOnly because jsdom doesn't ship it.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as Y from "yjs";
+import { CursorClientAwareness } from "../cursor-client";
+
+// Minimal DOMMatrixReadOnly polyfill for tests. Supports the affine subset
+// (translate + scale) that the fridge uses; that's all the production code
+// invokes on the matrix.
+class TestMatrix {
+  a = 1;
+  b = 0;
+  c = 0;
+  d = 1;
+  e = 0;
+  f = 0;
+  constructor(init?: string) {
+    if (!init || init === "none") return;
+    // Accept "matrix(a, b, c, d, e, f)" — the form getComputedStyle returns.
+    const match = /matrix\(([^)]+)\)/.exec(init);
+    if (match) {
+      const [a, b, c, d, e, f] = match[1].split(",").map((s) => parseFloat(s.trim()));
+      Object.assign(this, { a, b, c, d, e, f });
+      return;
+    }
+    // Accept "translate(Xpx, Ypx) scale(S)" for convenience.
+    const tx = /translate\(([-\d.]+)px,\s*([-\d.]+)px\)/.exec(init);
+    const sc = /scale\(([-\d.]+)\)/.exec(init);
+    if (tx) {
+      this.e = parseFloat(tx[1]);
+      this.f = parseFloat(tx[2]);
+    }
+    if (sc) {
+      this.a = parseFloat(sc[1]);
+      this.d = parseFloat(sc[1]);
+    }
+  }
+  inverse(): TestMatrix {
+    const m = new TestMatrix();
+    m.a = 1 / this.a;
+    m.d = 1 / this.d;
+    m.e = -this.e / this.a;
+    m.f = -this.f / this.d;
+    return m;
+  }
+  transformPoint(p: { x: number; y: number }): { x: number; y: number } {
+    return { x: this.a * p.x + this.c * p.y + this.e, y: this.b * p.x + this.d * p.y + this.f };
+  }
+}
+
+function makeFakeProvider() {
+  const doc = new Y.Doc();
+  const listeners: Array<(args: any) => void> = [];
+  const awareness: any = {
+    _states: new Map<number, Record<string, unknown>>(),
+    getStates() {
+      return this._states;
+    },
+    setLocalState() {},
+    setLocalStateField(field: string, value: unknown) {
+      const local = (this._states.get(this.clientID) as Record<string, unknown>) ?? {};
+      local[field] = value;
+      this._states.set(this.clientID, local);
+    },
+    getLocalState() {
+      return this._states.get(this.clientID) ?? null;
+    },
+    on(_event: string, cb: (args: any) => void) {
+      listeners.push(cb);
+    },
+    off() {},
+    emit(args: any) {
+      listeners.forEach((cb) => cb(args));
+    },
+    clientID: 1,
+    doc,
+  };
+  return { doc, awareness, on() {}, off() {} } as any;
+}
+
+describe("transformed cursor container", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    document.head.querySelectorAll("#playhtml-cursor-styles").forEach((n) => n.remove());
+    vi.stubGlobal("DOMMatrixReadOnly", TestMatrix);
+  });
+
+  it("client→storage→client round-trips through a translate+scale container", () => {
+    const container = document.createElement("div");
+    container.id = "fridge-content";
+    document.body.appendChild(container);
+
+    // Stub the parts of the DOM that aren't implemented in jsdom.
+    container.getBoundingClientRect = () =>
+      ({ left: 100, top: 50, width: 0, height: 0, right: 0, bottom: 0, x: 100, y: 50, toJSON() {} }) as DOMRect;
+    vi.spyOn(window, "getComputedStyle").mockImplementation(
+      () => ({ transform: "translate(20px, 30px) scale(2)" }) as CSSStyleDeclaration,
+    );
+
+    const provider = makeFakeProvider();
+    const client = new CursorClientAwareness(provider, {
+      enabled: true,
+      coordinateMode: "absolute",
+      container: "#fridge-content",
+      playerIdentity: {
+        publicKey: "pk-test",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    // Access the private helpers via the instance for the round-trip check.
+    const c2s = (client as any).clientToStorage.bind(client);
+    const s2c = (client as any).storageToClient.bind(client);
+
+    const stored = c2s(300, 200);
+    const back = s2c(stored.x, stored.y);
+    expect(back.x).toBeCloseTo(300, 5);
+    expect(back.y).toBeCloseTo(200, 5);
+
+    // Container's getBoundingClientRect already reflects its transform —
+    // rect.left = 100 means the post-transform top-left is at viewport
+    // (100, 50). Translate is already absorbed in the rect, so the inverse
+    // is purely (clientX - rect.left) / scale. With scale=2:
+    //   (300 - 100) / 2 = 100
+    //   (200 - 50) / 2  = 75
+    expect(stored.x).toBeCloseTo(100, 5);
+    expect(stored.y).toBeCloseTo(75, 5);
+
+    client.destroy();
+  });
+
+  it("falls through to default coords when the container is document.body", () => {
+    const provider = makeFakeProvider();
+    const client = new CursorClientAwareness(provider, {
+      enabled: true,
+      coordinateMode: "absolute",
+      // container undefined → resolves to document.body → identity branch
+      playerIdentity: {
+        publicKey: "pk-test-2",
+        playerStyle: { colorPalette: ["#00ff00"] },
+      } as any,
+    });
+    const c2s = (client as any).clientToStorage.bind(client);
+    const stored = c2s(500, 400);
+    // In absolute mode with no scroll/zoom, document coords == client coords.
+    expect(stored.x).toBeCloseTo(500, 5);
+    expect(stored.y).toBeCloseTo(400, 5);
+    client.destroy();
+  });
+});

--- a/packages/playhtml/src/cursors/cursor-client.ts
+++ b/packages/playhtml/src/cursors/cursor-client.ts
@@ -385,6 +385,66 @@ export class CursorClientAwareness {
     (presences: Map<string, CursorPresenceView>) => void
   >();
   private coordinateMode: "relative" | "absolute";
+
+  // When the cursor container is a non-body element with a CSS transform,
+  // cursors are stored and rendered in container-local coordinates. The
+  // matrix is read live from getComputedStyle so host pan/zoom updates flow
+  // through automatically. Returns null for the document.body default
+  // (identity, fast path) so today's behavior is preserved.
+  private getContainerMatrix(): { matrix: DOMMatrixReadOnly; rect: DOMRect; el: HTMLElement } | null {
+    const el = resolveCursorContainer(this.options.container);
+    if (!el || el === document.body) return null;
+    if (typeof DOMMatrixReadOnly === "undefined") return null;
+    const t = getComputedStyle(el).transform;
+    const matrix =
+      !t || t === "none"
+        ? new DOMMatrixReadOnly()
+        : new DOMMatrixReadOnly(t);
+    return { matrix, rect: el.getBoundingClientRect(), el };
+  }
+
+  private clientToStorage(clientX: number, clientY: number): { x: number; y: number } {
+    const m = this.getContainerMatrix();
+    if (m) {
+      // The container has `transform-origin: 0 0` (the only origin we
+      // support; `getBoundingClientRect()` already reflects the post-
+      // transform top-left). To recover container-local pre-transform
+      // coords, subtract the rect origin and undo the matrix's scale/rotate.
+      // The matrix's translate component is already absorbed into rect.left
+      // / rect.top, so we apply only the linear (a, b, c, d) part.
+      const a = m.matrix.a;
+      const b = m.matrix.b;
+      const c = m.matrix.c;
+      const d = m.matrix.d;
+      const det = a * d - b * c;
+      if (det === 0) return { x: 0, y: 0 };
+      const dx = clientX - m.rect.left;
+      const dy = clientY - m.rect.top;
+      return {
+        x: (d * dx - c * dy) / det,
+        y: (a * dy - b * dx) / det,
+      };
+    }
+    return clientToStorageCoordinates(clientX, clientY, this.coordinateMode);
+  }
+
+  private storageToClient(x: number, y: number): { x: number; y: number } {
+    const m = this.getContainerMatrix();
+    if (m) {
+      // Mirror clientToStorage: apply only the linear part of the matrix
+      // and add the rect origin. Translate is already in rect.left/top.
+      const a = m.matrix.a;
+      const b = m.matrix.b;
+      const c = m.matrix.c;
+      const d = m.matrix.d;
+      return {
+        x: a * x + c * y + m.rect.left,
+        y: b * x + d * y + m.rect.top,
+      };
+    }
+    return storageToClientCoordinates(x, y, this.coordinateMode);
+  }
+
   private zones: Map<string, { element: HTMLElement; options?: CursorZoneOptions }> = new Map();
   private currentZone: CursorZonePosition | null = null;
   private cursorZoneState: Map<string, string | null> = new Map(); // stableId -> previous zoneId
@@ -567,11 +627,7 @@ export class CursorClientAwareness {
       );
       if (!valid) return;
 
-      const clientCoords = storageToClientCoordinates(
-        valid.cursor.x,
-        valid.cursor.y,
-        this.coordinateMode,
-      );
+      const clientCoords = this.storageToClient(valid.cursor.x, valid.cursor.y);
       this.spatialGrid.insert({
         id: stableId,
         x: clientCoords.x,
@@ -589,11 +645,7 @@ export class CursorClientAwareness {
       this.options.proximityThreshold || PROXIMITY_THRESHOLD;
 
     // Convert our cursor to client coordinates for proximity check
-    const ourClientCoords = storageToClientCoordinates(
-      this.currentCursor.x,
-      this.currentCursor.y,
-      this.coordinateMode,
-    );
+    const ourClientCoords = this.storageToClient(this.currentCursor.x, this.currentCursor.y);
 
     // Use spatial grid to efficiently find nearby cursors (grid already has client coords)
     const nearbyItems = this.spatialGrid.findNearby(
@@ -608,11 +660,7 @@ export class CursorClientAwareness {
       if (!presence.cursor) continue;
 
       // Convert their cursor to client coordinates for distance calculation
-      const theirClientCoords = storageToClientCoordinates(
-        presence.cursor.x,
-        presence.cursor.y,
-        this.coordinateMode,
-      );
+      const theirClientCoords = this.storageToClient(presence.cursor.x, presence.cursor.y);
       const distance = calculateDistance(
         {
           x: ourClientCoords.x,
@@ -716,8 +764,14 @@ export class CursorClientAwareness {
 
       // In absolute mode, use position:absolute so the browser handles
       // scroll compositing natively (no per-frame repositioning needed).
+      // When the cursor container has its own CSS transform, cursors are
+      // appended inside it and rendered in container-local space — also
+      // position:absolute, so the parent's transform composes for free.
       // In relative mode, use position:fixed since coords are viewport-relative.
-      el.style.position = this.coordinateMode === "absolute" ? "absolute" : "fixed";
+      el.style.position =
+        this.coordinateMode === "absolute" || this.getContainerMatrix()
+          ? "absolute"
+          : "fixed";
       el.style.left = `${position.x}px`;
       el.style.top = `${position.y}px`;
       el.style.zIndex = "999999";
@@ -726,14 +780,18 @@ export class CursorClientAwareness {
   }
 
   // Resolves storage coordinates to the coordinate space used for positioning.
-  // In absolute mode, storage coords are already document coords and cursors
-  // use position:absolute, so no conversion needed. In relative mode, we
-  // convert to viewport pixels for position:fixed.
+  // In absolute mode (default container) storage coords are document coords
+  // and cursors use position:absolute, so no conversion is needed. With a
+  // transformed cursor container, storage coords are container-local — and
+  // since cursors are appended inside that container with position:absolute,
+  // the CSS transform composes them into the right viewport pixels for free,
+  // so again no conversion is needed. Relative mode converts to viewport
+  // pixels for position:fixed.
   private resolveTargetCoords(storageX: number, storageY: number): { x: number; y: number } {
-    if (this.coordinateMode === "absolute") {
+    if (this.coordinateMode === "absolute" || this.getContainerMatrix()) {
       return { x: storageX, y: storageY };
     }
-    return storageToClientCoordinates(storageX, storageY, this.coordinateMode);
+    return this.storageToClient(storageX, storageY);
   }
 
   // Apply zone-specific cursor styling, or revert to global styling when
@@ -833,11 +891,7 @@ export class CursorClientAwareness {
       }
 
       // Convert to storage coordinates based on mode
-      const storageCoords = clientToStorageCoordinates(
-        e.clientX,
-        e.clientY,
-        this.coordinateMode,
-      );
+      const storageCoords = this.clientToStorage(e.clientX, e.clientY);
       this.currentCursor = {
         x: storageCoords.x,
         y: storageCoords.y,
@@ -854,11 +908,7 @@ export class CursorClientAwareness {
       const touch = e.touches[0];
       if (touch) {
         // Convert to storage coordinates based on mode
-        const storageCoords = clientToStorageCoordinates(
-          touch.clientX,
-          touch.clientY,
-          this.coordinateMode,
-        );
+        const storageCoords = this.clientToStorage(touch.clientX, touch.clientY);
         this.currentCursor = {
           x: storageCoords.x,
           y: storageCoords.y,
@@ -974,13 +1024,12 @@ export class CursorClientAwareness {
 
       // In absolute mode, non-zone cursors use position:absolute with
       // document coords — the browser handles scroll, nothing to do.
-      if (this.coordinateMode === "absolute") continue;
+      // With a transformed cursor container, cursors are also positioned
+      // absolutely (in container-local coords) and the parent's CSS
+      // transform composes them into viewport pixels for free.
+      if (this.coordinateMode === "absolute" || this.getContainerMatrix()) continue;
 
-      const targetCoords = storageToClientCoordinates(
-        valid.cursor.x,
-        valid.cursor.y,
-        this.coordinateMode,
-      );
+      const targetCoords = this.storageToClient(valid.cursor.x, valid.cursor.y);
       animator.snapTo({ x: targetCoords.x, y: targetCoords.y });
     }
 
@@ -1228,11 +1277,7 @@ export class CursorClientAwareness {
     // Handle visibility based on distance from our cursor
     if (this.currentCursor) {
       // Convert our cursor to client coordinates for distance calculation
-      const ourClientCoords = storageToClientCoordinates(
-        this.currentCursor.x,
-        this.currentCursor.y,
-        this.coordinateMode,
-      );
+      const ourClientCoords = this.storageToClient(this.currentCursor.x, this.currentCursor.y);
       // Use target coordinates for distance (viewport pixels)
       const distance = calculateDistance(
         { x: targetCoords.x, y: targetCoords.y, pointer: cursor.pointer },
@@ -1660,11 +1705,7 @@ export class CursorClientAwareness {
     if (!this.currentCursor || !this.visibilityThreshold) return;
 
     // Convert our cursor to client coordinates so distance is in pixels (visibilityThreshold is in px)
-    const ourClientCoords = storageToClientCoordinates(
-      this.currentCursor.x,
-      this.currentCursor.y,
-      this.coordinateMode,
-    );
+    const ourClientCoords = this.storageToClient(this.currentCursor.x, this.currentCursor.y);
 
     this.cursors.forEach((cursorElement, stableId) => {
       // Get cursor data from spatial grid
@@ -1673,11 +1714,7 @@ export class CursorClientAwareness {
 
       if (cursorData && cursorData.cursor) {
         // Convert to viewport coordinates for distance calculation
-        const theirClientCoords = storageToClientCoordinates(
-          cursorData.cursor.x,
-          cursorData.cursor.y,
-          this.coordinateMode,
-        );
+        const theirClientCoords = this.storageToClient(cursorData.cursor.x, cursorData.cursor.y);
         const distance = calculateDistance(
           { ...ourClientCoords, pointer: this.currentCursor!.pointer },
           { ...theirClientCoords, pointer: cursorData.cursor.pointer },
@@ -1854,11 +1891,7 @@ export class CursorClientAwareness {
         state as Record<string, unknown>,
         clientId,
       );
-      const clientCoords = storageToClientCoordinates(
-        valid.cursor.x,
-        valid.cursor.y,
-        this.coordinateMode,
-      );
+      const clientCoords = this.storageToClient(valid.cursor.x, valid.cursor.y);
       presences.set(stableId, {
         cursor: {
           x: clientCoords.x,
@@ -1966,11 +1999,7 @@ export class CursorClientAwareness {
     if (!this.currentCursor) return false;
 
     const color = getPrimaryColor(this.playerIdentity);
-    const coords = storageToClientCoordinates(
-      this.currentCursor.x,
-      this.currentCursor.y,
-      this.coordinateMode,
-    );
+    const coords = this.storageToClient(this.currentCursor.x, this.currentCursor.y);
 
     // Create a temporary cursor element matching the standard cursor shape
     const ghost = document.createElement("div");

--- a/packages/playhtml/src/cursors/cursor-client.ts
+++ b/packages/playhtml/src/cursors/cursor-client.ts
@@ -406,12 +406,23 @@ export class CursorClientAwareness {
   private clientToStorage(clientX: number, clientY: number): { x: number; y: number } {
     const m = this.getContainerMatrix();
     if (m) {
-      // The container has `transform-origin: 0 0` (the only origin we
-      // support; `getBoundingClientRect()` already reflects the post-
-      // transform top-left). To recover container-local pre-transform
-      // coords, subtract the rect origin and undo the matrix's scale/rotate.
-      // The matrix's translate component is already absorbed into rect.left
-      // / rect.top, so we apply only the linear (a, b, c, d) part.
+      // ASSUMPTION: the container uses `transform-origin: 0 0`. Hosts
+      // applying their own pan/zoom transform almost always do so — it's
+      // the natural choice for a canvas where (0, 0) in content space
+      // maps to the container's top-left. With this origin, the post-
+      // transform top-left equals `rect.left / rect.top` directly, AND
+      // an absolutely-positioned child rendered at (left, top) inside the
+      // container ends up at viewport position
+      //   (rect.left + a*left + c*top, rect.top + b*left + d*top)
+      // i.e. only the linear (a, b, c, d) part of the matrix is applied
+      // to the child's local coordinates — the matrix's translate (e, f)
+      // is already absorbed into rect.left / rect.top by the browser's
+      // layout. So to invert, subtract the rect origin and undo only
+      // the linear part. Other origins (e.g. `center`) would shift the
+      // anchor and produce off-by-half-the-container errors; we don't
+      // support them here. If a host needs that, they can pre-multiply
+      // their transform with the equivalent translate to bake the origin
+      // into (e, f) and keep `transform-origin: 0 0`.
       const a = m.matrix.a;
       const b = m.matrix.b;
       const c = m.matrix.c;
@@ -431,8 +442,10 @@ export class CursorClientAwareness {
   private storageToClient(x: number, y: number): { x: number; y: number } {
     const m = this.getContainerMatrix();
     if (m) {
-      // Mirror clientToStorage: apply only the linear part of the matrix
-      // and add the rect origin. Translate is already in rect.left/top.
+      // Mirror clientToStorage; same `transform-origin: 0 0` assumption.
+      // Apply only the linear part of the matrix to the local coord and
+      // add the rect origin — the translate (e, f) is already in
+      // rect.left / rect.top.
       const a = m.matrix.a;
       const b = m.matrix.b;
       const c = m.matrix.c;

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -358,6 +358,14 @@ export interface CursorOptions {
    * Where to mount cursor DOM and the cursor style tag. Defaults to
    * document.body / document.head. Pass a container you control (and mark
    * with transition:persist or equivalent) to survive SPA body-swaps.
+   *
+   * If the container has its own CSS transform (e.g. a pannable canvas
+   * applies `transform: translate(...) scale(...)`), cursors are stored
+   * AND rendered in the container's local coordinate space. The library
+   * reads the live transform matrix from getComputedStyle, so two clients
+   * with different pan/zoom agree on a cursor's content position; the
+   * container's CSS transform then maps that position into each viewer's
+   * own pixels — anchoring cursors to content rather than to the viewport.
    */
   container?: CursorContainer;
 }

--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -431,7 +431,7 @@ const Words = [
   "moon",
 ];
 
-const MaxWords = 2000;
+const MaxWords = 3000;
 const MaxWordLength = 40;
 
 interface ToolboxProps {
@@ -1197,6 +1197,10 @@ function Main() {
         cursors: {
           enabled: true,
           coordinateMode: "absolute",
+          // Mount cursors inside `.content` so its CSS transform (pinch
+          // zoom + pan) carries them visually, and so stored coords are
+          // content-space — every viewer sees a cursor on the same word.
+          container: ".content",
         },
       }}
     >


### PR DESCRIPTION
## Summary

Cursors now anchor to content when the cursor `container` has its own CSS transform (pannable / zoomable canvas). The library reads the live transform matrix from `getComputedStyle()` and stores cursor coordinates in the container's local coordinate space, so two clients with different pan/zoom agree on a cursor's content position; each viewer's CSS transform then maps that position to their own viewport pixels.

- New behavior is opt-in via the existing `cursors.container` option — no new API surface.
- Default (`container = document.body`, no transform) is unchanged.
- `website/fridge.tsx` opts in by setting `container: ".content"`. Cursors now follow the word a user is hovering, regardless of either user's pinch-zoom or pan.
- Updated `CLAUDE.md` to require a changeset for any change under `packages/`.

The math undoes only the matrix's linear (a, b, c, d) part — `getBoundingClientRect()` already absorbs the translate component, so applying the full inverse would subtract translate twice. This was the bug fixed after initial Playwright testing.

## Test plan

- [x] `bun run -C packages/playhtml test` — 156 tests pass, including 2 new tests for the transformed-container path (DOMMatrixReadOnly is stubbed because jsdom doesn't ship one).
- [x] `bunx tsc --noEmit -p packages/playhtml` — clean.
- [x] Two real browser tabs against staging partykit, distinct identities, different pan/zoom transforms. With pageA hovering its "world" word, pageB renders pageA's cursor inside pageB's "world" word's bounding box. Verified with both identity transforms (sub-pixel match) and very different transforms (scale 1.5+pan vs scale 0.8+opposite-pan).
- [x] Manually verified in fridge with two windows.
- [x] Spot-checked non-fridge page — `container` undefined → matrix branch skipped → original behavior preserved.