### PR TITLE
phase 1b prep: move pageMetadata helpers into @playhtml/extension-types

### DIFF
--- a/.changeset/phase-1b-page-metadata-helpers.md
+++ b/.changeset/phase-1b-page-metadata-helpers.md
@@ -1,0 +1,9 @@
+---
+"@playhtml/extension-types": minor
+---
+
+Add `canonicalizeUrl`, `buildPageRef`, and `buildMetadataHash` to the public
+exports. These are the pure helpers both the extension client and the
+Cloudflare Worker use to build stable `page_ref` identifiers — moving them
+into the shared package lets the worker (now in a private repo) consume the
+exact same algorithm via npm instead of reaching into extension source.

--- a/extension/src/utils/pageMetadata.ts
+++ b/extension/src/utils/pageMetadata.ts
@@ -1,7 +1,22 @@
-// ABOUTME: Shared helpers for extracting and hashing page metadata
-// ABOUTME: Used by collectors and site-discovery flows to avoid duplicated logic
-// ABOUTME: canonicalizeUrl is intentionally free of window/document so it also runs server-side.
+// ABOUTME: DOM-side helpers for page metadata extraction. The pure
+// ABOUTME: canonicalization helpers live in @playhtml/extension-types so
+// ABOUTME: the worker (which has no DOM) can share the same algorithm.
 
+import {
+  canonicalizeUrl,
+  buildPageRef,
+  buildMetadataHash,
+} from "@playhtml/extension-types";
+
+// Re-export so existing call sites keep working.
+export { canonicalizeUrl, buildPageRef, buildMetadataHash };
+
+/**
+ * Capture-time page metadata snapshot used by the extension's collectors.
+ * The worker's database-row shape (with `metadata_hash` and `observed_at_ts`)
+ * lives in @playhtml/extension-types under the same name; they're related
+ * but not identical, so the extension keeps a local definition for clarity.
+ */
 export interface PageMetadataSnapshot {
   page_ref: string;
   canonical_url: string;
@@ -9,90 +24,12 @@ export interface PageMetadataSnapshot {
   favicon_url: string;
 }
 
-/**
- * Query parameters that are universally analytics/attribution-only and never
- * carry page-identity information. Only params where we are certain they don't
- * affect page content belong here — ambiguous ones like "ref" or "source" are
- * intentionally excluded because some sites use them as meaningful content params
- * (e.g. GitHub's ?tab=, search pages' ?q=, YouTube's ?v=).
- */
-const TRACKING_PARAMS = new Set([
-  // Google Analytics / Ads — always tracking, never content
-  'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id',
-  '_ga', 'gclid', 'gclsrc',
-  // Meta / Facebook
-  'fbclid',
-  // Microsoft
-  'msclkid',
-  // Twitter / X
-  'twclid',
-  // Mailchimp
-  'mc_cid', 'mc_eid',
-  // Instagram
-  'igshid',
-  // Yandex
-  'yclid',
-]);
-
-/**
- * Build a stable canonical URL for page identity.
- *
- * Normalizations applied:
- * - Strips hash fragment (in-page anchors should dedupe to the same page_ref)
- * - Strips known tracking/session query parameters
- * - Sorts remaining query parameters for a deterministic order
- * - Removes a trailing slash from non-root paths (e.g. /wiki/Python/ → /wiki/Python)
- *
- * Does NOT depend on window/document, so it can run in both browser and server contexts.
- * Pass `base` when resolving relative URLs outside of a browser environment.
- */
-export function canonicalizeUrl(inputUrl: string, base?: string): string {
-  try {
-    const parsed = new URL(inputUrl, base);
-
-    // 1. Strip hash fragment
-    parsed.hash = '';
-
-    // 2. Remove tracking params
-    for (const key of [...parsed.searchParams.keys()]) {
-      if (TRACKING_PARAMS.has(key) || key.startsWith('utm_')) {
-        parsed.searchParams.delete(key);
-      }
-    }
-
-    // 3. Sort remaining params for deterministic order
-    parsed.searchParams.sort();
-
-    // 4. Remove trailing slash from non-root paths
-    if (parsed.pathname.length > 1 && parsed.pathname.endsWith('/')) {
-      parsed.pathname = parsed.pathname.slice(0, -1);
-    }
-
-    return parsed.toString();
-  } catch {
-    return inputUrl;
-  }
-}
-
-/**
- * Generate a compact stable page reference from canonical URL.
- * Uses FNV-1a for speed and deterministic output (non-cryptographic).
- */
-export function buildPageRef(canonicalUrl: string): string {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < canonicalUrl.length; i++) {
-    hash ^= canonicalUrl.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return `pr_${(hash >>> 0).toString(16).padStart(8, '0')}`;
-}
-
 export function getPageTitle(fallback?: string): string {
   const safeFallback =
     fallback ||
-    (typeof window.location.hostname === 'string' && window.location.hostname.length > 0
+    (typeof window.location.hostname === "string" && window.location.hostname.length > 0
       ? window.location.hostname
-      : 'unknown');
+      : "unknown");
 
   return (document.title || safeFallback).trim() || safeFallback;
 }
@@ -117,14 +54,4 @@ export function getCurrentPageMetadata(url = window.location.href): PageMetadata
     title: getPageTitle(),
     favicon_url: getFaviconUrl(),
   };
