### PR TITLE
Report duplicate playhtml element IDs

### DIFF
--- a/.changeset/duplicate-playhtml-ids.md
+++ b/.changeset/duplicate-playhtml-ids.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Report duplicate playhtml element IDs during registration and surface duplicate ID groups in the development UI so developers can find shared-data collisions.

--- a/packages/playhtml/src/__tests__/duplicate-ids.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-ids.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Verifies playhtml reports duplicate element IDs during setup.
 // ABOUTME: Covers live registration diagnostics and dev UI conflict grouping.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listDuplicatePlayElements } from "../development";
+import { listDuplicatePlayElements, setupDevUI } from "../development";
 import { playhtml, resetPlayHTML } from "../index";
 
 describe("duplicate playhtml element IDs", () => {
@@ -76,5 +76,49 @@ describe("duplicate playhtml element IDs", () => {
         elements: [firstToggle, secondToggle],
       },
     ]);
+  });
+
+  it("renders duplicate IDs as an error callout in dev tools", () => {
+    vi.spyOn(console, "table").mockImplementation(() => {});
+
+    const firstToggle = document.createElement("div");
+    firstToggle.id = "shared-id";
+    firstToggle.setAttribute("can-toggle", "");
+
+    const secondToggle = document.createElement("button");
+    secondToggle.id = "shared-id";
+    secondToggle.setAttribute("can-toggle", "");
+
+    document.body.append(firstToggle, secondToggle);
+
+    setupDevUI({
+      elementHandlers: new Map([
+        [
+          "can-toggle",
+          new Map([
+            [
+              "shared-id",
+              {
+                element: firstToggle,
+                data: { on: false },
+                defaultData: { on: false },
+                setData: vi.fn(),
+              },
+            ],
+          ]),
+        ],
+      ]),
+      cursorClient: null,
+      roomId: "test-room",
+      host: "localhost:1999",
+    } as any);
+
+    document.querySelector<HTMLElement>(".ph-trigger")!.click();
+
+    const warning = document.querySelector<HTMLElement>(".ph-duplicate-warning");
+    expect(warning).toBeTruthy();
+    expect(warning!.textContent).toContain("Duplicate playhtml IDs");
+    expect(warning!.textContent).toContain("shared-id");
+    expect(warning!.textContent).toContain("can-toggle");
   });
 });

--- a/packages/playhtml/src/__tests__/duplicate-ids.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-ids.test.ts
@@ -1,0 +1,80 @@
+// ABOUTME: Verifies playhtml reports duplicate element IDs during setup.
+// ABOUTME: Covers live registration diagnostics and dev UI conflict grouping.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listDuplicatePlayElements } from "../development";
+import { playhtml, resetPlayHTML } from "../index";
+
+describe("duplicate playhtml element IDs", () => {
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+  });
+
+  it("reports and skips a duplicate ID for the same capability tag", async () => {
+    await playhtml.init({});
+
+    const first = document.createElement("div");
+    first.id = "duplicate-card";
+    first.setAttribute("can-toggle", "");
+
+    const second = document.createElement("div");
+    second.id = "duplicate-card";
+    second.setAttribute("can-toggle", "");
+
+    document.body.append(first, second);
+
+    await playhtml.setupPlayElementForTag(first, "can-toggle");
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await playhtml.setupPlayElementForTag(second, "can-toggle");
+
+    const handler = playhtml.elementHandlers
+      .get("can-toggle")!
+      .get("duplicate-card")!;
+    expect(handler.element).toBe(first);
+    expect(second.classList.contains("__playhtml-element")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate element id "duplicate-card"'),
+      { existingElement: first, duplicateElement: second },
+    );
+  });
+
+  it("groups duplicate DOM IDs by capability tag for dev tools", () => {
+    const firstToggle = document.createElement("div");
+    firstToggle.id = "shared-id";
+    firstToggle.setAttribute("can-toggle", "");
+
+    const secondToggle = document.createElement("button");
+    secondToggle.id = "shared-id";
+    secondToggle.setAttribute("can-toggle", "");
+
+    const moveElement = document.createElement("div");
+    moveElement.id = "shared-id";
+    moveElement.setAttribute("can-move", "");
+
+    const uniqueToggle = document.createElement("div");
+    uniqueToggle.id = "unique-id";
+    uniqueToggle.setAttribute("can-toggle", "");
+
+    document.body.append(firstToggle, secondToggle, moveElement, uniqueToggle);
+
+    expect(listDuplicatePlayElements(["can-toggle", "can-move"])).toEqual([
+      {
+        tagType: "can-toggle",
+        elementId: "shared-id",
+        elements: [firstToggle, secondToggle],
+      },
+    ]);
+  });
+});

--- a/packages/playhtml/src/development.ts
+++ b/packages/playhtml/src/development.ts
@@ -653,6 +653,36 @@ export function listSharedElements() {
   return out;
 }
 
