### PR TITLE
Fix Firefox cursor color picker

### DIFF
--- a/extension/src/__tests__/ColorPickerPage.test.tsx
+++ b/extension/src/__tests__/ColorPickerPage.test.tsx
@@ -1,0 +1,102 @@
+// ABOUTME: Verifies the standalone cursor color editor persists native picker values.
+// ABOUTME: Covers the extension-window color picker used when toolbar popups cannot host native dialogs.
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import type { PlayerIdentity } from "../types";
+import { syncParticipantColor } from "../storage/sync";
+
+vi.mock("../storage/sync", () => ({
+  syncParticipantColor: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../components/ColorPickerPage.scss", () => ({}));
+
+const storedIdentity: PlayerIdentity = {
+  publicKey: "pk_test",
+  playerStyle: {
+    colorPalette: ["#4a9a8a"],
+  },
+  discoveredSites: [],
+};
+
+async function renderColorPickerPage() {
+  const { ColorPickerPage } = await import("../components/ColorPickerPage");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<ColorPickerPage />);
+  });
+
+  return { container, root };
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe("ColorPickerPage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      playerIdentity: structuredClone(storedIdentity),
+    });
+    vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
+    vi.spyOn(window, "close").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("saves an arbitrary native color input value", async () => {
+    const { container, root } = await renderColorPickerPage();
+
+    try {
+      const colorInput = container.querySelector(
+        'input[type="color"]',
+      ) as HTMLInputElement | null;
+      expect(colorInput).toBeInstanceOf(HTMLInputElement);
+      expect(colorInput?.value).toBe("#4a9a8a");
+
+      await act(async () => {
+        colorInput!.value = "#123456";
+        colorInput!.dispatchEvent(
+          new Event("input", { bubbles: true, cancelable: true }),
+        );
+      });
+
+      const saveButton = container.querySelector(
+        '[aria-label="Save cursor color"]',
+      );
+      await act(async () => {
+        saveButton?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+      });
+
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        playerIdentity: {
+          ...storedIdentity,
+          playerStyle: {
+            colorPalette: ["#123456"],
+          },
+        },
+      });
+      expect(syncParticipantColor).toHaveBeenCalledWith("pk_test", "#123456");
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+});

