### PR TITLE
Stream admin backup parsing

### DIFF
--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -1,6 +1,9 @@
+// ABOUTME: Provides the browser admin console for inspecting and managing PlayHTML rooms.
+// ABOUTME: Includes backup comparison tools for restoring collaborative document state.
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { createRoot } from "react-dom/client";
 import { useStickyState } from "./hooks/useStickyState";
+import { findDocumentRowInBackup } from "./utils/backup";
 
 // Types from the original admin.ts
 interface RoomData {
@@ -847,8 +850,7 @@ const AdminConsole: React.FC = () => {
               `Re-processing backup for new room: ${decodeRoomId(roomId)}`
             );
             try {
-              const text = await currentBackupFile.text();
-              await processBackupText(text, currentBackupFile.name, roomId);
+              await processBackupFile(currentBackupFile, roomId);
             } catch (error) {
               addLog(
                 "error",
@@ -873,9 +875,8 @@ const AdminConsole: React.FC = () => {
                   1024
                 ).toFixed(2)} MB)`
               );
-              const text = await file.text();
               setCurrentBackupFile(file);
-              await processBackupText(text, file.name, roomId);
+              await processBackupFile(file, roomId);
             } else {
               addLog("warn", "Saved backup path found but file not in OPFS");
               setSavedBackupPath(null);
@@ -1680,14 +1681,11 @@ const AdminConsole: React.FC = () => {
         ).toFixed(2)} MB)`
       );
 
-      // Read backup file
-      const text = await file.text();
-
       // Store the file for re-processing on reload
       setCurrentBackupFile(file);
 
       // Process the backup
-      await processBackupText(text, file.name, currentRoomId);
+      await processBackupFile(file, currentRoomId);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       addLog("error", `Failed to load backup file: ${msg}`, error);
@@ -1743,36 +1741,18 @@ const AdminConsole: React.FC = () => {
     }
   };
 