+export interface DuplicatePlayElement {
+  tagType: string;
+  elementId: string;
+  elements: HTMLElement[];
+}
+
+export function listDuplicatePlayElements(
+  tagTypes: Iterable<string>,
+): DuplicatePlayElement[] {
+  const duplicates: DuplicatePlayElement[] = [];
+
+  for (const tagType of tagTypes) {
+    const elementsById = new Map<string, HTMLElement[]>();
+    document.querySelectorAll(`[${tagType}]`).forEach((node) => {
+      if (!(node instanceof HTMLElement) || !node.id) return;
+
+      const elements = elementsById.get(node.id) ?? [];
+      elements.push(node);
+      elementsById.set(node.id, elements);
+    });
+
+    elementsById.forEach((elements, elementId) => {
+      if (elements.length < 2) return;
+      duplicates.push({ tagType, elementId, elements });
+    });
+  }
+
+  return duplicates;
+}
+
 // ─── Helper: create element with classes ───────────────────────────────
 function el<K extends keyof HTMLElementTagNameMap>(
   tag: K,
@@ -764,6 +794,11 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
   statusRow1.appendChild(sep1);
   const elCountNode = document.createTextNode("");
   statusRow1.appendChild(elCountNode);
+  const sepConflicts = el("span", "ph-sep");
+  sepConflicts.textContent = "\u00B7";
+  statusRow1.appendChild(sepConflicts);
+  const conflictCountNode = el("span");
+  statusRow1.appendChild(conflictCountNode);
   status.appendChild(statusRow1);
 
   // Row 2: room + host
@@ -804,10 +839,18 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
     clientCountNode.textContent = `${clients} client${clients !== 1 ? "s" : ""}`;
 
     let total = 0;
-    elementHandlers.forEach((idMap) => {
+    const tagTypes = new Set<string>();
+    elementHandlers.forEach((idMap, tagType) => {
       total += idMap.size;
+      tagTypes.add(tagType);
     });
     elCountNode.textContent = `${total} element${total !== 1 ? "s" : ""}`;
+
+    const conflicts = listDuplicatePlayElements(tagTypes).length;
+    sepConflicts.style.display = conflicts > 0 ? "" : "none";
+    conflictCountNode.style.display = conflicts > 0 ? "" : "none";
+    conflictCountNode.textContent =
+      conflicts > 0 ? `${conflicts} conflict${conflicts !== 1 ? "s" : ""}` : "";
   }
   updateStatusCounts();
 
@@ -1213,6 +1256,7 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
     // Collect all tag types for the filter dropdown
     const tagTypes = new Set<string>();
     elementHandlers.forEach((_idMap, tagType) => tagTypes.add(tagType));
+    const duplicateElements = listDuplicatePlayElements(tagTypes);
 
     if (tagTypes.size > 1) {
       const filterSelect = el("select", "ph-tag-filter");
@@ -1370,6 +1414,51 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
         const noMatch = el("div", "ph-empty");
         noMatch.textContent = "No elements match the current filter.";
         dataArea.appendChild(noMatch);
+      }
+    }
+
+    if (duplicateElements.length > 0) {
+      const dividerEl = document.createElement("hr");
+      dividerEl.style.border = "none";
+      dividerEl.style.borderTop = "1px solid #d4cfc7";
+      dividerEl.style.margin = "6px 0";
+      dataArea.appendChild(dividerEl);
+
+      const duplicateHeader = el("div", "ph-data-header");
+      duplicateHeader.textContent = "Duplicate IDs";
+      duplicateHeader.style.fontSize = "10px";
+      dataArea.appendChild(duplicateHeader);
+
+      for (const entry of duplicateElements) {
+        const row = el("div", "ph-tree-item");
+
+        const badge = el("span", "ph-tree-badge");
+        badge.textContent = entry.tagType;
+        badge.style.background = "#c4724e";
+
+        const elName = el("span", "ph-tree-el-name");
+        elName.textContent = `#${entry.elementId} (${entry.elements.length})`;
+        elName.title =
+          "Multiple elements with this ID share the same capability tag.";
+        elName.onclick = (e) => {
+          e.stopPropagation();
+          for (const duplicateElement of entry.elements) {
+            duplicateElement.classList.add("ph-flash");
+            duplicateElement.addEventListener(
+              "animationend",
+              () => duplicateElement.classList.remove("ph-flash"),
+              { once: true }
+            );
+          }
+          entry.elements[0]?.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+          });
+        };
+
+        row.appendChild(badge);
+        row.appendChild(elName);
+        dataArea.appendChild(row);
       }
     }
 