-}
-
-export function buildMetadataHash(title: string, faviconUrl: string): string {
-  const value = `${title}\u0001${faviconUrl}`;
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < value.length; i++) {
-    hash ^= value.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return `mh_${(hash >>> 0).toString(16).padStart(8, '0')}`;
 }

--- a/packages/extension-types/package.json
+++ b/packages/extension-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playhtml/extension-types",
-  "description": "Shared event/metadata types for the playhtml 'we were online' extension and its Cloudflare Worker.",
+  "description": "Shared event/metadata types and URL canonicalization helpers for the playhtml 'we were online' extension and its Cloudflare Worker.",
   "version": "0.3.0",
   "license": "MIT",
   "type": "module",

--- a/packages/extension-types/src/index.ts
+++ b/packages/extension-types/src/index.ts
@@ -1,4 +1,6 @@
 // ABOUTME: Entry point for @playhtml/extension-types.
-// ABOUTME: Re-exports the shared event type contract used by extension and worker.
+// ABOUTME: Shared event-type contract + URL canonicalization helpers used by the
+// ABOUTME: extension client and the (private) Cloudflare Worker.
 
 export * from "./types";
+export * from "./pageMetadata";

--- a/packages/extension-types/src/pageMetadata.ts
+++ b/packages/extension-types/src/pageMetadata.ts
@@ -1,0 +1,108 @@
+// ABOUTME: Pure helpers for canonicalizing URLs and building page_ref hashes.
+// ABOUTME: Shared contract — both the extension (collection time) and the worker
+// ABOUTME: (read time) MUST use the same algorithm so page joins remain stable.
+
+/**
+ * Query parameters that are universally analytics/attribution-only and never
+ * carry page-identity information. Only params where we are certain they don't
+ * affect page content belong here — ambiguous ones like "ref" or "source" are
+ * intentionally excluded because some sites use them as meaningful content params
+ * (e.g. GitHub's ?tab=, search pages' ?q=, YouTube's ?v=).
+ */
+const TRACKING_PARAMS = new Set([
+  // Google Analytics / Ads — always tracking, never content
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "utm_id",
+  "_ga",
+  "gclid",
+  "gclsrc",
+  // Meta / Facebook
+  "fbclid",
+  // Microsoft
+  "msclkid",
+  // Twitter / X
+  "twclid",
+  // Mailchimp
+  "mc_cid",
+  "mc_eid",
+  // Instagram
+  "igshid",
+  // Yandex
+  "yclid",
+]);
+
+/**
+ * Build a stable canonical URL for page identity.
+ *
+ * Normalizations applied:
+ * - Strips hash fragment (in-page anchors should dedupe to the same page_ref)
+ * - Strips known tracking/session query parameters
+ * - Sorts remaining query parameters for a deterministic order
+ * - Removes a trailing slash from non-root paths (e.g. /wiki/Python/ → /wiki/Python)
+ *
+ * Pure function — no window/document dependencies, runs server-side too.
+ * Pass `base` when resolving relative URLs outside of a browser environment.
+ */
+export function canonicalizeUrl(inputUrl: string, base?: string): string {
+  try {
+    const parsed = new URL(inputUrl, base);
+
+    // 1. Strip hash fragment
+    parsed.hash = "";
+
+    // 2. Remove tracking params
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (TRACKING_PARAMS.has(key) || key.startsWith("utm_")) {
+        parsed.searchParams.delete(key);
+      }
+    }
+
+    // 3. Sort remaining params for deterministic order
+    parsed.searchParams.sort();
+
+    // 4. Remove trailing slash from non-root paths
+    if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+
+    return parsed.toString();
+  } catch {
+    return inputUrl;
+  }
+}
+
+/**
+ * Generate a compact stable page reference from canonical URL.
+ * Uses FNV-1a for speed and deterministic output (non-cryptographic).
+ */
+export function buildPageRef(canonicalUrl: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < canonicalUrl.length; i++) {
+    hash ^= canonicalUrl.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `pr_${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+/**
+ * Hash for page metadata (title + favicon). Used to detect when a page's
+ * metadata has changed without re-storing identical records.
+ *
+ * The U+0001 separator between fields ensures titles like "foo" + "bar.ico"
+ * don't collide with "foob" + "ar.ico". Must match the extension's
+ * implementation byte-for-byte for the hash to be deterministic across both
+ * sides of the contract.
+ */
+export function buildMetadataHash(title: string, faviconUrl: string): string {
+  const value = `${title}${faviconUrl}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `mh_${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}


### PR DESCRIPTION
## Summary

Prep for Phase 1b (moving the worker to a private repo). Moves three pure helper functions — `canonicalizeUrl`, `buildPageRef`, `buildMetadataHash` — from `extension/src/utils/pageMetadata.ts` into the published `@playhtml/extension-types` package so the worker can consume them via npm instead of reaching into extension source.

### Why

The worker currently has \`import { canonicalizeUrl, buildPageRef } from '../../../src/utils/pageMetadata'\` in \`extension/worker/src/routes/recent.ts\`. That works while the worker lives inside the monorepo — but Phase 1b moves the worker into its own private repo, where that relative path can't resolve.

These helpers are stable, pure (no DOM), and already designed for cross-context use. They're the algorithmic agreement between extension (collection time) and worker (read time) that makes \`page_ref\` joins deterministic. Moving them into the shared package matches the package's purpose: \"the contract between extension client and worker.\"

### What changes

- **`packages/extension-types/src/pageMetadata.ts`** (new): the three helpers + their `TRACKING_PARAMS` allowlist.
- **`packages/extension-types/src/index.ts`**: re-exports both `./types` and `./pageMetadata`.
- **`packages/extension-types/package.json`**: description updated to reflect the broader scope.
- **`extension/src/utils/pageMetadata.ts`**: refactored to re-export the three helpers from the package; DOM-dependent helpers (`getPageTitle`, `getFaviconUrl`, `getCurrentPageMetadata`) stay local since they read `window`/`document`.
- **Changeset**: minor bump for `@playhtml/extension-types`.

### What doesn't change

- Zero runtime behavior. The functions are byte-identical (verified the U+0001 separator in `buildMetadataHash` survived the move).
- Existing import sites (`NavigationCollector.ts`, `content.ts`, etc.) that pulled from `../utils/pageMetadata` keep working — the file now re-exports from the package.

## Test plan

- [x] `bun build-packages` succeeds; `packages/extension-types/dist/index.d.ts` exports all three helpers + `PageMetadataSnapshot`.
- [x] `cd extension && bun run build` succeeds.
- [x] `cd extension && bunx vitest run` — 117 tests pass.

## Follow-ups

- After this PR merges and `@playhtml/extension-types@0.4.0` publishes, Phase 1b proper continues: copy worker into its private repo, switch its dep to `^0.4.0`, remove `extension/worker/` from this repo.