### PR TITLE
make playhtml store in window read-only

### DIFF
--- a/.changeset/readonly-synced-store.md
+++ b/.changeset/readonly-synced-store.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Expose `playhtml.syncedStore` as a read-only inspection view so browser scripts cannot mutate shared element data directly. Element updates still go through playhtml's normal `setData()` path, while administrative data edits remain handled by the admin console.

--- a/packages/playhtml/src/__tests__/main.nested-data.test.ts
+++ b/packages/playhtml/src/__tests__/main.nested-data.test.ts
@@ -116,6 +116,40 @@ describe("playhtml SyncedStore CRDT behavior", () => {
     ).toBe("readonly-nested-el");
   });
 
+  it("keeps public shared state inspectable while blocking object mutation APIs", async () => {
+    setupSimpleElement("can-toggle", "readonly-api-el");
+
+    const tagData = playhtml.syncedStore["can-toggle"];
+    const elementData = tagData["readonly-api-el"];
+
+    expect(Object.keys(playhtml.syncedStore)).toContain("can-toggle");
+    expect(Object.keys(tagData)).toContain("readonly-api-el");
+    expect(elementData).toEqual({ on: false });
+
+    expect(() => {
+      delete tagData["readonly-api-el"];
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.defineProperty(tagData, "other", {
+        value: { on: true },
+      });
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.setPrototypeOf(elementData, null);
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.preventExtensions(elementData);
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.freeze(elementData);
+    }).toThrow(/read-only/);
+    await waitForSync();
+
+    expect(playhtml.syncedStore["can-toggle"]["readonly-api-el"]).toEqual({
+      on: false,
+    });
+  });
+
   it("prevents browser scripts from mutating public shared arrays", async () => {
     const tag = "can-duplicate";
     const target = document.createElement("div");
@@ -138,6 +172,12 @@ describe("playhtml SyncedStore CRDT behavior", () => {
 
     expect(() => {
       playhtml.syncedStore[tag]["readonly-array-el"].push("corrupted");
+    }).toThrow(/read-only/);
+    expect(() => {
+      playhtml.syncedStore[tag]["readonly-array-el"][0] = "corrupted";
+    }).toThrow(/read-only/);
+    expect(() => {
+      playhtml.syncedStore[tag]["readonly-array-el"].length = 0;
     }).toThrow(/read-only/);
     await waitForSync();
 

--- a/packages/playhtml/src/__tests__/main.nested-data.test.ts
+++ b/packages/playhtml/src/__tests__/main.nested-data.test.ts
@@ -66,6 +66,87 @@ describe("playhtml SyncedStore CRDT behavior", () => {
     expect(playhtml.syncedStore["can-toggle"]["el1"]).toEqual({ on: false });
   });
 
+  it("prevents browser scripts from mutating public shared state", async () => {
+    setupSimpleElement("can-toggle", "readonly-el");
+
+    const handler = playhtml
+      .elementHandlers!.get("can-toggle")!
+      .get("readonly-el")!;
+    expect(handler.data).toEqual({ on: false });
+    expect(playhtml.syncedStore["can-toggle"]["readonly-el"]).toEqual({
+      on: false,
+    });
+
+    expect(() => {
+      playhtml.syncedStore["can-toggle"]["readonly-el"] = {
+        corrupted: true,
+      };
+    }).toThrow(/read-only/);
+    await waitForSync();
+
+    expect(handler.data).toEqual({ on: false });
+    expect(playhtml.syncedStore["can-toggle"]["readonly-el"]).toEqual({
+      on: false,
+    });
+  });
+
+  it("prevents browser scripts from mutating nested public shared state", async () => {
+    setupSimpleElement("can-mirror", "readonly-nested-el");
+
+    const handler = playhtml
+      .elementHandlers!.get("can-mirror")!
+      .get("readonly-nested-el")!;
+    expect(handler.data.attributes.id).toBe("readonly-nested-el");
+
+    expect(() => {
+      playhtml.syncedStore["can-mirror"][
+        "readonly-nested-el"
+      ].attributes.id = "corrupted";
+    }).toThrow(/read-only/);
+    expect(() => {
+      delete playhtml.syncedStore["can-mirror"][
+        "readonly-nested-el"
+      ].attributes.id;
+    }).toThrow(/read-only/);
+    await waitForSync();
+
+    expect(handler.data.attributes.id).toBe("readonly-nested-el");
+    expect(
+      playhtml.syncedStore["can-mirror"]["readonly-nested-el"].attributes.id,
+    ).toBe("readonly-nested-el");
+  });
+
+  it("prevents browser scripts from mutating public shared arrays", async () => {
+    const tag = "can-duplicate";
+    const target = document.createElement("div");
+    target.id = "readonly-array-target";
+    document.body.appendChild(target);
+    const el = setupSimpleElement(tag, "readonly-array-el", {
+      "can-duplicate": "readonly-array-target",
+    });
+
+    // @ts-ignore
+    await playhtml.setupPlayElementForTag(el, tag);
+
+    const handler = playhtml
+      .elementHandlers!.get(tag)!
+      .get("readonly-array-el")!;
+    handler.setData((draft: any) => {
+      draft.push("existing");
+    });
+    await waitForSync();
+
+    expect(() => {
+      playhtml.syncedStore[tag]["readonly-array-el"].push("corrupted");
+    }).toThrow(/read-only/);
+    await waitForSync();
+
+    expect(handler.data).toEqual(["existing"]);
+    expect(playhtml.syncedStore[tag]["readonly-array-el"]).toEqual([
+      "existing",
+    ]);
+  });
+
   it("supports CRDT array operations with mutator form", async () => {
     const tag = "can-duplicate";
     const target = document.createElement("div");

--- a/packages/playhtml/src/__tests__/readOnlyStore.test.ts
+++ b/packages/playhtml/src/__tests__/readOnlyStore.test.ts
@@ -53,6 +53,26 @@ describe("createReadOnlyStore", () => {
     });
   });
 
+  it("does not expose mutation instructions in thrown errors", () => {
+    const view = createReadOnlyStore({
+      "can-toggle": {
+        element: { on: false },
+      },
+    });
+
+    let thrownError: unknown;
+    try {
+      view["can-toggle"].element.on = true;
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBeInstanceOf(Error);
+    expect((thrownError as Error).message).toBe(
+      "playhtml.syncedStore is read-only.",
+    );
+  });
+
   it("blocks array mutation paths", () => {
     const source = {
       "can-duplicate": {

--- a/packages/playhtml/src/__tests__/readOnlyStore.test.ts
+++ b/packages/playhtml/src/__tests__/readOnlyStore.test.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Tests read-only views over shared playhtml data.
+// ABOUTME: Verifies inspection behavior and blocked mutation paths.
+import { describe, expect, it } from "vitest";
+import { createReadOnlyStore } from "../readOnlyStore";
+
+describe("createReadOnlyStore", () => {
+  it("allows key enumeration and deep reads", () => {
+    const source = {
+      "can-toggle": {
+        element: { on: false },
+      },
+    };
+    const view = createReadOnlyStore(source);
+
+    expect(Object.keys(view)).toEqual(["can-toggle"]);
+    expect(Object.keys(view["can-toggle"])).toEqual(["element"]);
+    expect(view["can-toggle"].element).toEqual({ on: false });
+  });
+
+  it("blocks object mutation paths", () => {
+    const source = {
+      "can-toggle": {
+        element: { on: false },
+      },
+    };
+    const view = createReadOnlyStore(source);
+
+    expect(() => {
+      view["can-toggle"] = {};
+    }).toThrow(/read-only/);
+    expect(() => {
+      delete view["can-toggle"].element;
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.defineProperty(view["can-toggle"], "other", {
+        value: { on: true },
+      });
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.setPrototypeOf(view["can-toggle"], null);
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.preventExtensions(view["can-toggle"]);
+    }).toThrow(/read-only/);
+    expect(() => {
+      Object.freeze(view["can-toggle"]);
+    }).toThrow(/read-only/);
+
+    expect(source).toEqual({
+      "can-toggle": {
+        element: { on: false },
+      },
+    });
+  });
+
+  it("blocks array mutation paths", () => {
+    const source = {
+      "can-duplicate": {
+        element: ["existing"],
+      },
+    };
+    const view = createReadOnlyStore(source);
+    const publicArray = view["can-duplicate"].element;
+
+    expect(publicArray).toEqual(["existing"]);
+    expect(() => {
+      publicArray.push("corrupted");
+    }).toThrow(/read-only/);
+    expect(() => {
+      publicArray[0] = "corrupted";
+    }).toThrow(/read-only/);
+    expect(() => {
+      publicArray.length = 0;
+    }).toThrow(/read-only/);
+
+    expect(source["can-duplicate"].element).toEqual(["existing"]);
+  });
+
+  it("keeps non-configurable values inspectable and read-only", () => {
+    const nested = { ok: true };
+    const source = {};
+    Object.defineProperty(source, "fixed", {
+      value: nested,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+
+    const view = createReadOnlyStore(source as { fixed: { ok: boolean } });
+
+    expect(view.fixed).toEqual({ ok: true });
+    expect(() => {
+      view.fixed.ok = false;
+    }).toThrow(/read-only/);
+    expect(nested).toEqual({ ok: true });
+  });
+});

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -47,6 +47,7 @@ import {
 import { parseDataSource, normalizeHost } from "@playhtml/common";
 import type { PageDataChannel } from "@playhtml/common";
 import { createPageDataChannel, PAGE_TAG } from "./page-data";
+import { createReadOnlyStore, type ReadOnlyStore } from "./readOnlyStore";
 
 const DefaultPartykitHost = "playhtml.spencerc99.workers.dev";
 const StagingPartykitHost = "playhtml-staging.spencerc99.workers.dev";
@@ -85,6 +86,7 @@ type StoreShape = {
 };
 const store = syncedStore<StoreShape>({ play: {} });
 const doc = getYjsDoc(store);
+const publicSyncedStore = createReadOnlyStore(store.play);
 
 function getDefaultRoom({ includeSearch }: DefaultRoomOptions): string {
   // TODO: Strip filename extension
@@ -1369,7 +1371,7 @@ export interface PlayHTMLComponents {
   removePlayElement: typeof removePlayElement;
   deleteElementData: typeof deleteElementData;
   setupPlayElementForTag: typeof setupPlayElementForTag;
-  syncedStore: (typeof store)["play"];
+  syncedStore: ReadOnlyStore<(typeof store)["play"]>;
   elementHandlers: Map<string, Map<string, ElementHandler>>;
   eventHandlers: Map<string, Array<RegisteredPlayEvent>>;
   dispatchPlayEvent: typeof dispatchPlayEvent;
@@ -1494,7 +1496,7 @@ export const playhtml: PlayHTMLComponents = {
   removePlayElement,
   deleteElementData,
   setupPlayElementForTag,
-  syncedStore: store.play,
+  syncedStore: publicSyncedStore,
   elementHandlers,
   eventHandlers,
   dispatchPlayEvent,

--- a/packages/playhtml/src/readOnlyStore.ts
+++ b/packages/playhtml/src/readOnlyStore.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Creates read-only views over shared playhtml data.
+// ABOUTME: Preserves public inspection while blocking direct mutation.
+type DeepReadonlyStore<T> = T extends (...args: any[]) => any
+  ? T
+  : T extends readonly (infer U)[]
+    ? ReadonlyArray<DeepReadonlyStore<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonlyStore<T[K]> }
+      : T;
+
+const READ_ONLY_STORE_MESSAGE = [
+  "playhtml.syncedStore is read-only.",
+  "Use setData() or the admin console to change shared data.",
+].join(" ");
+const ARRAY_MUTATION_METHODS = new Set<PropertyKey>([
+  "copyWithin",
+  "fill",
+  "pop",
+  "push",
+  "reverse",
+  "shift",
+  "sort",
+  "splice",
+  "unshift",
+]);
+
+function throwReadOnlyStoreError(): never {
+  throw new Error(READ_ONLY_STORE_MESSAGE);
+}
+
+export function createReadOnlyStore<T extends object>(
+  source: T,
+): DeepReadonlyStore<T> {
+  const proxyBySource = new WeakMap<object, unknown>();
+
+  function readOnlyValue<TValue>(value: TValue): TValue {
+    if (value === null || typeof value !== "object") {
+      return value;
+    }
+
+    const cached = proxyBySource.get(value);
+    if (cached) {
+      return cached as TValue;
+    }
+
+    const proxy = new Proxy(value, {
+      get(target, property, receiver) {
+        if (Array.isArray(target) && ARRAY_MUTATION_METHODS.has(property)) {
+          return throwReadOnlyStoreError;
+        }
+        return readOnlyValue(Reflect.get(target, property, receiver));
+      },
+      getOwnPropertyDescriptor(target, property) {
+        const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+        if (!descriptor) {
+          return descriptor;
+        }
+
+        if ("value" in descriptor) {
+          const writable =
+            descriptor.configurable === false
+              ? descriptor.writable
+              : false;
+          return {
+            ...descriptor,
+            value: readOnlyValue(descriptor.value),
+            writable,
+          };
+        }
+
+        return descriptor;
+      },
+      set: throwReadOnlyStoreError,
+      deleteProperty: throwReadOnlyStoreError,
+      defineProperty: throwReadOnlyStoreError,
+      setPrototypeOf: throwReadOnlyStoreError,
+      preventExtensions: throwReadOnlyStoreError,
+    });
+
+    proxyBySource.set(value, proxy);
+    return proxy as TValue;
+  }
+
+  return readOnlyValue(source) as DeepReadonlyStore<T>;
+}
+
+export type ReadOnlyStore<T extends object> = DeepReadonlyStore<T>;

--- a/packages/playhtml/src/readOnlyStore.ts
+++ b/packages/playhtml/src/readOnlyStore.ts
@@ -28,6 +28,18 @@ function throwReadOnlyStoreError(): never {
   throw new Error(READ_ONLY_STORE_MESSAGE);
 }
 
+function createTargetFor(source: object): object {
+  return Array.isArray(source) ? [] : {};
+}
+
+function syncArrayLength(source: object, target: object): void {
+  if (!Array.isArray(source) || !Array.isArray(target)) {
+    return;
+  }
+
+  target.length = source.length;
+}
+
 export function createReadOnlyStore<T extends object>(
   source: T,
 ): DeepReadonlyStore<T> {
@@ -43,32 +55,60 @@ export function createReadOnlyStore<T extends object>(
       return cached as TValue;
     }
 
-    const proxy = new Proxy(value, {
-      get(target, property, receiver) {
-        if (Array.isArray(target) && ARRAY_MUTATION_METHODS.has(property)) {
+    const sourceObject = value as object;
+    const target = createTargetFor(sourceObject);
+    const proxy = new Proxy(target, {
+      get(_target, property) {
+        if (
+          Array.isArray(sourceObject) &&
+          ARRAY_MUTATION_METHODS.has(property)
+        ) {
           return throwReadOnlyStoreError;
         }
-        return readOnlyValue(Reflect.get(target, property, receiver));
+        return readOnlyValue(Reflect.get(sourceObject, property, sourceObject));
       },
-      getOwnPropertyDescriptor(target, property) {
-        const descriptor = Reflect.getOwnPropertyDescriptor(target, property);
+      getOwnPropertyDescriptor(_target, property) {
+        syncArrayLength(sourceObject, target);
+
+        if (Array.isArray(sourceObject) && property === "length") {
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        }
+
+        const descriptor = Reflect.getOwnPropertyDescriptor(
+          sourceObject,
+          property,
+        );
         if (!descriptor) {
           return descriptor;
         }
 
         if ("value" in descriptor) {
-          const writable =
-            descriptor.configurable === false
-              ? descriptor.writable
-              : false;
           return {
             ...descriptor,
+            configurable: true,
             value: readOnlyValue(descriptor.value),
-            writable,
+            writable: false,
           };
         }
 
-        return descriptor;
+        return {
+          configurable: true,
+          enumerable: descriptor.enumerable,
+          value: readOnlyValue(
+            Reflect.get(sourceObject, property, sourceObject),
+          ),
+          writable: false,
+        };
+      },
+      has(_target, property) {
+        return property in sourceObject;
+      },
+      ownKeys() {
+        syncArrayLength(sourceObject, target);
+        return Reflect.ownKeys(sourceObject);
+      },
+      getPrototypeOf() {
+        return Reflect.getPrototypeOf(sourceObject);
       },
       set: throwReadOnlyStoreError,
       deleteProperty: throwReadOnlyStoreError,

--- a/packages/playhtml/src/readOnlyStore.ts
+++ b/packages/playhtml/src/readOnlyStore.ts
@@ -8,10 +8,7 @@ type DeepReadonlyStore<T> = T extends (...args: any[]) => any
       ? { readonly [K in keyof T]: DeepReadonlyStore<T[K]> }
       : T;
 
-const READ_ONLY_STORE_MESSAGE = [
-  "playhtml.syncedStore is read-only.",
-  "Use setData() or the admin console to change shared data.",
-].join(" ");
+const READ_ONLY_STORE_MESSAGE = "playhtml.syncedStore is read-only.";
 const ARRAY_MUTATION_METHODS = new Set<PropertyKey>([
   "copyWithin",
   "fill",


### PR DESCRIPTION
## Summary

- Expose `playhtml.syncedStore` as a deep read-only inspection view instead of a mutable shared-state object.
- Keep internal update behavior unchanged for normal playhtml interactions.
- Add regression coverage for direct browser-script mutation attempts, nested writes, deletes, array writes, descriptor/prototype mutation APIs, and proxy invariant behavior.
- Add a patch changeset for `playhtml`.

## Root Cause

The public browser API exposed mutable shared element state, so page scripts could write through it directly.

## Validation

- `/Users/spencerchang/.bun/bin/bun run test src/__tests__/readOnlyStore.test.ts src/__tests__/main.nested-data.test.ts` in `packages/playhtml`: 2 files, 15 tests passed.
- `../../node_modules/.bin/tsc` in `packages/playhtml`: passed with no output.

## Notes

This is client API hardening, not a server-side authorization boundary.