--- a/extension/src/__tests__/ProfilePage.test.tsx
+++ b/extension/src/__tests__/ProfilePage.test.tsx
@@ -49,11 +49,23 @@ function cleanupRoot(root: Root, container: HTMLDivElement) {
 }
 
 describe("ProfilePage", () => {
+  let createWindow: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.resetModules();
     vi.stubEnv("FIREFOX", "true");
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
       true;
+    createWindow = vi.fn().mockResolvedValue({});
+    Object.assign(browser, {
+      windows: {
+        create: createWindow,
+      },
+    });
+    Object.assign(browser.runtime, {
+      getURL: vi.fn((path: string) => `moz-extension://test/${path}`),
+    });
+    vi.spyOn(window, "close").mockImplementation(() => {});
     vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
       success: true,
       stats: { totalEvents: 0, estimatedSizeBytes: 0 },
@@ -66,17 +78,29 @@ describe("ProfilePage", () => {
     document.body.innerHTML = "";
   });
 
-  it("uses an inline color picker in Firefox popup builds", async () => {
+  it("opens a real extension window for Firefox native color picking", async () => {
     const { container, root } = await renderProfilePage();
 
     try {
       expect(container.querySelector('input[type="color"]')).toBeNull();
-      expect(
-        container.querySelector('[aria-label="Custom cursor color hex value"]'),
-      ).toBeInstanceOf(HTMLInputElement);
-      expect(
-        container.querySelector('[aria-label="Use #ef4444 as cursor color"]'),
-      ).toBeInstanceOf(HTMLButtonElement);
+      expect(container.querySelector(".profile-section__swatch")).toBeNull();
+      const pickerButton = container.querySelector(
+        '[aria-label="Open native cursor color picker"]',
+      );
+      expect(pickerButton).toBeInstanceOf(HTMLButtonElement);
+
+      await act(async () => {
+        pickerButton?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true }),
+        );
+      });
+
+      expect(createWindow).toHaveBeenCalledWith({
+        url: expect.stringContaining("color-picker.html"),
+        type: "popup",
+        width: 360,
+        height: 260,
+      });
     } finally {
       cleanupRoot(root, container);
     }

--- a/extension/src/__tests__/ProfilePage.test.tsx
+++ b/extension/src/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,84 @@
+// ABOUTME: Verifies popup profile color controls avoid Firefox popup focus loss.
+// ABOUTME: Covers the cursor color picker UI rendered inside the extension popup.
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import type { PlayerIdentity } from "../types";
+
+vi.mock("../storage/sync", () => ({
+  syncParticipantColor: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../components/ProfilePage.scss", () => ({}));
+
+const identity: PlayerIdentity = {
+  publicKey: "pk_test",
+  playerStyle: {
+    colorPalette: ["#4a9a8a"],
+  },
+  discoveredSites: [],
+};
+
+async function renderProfilePage() {
+  const { ProfilePage } = await import("../components/ProfilePage");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <ProfilePage
+        playerIdentity={identity}
+        onBack={vi.fn()}
+        onIdentityUpdated={vi.fn()}
+      />,
+    );
+  });
+
+  return { container, root };
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("FIREFOX", "true");
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
+      success: true,
+      stats: { totalEvents: 0, estimatedSizeBytes: 0 },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("uses an inline color picker in Firefox popup builds", async () => {
+    const { container, root } = await renderProfilePage();
+
+    try {
+      expect(container.querySelector('input[type="color"]')).toBeNull();
+      expect(
+        container.querySelector('[aria-label="Custom cursor color hex value"]'),
+      ).toBeInstanceOf(HTMLInputElement);
+      expect(
+        container.querySelector('[aria-label="Use #ef4444 as cursor color"]'),
+      ).toBeInstanceOf(HTMLButtonElement);
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+});

--- a/extension/src/components/ColorPickerPage.scss
+++ b/extension/src/components/ColorPickerPage.scss
@@ -1,0 +1,90 @@
+// ABOUTME: Styles for the standalone cursor color picker extension window.
+// ABOUTME: Keeps native color selection compact and consistent with popup UI.
+
+@use "../styles/variables" as *;
+
+body {
+  margin: 0;
+  background: $bg;
+}
+
+.color-picker-page {
+  min-height: 100vh;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  font-family: $font-body;
+  color: $text;
+
+  &__header {
+    display: flex;
+    align-items: center;
+  }
+
+  &__title {
+    @include heading;
+    margin: 0;
+    font-size: 18px;
+  }
+
+  &__body {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex: 1;
+  }
+
+  &__preview {
+    width: 72px;
+    height: 72px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+  }
+
+  &__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__label {
+    font-size: 12px;
+    font-weight: 600;
+    color: $text-muted;
+  }
+
+  &__input {
+    width: 96px;
+    height: 44px;
+    padding: 0;
+    border: 1px solid $border-strong;
+    border-radius: 6px;
+    background: $surface;
+    cursor: pointer;
+
+    &:disabled {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  &__cancel {
+    @include btn-secondary;
+  }
+
+  &__save {
+    @include btn-teal;
+  }
+}

--- a/extension/src/components/ColorPickerPage.tsx
+++ b/extension/src/components/ColorPickerPage.tsx
@@ -1,0 +1,86 @@
+// ABOUTME: Standalone cursor color editor for native browser color picking.
+// ABOUTME: Runs in a real extension window so Firefox does not close toolbar popup state.
+
+import React, { useEffect, useState } from "react";
+import browser from "webextension-polyfill";
+import { CursorSvg } from "./icons";
+import { savePlayerColor } from "../storage/playerColor";
+import type { PlayerIdentity } from "../types";
+import "./ColorPickerPage.scss";
+
+export function ColorPickerPage() {
+  const [color, setColor] = useState("#4a9a8a");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [hasIdentity, setHasIdentity] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { playerIdentity } = await browser.storage.local.get([
+          "playerIdentity",
+        ]);
+        const identity = playerIdentity as PlayerIdentity | undefined;
+        const storedColor = identity?.playerStyle?.colorPalette?.[0];
+        if (storedColor) setColor(storedColor);
+        setHasIdentity(Boolean(identity));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await savePlayerColor(color);
+      window.close();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <main className="color-picker-page">
+      <header className="color-picker-page__header">
+        <h1 className="color-picker-page__title">Cursor color</h1>
+      </header>
+
+      <section className="color-picker-page__body">
+        <div className="color-picker-page__preview" aria-hidden="true">
+          <CursorSvg size={52} color={color} />
+        </div>
+        <label className="color-picker-page__field">
+          <span className="color-picker-page__label">Color</span>
+          <input
+            type="color"
+            value={color}
+            onInput={(e) => setColor(e.currentTarget.value)}
+            onChange={(e) => setColor(e.currentTarget.value)}
+            disabled={loading || !hasIdentity}
+            className="color-picker-page__input"
+          />
+        </label>
+      </section>
+
+      <footer className="color-picker-page__actions">
+        <button
+          type="button"
+          onClick={() => window.close()}
+          className="color-picker-page__cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          aria-label="Save cursor color"
+          onClick={handleSave}
+          disabled={loading || saving || !hasIdentity}
+          className="color-picker-page__save"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </footer>
+    </main>
+  );
+}

--- a/extension/src/components/ProfilePage.scss
+++ b/extension/src/components/ProfilePage.scss
@@ -96,58 +96,17 @@
     }
   }
 
-  &__inline-picker {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex: 1 1 190px;
-    min-width: 0;
-  }
-
-  &__swatches {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    flex-wrap: wrap;
-  }
-
-  &__swatch {
-    width: 22px;
-    height: 22px;
-    border: 1px solid $border;
-    border-radius: 999px;
-    cursor: pointer;
-    padding: 0;
-    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
-
-    &:hover {
-      border-color: $border-strong;
-    }
-  }
-
-  &__swatch--active {
-    border-color: $text;
-    box-shadow:
-      inset 0 0 0 2px rgba(255, 255, 255, 0.85),
-      0 0 0 2px rgba(17, 24, 39, 0.14);
-  }
-
-  &__hex-input {
-    width: 76px;
-    min-width: 0;
-    padding: 6px 7px;
-    border: 1px solid $border;
-    border-radius: 6px;
-    font-family: $font-mono;
-    font-size: 11px;
-    color: $text;
-    background: $surface;
-  }
-
   &__reroll-btn {
     @include btn-secondary;
     padding: 8px 10px;
     font-size: 14px;
+    border-radius: 6px;
+  }
+
+  &__picker-window-btn {
+    @include btn-secondary;
+    padding: 8px 10px;
+    font-size: 12px;
     border-radius: 6px;
   }
 

--- a/extension/src/components/ProfilePage.scss
+++ b/extension/src/components/ProfilePage.scss
@@ -58,6 +58,7 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-wrap: wrap;
   }
 
   &__color-input--hidden {
@@ -84,6 +85,63 @@
       border-color: $border-strong;
       background: $surface-hover;
     }
+  }
+
+  &__cursor-preview--static {
+    cursor: default;
+
+    &:hover {
+      border-color: $border;
+      background: $surface;
+    }
+  }
+
+  &__inline-picker {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1 1 190px;
+    min-width: 0;
+  }
+
+  &__swatches {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    flex-wrap: wrap;
+  }
+
+  &__swatch {
+    width: 22px;
+    height: 22px;
+    border: 1px solid $border;
+    border-radius: 999px;
+    cursor: pointer;
+    padding: 0;
+    box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.7);
+
+    &:hover {
+      border-color: $border-strong;
+    }
+  }
+
+  &__swatch--active {
+    border-color: $text;
+    box-shadow:
+      inset 0 0 0 2px rgba(255, 255, 255, 0.85),
+      0 0 0 2px rgba(17, 24, 39, 0.14);
+  }
+
+  &__hex-input {
+    width: 76px;
+    min-width: 0;
+    padding: 6px 7px;
+    border: 1px solid $border;
+    border-radius: 6px;
+    font-family: $font-mono;
+    font-size: 11px;
+    color: $text;
+    background: $surface;
   }
 
   &__reroll-btn {

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -4,8 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import browser from "webextension-polyfill";
 import type { PlayerIdentity } from "../types";
 import { CursorSvg } from "./icons";
-import { syncParticipantColor } from "../storage/sync";
-import { getParticipantId } from "../storage/participant";
+import { savePlayerColor } from "../storage/playerColor";
 import "./ProfilePage.scss";
 import { hslToHex } from "../utils/color";
 
@@ -20,28 +19,6 @@ function randomPrimaryColor(): string {
   return hslToHex(hue, 70, 60);
 }
 
-const INLINE_COLOR_OPTIONS = [
-  "#ef4444",
-  "#f97316",
-  "#f59e0b",
-  "#84cc16",
-  "#14b8a6",
-  "#3b82f6",
-  "#8b5cf6",
-  "#ec4899",
-];
-
-function normalizeHexColor(value: string): string | null {
-  const match = value.trim().match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
-  if (!match) return null;
-
-  const hex = match[1].toLowerCase();
-  if (hex.length === 3) {
-    return `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`;
-  }
-  return `#${hex}`;
-}
-
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -51,9 +28,6 @@ function formatBytes(bytes: number): string {
 export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props) {
   const savedColor = playerIdentity.playerStyle?.colorPalette?.[0] ?? "#4a9a8a";
   const [color, setColor] = useState(savedColor);
-  const [hexInputValue, setHexInputValue] = useState(
-    normalizeHexColor(savedColor) ?? "",
-  );
   const [copied, setCopied] = useState(false);
   const [saving, setSaving] = useState(false);
   const [storageStats, setStorageStats] = useState<{
@@ -61,7 +35,7 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
     estimatedSizeBytes: number;
   } | null>(null);
   const colorInputRef = useRef<HTMLInputElement>(null);
-  const useInlineColorPicker = Boolean(import.meta.env.FIREFOX);
+  const opensNativePickerInPopup = !import.meta.env.FIREFOX;
 
   const hasColorChanged = color !== savedColor;
 
@@ -81,37 +55,23 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
 
   const commitColor = (nextColor: string) => {
     setColor(nextColor);
-    setHexInputValue(normalizeHexColor(nextColor) ?? "");
   };
 
-  const handleHexColorChange = (value: string) => {
-    setHexInputValue(value);
-    const nextColor = normalizeHexColor(value);
-    if (nextColor) setColor(nextColor);
+  const handleOpenNativeColorPicker = async () => {
+    await browser.windows.create({
+      url: browser.runtime.getURL("color-picker.html"),
+      type: "popup",
+      width: 360,
+      height: 260,
+    });
+    window.close();
   };
 
   const handleSaveColor = async () => {
     setSaving(true);
     try {
-      const { playerIdentity: stored } = await browser.storage.local.get(["playerIdentity"]);
-      if (stored) {
-        if (!stored.playerStyle) stored.playerStyle = { colorPalette: [color] };
-        else {
-          const palette = Array.isArray(stored.playerStyle.colorPalette)
-            ? stored.playerStyle.colorPalette
-            : [];
-          palette[0] = color;
-          stored.playerStyle.colorPalette = palette;
-        }
-        await browser.storage.local.set({ playerIdentity: stored });
-        onIdentityUpdated(stored);
-
-        // Sync to server
-        try {
-          const pid = await getParticipantId();
-          await syncParticipantColor(pid, color);
-        } catch {}
-      }
+      const updated = await savePlayerColor(color);
+      if (updated) onIdentityUpdated(updated);
     } catch {} finally {
       setSaving(false);
     }
@@ -142,14 +102,7 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
         <section className="profile-section">
           <label className="profile-section__label">Cursor color</label>
           <div className="profile-section__color-row">
-            {useInlineColorPicker ? (
-              <div
-                className="profile-section__cursor-preview profile-section__cursor-preview--static"
-                aria-hidden="true"
-              >
-                <CursorSvg size={36} color={color} />
-              </div>
-            ) : (
+            {opensNativePickerInPopup ? (
               <>
                 <input
                   ref={colorInputRef}
@@ -168,6 +121,13 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
                   <CursorSvg size={36} color={color} />
                 </button>
               </>
+            ) : (
+              <div
+                className="profile-section__cursor-preview profile-section__cursor-preview--static"
+                aria-hidden="true"
+              >
+                <CursorSvg size={36} color={color} />
+              </div>
             )}
             <button
               type="button"
@@ -178,40 +138,16 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
             >
               ↻
             </button>
-            {useInlineColorPicker && (
-              <div
-                className="profile-section__inline-picker"
-                role="group"
-                aria-label="Cursor color choices"
+            {!opensNativePickerInPopup && (
+              <button
+                type="button"
+                aria-label="Open native cursor color picker"
+                title="Open native color picker"
+                onClick={handleOpenNativeColorPicker}
+                className="profile-section__picker-window-btn"
               >
-                <div className="profile-section__swatches">
-                  {INLINE_COLOR_OPTIONS.map((option) => (
-                    <button
-                      key={option}
-                      type="button"
-                      aria-label={`Use ${option} as cursor color`}
-                      aria-pressed={color === option}
-                      onClick={() => commitColor(option)}
-                      className={
-                        "profile-section__swatch" +
-                        (color === option
-                          ? " profile-section__swatch--active"
-                          : "")
-                      }
-                      style={{ backgroundColor: option }}
-                    />
-                  ))}
-                </div>
-                <input
-                  type="text"
-                  value={hexInputValue}
-                  onChange={(e) => handleHexColorChange(e.target.value)}
-                  placeholder="#4a9a8a"
-                  aria-label="Custom cursor color hex value"
-                  spellCheck={false}
-                  className="profile-section__hex-input"
-                />
-              </div>
+                Choose
+              </button>
             )}
             {hasColorChanged && (
               <button

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -20,6 +20,28 @@ function randomPrimaryColor(): string {
   return hslToHex(hue, 70, 60);
 }
 
+const INLINE_COLOR_OPTIONS = [
+  "#ef4444",
+  "#f97316",
+  "#f59e0b",
+  "#84cc16",
+  "#14b8a6",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+];
+
+function normalizeHexColor(value: string): string | null {
+  const match = value.trim().match(/^#?([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!match) return null;
+
+  const hex = match[1].toLowerCase();
+  if (hex.length === 3) {
+    return `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`;
+  }
+  return `#${hex}`;
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -29,6 +51,9 @@ function formatBytes(bytes: number): string {
 export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props) {
   const savedColor = playerIdentity.playerStyle?.colorPalette?.[0] ?? "#4a9a8a";
   const [color, setColor] = useState(savedColor);
+  const [hexInputValue, setHexInputValue] = useState(
+    normalizeHexColor(savedColor) ?? "",
+  );
   const [copied, setCopied] = useState(false);
   const [saving, setSaving] = useState(false);
   const [storageStats, setStorageStats] = useState<{
@@ -36,6 +61,7 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
     estimatedSizeBytes: number;
   } | null>(null);
   const colorInputRef = useRef<HTMLInputElement>(null);
+  const useInlineColorPicker = Boolean(import.meta.env.FIREFOX);
 
   const hasColorChanged = color !== savedColor;
 
@@ -52,6 +78,17 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
       } catch {}
     })();
   }, []);
+
+  const commitColor = (nextColor: string) => {
+    setColor(nextColor);
+    setHexInputValue(normalizeHexColor(nextColor) ?? "");
+  };
+
+  const handleHexColorChange = (value: string) => {
+    setHexInputValue(value);
+    const nextColor = normalizeHexColor(value);
+    if (nextColor) setColor(nextColor);
+  };
 
   const handleSaveColor = async () => {
     setSaving(true);
@@ -105,31 +142,77 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
         <section className="profile-section">
           <label className="profile-section__label">Cursor color</label>
           <div className="profile-section__color-row">
-            <input
-              ref={colorInputRef}
-              type="color"
-              value={color}
-              onChange={(e) => setColor(e.target.value)}
-              className="profile-section__color-input--hidden"
-            />
-            <button
-              type="button"
-              aria-label="Pick cursor color"
-              title="Click to pick a color"
-              onClick={() => colorInputRef.current?.click()}
-              className="profile-section__cursor-preview"
-            >
-              <CursorSvg size={36} color={color} />
-            </button>
+            {useInlineColorPicker ? (
+              <div
+                className="profile-section__cursor-preview profile-section__cursor-preview--static"
+                aria-hidden="true"
+              >
+                <CursorSvg size={36} color={color} />
+              </div>
+            ) : (
+              <>
+                <input
+                  ref={colorInputRef}
+                  type="color"
+                  value={color}
+                  onChange={(e) => commitColor(e.target.value)}
+                  className="profile-section__color-input--hidden"
+                />
+                <button
+                  type="button"
+                  aria-label="Pick cursor color"
+                  title="Click to pick a color"
+                  onClick={() => colorInputRef.current?.click()}
+                  className="profile-section__cursor-preview"
+                >
+                  <CursorSvg size={36} color={color} />
+                </button>
+              </>
+            )}
             <button
               type="button"
               aria-label="Re-roll color"
               title="Re-roll color"
-              onClick={() => setColor(randomPrimaryColor())}
+              onClick={() => commitColor(randomPrimaryColor())}
               className="profile-section__reroll-btn"
             >
               ↻
             </button>
+            {useInlineColorPicker && (
+              <div
+                className="profile-section__inline-picker"
+                role="group"
+                aria-label="Cursor color choices"
+              >
+                <div className="profile-section__swatches">
+                  {INLINE_COLOR_OPTIONS.map((option) => (
+                    <button
+                      key={option}
+                      type="button"
+                      aria-label={`Use ${option} as cursor color`}
+                      aria-pressed={color === option}
+                      onClick={() => commitColor(option)}
+                      className={
+                        "profile-section__swatch" +
+                        (color === option
+                          ? " profile-section__swatch--active"
+                          : "")
+                      }
+                      style={{ backgroundColor: option }}
+                    />
+                  ))}
+                </div>
+                <input
+                  type="text"
+                  value={hexInputValue}
+                  onChange={(e) => handleHexColorChange(e.target.value)}
+                  placeholder="#4a9a8a"
+                  aria-label="Custom cursor color hex value"
+                  spellCheck={false}
+                  className="profile-section__hex-input"
+                />
+              </div>
+            )}
             {hasColorChanged && (
               <button
                 type="button"

--- a/extension/src/entrypoints/color-picker/color-picker.tsx
+++ b/extension/src/entrypoints/color-picker/color-picker.tsx
@@ -1,0 +1,11 @@
+// ABOUTME: Mounts the standalone cursor color editor extension page.
+// ABOUTME: Used from Firefox popup flow to host native color input outside toolbar popups.
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { ColorPickerPage } from "../../components/ColorPickerPage";
+
+const container = document.getElementById("root");
+if (container) {
+  createRoot(container).render(<ColorPickerPage />);
+}

--- a/extension/src/entrypoints/color-picker/index.html
+++ b/extension/src/entrypoints/color-picker/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cursor color — we were online</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./color-picker.tsx"></script>
+  </body>
+</html>

--- a/extension/src/storage/playerColor.ts
+++ b/extension/src/storage/playerColor.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Persists the participant's primary cursor color for extension UI.
+// ABOUTME: Updates local identity storage and best-effort server color sync.
+
+import browser from "webextension-polyfill";
+import type { PlayerIdentity } from "../types";
+import { syncParticipantColor } from "./sync";
+
+export async function savePlayerColor(color: string): Promise<PlayerIdentity | null> {
+  const { playerIdentity: stored } = await browser.storage.local.get([
+    "playerIdentity",
+  ]);
+
+  if (!stored) return null;
+
+  const identity = stored as PlayerIdentity;
+  const colorPalette = Array.isArray(identity.playerStyle?.colorPalette)
+    ? [...identity.playerStyle.colorPalette]
+    : [];
+  colorPalette[0] = color;
+
+  const updated: PlayerIdentity = {
+    ...identity,
+    playerStyle: {
+      ...identity.playerStyle,
+      colorPalette,
+    },
+  };
+
+  await browser.storage.local.set({ playerIdentity: updated });
+
+  if (updated.publicKey) {
+    try {
+      await syncParticipantColor(updated.publicKey, color);
+    } catch {}
+  }
+
+  return updated;
+}

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
     setupFiles: [setupFile],
     include: [
       "src/__tests__/**/*.test.ts",
+      "src/__tests__/**/*.test.tsx",
       "website/shared/**/*.test.ts",
       "website/shared/**/*.test.tsx",
     ],

--- a/extension/website/shared/portrait-styles.scss
+++ b/extension/website/shared/portrait-styles.scss
@@ -1,7 +1,7 @@
 // ABOUTME: Styles for the internet movement visualization page.
 // ABOUTME: Full-viewport layout with canvas positioning and RISO-inspired background.
 
-@import "./base.scss";
+@use "./base.scss";
 
 body {
   margin: 0;

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,6 +1,5 @@
 // ABOUTME: WXT build configuration for the browser extension.
 // ABOUTME: Defines manifest metadata, output settings, and Vite aliases.
-
 import { defineConfig } from "wxt";
 import path from "path";
 
@@ -49,6 +48,10 @@ export default defineConfig({
       alias: {
         "@extension": path.resolve(__dirname, "src"),
         "@movement": path.resolve(__dirname, "website/shared"),
+        "@playhtml/extension-types": path.resolve(
+          __dirname,
+          "../packages/extension-types/src/index.ts",
+        ),
       },
     },
   }),


### PR DESCRIPTION
## Summary

Fixes the Firefox extension popup cursor color flow without limiting available colors.

- Keeps Chrome using the native color input directly inside the toolbar popup.
- Routes Firefox to a small `color-picker.html` extension popup window that hosts the native `<input type="color">`, avoiding Firefox toolbar popup teardown when the native picker takes focus.
- Extracts cursor color persistence into `savePlayerColor()` so the popup and standalone color picker share the same storage/server-sync path.
- Adds regression coverage for the Firefox launcher and standalone native color picker save flow.
- Updates extension test/build aliases so tests and WXT builds resolve local workspace source instead of stale package output.

## Root Cause

Firefox closes WebExtension toolbar popups when focus leaves the popup. Opening the native color picker from the toolbar popup unloads the popup document before the selected value can be saved.

## Validation

- `cd extension && /Users/spencerchang/.bun/bin/bun run test -- --run` - 121 tests passed
- `cd extension && PATH=/Users/spencerchang/.bun/bin:$PATH /Users/spencerchang/.bun/bin/bun run build:firefox` - passed
- `cd extension && PATH=/Users/spencerchang/.bun/bin:$PATH /Users/spencerchang/.bun/bin/bun run build` - passed