--- a/packages/playhtml/src/development.ts
+++ b/packages/playhtml/src/development.ts
@@ -463,6 +463,40 @@ const DEV_STYLES = `
   font-size: 12px;
   font-family: 'Atkinson Hyperlegible', sans-serif;
 }
+.ph-duplicate-warning {
+  margin: 0 0 8px 0;
+  padding: 8px 10px;
+  background: #fff0ec;
+  border: 2px solid #c4724e;
+  box-shadow: inset 3px 0 0 #c4724e;
+  color: #3d3833;
+}
+.ph-duplicate-warning-title {
+  font-family: 'Atkinson Hyperlegible', sans-serif;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #9f3f2a;
+}
+.ph-duplicate-warning-message {
+  margin-top: 3px;
+  font-size: 11px;
+  color: #6b352b;
+}
+.ph-duplicate-warning-list {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-family: 'Martian Mono', 'SF Mono', monospace;
+  font-size: 11px;
+}
+.ph-duplicate-warning-item {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
 .ph-inspect-highlight {
   outline: 2px dashed #4a9a8a;
   outline-offset: 2px;
@@ -1292,6 +1326,37 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
     searchBar.appendChild(resetAllBtn);
 
     dataArea.appendChild(searchBar);
+
+    if (duplicateElements.length > 0) {
+      const warning = el("div", "ph-duplicate-warning");
+
+      const warningTitle = el("div", "ph-duplicate-warning-title");
+      warningTitle.textContent = "Error: Duplicate playhtml IDs";
+      warning.appendChild(warningTitle);
+
+      const warningMessage = el("div", "ph-duplicate-warning-message");
+      warningMessage.textContent =
+        "These elements share synced data and later duplicates are ignored.";
+      warning.appendChild(warningMessage);
+
+      const warningList = el("div", "ph-duplicate-warning-list");
+      for (const entry of duplicateElements) {
+        const item = el("div", "ph-duplicate-warning-item");
+
+        const badge = el("span", "ph-tree-badge");
+        badge.textContent = entry.tagType;
+        badge.style.background = "#c4724e";
+
+        const label = el("span");
+        label.textContent = `#${entry.elementId} (${entry.elements.length})`;
+
+        item.appendChild(badge);
+        item.appendChild(label);
+        warningList.appendChild(item);
+      }
+      warning.appendChild(warningList);
+      dataArea.insertBefore(warning, searchBar);
+    }
 
     // Restore focus to search input after re-render
     requestAnimationFrame(() => {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1561,6 +1561,28 @@ function isElementValidForTag(
   );
 }
 
+function describeElementForError(element: HTMLElement): string {
+  const tagName = element.tagName.toLowerCase();
+  const id = element.id ? `#${element.id}` : "";
+  const classes = Array.from(element.classList)
+    .map((className) => `.${className}`)
+    .join("");
+
+  return `<${tagName}${id}${classes}>`;
+}
+
+function reportDuplicateElementId(
+  tag: TagType | string,
+  elementId: string,
+  existingElement: HTMLElement,
+  duplicateElement: HTMLElement,
+): void {
+  console.error(
+    `[playhtml] Duplicate element id "${elementId}" for ${tag}. Element IDs must be unique per capability tag because playhtml stores shared data by tag and ID. Keeping ${describeElementForError(existingElement)} and ignoring ${describeElementForError(duplicateElement)}.`,
+    { existingElement, duplicateElement },
+  );
+}
+
 /**
  * Sets up a playhtml element to handle the given tag's capabilities.
  */
@@ -1621,9 +1643,19 @@ async function setupPlayElementForTag<T extends TagType | string>(
     elementInitializerInfo,
     elementId,
   );
-  if (tagElementHandlers.has(elementId)) {
-    // Try to update the elements info
-    tagElementHandlers.get(elementId)!.reinitializeElementData(elementData);
+  const existingHandler = tagElementHandlers.get(elementId);
+  if (existingHandler) {
+    if (existingHandler.element !== element) {
+      reportDuplicateElementId(
+        tag,
+        elementId,
+        existingHandler.element,
+        element,
+      );
+      return;
+    }
+
+    existingHandler.reinitializeElementData(elementData);
     // ensure observer is attached
     attachSyncedStoreObserver(tag as string, elementId);
     return;


### PR DESCRIPTION
## Summary

- reports duplicate playhtml element IDs during registration and skips the duplicate element for that capability tag
- adds duplicate-ID grouping to the development UI, with a prominent error callout above the Data tab controls
- adds focused coverage for live registration diagnostics and dev UI duplicate rendering

## Why

Fixes #39. Duplicate DOM IDs currently collapse into the same playhtml handler/data entry, which makes collisions hard to notice and debug. The runtime now flags the collision directly, and development mode makes the conflict visible in the sidebar.

## Validation

- `bun run test src/__tests__/duplicate-ids.test.ts`
- `bun run test` in `packages/playhtml` (21 files, 165 tests)
- `bun run build` in `packages/playhtml`

Note: the full test suite still prints its existing performance summaries, and the build still emits the existing API Extractor TypeScript-version warning.

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/12f76b93-f3ca-4b21-8bd0-c96b2723c377" />