-  const processBackupText = async (
-    text: string,
-    fileName: string,
-    targetRoomId: string
-  ) => {
+  const processBackupFile = async (file: File, targetRoomId: string) => {
     try {
       setShowBackupComparison(true);
       addLog("info", "Searching for documents section in backup...");
 
-      // Find COPY public.documents section
-      const copyMatch = text.match(
-        /COPY public\.documents \(id, created_at, document, name\) FROM stdin;\n([\s\S]*?)\n\\\.\n/
-      );
-      if (!copyMatch) {
-        throw new Error(
-          "Could not find COPY public.documents section in backup file"
-        );
-      }
-
-      addLog("info", "Found documents section, searching for room...");
-
-      // Split into lines and find matching room
-      const lines = copyMatch[1].split("\n").filter((l) => l.trim());
       const encodedRoomId = ensureEncodedRoomId(targetRoomId);
-      const roomLine = lines.find((line) => {
-        const cols = line.split("\t");
-        return cols[3] === encodedRoomId;
-      });
+      const backupRow = await findDocumentRowInBackup(
+        file.stream(),
+        encodedRoomId
+      );
 
-      if (!roomLine) {
+      if (!backupRow) {
         addLog(
           "warn",
           `Room ${decodeRoomId(encodedRoomId)} not found in backup file`
@@ -1782,10 +1762,8 @@ const AdminConsole: React.FC = () => {
 
       addLog("info", `Found room data in backup`);
 
-      // Parse the line: id, created_at, document (base64), name
-      const cols = roomLine.split("\t");
-      const backupTimestamp = cols[1];
-      const base64Doc = cols[2];
+      const backupTimestamp = backupRow.timestamp;
+      const base64Doc = backupRow.base64Doc;
 
       // Store the base64 for copy functionality
       setBackupBase64(base64Doc);

--- a/website/index.tsx
+++ b/website/index.tsx
@@ -17,6 +17,12 @@ interface FormData {
   timestamp: number;
 }
 
+const GuestbookSubmissionLimit = {
+  maxEntries: 3,
+  windowMs: 10 * 60 * 1000,
+  storageKey: "playhtml:guestbook-submission-timestamps",
+};
+
 function getFormDataId(formData: FormData) {
   return `${formData.name}-${formData.timestamp}`;
 }
@@ -115,6 +121,26 @@ if (reactContentElement) {
             },
             onMount: ({ getElement, setData }) => {
               const element = getElement();
+              let guestbookSubmissionTimestamps: number[] = [];
+
+              try {
+                const storedTimestamps = window.localStorage.getItem(
+                  GuestbookSubmissionLimit.storageKey
+                );
+                if (storedTimestamps) {
+                  const parsedTimestamps = JSON.parse(storedTimestamps);
+                  if (Array.isArray(parsedTimestamps)) {
+                    guestbookSubmissionTimestamps = parsedTimestamps.filter(
+                      (timestamp): timestamp is number =>
+                        typeof timestamp === "number" &&
+                        Number.isFinite(timestamp)
+                    );
+                  }
+                }
+              } catch {
+                guestbookSubmissionTimestamps = [];
+              }
+
               element.addEventListener("submit", (e: SubmitEvent) => {
                 e.preventDefault();
                 e.stopImmediatePropagation();
@@ -157,6 +183,23 @@ if (reactContentElement) {
                 // TODO: add length validation here
 
                 const timestamp = Date.now();
+                const earliestAllowedSubmission =
+                  timestamp - GuestbookSubmissionLimit.windowMs;
+                guestbookSubmissionTimestamps =
+                  guestbookSubmissionTimestamps.filter(
+                    (submittedAt) =>
+                      submittedAt > earliestAllowedSubmission &&
+                      submittedAt <= timestamp
+                  );
+
+                if (
+                  guestbookSubmissionTimestamps.length >=
+                  GuestbookSubmissionLimit.maxEntries
+                ) {
+                  alert("please wait a bit before adding more guestbook notes");
+                  return false;
+                }
+
                 const newEntry: FormData = {
                   name: "someone",
                   message: "something",
@@ -167,6 +210,18 @@ if (reactContentElement) {
                 setData((d: FormData[]) => {
                   d.push(newEntry);
                 });
+                guestbookSubmissionTimestamps = [
+                  ...guestbookSubmissionTimestamps,
+                  timestamp,
+                ];
+                try {
+                  window.localStorage.setItem(
+                    GuestbookSubmissionLimit.storageKey,
+                    JSON.stringify(guestbookSubmissionTimestamps)
+                  );
+                } catch {
+                  // Ignore local storage failures so valid guestbook posts still work.
+                }
                 clearMessage();
                 return false;
               });

--- a/website/test/admin.tsx
+++ b/website/test/admin.tsx
@@ -1,7 +1,10 @@
+// ABOUTME: Provides the browser test admin console for inspecting PlayHTML room state.
+// ABOUTME: Includes backup comparison tools for validating collaborative document state.
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { createRoot } from "react-dom/client";
 import { Buffer } from "buffer";
 import { useStickyState } from "../hooks/useStickyState";
+import { findDocumentRowInBackup } from "../utils/backup";
 
 // Types from the original admin.ts
 interface RoomData {
@@ -848,8 +851,7 @@ const AdminConsole: React.FC = () => {
               `Re-processing backup for new room: ${decodeRoomId(roomId)}`
             );
             try {
-              const text = await currentBackupFile.text();
-              await processBackupText(text, currentBackupFile.name, roomId);
+              await processBackupFile(currentBackupFile, roomId);
             } catch (error) {
               addLog(
                 "error",
@@ -874,9 +876,8 @@ const AdminConsole: React.FC = () => {
                   1024
                 ).toFixed(2)} MB)`
               );
-              const text = await file.text();
               setCurrentBackupFile(file);
-              await processBackupText(text, file.name, roomId);
+              await processBackupFile(file, roomId);
             } else {
               addLog("warn", "Saved backup path found but file not in OPFS");
               setSavedBackupPath(null);
@@ -1681,14 +1682,11 @@ const AdminConsole: React.FC = () => {
         ).toFixed(2)} MB)`
       );
 
-      // Read backup file
-      const text = await file.text();
-
       // Store the file for re-processing on reload
       setCurrentBackupFile(file);
 
       // Process the backup
-      await processBackupText(text, file.name, currentRoomId);
+      await processBackupFile(file, currentRoomId);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       addLog("error", `Failed to load backup file: ${msg}`, error);
@@ -1744,36 +1742,18 @@ const AdminConsole: React.FC = () => {
     }
   };
 
-  const processBackupText = async (
-    text: string,
-    fileName: string,
-    targetRoomId: string
-  ) => {
+  const processBackupFile = async (file: File, targetRoomId: string) => {
     try {
       setShowBackupComparison(true);
       addLog("info", "Searching for documents section in backup...");
 
-      // Find COPY public.documents section
-      const copyMatch = text.match(
-        /COPY public\.documents \(id, created_at, document, name\) FROM stdin;\n([\s\S]*?)\n\\\.\n/
-      );
-      if (!copyMatch) {
-        throw new Error(
-          "Could not find COPY public.documents section in backup file"
-        );
-      }
-
-      addLog("info", "Found documents section, searching for room...");
-
-      // Split into lines and find matching room
-      const lines = copyMatch[1].split("\n").filter((l) => l.trim());
       const encodedRoomId = ensureEncodedRoomId(targetRoomId);
-      const roomLine = lines.find((line) => {
-        const cols = line.split("\t");
-        return cols[3] === encodedRoomId;
-      });
+      const backupRow = await findDocumentRowInBackup(
+        file.stream(),
+        encodedRoomId
+      );
 
-      if (!roomLine) {
+      if (!backupRow) {
         addLog(
           "warn",
           `Room ${decodeRoomId(encodedRoomId)} not found in backup file`
@@ -1783,10 +1763,8 @@ const AdminConsole: React.FC = () => {
 
       addLog("info", `Found room data in backup`);
 
-      // Parse the line: id, created_at, document (base64), name
-      const cols = roomLine.split("\t");
-      const backupTimestamp = cols[1];
-      const base64Doc = cols[2];
+      const backupTimestamp = backupRow.timestamp;
+      const base64Doc = backupRow.base64Doc;
 
       // Store the base64 for copy functionality
       setBackupBase64(base64Doc);

--- a/website/utils/backup.test.ts
+++ b/website/utils/backup.test.ts
@@ -1,0 +1,108 @@
+// ABOUTME: Verifies streamed parsing for PostgreSQL backup document rows.
+// ABOUTME: Covers room lookup behavior without loading whole backup files.
+import { describe, expect, test } from "bun:test";
+
+import { findDocumentRowInBackup } from "./backup";
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+
+      controller.enqueue(encoder.encode(chunks[index]));
+      index += 1;
+    },
+  });
+}
+
+function streamThatFailsAfterTarget(): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  const chunks = [
+    "COPY public.documents (id, created_at, document, name) FROM stdin;\n",
+    "1\t2026-05-23T10:00:00.000Z\tAAAA\troom-a\n",
+  ];
+  let index = 0;
+
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        throw new Error("Read past target row");
+      }
+
+      controller.enqueue(encoder.encode(chunks[index]));
+      index += 1;
+    },
+  });
+}
+
+describe("findDocumentRowInBackup", () => {
+  test("finds a matching room from split chunks", async () => {
+    const row = await findDocumentRowInBackup(
+      streamFromChunks([
+        "irrelevant prelude\n",
+        "COPY public.documents (id, created_at, document, name) FROM stdin;\n",
+        "1\t2026-05-23T10:00:00.000Z\tAAAA\troom-a\n2\t2026-05-23T11:",
+        "00:00.000Z\tBBBB\troom-b\n\\.\ntrailing data",
+      ]),
+      "room-b"
+    );
+
+    expect(row).toEqual({
+      timestamp: "2026-05-23T11:00:00.000Z",
+      base64Doc: "BBBB",
+    });
+  });
+
+  test("returns null when the documents section does not contain the room", async () => {
+    const row = await findDocumentRowInBackup(
+      streamFromChunks([
+        "COPY public.documents (id, created_at, document, name) FROM stdin;\n",
+        "1\t2026-05-23T10:00:00.000Z\tAAAA\troom-a\n\\.\n",
+      ]),
+      "room-b"
+    );
+
+    expect(row).toBeNull();
+  });
+
+  test("stops reading after it finds the matching room", async () => {
+    const row = await findDocumentRowInBackup(
+      streamThatFailsAfterTarget(),
+      "room-a"
+    );
+
+    expect(row).toEqual({
+      timestamp: "2026-05-23T10:00:00.000Z",
+      base64Doc: "AAAA",
+    });
+  });
+
+  test("throws when a matching row is missing document data", async () => {
+    await expect(
+      findDocumentRowInBackup(
+        streamFromChunks([
+          "COPY public.documents (id, created_at, document, name) FROM stdin;\n",
+          "1\t2026-05-23T10:00:00.000Z\t\troom-a\n",
+        ]),
+        "room-a"
+      )
+    ).rejects.toThrow("Backup documents row is missing document data");
+  });
+
+  test("throws when the documents section is missing", async () => {
+    await expect(
+      findDocumentRowInBackup(
+        streamFromChunks(["COPY public.other FROM stdin;\n\\."]),
+        "room-a"
+      )
+    ).rejects.toThrow(
+      "Could not find COPY public.documents section in backup file"
+    );
+  });
+});

--- a/website/utils/backup.ts
+++ b/website/utils/backup.ts
@@ -1,0 +1,118 @@
+// ABOUTME: Reads PostgreSQL backup streams for room document data.
+// ABOUTME: Keeps admin backup comparison parsing bounded to relevant rows.
+export interface BackupDocumentRow {
+  timestamp: string;
+  base64Doc: string;
+}
+
+const DOCUMENTS_COPY_HEADER =
+  "COPY public.documents (id, created_at, document, name) FROM stdin;";
+const COPY_END_MARKER = "\\.";
+
+type LineResult = BackupDocumentRow | "section-end" | null;
+
+function parseBackupLine(
+  line: string,
+  encodedRoomId: string,
+  state: { isInDocumentsSection: boolean; foundDocumentsSection: boolean }
+): LineResult {
+  const normalizedLine = line.endsWith("\r") ? line.slice(0, -1) : line;
+
+  if (!state.isInDocumentsSection) {
+    if (normalizedLine === DOCUMENTS_COPY_HEADER) {
+      state.isInDocumentsSection = true;
+      state.foundDocumentsSection = true;
+    }
+
+    return null;
+  }
+
+  if (normalizedLine === COPY_END_MARKER) {
+    state.isInDocumentsSection = false;
+    return "section-end";
+  }
+
+  if (!normalizedLine.trim()) {
+    return null;
+  }
+
+  const cols = normalizedLine.split("\t");
+  if (cols[3] !== encodedRoomId) {
+    return null;
+  }
+
+  if (!cols[1]) {
+    throw new Error("Backup documents row is missing timestamp data");
+  }
+
+  if (!cols[2]) {
+    throw new Error("Backup documents row is missing document data");
+  }
+
+  return {
+    timestamp: cols[1],
+    base64Doc: cols[2],
+  };
+}
+
+export async function findDocumentRowInBackup(
+  stream: ReadableStream<Uint8Array>,
+  encodedRoomId: string
+): Promise<BackupDocumentRow | null> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const state = {
+    isInDocumentsSection: false,
+    foundDocumentsSection: false,
+  };
+  let pendingText = "";
+
+  const processLine = (line: string): LineResult =>
+    parseBackupLine(line, encodedRoomId, state);
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        pendingText += decoder.decode();
+        break;
+      }
+
+      pendingText += decoder.decode(value, { stream: true });
+      let newlineIndex = pendingText.indexOf("\n");
+
+      while (newlineIndex !== -1) {
+        const line = pendingText.slice(0, newlineIndex);
+        pendingText = pendingText.slice(newlineIndex + 1);
+
+        const result = processLine(line);
+        if (result === "section-end") {
+          return null;
+        }
+        if (result) {
+          await reader.cancel();
+          return result;
+        }
+
+        newlineIndex = pendingText.indexOf("\n");
+      }
+    }
+
+    if (pendingText) {
+      const result = processLine(pendingText);
+      if (result && result !== "section-end") {
+        return result;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (!state.foundDocumentsSection) {
+    throw new Error(
+      "Could not find COPY public.documents section in backup file"
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Add a streaming PostgreSQL backup parser for admin backup comparison.
- Use file.stream() in the admin console instead of file.text() so large backups are scanned without loading the whole file into memory.
- Keep the existing Yjs decode/comparison flow after the target room row is found.
- Add an inline local homepage guestbook submission limit of 3 successful entries per rolling 10-minute window.

## Root Cause

The admin console read the full backup with file.text() before parsing, which is not viable for multi-gigabyte backup files and can trigger browser File API read failures or memory pressure.

The guestbook had no local rate limit, so one browser could submit repeatedly without pause. This frontend limit slows casual repeat submissions, but it is not a substitute for server-side anti-spam.

## Validation

- /Users/spencerchang/.bun/bin/bun test ./website/utils/backup.test.ts -> 5 pass, 0 fail
- /Users/spencerchang/.bun/bin/bunx vite build website --config vite.config.site.mts -> exit 0, with existing Sass @import deprecation warnings
- /Users/spencerchang/.bun/bin/bunx tsc from website/ -> fails on unrelated existing homepage TypeScript issues outside this PR's new guestbook/admin logic

## Review

Requested code review with superpowers:requesting-code-review before adding the guestbook change; reviewer found no Critical, Important, or Minor issues in the streaming admin/parser changes.