### PR TITLE
ci: auto-PR-driven extension release flow (changesets-style)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@playhtml/extension-worker", "wewere-online", "@playhtml/docs-site"],
+  "ignore": ["@playhtml/extension", "@playhtml/extension-worker", "wewere-online", "@playhtml/docs-site"],
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@playhtml/extension", "@playhtml/extension-worker", "wewere-online", "@playhtml/docs-site"],
+  "ignore": ["@playhtml/extension-worker", "wewere-online", "@playhtml/docs-site"],
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{commit}"

--- a/.github/workflows/extension-release-prep.yml
+++ b/.github/workflows/extension-release-prep.yml
@@ -1,0 +1,187 @@
+name: Extension Release Prep
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "extension/**"
+      - "packages/**"
+      - ".github/workflows/extension-release-prep.yml"
+
+concurrency: ${{ github.workflow }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prep:
+    name: Open or update release PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Check for pending changes
+        id: pending
+        run: |
+          BODY=$(awk '/<!--/{c=1} c{if(/-->/)c=0; next} 1' extension/PENDING.md \
+            | sed '/^# Unreleased[[:space:]]*$/d' \
+            | sed '/^[[:space:]]*$/d')
+          if [ -z "$BODY" ]; then
+            echo "No pending changes — exiting."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Pending changes detected:"
+            echo "$BODY"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "body<<PENDING_EOF"
+              echo "$BODY"
+              echo "PENDING_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.pending.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute target version
+        if: steps.pending.outputs.has_changes == 'true'
+        id: version
+        env:
+          RELEASE_BRANCH: extension-release
+        run: |
+          MAIN_VERSION=$(node -p "require('./extension/package.json').version")
+
+          REMOTE_VERSION=""
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+            git fetch origin "$RELEASE_BRANCH":"refs/remotes/origin/$RELEASE_BRANCH"
+            REMOTE_VERSION=$(git show "origin/$RELEASE_BRANCH:extension/package.json" 2>/dev/null \
+              | node -e "let s=''; process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))" \
+              || true)
+          fi
+
+          AUTO_VERSION=$(node -p "
+            const [a,b,c] = '$MAIN_VERSION'.split('.').map(Number);
+            [a, b, c + 1].join('.');
+          ")
+
+          if [ -n "$REMOTE_VERSION" ] && node -e "
+            const [ra,rb,rc] = '$REMOTE_VERSION'.split('.').map(Number);
+            const [aa,ab,ac] = '$AUTO_VERSION'.split('.').map(Number);
+            process.exit((ra > aa || (ra === aa && rb > ab) || (ra === aa && rb === ab && rc >= ac)) ? 0 : 1);
+          "; then
+            VERSION="$REMOTE_VERSION"
+            echo "Using manual override from release branch: $VERSION"
+          else
+            VERSION="$AUTO_VERSION"
+            echo "Using auto-computed patch bump: $VERSION (main is $MAIN_VERSION)"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build release branch
+        if: steps.pending.outputs.has_changes == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          BODY: ${{ steps.pending.outputs.body }}
+          RELEASE_BRANCH: extension-release
+        run: |
+          git checkout -B "$RELEASE_BRANCH"
+
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('extension/package.json', 'utf8'));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync('extension/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          DATE=$(date -u +%Y-%m-%d)
+          {
+            echo "# @playhtml/extension"
+            echo ""
+            echo "## $VERSION ($DATE)"
+            echo ""
+            echo "$BODY"
+            echo ""
+            tail -n +2 extension/CHANGELOG.md
+          } > extension/CHANGELOG.md.new
+          mv extension/CHANGELOG.md.new extension/CHANGELOG.md
+
+          cat > extension/PENDING.md <<'TEMPLATE_EOF'
+          # Unreleased
+
+          <!--
+          Add a bullet here in any PR that touches extension/**. The release-prep workflow
+          watches this file: when there are bullets, it opens (or updates) a release PR
+          that bumps the version, moves these bullets into CHANGELOG.md, and clears this
+          file back to just the header. Merge that PR to ship.
+
+          Format suggestion: "- short user-facing description (#PR)"
+          -->
+          TEMPLATE_EOF
+
+          git add extension/package.json extension/CHANGELOG.md extension/PENDING.md
+          git commit -m "extension: release v$VERSION"
+          git push --force origin "$RELEASE_BRANCH"
+
+      - name: Open or update PR
+        if: steps.pending.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BODY: ${{ steps.pending.outputs.body }}
+          RELEASE_BRANCH: extension-release
+        run: |
+          TITLE="Release: @playhtml/extension v$VERSION"
+          PR_BODY=$(cat <<EOF
+          Auto-generated release PR for the extension. Merging this:
+
+          - Bumps \`extension/package.json\` to **$VERSION**
+          - Moves bullets from \`PENDING.md\` into \`CHANGELOG.md\`
+          - Triggers the Extension Release workflow on merge → builds Chrome + Firefox zips, submits to both stores, tags \`@playhtml/extension@$VERSION\`
+
+          ## Changes in this release
+
+          $BODY
+
+          ---
+
+          To bump minor or major instead of patch: edit \`extension/package.json\` on this branch directly. The prep workflow will preserve your override.
+
+          To skip a release: empty out \`extension/PENDING.md\` on \`main\`. This PR will close itself on the next prep run.
+          EOF
+          )
+
+          EXISTING=$(gh pr list --head "$RELEASE_BRANCH" --base main --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing PR #$EXISTING"
+            gh pr edit "$EXISTING" --title "$TITLE" --body "$PR_BODY"
+          else
+            echo "Creating new release PR"
+            gh pr create --base main --head "$RELEASE_BRANCH" --title "$TITLE" --body "$PR_BODY"
+          fi
+
+      - name: Close stale release PR
+        if: steps.pending.outputs.has_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: extension-release
+        run: |
+          EXISTING=$(gh pr list --head "$RELEASE_BRANCH" --base main --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            echo "PENDING.md is empty but release PR #$EXISTING is still open — closing it."
+            gh pr close "$EXISTING" --comment "Closing because \`extension/PENDING.md\` no longer has unreleased changes."
+          fi

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -1,21 +1,17 @@
 name: Extension Release
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "extension/package.json"
   workflow_dispatch:
     inputs:
-      bump:
-        description: "Version bump type (or pick 'custom' and set version)"
-        type: choice
-        options: [patch, minor, major, custom]
-        default: patch
-      version:
-        description: "Custom version (only used when bump=custom, e.g. 0.2.0)"
-        type: string
-        default: ""
       dry-run:
-        description: "Dry run (build + validate, do not submit, do not commit)"
+        description: "Dry run (build + validate, do not submit, do not tag)"
         type: boolean
-        default: false
+        default: true
       skip-chrome:
         description: "Skip Chrome submission"
         type: boolean
@@ -31,15 +27,65 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Bump, build, submit
+  guard:
+    name: Should this run trigger a release?
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Decide
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Triggered manually."
+            VERSION=$(node -p "require('./extension/package.json').version")
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For push events: only release if the head commit is the prep
+          # workflow's release commit. This avoids accidental releases from
+          # unrelated edits to extension/package.json (e.g. dependency bumps).
+          FIRST_LINE=$(echo "$HEAD_MSG" | head -n 1)
+          case "$FIRST_LINE" in
+            "extension: release v"*)
+              VERSION=$(node -p "require('./extension/package.json').version")
+              EXPECTED="extension: release v$VERSION"
+              if [ "$FIRST_LINE" = "$EXPECTED" ]; then
+                echo "Release commit detected for v$VERSION."
+                echo "should_release=true" >> "$GITHUB_OUTPUT"
+                echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+              else
+                echo "Release commit message ($FIRST_LINE) doesn't match package.json version ($VERSION). Skipping."
+                echo "should_release=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "Head commit is not a release commit. Skipping."
+              echo "should_release=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  submit:
+    name: Build and submit to stores
+    needs: guard
+    if: needs.guard.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     env:
-      BUMP: ${{ inputs.bump }}
-      CUSTOM_VERSION: ${{ inputs.version }}
       DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
       SKIP_CHROME: ${{ inputs.skip-chrome && 'true' || 'false' }}
       SKIP_FIREFOX: ${{ inputs.skip-firefox && 'true' || 'false' }}
+      VERSION: ${{ needs.guard.outputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -63,32 +109,6 @@ jobs:
       - name: Build packages
         run: bun run build-packages
 
-      - name: Bump extension version
-        id: version
-        working-directory: extension
-        run: |
-          if [ "$BUMP" = "custom" ]; then
-            if [ -z "$CUSTOM_VERSION" ]; then
-              echo "bump=custom requires a version input" >&2
-              exit 1
-            fi
-            NEW_VERSION="$CUSTOM_VERSION"
-          else
-            NEW_VERSION=$(node -p "
-              const semver = require('./package.json').version.split('.').map(Number);
-              const [maj, min, pat] = semver;
-              ({ patch: [maj, min, pat + 1], minor: [maj, min + 1, 0], major: [maj + 1, 0, 0] })['$BUMP'].join('.')
-            ")
-          fi
-          echo "Bumping to $NEW_VERSION"
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '$NEW_VERSION';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Build Chrome zip
         if: env.SKIP_CHROME != 'true'
         run: WXT_OUT_DIR=publish bun run -C extension wxt zip
@@ -100,8 +120,6 @@ jobs:
       - name: Resolve zip paths
         id: zips
         working-directory: extension
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
           CHROME_ZIP=$(ls publish/*-"$VERSION"-chrome.zip 2>/dev/null | head -1 || true)
           FIREFOX_ZIP=$(ls publish/*-"$VERSION"-firefox.zip 2>/dev/null | head -1 || true)
@@ -139,24 +157,25 @@ jobs:
             bun run wxt submit "${ARGS[@]}"
           fi
 
-      - name: Commit version bump and tag
+      - name: Tag release
         if: env.DRY_RUN != 'true'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add extension/package.json
-          git commit -m "extension: release v$VERSION"
-          git tag "@playhtml/extension@$VERSION"
-          git push origin HEAD:main
-          git push origin "@playhtml/extension@$VERSION"
+          TAG="@playhtml/extension@$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping."
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "Tagged $TAG"
+          fi
 
       - name: Upload zips as artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: extension-${{ steps.version.outputs.version }}
+          name: extension-${{ env.VERSION }}
           path: extension/publish/*.zip
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -1,0 +1,118 @@
+name: Extension Release
+
+on:
+  push:
+    tags:
+      - "@playhtml/extension@*"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Dry run (build + validate, do not submit)"
+        type: boolean
+        default: true
+      skip-chrome:
+        description: "Skip Chrome submission"
+        type: boolean
+        default: false
+      skip-firefox:
+        description: "Skip Firefox submission"
+        type: boolean
+        default: false
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Build and submit to stores
+    runs-on: ubuntu-latest
+    env:
+      DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
+      SKIP_CHROME: ${{ inputs.skip-chrome && 'true' || 'false' }}
+      SKIP_FIREFOX: ${{ inputs.skip-firefox && 'true' || 'false' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build packages
+        run: bun run build-packages
+
+      - name: Read extension version
+        id: version
+        run: echo "version=$(node -p "require('./extension/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Build Chrome zip
+        if: env.SKIP_CHROME != 'true'
+        run: WXT_OUT_DIR=publish bun run -C extension wxt zip
+
+      - name: Build Firefox zip
+        if: env.SKIP_FIREFOX != 'true'
+        run: WXT_OUT_DIR=publish bun run -C extension wxt zip -b firefox
+
+      - name: Resolve zip paths
+        id: zips
+        working-directory: extension
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -d publish ]; then
+            CHROME_ZIP=$(ls publish/*-"$VERSION"-chrome.zip 2>/dev/null | head -1 || true)
+            FIREFOX_ZIP=$(ls publish/*-"$VERSION"-firefox.zip 2>/dev/null | head -1 || true)
+            SOURCES_ZIP=$(ls publish/*-"$VERSION"-sources.zip 2>/dev/null | head -1 || true)
+            echo "chrome=$CHROME_ZIP" >> "$GITHUB_OUTPUT"
+            echo "firefox=$FIREFOX_ZIP" >> "$GITHUB_OUTPUT"
+            echo "sources=$SOURCES_ZIP" >> "$GITHUB_OUTPUT"
+            echo "Built artifacts:"
+            ls -la publish/
+          fi
+
+      - name: Submit to stores
+        working-directory: extension
+        env:
+          CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
+          CHROME_CLIENT_SECRET: ${{ secrets.CHROME_CLIENT_SECRET }}
+          CHROME_REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
+          FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+          CHROME_ZIP: ${{ steps.zips.outputs.chrome }}
+          FIREFOX_ZIP: ${{ steps.zips.outputs.firefox }}
+          SOURCES_ZIP: ${{ steps.zips.outputs.sources }}
+        run: |
+          ARGS=()
+          if [ "$SKIP_CHROME" != "true" ] && [ -n "$CHROME_ZIP" ]; then
+            ARGS+=(--chrome-zip "$CHROME_ZIP")
+          fi
+          if [ "$SKIP_FIREFOX" != "true" ] && [ -n "$FIREFOX_ZIP" ]; then
+            ARGS+=(--firefox-zip "$FIREFOX_ZIP" --firefox-sources-zip "$SOURCES_ZIP")
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            bun run wxt submit --dry-run "${ARGS[@]}"
+          else
+            bun run wxt submit "${ARGS[@]}"
+          fi
+
+      - name: Upload zips as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-${{ steps.version.outputs.version }}
+          path: extension/publish/*.zip
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -1,15 +1,21 @@
 name: Extension Release
 
 on:
-  push:
-    tags:
-      - "@playhtml/extension@*"
   workflow_dispatch:
     inputs:
+      bump:
+        description: "Version bump type (or pick 'custom' and set version)"
+        type: choice
+        options: [patch, minor, major, custom]
+        default: patch
+      version:
+        description: "Custom version (only used when bump=custom, e.g. 0.2.0)"
+        type: string
+        default: ""
       dry-run:
-        description: "Dry run (build + validate, do not submit)"
+        description: "Dry run (build + validate, do not submit, do not commit)"
         type: boolean
-        default: true
+        default: false
       skip-chrome:
         description: "Skip Chrome submission"
         type: boolean
@@ -19,22 +25,27 @@ on:
         type: boolean
         default: false
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  submit:
-    name: Build and submit to stores
+  release:
+    name: Bump, build, submit
     runs-on: ubuntu-latest
     env:
+      BUMP: ${{ inputs.bump }}
+      CUSTOM_VERSION: ${{ inputs.version }}
       DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
       SKIP_CHROME: ${{ inputs.skip-chrome && 'true' || 'false' }}
       SKIP_FIREFOX: ${{ inputs.skip-firefox && 'true' || 'false' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -52,9 +63,31 @@ jobs:
       - name: Build packages
         run: bun run build-packages
 
-      - name: Read extension version
+      - name: Bump extension version
         id: version
-        run: echo "version=$(node -p "require('./extension/package.json').version")" >> "$GITHUB_OUTPUT"
+        working-directory: extension
+        run: |
+          if [ "$BUMP" = "custom" ]; then
+            if [ -z "$CUSTOM_VERSION" ]; then
+              echo "bump=custom requires a version input" >&2
+              exit 1
+            fi
+            NEW_VERSION="$CUSTOM_VERSION"
+          else
+            NEW_VERSION=$(node -p "
+              const semver = require('./package.json').version.split('.').map(Number);
+              const [maj, min, pat] = semver;
+              ({ patch: [maj, min, pat + 1], minor: [maj, min + 1, 0], major: [maj + 1, 0, 0] })['$BUMP'].join('.')
+            ")
+          fi
+          echo "Bumping to $NEW_VERSION"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$NEW_VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build Chrome zip
         if: env.SKIP_CHROME != 'true'
@@ -70,16 +103,14 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if [ -d publish ]; then
-            CHROME_ZIP=$(ls publish/*-"$VERSION"-chrome.zip 2>/dev/null | head -1 || true)
-            FIREFOX_ZIP=$(ls publish/*-"$VERSION"-firefox.zip 2>/dev/null | head -1 || true)
-            SOURCES_ZIP=$(ls publish/*-"$VERSION"-sources.zip 2>/dev/null | head -1 || true)
-            echo "chrome=$CHROME_ZIP" >> "$GITHUB_OUTPUT"
-            echo "firefox=$FIREFOX_ZIP" >> "$GITHUB_OUTPUT"
-            echo "sources=$SOURCES_ZIP" >> "$GITHUB_OUTPUT"
-            echo "Built artifacts:"
-            ls -la publish/
-          fi
+          CHROME_ZIP=$(ls publish/*-"$VERSION"-chrome.zip 2>/dev/null | head -1 || true)
+          FIREFOX_ZIP=$(ls publish/*-"$VERSION"-firefox.zip 2>/dev/null | head -1 || true)
+          SOURCES_ZIP=$(ls publish/*-"$VERSION"-sources.zip 2>/dev/null | head -1 || true)
+          echo "chrome=$CHROME_ZIP" >> "$GITHUB_OUTPUT"
+          echo "firefox=$FIREFOX_ZIP" >> "$GITHUB_OUTPUT"
+          echo "sources=$SOURCES_ZIP" >> "$GITHUB_OUTPUT"
+          echo "Built artifacts:"
+          ls -la publish/
 
       - name: Submit to stores
         working-directory: extension
@@ -107,6 +138,19 @@ jobs:
           else
             bun run wxt submit "${ARGS[@]}"
           fi
+
+      - name: Commit version bump and tag
+        if: env.DRY_RUN != 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add extension/package.json
+          git commit -m "extension: release v$VERSION"
+          git tag "@playhtml/extension@$VERSION"
+          git push origin HEAD:main
+          git push origin "@playhtml/extension@$VERSION"
 
       - name: Upload zips as artifacts
         if: always()

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -17,17 +17,35 @@ Worker backend (in `worker/`):
 
 ## Releases
 
-The extension ships independently of the core packages. Trigger a release from
-the GitHub Actions tab: `Actions → Extension Release → Run workflow`. Pick a
-bump type (`patch`/`minor`/`major`/`custom`) and the workflow:
+The extension ships independently of the core packages, mirroring the
+changesets release-PR flow but on a separate cadence.
 
-1. Bumps `extension/package.json`
-2. Builds Chrome + Firefox zips
-3. Runs `wxt submit` for both stores
-4. Commits the version bump to `main` and tags it as `@playhtml/extension@x.y.z`
+**Day-to-day:** when a PR touches `extension/**`, add a bullet to
+`extension/PENDING.md` describing the user-facing change. That's it.
 
-Use the `dry-run` toggle (off by default) to validate build + auth without
-submitting or committing — useful for testing credentials.
+**What the bot does:**
+
+- `.github/workflows/extension-release-prep.yml` runs on every push to `main`.
+  When `PENDING.md` has any bullets, it (re)builds the `extension-release`
+  branch with: bumped `package.json` (patch by default), prepended `CHANGELOG.md`
+  entry, cleared `PENDING.md`. Opens or updates a PR titled
+  `Release: @playhtml/extension v{version}`. Force-pushes the release branch
+  on every prep cycle so the PR always reflects current `main`.
+- Merging that PR to `main` triggers `.github/workflows/extension-release.yml`,
+  which builds Chrome + Firefox zips, runs `wxt submit` for both stores, and
+  pushes a `@playhtml/extension@x.y.z` tag.
+
+**To bump minor or major instead of patch:** edit `extension/package.json`
+on the release branch directly (in the GitHub PR UI is fine). The prep
+workflow preserves any manual override that's higher than the auto-computed
+patch bump.
+
+**To skip a release entirely:** empty out `PENDING.md` on `main`. The next
+prep run will close the open release PR.
+
+**Manual trigger / testing:** the release workflow also supports
+`workflow_dispatch` with a `dry-run` toggle (defaults to true). Use it to
+validate credentials and build without submitting.
 
 **Required GitHub Actions secrets** (set once at repo level):
 

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -15,6 +15,41 @@ Worker backend (in `worker/`):
 - `cd worker && wrangler dev`: Local API server (localhost:8787)
 - `cd worker && wrangler deploy`: Deploy to Cloudflare
 
+## Releases
+
+The extension uses the same Changesets flow as the core packages. Add a
+`.changeset/<slug>.md` file describing user-facing changes (frontmatter:
+`"@playhtml/extension": patch|minor|major`). Changesets bumps the version,
+updates `extension/CHANGELOG.md`, and pushes a tag (`@playhtml/extension@x.y.z`)
+when the "Release: Version packages" PR merges. Because the package is
+`private: true`, `changeset publish` skips npm — the tag is the trigger.
+
+The tag push fires `.github/workflows/extension-release.yml`, which builds
+Chrome + Firefox zips and runs `wxt submit` for both stores.
+
+**Required GitHub Actions secrets** (set once at repo level):
+
+Chrome Web Store:
+- `CHROME_EXTENSION_ID`
+- `CHROME_CLIENT_ID` — OAuth Desktop-app client (NOT Web app — Web clients use
+  the deprecated OOB flow which Google penalizes with ~7-day token expiry)
+- `CHROME_CLIENT_SECRET`
+- `CHROME_REFRESH_TOKEN` — generated once via OAuth Playground, scope
+  `https://www.googleapis.com/auth/chromewebstore`. Long-lived but can be
+  invalidated by Google account password change, 6-month inactivity, or
+  security events. Regenerate locally with `bun run submit:refresh-chrome-token`
+  and update the secret if CI fails with an OAuth error.
+
+Firefox AMO:
+- `FIREFOX_EXTENSION_ID`
+- `FIREFOX_JWT_ISSUER` — from addons.mozilla.org → Developer Hub → Manage API Keys
+- `FIREFOX_JWT_SECRET`
+
+**Manual fallback / testing:** The workflow also supports `workflow_dispatch`
+with a `dry-run` toggle (defaults to true) — run it from the Actions tab to
+verify zips build and credentials work without actually submitting. The local
+`./release.sh` continues to work as a manual escape hatch.
+
 ## Website & experiments (`extension/website/`)
 
 The `extension/website/` Vite app serves both the marketing/landing pages

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -17,15 +17,17 @@ Worker backend (in `worker/`):
 
 ## Releases
 
-The extension uses the same Changesets flow as the core packages. Add a
-`.changeset/<slug>.md` file describing user-facing changes (frontmatter:
-`"@playhtml/extension": patch|minor|major`). Changesets bumps the version,
-updates `extension/CHANGELOG.md`, and pushes a tag (`@playhtml/extension@x.y.z`)
-when the "Release: Version packages" PR merges. Because the package is
-`private: true`, `changeset publish` skips npm — the tag is the trigger.
+The extension ships independently of the core packages. Trigger a release from
+the GitHub Actions tab: `Actions → Extension Release → Run workflow`. Pick a
+bump type (`patch`/`minor`/`major`/`custom`) and the workflow:
 
-The tag push fires `.github/workflows/extension-release.yml`, which builds
-Chrome + Firefox zips and runs `wxt submit` for both stores.
+1. Bumps `extension/package.json`
+2. Builds Chrome + Firefox zips
+3. Runs `wxt submit` for both stores
+4. Commits the version bump to `main` and tags it as `@playhtml/extension@x.y.z`
+
+Use the `dry-run` toggle (off by default) to validate build + auth without
+submitting or committing — useful for testing credentials.
 
 **Required GitHub Actions secrets** (set once at repo level):
 
@@ -45,10 +47,9 @@ Firefox AMO:
 - `FIREFOX_JWT_ISSUER` — from addons.mozilla.org → Developer Hub → Manage API Keys
 - `FIREFOX_JWT_SECRET`
 
-**Manual fallback / testing:** The workflow also supports `workflow_dispatch`
-with a `dry-run` toggle (defaults to true) — run it from the Actions tab to
-verify zips build and credentials work without actually submitting. The local
-`./release.sh` continues to work as a manual escape hatch.
+**Manual fallback:** The local `./release.sh` continues to work as an escape
+hatch (uses `.env.submit` instead of GitHub secrets, requires a manual
+`extension/package.json` bump first).
 
 ## Website & experiments (`extension/website/`)
 

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,0 +1,10 @@
+# Unreleased
+
+<!--
+Add a bullet here in any PR that touches extension/**. The release-prep workflow
+watches this file: when there are bullets, it opens (or updates) a release PR
+that bumps the version, moves these bullets into CHANGELOG.md, and clears this
+file back to just the header. Merge that PR to ship.
+
+Format suggestion: "- short user-facing description (#PR)"
+-->


### PR DESCRIPTION
## Summary

Implements a changesets-style auto-PR flow for the extension, decoupled from core package releases. Day-to-day usage matches the core package experience: add a bullet to a markdown file, the release PR opens itself, merge to ship.

## How it works

**Day-to-day in extension PRs:** add a bullet to `extension/PENDING.md` describing the change. That's the only discipline.

**Auto-prep workflow** (`extension-release-prep.yml`):
- Triggers on every push to `main`
- If `PENDING.md` has bullets: (re)builds the `extension-release` branch with bumped `package.json` (patch by default), prepended `CHANGELOG.md`, cleared `PENDING.md`. Force-pushes. Opens or updates a `Release: @playhtml/extension v{version}` PR
- If `PENDING.md` is empty: closes any stale release PR
- Force-pushing the release branch is intentional — same pattern as `changesets/action` — so the PR always reflects current `main` state
- Manual `package.json` edits on the release branch are preserved if they specify a higher version than the auto-computed patch bump (lets you manually choose minor/major)

**Release workflow** (`extension-release.yml`, rewritten):
- Triggers on push to `main` when the head commit is `extension: release v{version}` (the prep bot's commit shape — protects against accidental triggers from unrelated `package.json` edits)
- Builds Chrome + Firefox zips, runs `wxt submit`, pushes a `@playhtml/extension@x.y.z` tag
- `workflow_dispatch` retained for manual dry-runs and emergency releases (defaults to dry-run)

## Why this shape (vs. the previous workflow_dispatch approach)

The dispatch approach required remembering to trigger releases and didn't surface "is something pending?" clearly. The auto-PR approach mirrors the core package release flow you're already used to — at any moment, an open `Release: @playhtml/extension v...` PR means there's something queued; no PR means main is up to date.

Force-push concerns were considered and dismissed: changesets uses the exact same pattern at scale, and the release branch is bot-owned (no human reviews intermediate states).

## Required GitHub Actions secrets

Already added (per earlier conversation):

- `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`
- `FIREFOX_EXTENSION_ID`, `FIREFOX_JWT_ISSUER`, `FIREFOX_JWT_SECRET`

## Test plan

- [ ] Merge this PR. The prep workflow will run on the merge commit; since `PENDING.md` only has the header (no bullets), no release PR opens. Confirm that's the case.
- [ ] In a follow-up PR, add a bullet to `extension/PENDING.md`. After merge, confirm the prep workflow opens a `Release: @playhtml/extension v...` PR.
- [ ] Add another bullet in a separate PR. After merge, confirm the existing release PR updates (force-push) with the new bullet in its CHANGELOG and the version still on the same patch bump.
- [ ] Manually edit `extension/package.json` on the release branch to a minor bump (e.g. `0.2.0`). Add another bullet via a regular PR. Confirm the prep workflow preserves `0.2.0` instead of overwriting with the auto-computed patch.
- [ ] Run `Extension Release` workflow with `dry-run: true` first to verify credentials are accepted by both stores end-to-end before relying on the auto trigger.
- [ ] Merge the release PR. Confirm the release workflow fires (head commit is `extension: release v...`), builds zips, submits, and tags `@playhtml/extension@v...`.

## Files

- `extension/PENDING.md` — new, source of truth for unreleased changes
- `.github/workflows/extension-release-prep.yml` — new
- `.github/workflows/extension-release.yml` — rewritten (push trigger replaces workflow_dispatch as primary)
- `extension/CLAUDE.md` — updated docs
- `.changeset/config.json` — `@playhtml/extension` stays in `ignore` (no coupling with core package release flow)