### PR TITLE
Keep dev UI data inspector read-only

### DIFF
--- a/.changeset/read-only-dev-ui.md
+++ b/.changeset/read-only-dev-ui.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Keep the development data inspector read-only by default, and require an explicit hosted-development reset opt-in before showing the Reset All control.

--- a/apps/docs/src/content/docs/reference/init-options.md
+++ b/apps/docs/src/content/docs/reference/init-options.md
@@ -107,7 +107,7 @@ playhtml.init({
 
 ## `developmentMode`
 
-**Type:** `boolean` &nbsp; **Default:** `false`
+**Type:** `boolean | { allowDataReset?: boolean }` &nbsp; **Default:** `false`
 
 Enable the in-page devtools panel. Shows element inspector, live data tree, connection status, and tag-type badges — modeled after RollerCoaster Tycoon's inspect UI. Useful while debugging.
 
@@ -115,8 +115,18 @@ Enable the in-page devtools panel. Shows element inspector, live data tree, conn
 playhtml.init({ developmentMode: true });
 ```
 
+The data inspector is read-only by default. To show a reset-all control on local or known hosted-development domains, explicitly opt in:
+
+```js
+playhtml.init({
+  developmentMode: {
+    allowDataReset: true,
+  },
+});
+```
+
 :::note
-Turn this on in development builds, not production. A dedicated guide covering the devtools is planned.
+`allowDataReset` is a convenience for trusted development pages. If the reset control appears on a page, every visitor to that page can use it.
 :::
 
 ## `cursors`

--- a/packages/playhtml/src/__tests__/duplicate-ids.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-ids.test.ts
@@ -1,7 +1,11 @@
 // ABOUTME: Verifies playhtml reports duplicate element IDs during setup.
 // ABOUTME: Covers live registration diagnostics and dev UI conflict grouping.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listDuplicatePlayElements, setupDevUI } from "../development";
+import {
+  listDuplicatePlayElements,
+  setupDevUI,
+  shouldAllowDataResetControls,
+} from "../development";
 import { playhtml, resetPlayHTML } from "../index";
 
 describe("duplicate playhtml element IDs", () => {
@@ -120,5 +124,101 @@ describe("duplicate playhtml element IDs", () => {
     expect(warning!.textContent).toContain("Duplicate playhtml IDs");
     expect(warning!.textContent).toContain("shared-id");
     expect(warning!.textContent).toContain("can-toggle");
+  });
+
+  it("does not render shared data mutation controls in dev tools", () => {
+    vi.spyOn(console, "table").mockImplementation(() => {});
+
+    const element = document.createElement("button");
+    element.id = "safe-button";
+    element.setAttribute("can-toggle", "");
+    document.body.append(element);
+
+    setupDevUI({
+      elementHandlers: new Map([
+        [
+          "can-toggle",
+          new Map([
+            [
+              "safe-button",
+              {
+                element,
+                data: { on: false },
+                defaultData: { on: false },
+                setData: vi.fn(),
+              },
+            ],
+          ]),
+        ],
+      ]),
+      cursorClient: null,
+      roomId: "test-room",
+      host: "localhost:1999",
+    } as any);
+
+    document.querySelector<HTMLElement>(".ph-trigger")!.click();
+
+    expect(document.querySelector(".ph-reset-btn")).toBeNull();
+    expect(document.querySelector(".ph-tree-reset")).toBeNull();
+  });
+
+  it("allows data reset controls on local and hosted development hosts", () => {
+    expect(shouldAllowDataResetControls(true, "localhost")).toBe(true);
+    expect(shouldAllowDataResetControls(true, "127.0.0.1")).toBe(true);
+    expect(shouldAllowDataResetControls(true, "project.glitch.me")).toBe(true);
+    expect(shouldAllowDataResetControls(true, "app.replit.dev")).toBe(true);
+    expect(shouldAllowDataResetControls(true, "preview.csb.app")).toBe(true);
+  });
+
+  it("blocks data reset controls without explicit opt-in or on production-looking hosts", () => {
+    expect(shouldAllowDataResetControls(false, "project.glitch.me")).toBe(false);
+    expect(shouldAllowDataResetControls(true, "example.com")).toBe(false);
+    expect(shouldAllowDataResetControls(true, "playhtml.fun")).toBe(false);
+    expect(shouldAllowDataResetControls(true, "site.pages.dev")).toBe(false);
+    expect(shouldAllowDataResetControls(true, "app.vercel.app")).toBe(false);
+  });
+
+  it("renders reset all when data reset controls are allowed", () => {
+    vi.spyOn(console, "table").mockImplementation(() => {});
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const element = document.createElement("button");
+    element.id = "resettable-button";
+    element.setAttribute("can-toggle", "");
+    document.body.append(element);
+
+    const setData = vi.fn();
+    const defaultData = { on: false };
+
+    setupDevUI(
+      {
+        elementHandlers: new Map([
+          [
+            "can-toggle",
+            new Map([
+              [
+                "resettable-button",
+                {
+                  element,
+                  data: { on: true },
+                  defaultData,
+                  setData,
+                },
+              ],
+            ]),
+          ],
+        ]),
+        cursorClient: null,
+        roomId: "test-room",
+        host: "localhost:1999",
+      } as any,
+      { allowDataReset: true },
+    );
+
+    document.querySelector<HTMLElement>(".ph-trigger")!.click();
+    document.querySelector<HTMLElement>(".ph-reset-btn")!.click();
+
+    expect(setData).toHaveBeenCalledWith(defaultData);
+    expect(document.querySelector(".ph-tree-reset")).toBeNull();
   });
 });

--- a/packages/playhtml/src/development.ts
+++ b/packages/playhtml/src/development.ts
@@ -20,6 +20,41 @@ let originalConsoleMethods: Record<ConsoleMethod, (...args: unknown[]) => void> 
 let activeWindowErrorListener: ((ev: ErrorEvent) => void) | null = null;
 let activeWindowRejectionListener: ((ev: PromiseRejectionEvent) => void) | null = null;
 
+const DATA_RESET_HOST_SUFFIXES = [
+  ".glitch.me",
+  ".replit.dev",
+  ".repl.co",
+  ".replit.app",
+  ".codesandbox.io",
+  ".csb.app",
+  ".stackblitz.io",
+];
+
+export interface DevUIOptions {
+  allowDataReset?: boolean;
+}
+
+export function shouldAllowDataResetControls(
+  allowDataReset: boolean,
+  hostname: string = window.location.hostname,
+): boolean {
+  if (!allowDataReset) return false;
+
+  const normalizedHost = hostname.toLowerCase().replace(/\.$/, "");
+  if (
+    normalizedHost === "localhost" ||
+    normalizedHost === "127.0.0.1" ||
+    normalizedHost === "::1" ||
+    normalizedHost.endsWith(".local")
+  ) {
+    return true;
+  }
+
+  return DATA_RESET_HOST_SUFFIXES.some((suffix) => {
+    return normalizedHost === suffix.slice(1) || normalizedHost.endsWith(suffix);
+  });
+}
+
 // ─── Logo (base64 PNG, 48x48 — self-contained, no external deps) ─────
 const LOGO_URI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAeGVYSWZNTQAqAAAACAAEARoABQAAAAEAAAA+ARsABQAAAAEAAABGASgAAwAAAAEAAgAAh2kABAAAAAEAAABOAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADouFg7AAAACXBIWXMAAAsTAAALEwEAmpwYAAAYFUlEQVRoBZ1aaZBdR3U+3X2Xd986b1bNSBptIysaSUhIXsrYYBmDbZCBIhXbbCH5kWIzlSrHhCRVFJKohMqPQDCEqsSBEEKFChYkpOIFgwwabMmLPJLtkcbSWJqRNNKMZp95y73vLt2dr++bsU0oXIQ3uu/u3d85/Z3vnO4nRr/jR2tiRJoOHjzIaD9RP51md9PdNDh4mA+izbLXg/vNz8b+bj1Ig3QN9ei91K8P0SEapm16P+3X5glmmmJo7Hf4vNbJb/Wu1sz0cpAOMgMYINhdgxNsuuRyr6+NzdASW5iss8nuybS5bnybo5V9P/WlIDsulPRQMqfdpVBds6dHz8CoYRpeNgjm/D+M+a0MWPE2sDB4jy0MLvDynklGl4vCW1Nhg3SEH6HTdAPtFHeeu7dQmvSKMiy4LNIOWTbFnoopFwdRabL2i01/v0R0LsnRHzKa6qJ1sVRX1yTKHQxVec+CuhsjQ3QAG4aYpf5KnfGbvt7UgCZw8+oBAO9nHdTBhs4NiQ25eXGpe5obKvxp7b7s1p9c21eY7bjBStzdWolezUSXErygOHnKEiQt3ZCClpSlZxKhxsJsdCosXj16dcsz517uOuT3z9xCXken2kj9STB4WI++wZAU4JuMyG80QIMuTasPsiNEvBPb6CRZyr4kHm1/if/RsU+0bzq+fV+mkb1TaeutmrOCEsySnOGUSRyrWMCPFiNpXGlxkpyEsrhQgmLcryW2PJl41f+a33DqFy9t+uupDXSb9iY71Vh9Tu643Cb37iVFiJM3G4k3MeAAPHwadCnztXu288nZy85I+xi/fnZz9h3fv3NfdqHwCUaiH4CFtACIM60MWLNxYgCJY44BWT5//ZgkrsEQ0oLDYEqkpU4nxcWHRlcfeqK47lStOLNbUwclIzQhJ6lHmmD/TUb8mgErnj9E93CMgFhzeY0YzZbsx1oPiy//x+e2dp7u/nMrcd4NYBwg0TnXALQMGPvUAABMDQD4piEAy3QCw7QNozjXCZ5DG1rjvmLcwrGM7egJv/PMV872f+mVvvnrqaV1Q3x5uCKpv1+aID9gYuP/0Amvv/4xnIcqsgEaEB3rOwWG05pfrZ2z3qjzhQc/fVfXue6v2IlzLcFr2BRxgGCa4xjf2Bs34ducg//pFTLeFuk5gxFmS89BUGM0njNtEIwyOOx+K+i8pW3hlsmljU+MiQWHs14bnc3QZ+g0XrmHjhw4YmTwtU/6Wnq2rOv79/ez/k7iHpE1203OSRp17n/wIx9pn2r5GjD3EiURIT6gD9g0RwNmD9cb32BPRmoBa3lsISfmKH1cGQNTI82I4RhPvW4IRoLrkDGxzq2t/kb74Bc/Vi2/YCWLi85GYDk0vE0Y6U51GH2sWGCtHGB4oDT3sI1U5l65By+SM9ty3vn8Nz/0kcKct5+4dAE1MR1yIJFNrEAGSwwq05ARP4PYtI9rqU9Sk3APlxhoLzkMXDYTBqSmpvFjxk/gZtoHy9hR+4Hyi19jk7u+/O/jiy3k9RMFw9vo0Om0DyBoIk9HwPC+/xACFuAnJ3vsxCPn+ZbT9se/e/udxXn3APEko0WsNI9BDzCZQ1eUhiHoT6JjpcEXyJTBiZFotm1gNoGnV3ACSTEeZKCd8b6hTkq5lHxmNCgloqEkGmeuHXd+sXv483dVWp4SCZHjlclauLvMDx06xFdiNY0BdoDx/m2dvI0KlozJnixP2B/86Q39q8+VvyoUtcF7Ev2bztFts6OU6Ib+6FiASBKwEIxNYLhmuG0CNAWKgDXcT9VHpHJqAng5HmC2BVtxjtfTZk0vqdGcu0IWdjn+xufnW385QzMZ1ltuVbltM/q7NEBHDh6BxfD+fiSpoXNzYnTWs2tO6LZP54q9Z0sPQCs2KBFJEjE6SyCY2PPICCfokMDZCXu1Mc2eTa5YdfBKYCQESGTBtY6JYUMl/DOflFXGKOBNA9moFYIYRsIny39GAGAHM8Zgw0iAqWJ9trb9gfzSxhJlfacy69szcGQaD8AujPcLZAkrhCB6ifti4YJz74/f8v7Con0fhjRZadowt3ls+jB0ZvzFeJqP1CZYezZD7uZ2np8lVbEkGxVVflFXRJRlLMccaL5RHqBJRwFSYDfPzTWjUhhGYxhGABamo2BGA/dMj3icMXtTJlp7IVn3xHCYZMmbz6jewk79z/SIFnv3kuhe324tJYGT2NrdfaajZ/PZ4kHwuwtOhFTCnaat1JNGR4xXDVtRqKFY2Co2ad9eRayTWOusVCfYrFWItepkWcVWCeRmS4NPOrGBxBiyvMkV8GYEABr0QZtofIVKqWE4x3UYIzjLro11+CR3p/3JRST48hVZojHN79p7DavBB5bFrfFcRWw9U7zV0kk/WXFKHdCGmIjwRMSYlaCTEJ3EpO2YZplknzp3wb7//CvOI5VEHHaLogopOkFdYkB3WFP1PEQJ4QccMBkxYjzfjAUTH3AMAMITuGZyBIIJfTXP8Y4xxtwDbbVEh9tytbe/N6RXWUcHt8SUaxnRsYYuRKKrSFYgE3tTVCiWKvIDUBsHrYcQPagklFYbzyutlZEYCzKimQ92XV3y2WI1oMSRND7F2WnvBjtayKNqmwVoi8pyNf1xjxX1utIAR1kBJQIosxlvN8ECsKEPrjGO9G6hP1OWyATAcQPsgnjgg6dl6x2u2v2jsBEuzdj5eC2FnEfuepQECPaOHN/2SmazUHIXPByTMB6H54XxOHJXum/gOEBnIYVezJbqDYhbhrlegZS/REvT50i3byHbQcpIGjR67gwNLOWETDnepI+JA0q9DGTL6kOoixjYlqDqfun4z8Wrw4OC2XAUjIQRK7ERc3J2Zus391G+KhyLrPHJUPBrukGORmhfpMDqmKYbOY9z0Hx0YhQnBtiIeGoMDLFCSB42EfB5HvCh6bNsce4iLc1NICHZNDc+Rg7q/5nZNpqfEzRzOaTnzi+IMcqiDjXFHTyfFnHwfgo6pQucwpnlOnRu5GX++A+/LV56/gjKPHDHPGPiIt2Mell5O15/Qy2Y5LhlWXaLsBYXIUEF3yqDZF4cbcdlDCDSkxk0UweDpNXIxJ6gjLBgFJDAW4tRTJ/b3iPFNRYtKIuGihl+yp9HVbZEhbY1tHglogC2XrykaGiXa3WWw0gikOFtiAoi0/DdqA6QmDgIk5CdPHZYWLZLO2+6TflBnTmeB+fhPgLI0IgjmBWVdpVzLQ6Xvmy1ssjd9VAkLMv7LjttlpTriBkPp7RBR6H13Py8/svnzoh/PDPGcQ5qN0g7ocYfK2SIetttvaM7q3e1OnpdXuilqcvUucoi7hYpX3SpuhjSi+MxX7TcJnDUZwQDmA0umQ0GCddmZ15+jk9cfJVt3nmdTlBufe+rX7Ce/M9/FXESNZ/DK7ADg+GsFbUdrX4jEVrMCCtTKvAai3i2KouCRe3IiqYsM0ppHZ8M1TdOzoggUXRXX0mTHQioslIiQyNXKuyx8Ssin3GolC9Saf0WymWXaPLqFLX21sjN5iib47S4ENL5sRq7cG2b1d/akKCaycAYyXRwIX+C6n6FBp/6qXDcDO259U7l5fIoJTidGPgpjxGOt3/0T5TtZKAhCqpid3LqKDl8bDrDiijMg0g0KBFujLTDI+hRiPQWiuNTNfX1E9M8lJo++daSfk+fw7UINLMDVtc1um6V0F+6qazue0tB7esVyuUx3drV0Lzhk6xdpVzJIzeXJxsxMzNZo7MzyN9OhoOHqHIQvR6CNCNIZB0aPnGUT10ao2v23KjXbOmn9rXr2fs/+WeyY3WvPv3sAP/Z97/Fo7ixoloFrnOejdDWQSJ40vDTVAXXOozHGSgOPzMf6K+/sMhjVF+fvDarbt8M7ouGwgiAw3W+hBphPIjYOOq1uquZVwQjXJv2rFmg9YVAT1++TB3tKCpEjnI5onoloOHhClviHud5pGEPxHdgBKizVJnnLz59mHv5Au2+7U6MMubQyB2rNmxi7/v0A7pjzTp96pkBfuzRHwrQTSMxZqAErp+JuMjZEGsvSxgBjgk3LIT6IIJ9mWg/1lR0GfWWET5OYAIaqciEkqSqamEjExM0Nh1zxm2tnTyVOmtsTdclvXt1nn1vuECr+uYpWypSsOCQng5pdGSRzk918Y4eV2u0jZaYgOa//OhhNjdxhXa/6z26a+MmpB7kHASuqZdaOjsp31ImMzpxiPgz8YzbRgesCuMV9A4dsJgXgfg2SnwrCiGqetcaRffuZHqxoenvnm7wM3OhJjfgZPuo0hq05NfZJ24O6L531OgzN8/Qx3dfobUlTCBK8/zdO16lDNVpZmyE2jpyoFGRMpmI5q7W6NixJVYx88+cYCJrs5mr4+zkz59gpY4OunbfB0BPKBwGh0NSg0adHnnoQT46dJJt2nUt3fj79yKCQXkIlqKGSoDbKCVsMl8Jq2HKqkTsmwTGrZDfszthH96t9HRN01cHFBueiTRzkMiciCaqMQ1cctmxKzkanM2zkVqJFUooaopF2rDRpuv66nR5dJxsPUeFjlVUKNkko4BOPnWFjr9QJ+YgGaIUOfGzx1htYZ627b2N2tat5qgXUqUK6lX2+D99nY8cf4Y27tpD+z5zvyq0tpn5BPKJrMXMjzwzm8imBoDX+FQ8UZdOMktomKwIdXGk77m2QR+9PtKTFUY/OAnVsHyK0I3gPnS7QpPVhEamOT1/waZq4hJlyzCiTO+7qQHKxTQ2+EvKZxrUuWk9uW5Cs1cW6AcPjbKBX4R6cXFGXx4+Qa09q2nXHbeDGWAVwoJDZi+cfonOPnuUNu25jvZ99n7tlUqoLVFXYoQUk/OaL9ZDFOzkg4c/qv9Nt/SDYj3Lin9w/NTf5mX0TpKQHsN3M0nBi2PIqp6rqadN0Vw9T7NBibasN/UOQDs2XZxspwvBFrpl6yjOSyTdFnrgH1ro8LOoSCxNnX07idw19OrJK1SZrlCx1aXr37Wa3v72ht642dItnWtQZxgyIH8gUQY1n82Nj1M7VCiTzzEtm+WQBekJw9nDV4K/+Kus2151hVWxMvVYBy4padtJzbOG8/XqO0mY2t8YYBIHo02ICYQcNosW4zw9ctKho+e7zCwCABlVEB7bt+EZB5JjeSRyGfrUhyx6/lRC1XpC4y89RS1dq2kPqHJiYJQWJmbpyYfnafLSRvaxz/ZSucvH1MRGusUkCRVfJufo3u1bAcoELaZcSNqGJZgvgezzI5imyBilZQjs4mNfvNFLlLJlRJkssuuq6sIdqAyNK0AwUxmazQZ4bDa8vdBOXYUKbepR1AWFai8RLdY59axuo55V6MH2oCBZ6lidwwJXoo8+U0eRaZNfmaYc6LRu21a6+MorwFCjq2OXKYzyrG9HgQpFFL943ThNowpWCmU4Rt/UESl8U9VoFTX00W9pmp6AtxqYpoeWgzWQQAuZs6UcK3de3DI9dSbL5M50SE0tiw0IYERzm0U87NqUp2IBBmEENHdoJoAaI0dBPnANlaiAdALJLW/L6ClMEH7833Ns5opmY0Mv061bt8OI66gyP0UyrtHE+SkaPdtD3d3wqQliU/Ux8A4hawxBozACAgjHxPHicBAPXpQ2JktxKCnbkFZVulLKGIlAyqVsrjpfKD2V9asgLQwGaIRVEzzASnJp6NUFOnISIeTgHu4HUNj+vjKtXrca4JtGGWNRB5IfJrT3vXm564MZ+ctH5q2xUwFT1af5Te/4PS0yiBXZQvX5aeZPnsTkd4PJM8YImI6QhiFQexiC/lF3SBnoSJ4/nCTTVUu2oRDKJJWKray6gq8lVv1QR2e1r4Y6ugc6x6P3A18vWmyCN96HAUkiaN/NHq1ZVYCX4W2Uzob/tdBC6QD1MiOQUs7Mxom8IukIFWgRVe8dH1+FAiiXVC4mPNs6hXDJA1qG/EWbNeaxXMMwAiZLGc8b8IY62EwAcNRPUlXOV+XR55hdALlQ6wuFNao6llXjmswmdqJzPEQOi6fzhenJQumH6xr1+03FZTzRpI9FbsaiLZsQEyYeLMgYPJ5twd5GWSrMcyZeDAWMAUoXOywIiKII8yvjV8zqqLjew9zSBCx2AJtt9XSutUVLiUU5hqye0gh3TUAYITHzSrzYkK/8qB6cm/bsVsyyVCSryFuWK7kM8jLjoZRL4hjq2UAgxy92rTriW5kXCDOrlOeGGiaQzd6AN0AR569t6QTXgG8aAO1K/YgZaPppikjKacQhZIUS2JPABGyYhSkFTGbuTKaUMSOBOTfDdewxA+CxnH6u0njyaS9TxLK8CA3WJKsSg53vWD8hRZyTeVdGKhEh6NTwmaqcai3/m2QWEptjipbUkBTgyvHKfsXr8LwJeDyY+jDVD0MJONEYYCihEUXIcNhjvmuOAdpM+psTfxhjjjHXNsZh6o/ZpOKJqk/Vo2PfU8yvCGCDOoV5Nxs1yjLZsb5b8lF6l3KCugwSKy4K1UD0Ba7i4ZlS7sxoPvcvmlvIRk2v43jZy2/cr1CsGdRGftG7kW8AAc5UVyAFIGOT02ZhADex0GAKQ0z+8KAxIjUOzxu2IXMxiewbRY1k6NuBHBoRPBvGBlschUESxPLCrBylsuJ3Y919ZG5CliKZ+KGOMLcJIEr1bCTD4y35gYuu8x0AT0zAokgCqBXwrwNvUgreNyOALfV+6nucAma6GToDZgra6LtZ5Vg2wni8SSFDowTvS6Ehmo1o5Du16OhRUjkUaHYNU/jAbY8bDWDdsd5JfzNAj/u1+aVQVnsT36vFodANVKQBklDdUio42pb5n0sZC0ZgfRWJ7PVgNcaYgDWGoJnl4DVwUwNSsE3MZlFvJQ5S76f0WTbCjMLySKR7LLogFqI4Hv3Okn/kMcEdH+/UgDnIR7oxO58k7dUwQT5X5pcbVApMDyCsx5dOKcffEIc+FkdZyYdXa6jNa65iwdESe/Sswx6MGZ9FVdYEbLxtQK8AB1WM900qMkLYNAIGmMvYgdzYmRFYMc/sscaaFgiGUul1S+vGTCN59Zvz9WM/cWzPl1LUsAxbb7GVrxwndHwrxk+6cvjgNjRo/tK2TeMH2UM0IbypotPa1eYszi/kMIfMu7YuJHFSih07syEUW7Yn3oeLwt1jKAX0yDGgFjJvM4lhHRRy2kAhUEcQBth88BmTTF2H8phiAVMudIp3sWAG2cQeFRqqKmgxxLbxYtA4/3AQXjrLAZ4nooLArjaYrDl+1m+ARf1dm6M9NImAOWB8ZYA3P2gax4f44+euWqLvkrVUybsi8bP4EStvWzyPZY8ilswxg3VKO5T3trW8sM/lzrpUas1CqYkPGKK4AHDM6MBxAzxYNqABsYRB6BHZNV3RMg7AvBKVIybrl5Nk8fEgHD0mo2iJW3YdSxNVeKaGHyBqmOgEOT9unAV1VvVdTe6mhyFvRt9M/frax9iitdd3UAaEpZUQ1MPiXODlDMUVqk44F6oWK/WsqPzsvA6H+qi0Z1VCN2WF1weptU2MwBSUv9gMi5ramVa0aN3QFSRKRx6YVahVcFYrfzCKpp6Lw8oMt52G7WZqUsl64opaEks/C/DlghsGU7VkB6gzQG1pAyuwXxsBcwGdsoN0gN2CzgL8XjBb6LUy3oTrRnYm1DyL5bAsKtUsxTKfcO2Z6akjeanHLq7pEcXtBTu/3mJ2Z8x1CYuRmQbWQKDLUAUZ+pT4GI35ROpZmURjMvbPKl27HMVB1eIZhBcL0F4d65B1JKrAZRk/dDBdD6ejbR2d0SE6gqDdi0DZD+o0vW8w/4oB5oIJNo14OAIjhs61ig198yK5sOjwbNZNHJZxpPKU0B5STRbx54HCuCSdiKFQUsIpca/oMTuLFTWUpEZ/EdKMQVYakHFdlypGfYriHUJv2Zj2aRYiOTcsZvkxlAYTesh4FNp2rlENa3GmKx93HCG1d+9+kzgQN6+DN+dvoJA5Bf70e78eOHhQ9e9fpbvplBq1ctrtTFDbtiTKX4xZ7IRIqCYrZljCXYiPm8XUDGnfDmVcxQPNXxYkijR8UAxjrQlBACpaKB1Bt1jFEng5BlaG3FaNmtRh3lONnCyEkbLjWstSnBkuSerqlwMDw/rWW38VeAoTX78+Ait3sDeUOkQP8434zx1DbZMil5u2Kq7rrOUlqxb5jp11bJQrThwoF1Niy0owHlh0RZJCBYYS2PAdH+RoPIb5FNBicdMsKMTCQkWJVJsESYz/wBCxOBsFmQZ+667EHXU/GUGiKkPr3xiwb4D22uH/At4IJ6pN/ZoEAAAAAElFTkSuQmCC";
 
@@ -251,21 +286,6 @@ const DEV_STYLES = `
 .ph-tree-el-name {
   font-family: 'Atkinson Hyperlegible', sans-serif;
   font-size: 12px;
-}
-.ph-tree-reset {
-  font-family: 'Atkinson Hyperlegible', sans-serif;
-  font-size: 10px;
-  color: #c4724e;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s;
-  background: none;
-  border: none;
-  padding: 0;
-  margin-left: 4px;
-}
-.ph-tree-item:hover > .ph-tree-reset {
-  opacity: 1;
 }
 .ph-tree-children {
   display: none;
@@ -730,7 +750,10 @@ function el<K extends keyof HTMLElementTagNameMap>(
 }
 
 // ─── Main Setup ────────────────────────────────────────────────────────
-export function setupDevUI(playhtml: PlayHTMLComponents) {
+export function setupDevUI(
+  playhtml: PlayHTMLComponents,
+  options: DevUIOptions = {},
+) {
   // Guard against duplicate setup (e.g. HMR)
   const existing = document.getElementById("playhtml-dev-root");
   if (existing) existing.remove();
@@ -1312,18 +1335,20 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
       searchBar.appendChild(filterSelect);
     }
 
-    const resetAllBtn = el("button", "ph-reset-btn");
-    resetAllBtn.textContent = "Reset All";
-    resetAllBtn.onclick = () => {
-      if (!window.confirm("Reset all playhtml element data?")) return;
-      elementHandlers.forEach((idMap) => {
-        idMap.forEach((handler) => {
-          handler.setData(handler.defaultData);
+    if (options.allowDataReset) {
+      const resetAllBtn = el("button", "ph-reset-btn");
+      resetAllBtn.textContent = "Reset All";
+      resetAllBtn.onclick = () => {
+        if (!window.confirm("Reset all playhtml element data?")) return;
+        elementHandlers.forEach((idMap) => {
+          idMap.forEach((handler) => {
+            handler.setData(handler.defaultData);
+          });
         });
-      });
-      renderDataWalker();
-    };
-    searchBar.appendChild(resetAllBtn);
+        renderDataWalker();
+      };
+      searchBar.appendChild(resetAllBtn);
+    }
 
     dataArea.appendChild(searchBar);
 
@@ -1404,15 +1429,6 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
           const elName = el("span", "ph-tree-el-name");
           elName.textContent = `#${elementId}`;
 
-          // Per-element reset (restore to default data)
-          const resetBtn = el("button", "ph-tree-reset");
-          resetBtn.textContent = "reset";
-          resetBtn.onclick = (e) => {
-            e.stopPropagation();
-            handler.setData(handler.defaultData);
-            renderDataWalker();
-          };
-
           // Highlight element on page when hovering tree row
           row.onmouseenter = () => {
             const target = document.getElementById(elementId);
@@ -1430,11 +1446,8 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
           row.appendChild(toggle);
           row.appendChild(badge);
           row.appendChild(elName);
-          row.appendChild(resetBtn);
 
           // Children container (recursive JSON tree)
-          // TODO: make values editable inline (click to edit, enter to save back to store)
-          // TODO: add per-key reset and per-nested-level reset (not just per-element)
           const children = el("div", "ph-tree-children");
           renderJsonTree(children, handler.data, 0);
 
@@ -1451,8 +1464,8 @@ export function setupDevUI(playhtml: PlayHTMLComponents) {
           // Row click: scroll to element + highlight + expand data
           row.onclick = (e) => {
             const clickTarget = e.target as HTMLElement;
-            // Let triangle and reset handle their own clicks
-            if (clickTarget.closest(".ph-tree-toggle") || clickTarget.closest(".ph-tree-reset")) return;
+            // Let triangle handle its own clicks
+            if (clickTarget.closest(".ph-tree-toggle")) return;
             // Scroll to element and flash
             const domTarget = document.getElementById(elementId);
             if (domTarget) {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -19,6 +19,7 @@ import {
 } from "@playhtml/common";
 import {
   listSharedElements as devListSharedElements,
+  shouldAllowDataResetControls,
   teardownDevUI,
   setupDevUI,
 } from "./development";
@@ -418,12 +419,33 @@ export interface InitOptions<T = unknown> {
   /**
    * If true, will render some helpful development UI.
    */
-  developmentMode?: boolean;
+  developmentMode?: boolean | DevelopmentModeOptions;
 
   /**
    * Cursor tracking and proximity detection configuration
    */
   cursors?: CursorOptions;
+}
+
+export interface DevelopmentModeOptions {
+  allowDataReset?: boolean;
+}
+
+function getDevelopmentModeOptions(
+  developmentMode: InitOptions["developmentMode"],
+): { enabled: boolean; allowDataReset: boolean } {
+  if (developmentMode === true) {
+    return { enabled: true, allowDataReset: false };
+  }
+
+  if (developmentMode && typeof developmentMode === "object") {
+    return {
+      enabled: true,
+      allowDataReset: developmentMode.allowDataReset === true,
+    };
+  }
+
+  return { enabled: false, allowDataReset: false };
 }
 
 let capabilitiesToInitializer: Record<TagType | string, ElementInitializer> =
@@ -839,7 +861,8 @@ async function initPlayHTMLOnce({
   const inputRoom = explicitRoom ?? getDefaultRoom(defaultRoomOptions);
   cursorOptionsCache = cursors;
   cachedOnError = onError;
-  isDevelopmentMode = developmentMode;
+  const developmentOptions = getDevelopmentModeOptions(developmentMode);
+  isDevelopmentMode = developmentOptions.enabled;
   // @ts-ignore
   window.playhtml = playhtml;
   // DOM marker visible to browser extension content scripts (which run in an
@@ -938,8 +961,12 @@ async function initPlayHTMLOnce({
   playStyles.href = "https://unpkg.com/playhtml@latest/dist/style.css";
   document.head.appendChild(playStyles);
 
-  if (developmentMode) {
-    setupDevUI(playhtml);
+  if (developmentOptions.enabled) {
+    setupDevUI(playhtml, {
+      allowDataReset: shouldAllowDataResetControls(
+        developmentOptions.allowDataReset,
+      ),
+    });
   }
   // TODO: expose a way to activate the dev tools UI on any page at runtime
   // (e.g. window.playhtml.showDevTools()) so it can be triggered from the


### PR DESCRIPTION
## Summary
- Keep the dev data inspector read-only by default
- Add an explicit `developmentMode.allowDataReset` opt-in for the Reset All control
- Gate Reset All to local and known hosted-development domains, while suppressing it on production-looking hosts
- Keep per-element reset controls removed
- Document the new init option and add a patch changeset

## Verification
- `/Users/spencerchang/.bun/bin/bun run test src/__tests__/duplicate-ids.test.ts`
- `../../node_modules/.bin/tsc`
- `/Users/spencerchang/.bun/bin/bun run test`
- `/Users/spencerchang/.bun/bin/bun run build` in `packages/common`
- `/Users/spencerchang/.bun/bin/bun run build` in `packages/playhtml`
- `/Users/spencerchang/.bun/bin/bun run build` in `apps/docs`