### PR TITLE
partykit: add server abuse limits

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "load-test:full": "bun load-test/src/runner.ts --config full-suite",
     "smoke": "cd smoke-tests && bun run test",
     "smoke:partykit": "cd smoke-tests && bun run test:partykit",
+    "smoke:partykit:limits": "cd smoke-tests && bun run test:partykit:limits",
     "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",
     "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",
     "smoke:partykit:emergency": "cd smoke-tests && bun run test:partykit:emergency",

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -31,7 +31,6 @@ describe("checkMessageLimits", () => {
     const first = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_000,
       state: undefined,
     });
@@ -40,7 +39,6 @@ describe("checkMessageLimits", () => {
     const second = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_500,
       state: first.state,
     });
@@ -51,21 +49,18 @@ describe("checkMessageLimits", () => {
     const first = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_000,
       state: undefined,
     });
     const second = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_100,
       state: first.state,
     });
     const third = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_200,
       state: second.state,
     });
@@ -81,14 +76,12 @@ describe("checkMessageLimits", () => {
     const first = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 1_000,
       state: undefined,
     });
     const second = checkMessageLimits({
       limits,
       messageSizeBytes: 5,
-      currentDocumentBytes: 10,
       now: 2_000,
       state: first.state,
     });
@@ -101,7 +94,6 @@ describe("checkMessageLimits", () => {
     const result = checkMessageLimits({
       limits,
       messageSizeBytes: 11,
-      currentDocumentBytes: 10,
       now: 1_000,
       state: undefined,
     });
@@ -113,20 +105,15 @@ describe("checkMessageLimits", () => {
     });
   });
 
-  it("rejects messages that would exceed the document limit", () => {
+  it("does not reject ordinary messages just because the document is near its limit", () => {
     const result = checkMessageLimits({
       limits,
       messageSizeBytes: 6,
-      currentDocumentBytes: 25,
       now: 1_000,
       state: undefined,
     });
 
-    expect(result.violation).toEqual({
-      kind: "document-size",
-      closeCode: 1009,
-      reason: "Document Too Large",
-    });
+    expect(result.violation).toBe(null);
   });
 });
 

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -15,7 +15,7 @@ const limits: ServerLimits = {
   messageRateWindowMs: 1_000,
   maxMessageBytes: 10,
   maxRequestBytes: 20,
-  maxDocumentBytes: 30,
+  documentWarningBytes: 30,
 };
 
 describe("getMessageSizeBytes", () => {

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Verifies PartyServer abuse limits for message rate, payload size, and document size.
 // ABOUTME: Keeps limit decisions testable without a Cloudflare Durable Object runtime.
 import { describe, expect, it } from "bun:test";
+import { DEFAULT_MESSAGE_RATE_LIMIT } from "../const";
 import {
   checkMessageLimits,
   getMessageSizeBytes,
@@ -114,6 +115,25 @@ describe("checkMessageLimits", () => {
     });
 
     expect(result.violation).toBe(null);
+  });
+
+  it("allows sustained interaction traffic below the default rate limit", () => {
+    let state = undefined;
+    const interactionMessages = 420;
+
+    for (let i = 0; i < interactionMessages; i += 1) {
+      const result = checkMessageLimits({
+        limits: {
+          ...limits,
+          maxMessagesPerWindow: DEFAULT_MESSAGE_RATE_LIMIT,
+        },
+        messageSizeBytes: 6,
+        now: 1_000,
+        state,
+      });
+      expect(result.violation).toBe(null);
+      state = result.state;
+    }
   });
 });
 

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -3,8 +3,7 @@
 import { describe, expect, it } from "bun:test";
 import { DEFAULT_MESSAGE_RATE_LIMIT } from "../const";
 import {
-  checkMessageLimits,
-  getMessageSizeBytes,
+  checkMessageRate,
   shouldAcceptRequestBody,
   shouldWarnForDocumentSize,
   type ServerLimits,
@@ -13,33 +12,21 @@ import {
 const limits: ServerLimits = {
   maxMessagesPerWindow: 2,
   messageRateWindowMs: 1_000,
-  maxMessageBytes: 10,
   maxRequestBytes: 20,
   documentWarningBytes: 30,
 };
 
-describe("getMessageSizeBytes", () => {
-  it("counts string and binary WebSocket payload bytes", () => {
-    expect(getMessageSizeBytes("hello")).toBe(5);
-    expect(getMessageSizeBytes("é")).toBe(2);
-    expect(getMessageSizeBytes(new Uint8Array([1, 2, 3]))).toBe(3);
-    expect(getMessageSizeBytes(new ArrayBuffer(4))).toBe(4);
-  });
-});
-
-describe("checkMessageLimits", () => {
+describe("checkMessageRate", () => {
   it("allows messages inside the configured rate window", () => {
-    const first = checkMessageLimits({
+    const first = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_000,
       state: undefined,
     });
     expect(first.violation).toBe(null);
 
-    const second = checkMessageLimits({
+    const second = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_500,
       state: first.state,
     });
@@ -47,21 +34,18 @@ describe("checkMessageLimits", () => {
   });
 
   it("rejects messages above the configured rate window", () => {
-    const first = checkMessageLimits({
+    const first = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_000,
       state: undefined,
     });
-    const second = checkMessageLimits({
+    const second = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_100,
       state: first.state,
     });
-    const third = checkMessageLimits({
+    const third = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_200,
       state: second.state,
     });
@@ -74,15 +58,13 @@ describe("checkMessageLimits", () => {
   });
 
   it("starts a new rate window after the configured interval", () => {
-    const first = checkMessageLimits({
+    const first = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 1_000,
       state: undefined,
     });
-    const second = checkMessageLimits({
+    const second = checkMessageRate({
       limits,
-      messageSizeBytes: 5,
       now: 2_000,
       state: first.state,
     });
@@ -91,25 +73,19 @@ describe("checkMessageLimits", () => {
     expect(second.state).toEqual({ windowStartedAt: 2_000, messageCount: 1 });
   });
 
-  it("rejects individual messages above the payload limit", () => {
-    const result = checkMessageLimits({
+  it("leaves oversized WebSocket messages to the platform limit", () => {
+    const result = checkMessageRate({
       limits,
-      messageSizeBytes: 11,
       now: 1_000,
       state: undefined,
     });
 
-    expect(result.violation).toEqual({
-      kind: "message-size",
-      closeCode: 1009,
-      reason: "Message Too Large",
-    });
+    expect(result.violation).toBe(null);
   });
 
   it("does not reject ordinary messages just because the document is near its limit", () => {
-    const result = checkMessageLimits({
+    const result = checkMessageRate({
       limits,
-      messageSizeBytes: 6,
       now: 1_000,
       state: undefined,
     });
@@ -122,12 +98,11 @@ describe("checkMessageLimits", () => {
     const interactionMessages = 420;
 
     for (let i = 0; i < interactionMessages; i += 1) {
-      const result = checkMessageLimits({
+      const result = checkMessageRate({
         limits: {
           ...limits,
           maxMessagesPerWindow: DEFAULT_MESSAGE_RATE_LIMIT,
         },
-        messageSizeBytes: 6,
         now: 1_000,
         state,
       });

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -6,7 +6,7 @@ import {
   checkMessageLimits,
   getMessageSizeBytes,
   shouldAcceptRequestBody,
-  shouldPersistDocument,
+  shouldWarnForDocumentSize,
   type ServerLimits,
 } from "../serverLimits";
 
@@ -144,9 +144,9 @@ describe("shouldAcceptRequestBody", () => {
   });
 });
 
-describe("shouldPersistDocument", () => {
-  it("rejects autosave snapshots above the configured document limit", () => {
-    expect(shouldPersistDocument(30, limits)).toBe(true);
-    expect(shouldPersistDocument(31, limits)).toBe(false);
+describe("shouldWarnForDocumentSize", () => {
+  it("warns when autosave snapshots exceed the configured document threshold", () => {
+    expect(shouldWarnForDocumentSize(30, limits)).toBe(false);
+    expect(shouldWarnForDocumentSize(31, limits)).toBe(true);
   });
 });

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -1,0 +1,145 @@
+// ABOUTME: Verifies PartyServer abuse limits for message rate, payload size, and document size.
+// ABOUTME: Keeps limit decisions testable without a Cloudflare Durable Object runtime.
+import { describe, expect, it } from "bun:test";
+import {
+  checkMessageLimits,
+  getMessageSizeBytes,
+  shouldAcceptRequestBody,
+  shouldPersistDocument,
+  type ServerLimits,
+} from "../serverLimits";
+
+const limits: ServerLimits = {
+  maxMessagesPerWindow: 2,
+  messageRateWindowMs: 1_000,
+  maxMessageBytes: 10,
+  maxRequestBytes: 20,
+  maxDocumentBytes: 30,
+};
+
+describe("getMessageSizeBytes", () => {
+  it("counts string and binary WebSocket payload bytes", () => {
+    expect(getMessageSizeBytes("hello")).toBe(5);
+    expect(getMessageSizeBytes("é")).toBe(2);
+    expect(getMessageSizeBytes(new Uint8Array([1, 2, 3]))).toBe(3);
+    expect(getMessageSizeBytes(new ArrayBuffer(4))).toBe(4);
+  });
+});
+
+describe("checkMessageLimits", () => {
+  it("allows messages inside the configured rate window", () => {
+    const first = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_000,
+      state: undefined,
+    });
+    expect(first.violation).toBe(null);
+
+    const second = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_500,
+      state: first.state,
+    });
+    expect(second.violation).toBe(null);
+  });
+
+  it("rejects messages above the configured rate window", () => {
+    const first = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_000,
+      state: undefined,
+    });
+    const second = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_100,
+      state: first.state,
+    });
+    const third = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_200,
+      state: second.state,
+    });
+
+    expect(third.violation).toEqual({
+      kind: "message-rate",
+      closeCode: 1008,
+      reason: "Message Rate Limit Exceeded",
+    });
+  });
+
+  it("starts a new rate window after the configured interval", () => {
+    const first = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 1_000,
+      state: undefined,
+    });
+    const second = checkMessageLimits({
+      limits,
+      messageSizeBytes: 5,
+      currentDocumentBytes: 10,
+      now: 2_000,
+      state: first.state,
+    });
+
+    expect(second.violation).toBe(null);
+    expect(second.state).toEqual({ windowStartedAt: 2_000, messageCount: 1 });
+  });
+
+  it("rejects individual messages above the payload limit", () => {
+    const result = checkMessageLimits({
+      limits,
+      messageSizeBytes: 11,
+      currentDocumentBytes: 10,
+      now: 1_000,
+      state: undefined,
+    });
+
+    expect(result.violation).toEqual({
+      kind: "message-size",
+      closeCode: 1009,
+      reason: "Message Too Large",
+    });
+  });
+
+  it("rejects messages that would exceed the document limit", () => {
+    const result = checkMessageLimits({
+      limits,
+      messageSizeBytes: 6,
+      currentDocumentBytes: 25,
+      now: 1_000,
+      state: undefined,
+    });
+
+    expect(result.violation).toEqual({
+      kind: "document-size",
+      closeCode: 1009,
+      reason: "Document Too Large",
+    });
+  });
+});
+
+describe("shouldAcceptRequestBody", () => {
+  it("rejects HTTP request bodies above the configured payload limit", () => {
+    expect(shouldAcceptRequestBody(20, limits)).toBe(true);
+    expect(shouldAcceptRequestBody(21, limits)).toBe(false);
+  });
+});
+
+describe("shouldPersistDocument", () => {
+  it("rejects autosave snapshots above the configured document limit", () => {
+    expect(shouldPersistDocument(30, limits)).toBe(true);
+    expect(shouldPersistDocument(31, limits)).toBe(false);
+  });
+});

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -43,9 +43,6 @@ export const DEFAULT_MESSAGE_RATE_WINDOW_MS = (() => {
 export const DEFAULT_MESSAGE_RATE_LIMIT = (() => {
   return 1000;
 })();
-export const DEFAULT_MAX_MESSAGE_BYTES = (() => {
-  return 1024 * 1024 * 32;
-})();
 export const DEFAULT_MAX_REQUEST_BYTES = (() => {
   return 1024 * 1024 * 16;
 })();

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -44,10 +44,10 @@ export const DEFAULT_MESSAGE_RATE_LIMIT = (() => {
   return 120;
 })();
 export const DEFAULT_MAX_MESSAGE_BYTES = (() => {
-  return 1024 * 1024;
+  return 1024 * 1024 * 16;
 })();
 export const DEFAULT_MAX_REQUEST_BYTES = (() => {
-  return 1024 * 1024;
+  return 1024 * 1024 * 16;
 })();
 export const DEFAULT_MAX_DOCUMENT_BYTES = (() => {
   return 1024 * 1024 * 64;

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -41,7 +41,7 @@ export const DEFAULT_MESSAGE_RATE_WINDOW_MS = (() => {
   return 1000;
 })();
 export const DEFAULT_MESSAGE_RATE_LIMIT = (() => {
-  return 120;
+  return 1000;
 })();
 export const DEFAULT_MAX_MESSAGE_BYTES = (() => {
   return 1024 * 1024 * 16;

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -50,7 +50,7 @@ export const DEFAULT_MAX_REQUEST_BYTES = (() => {
   return 1024 * 1024 * 16;
 })();
 export const DEFAULT_MAX_DOCUMENT_BYTES = (() => {
-  return 1024 * 1024 * 64;
+  return 1024 * 1024 * 40;
 })();
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -37,6 +37,21 @@ export const DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES = (() => {
 export const DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS = (() => {
   return 60 * 60 * 1000;
 })();
+export const DEFAULT_MESSAGE_RATE_WINDOW_MS = (() => {
+  return 1000;
+})();
+export const DEFAULT_MESSAGE_RATE_LIMIT = (() => {
+  return 120;
+})();
+export const DEFAULT_MAX_MESSAGE_BYTES = (() => {
+  return 1024 * 1024;
+})();
+export const DEFAULT_MAX_REQUEST_BYTES = (() => {
+  return 1024 * 1024;
+})();
+export const DEFAULT_MAX_DOCUMENT_BYTES = (() => {
+  return 1024 * 1024 * 64;
+})();
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";
 

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -44,12 +44,12 @@ export const DEFAULT_MESSAGE_RATE_LIMIT = (() => {
   return 1000;
 })();
 export const DEFAULT_MAX_MESSAGE_BYTES = (() => {
-  return 1024 * 1024 * 16;
+  return 1024 * 1024 * 32;
 })();
 export const DEFAULT_MAX_REQUEST_BYTES = (() => {
   return 1024 * 1024 * 16;
 })();
-export const DEFAULT_MAX_DOCUMENT_BYTES = (() => {
+export const DEFAULT_DOCUMENT_WARNING_BYTES = (() => {
   return 1024 * 1024 * 40;
 })();
 export const ORIGIN_S2C = "__bridge_s2c__";

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -23,7 +23,7 @@ import {
   DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
   DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
-  DEFAULT_MAX_DOCUMENT_BYTES,
+  DEFAULT_DOCUMENT_WARNING_BYTES,
   DEFAULT_MAX_MESSAGE_BYTES,
   DEFAULT_MAX_REQUEST_BYTES,
   DEFAULT_MESSAGE_RATE_LIMIT,
@@ -271,9 +271,9 @@ export class PartyServer extends YServer {
         "MAX_REQUEST_BYTES",
         DEFAULT_MAX_REQUEST_BYTES
       ),
-      maxDocumentBytes: readPositiveNumberEnv(
-        "MAX_DOCUMENT_BYTES",
-        DEFAULT_MAX_DOCUMENT_BYTES
+      documentWarningBytes: readPositiveNumberEnv(
+        "DOCUMENT_WARNING_BYTES",
+        DEFAULT_DOCUMENT_WARNING_BYTES
       ),
     };
   }
@@ -1223,7 +1223,7 @@ export class PartyServer extends YServer {
       console.warn(
         `[PartyServer] Large document warning for room ${this.name}: ` +
           `documentBytes=${documentSize}, ` +
-          `warningThresholdBytes=${serverLimits.maxDocumentBytes}. ` +
+          `warningThresholdBytes=${serverLimits.documentWarningBytes}. ` +
           "Autosave will continue."
       );
     }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -287,7 +287,6 @@ export class PartyServer extends YServer {
     const decision = checkMessageLimits({
       limits: this.getServerLimits(),
       messageSizeBytes,
-      currentDocumentBytes: this.lastKnownDocumentBytes,
       now: Date.now(),
       state: limitConnection.state?.[MESSAGE_LIMIT_STATE_KEY],
     });

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -24,7 +24,6 @@ import {
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
   DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
   DEFAULT_DOCUMENT_WARNING_BYTES,
-  DEFAULT_MAX_MESSAGE_BYTES,
   DEFAULT_MAX_REQUEST_BYTES,
   DEFAULT_MESSAGE_RATE_LIMIT,
   DEFAULT_MESSAGE_RATE_WINDOW_MS,
@@ -47,8 +46,7 @@ import {
   isApplySubtreesImmediateRequest,
 } from "./request";
 import {
-  checkMessageLimits,
-  getMessageSizeBytes,
+  checkMessageRate,
   shouldAcceptRequestBody,
   shouldWarnForDocumentSize,
   type MessageLimitState,
@@ -263,10 +261,6 @@ export class PartyServer extends YServer {
         "MESSAGE_RATE_WINDOW_MS",
         DEFAULT_MESSAGE_RATE_WINDOW_MS
       ),
-      maxMessageBytes: readPositiveNumberEnv(
-        "MAX_MESSAGE_BYTES",
-        DEFAULT_MAX_MESSAGE_BYTES
-      ),
       maxRequestBytes: readPositiveNumberEnv(
         "MAX_REQUEST_BYTES",
         DEFAULT_MAX_REQUEST_BYTES
@@ -278,16 +272,11 @@ export class PartyServer extends YServer {
     };
   }
 
-  private checkConnectionMessageLimits(
-    connection: Party.Connection,
-    message: Party.WSMessage
-  ) {
+  private checkConnectionMessageRate(connection: Party.Connection) {
     const limitConnection =
       connection as Party.Connection<PartyServerConnectionState>;
-    const messageSizeBytes = getMessageSizeBytes(message);
-    const decision = checkMessageLimits({
+    const decision = checkMessageRate({
       limits: this.getServerLimits(),
-      messageSizeBytes,
       now: Date.now(),
       state: limitConnection.state?.[MESSAGE_LIMIT_STATE_KEY],
     });
@@ -301,7 +290,7 @@ export class PartyServer extends YServer {
       };
     });
 
-    return { messageSizeBytes, violation: decision.violation };
+    return { violation: decision.violation };
   }
 
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
@@ -1076,12 +1065,11 @@ export class PartyServer extends YServer {
     connection: Party.Connection,
     message: Party.WSMessage
   ): Promise<void> {
-    const limitResult = this.checkConnectionMessageLimits(connection, message);
+    const limitResult = this.checkConnectionMessageRate(connection);
     if (limitResult.violation) {
       console.warn(
         `[PartyServer] Closing connection for ${limitResult.violation.kind}: ` +
           `connectionId=${connection.id}, ` +
-          `messageBytes=${limitResult.messageSizeBytes}, ` +
           `documentBytes=${this.lastKnownDocumentBytes}`
       );
       connection.close(

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -50,7 +50,7 @@ import {
   checkMessageLimits,
   getMessageSizeBytes,
   shouldAcceptRequestBody,
-  shouldPersistDocument,
+  shouldWarnForDocumentSize,
   type MessageLimitState,
   type ServerLimits,
 } from "./serverLimits";
@@ -130,6 +130,7 @@ export class PartyServer extends YServer {
   private compactionAutosaveSnapshot: string | null = null;
   private cachedResetEpoch: number | null | undefined;
   private lastKnownDocumentBytes = 0;
+  private hasWarnedDocumentSize = false;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -1214,14 +1215,17 @@ export class PartyServer extends YServer {
     const activeConnectionCount = this.getOpenConnectionCount();
 
     const serverLimits = this.getServerLimits();
-    if (!shouldPersistDocument(documentSize, serverLimits)) {
+    if (
+      !this.hasWarnedDocumentSize &&
+      shouldWarnForDocumentSize(documentSize, serverLimits)
+    ) {
+      this.hasWarnedDocumentSize = true;
       console.warn(
-        `[PartyServer] Autosave rejected for room ${this.name}: ` +
+        `[PartyServer] Large document warning for room ${this.name}: ` +
           `documentBytes=${documentSize}, ` +
-          `maxDocumentBytes=${serverLimits.maxDocumentBytes}`
+          `warningThresholdBytes=${serverLimits.maxDocumentBytes}. ` +
+          "Autosave will continue."
       );
-      this.closeConnections("Document Too Large");
-      return;
     }
 
     // Log structured information about the save

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -304,14 +304,65 @@ export class PartyServer extends YServer {
   }
 
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
-    const bodyText = await request.text();
-    const bodySizeBytes = new TextEncoder().encode(bodyText).byteLength;
+    const limits = this.getServerLimits();
+    const contentLength = request.headers.get("content-length");
+    const declaredBodySize =
+      contentLength === null ? null : Number(contentLength);
+    const declaredTooLarge =
+      declaredBodySize !== null &&
+      (!Number.isFinite(declaredBodySize) ||
+        !shouldAcceptRequestBody(declaredBodySize, limits));
 
-    if (!shouldAcceptRequestBody(bodySizeBytes, this.getServerLimits())) {
-      return new Response("Payload Too Large", { status: 413 });
+    const bodyText = await this.readLimitedRequestText(
+      request,
+      limits,
+      declaredTooLarge
+    );
+    if (bodyText instanceof Response) {
+      return bodyText;
     }
 
     return JSON.parse(bodyText);
+  }
+
+  private async readLimitedRequestText(
+    request: Request,
+    limits: ServerLimits,
+    alreadyTooLarge: boolean
+  ): Promise<string | Response> {
+    if (!request.body) {
+      return alreadyTooLarge
+        ? new Response("Payload Too Large", { status: 413 })
+        : "";
+    }
+
+    const reader = request.body.getReader();
+    const decoder = new TextDecoder();
+    let bodyText = "";
+    let bodySizeBytes = 0;
+    let isTooLarge = alreadyTooLarge;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      bodySizeBytes += value.byteLength;
+      if (isTooLarge || !shouldAcceptRequestBody(bodySizeBytes, limits)) {
+        isTooLarge = true;
+        continue;
+      }
+
+      bodyText += decoder.decode(value, { stream: true });
+    }
+
+    if (isTooLarge) {
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    bodyText += decoder.decode();
+    return bodyText;
   }
 
   private async waitForEmptyRoomCompaction(): Promise<void> {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -23,6 +23,11 @@ import {
   DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
   DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  DEFAULT_MAX_MESSAGE_BYTES,
+  DEFAULT_MAX_REQUEST_BYTES,
+  DEFAULT_MESSAGE_RATE_LIMIT,
+  DEFAULT_MESSAGE_RATE_WINDOW_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
   ORIGIN_S2C,
@@ -42,6 +47,14 @@ import {
   isApplySubtreesImmediateRequest,
 } from "./request";
 import {
+  checkMessageLimits,
+  getMessageSizeBytes,
+  shouldAcceptRequestBody,
+  shouldPersistDocument,
+  type MessageLimitState,
+  type ServerLimits,
+} from "./serverLimits";
+import {
   getSourceRoomId,
   parseSharedElementsFromUrl,
   parseSharedReferencesFromUrl,
@@ -57,9 +70,11 @@ import {
 import { isResetEpochStale, parseClientResetEpoch } from "./resetEpochPolicy";
 
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
+const MESSAGE_LIMIT_STATE_KEY = "__playhtmlMessageLimit";
 
-type ResetEpochConnectionState = Record<string, unknown> & {
+type PartyServerConnectionState = Record<string, unknown> & {
   [ACCEPTED_RESET_EPOCH_STATE_KEY]?: number | null;
+  [MESSAGE_LIMIT_STATE_KEY]?: MessageLimitState;
 };
 
 type CompactedDocument = {
@@ -114,6 +129,7 @@ export class PartyServer extends YServer {
   private emptyRoomCompactionPromise: Promise<void> | null = null;
   private compactionAutosaveSnapshot: string | null = null;
   private cachedResetEpoch: number | null | undefined;
+  private lastKnownDocumentBytes = 0;
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -234,6 +250,69 @@ export class PartyServer extends YServer {
       "EMERGENCY_COMPACT_RECHECK_DELAY_MS",
       DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS
     );
+  }
+
+  private getServerLimits(): ServerLimits {
+    return {
+      maxMessagesPerWindow: readPositiveNumberEnv(
+        "MESSAGE_RATE_LIMIT",
+        DEFAULT_MESSAGE_RATE_LIMIT
+      ),
+      messageRateWindowMs: readPositiveNumberEnv(
+        "MESSAGE_RATE_WINDOW_MS",
+        DEFAULT_MESSAGE_RATE_WINDOW_MS
+      ),
+      maxMessageBytes: readPositiveNumberEnv(
+        "MAX_MESSAGE_BYTES",
+        DEFAULT_MAX_MESSAGE_BYTES
+      ),
+      maxRequestBytes: readPositiveNumberEnv(
+        "MAX_REQUEST_BYTES",
+        DEFAULT_MAX_REQUEST_BYTES
+      ),
+      maxDocumentBytes: readPositiveNumberEnv(
+        "MAX_DOCUMENT_BYTES",
+        DEFAULT_MAX_DOCUMENT_BYTES
+      ),
+    };
+  }
+
+  private checkConnectionMessageLimits(
+    connection: Party.Connection,
+    message: Party.WSMessage
+  ) {
+    const limitConnection =
+      connection as Party.Connection<PartyServerConnectionState>;
+    const messageSizeBytes = getMessageSizeBytes(message);
+    const decision = checkMessageLimits({
+      limits: this.getServerLimits(),
+      messageSizeBytes,
+      currentDocumentBytes: this.lastKnownDocumentBytes,
+      now: Date.now(),
+      state: limitConnection.state?.[MESSAGE_LIMIT_STATE_KEY],
+    });
+
+    limitConnection.setState((previousState) => {
+      const state =
+        previousState && typeof previousState === "object" ? previousState : {};
+      return {
+        ...(state as Record<string, unknown>),
+        [MESSAGE_LIMIT_STATE_KEY]: decision.state,
+      };
+    });
+
+    return { messageSizeBytes, violation: decision.violation };
+  }
+
+  private async readLimitedJson(request: Request): Promise<unknown | Response> {
+    const bodyText = await request.text();
+    const bodySizeBytes = new TextEncoder().encode(bodyText).byteLength;
+
+    if (!shouldAcceptRequestBody(bodySizeBytes, this.getServerLimits())) {
+      return new Response("Payload Too Large", { status: 413 });
+    }
+
+    return JSON.parse(bodyText);
   }
 
   private async waitForEmptyRoomCompaction(): Promise<void> {
@@ -357,7 +436,7 @@ export class PartyServer extends YServer {
     resetEpoch: number | null
   ): void {
     const resetConnection =
-      connection as Party.Connection<ResetEpochConnectionState>;
+      connection as Party.Connection<PartyServerConnectionState>;
     resetConnection.setState((previousState) => {
       const state =
         previousState && typeof previousState === "object" ? previousState : {};
@@ -371,7 +450,7 @@ export class PartyServer extends YServer {
   private getConnectionAcceptedResetEpoch(
     connection: Party.Connection
   ): number | null {
-    const state = (connection as Party.Connection<ResetEpochConnectionState>)
+    const state = (connection as Party.Connection<PartyServerConnectionState>)
       .state;
     const value = state?.[ACCEPTED_RESET_EPOCH_STATE_KEY];
     return typeof value === "number" && Number.isFinite(value) ? value : null;
@@ -946,6 +1025,21 @@ export class PartyServer extends YServer {
     connection: Party.Connection,
     message: Party.WSMessage
   ): Promise<void> {
+    const limitResult = this.checkConnectionMessageLimits(connection, message);
+    if (limitResult.violation) {
+      console.warn(
+        `[PartyServer] Closing connection for ${limitResult.violation.kind}: ` +
+          `connectionId=${connection.id}, ` +
+          `messageBytes=${limitResult.messageSizeBytes}, ` +
+          `documentBytes=${this.lastKnownDocumentBytes}`
+      );
+      connection.close(
+        limitResult.violation.closeCode,
+        limitResult.violation.reason
+      );
+      return;
+    }
+
     const serverResetEpoch = await this.getResetEpoch();
     const connectionResetEpoch =
       this.getConnectionAcceptedResetEpoch(connection);
@@ -1016,6 +1110,8 @@ export class PartyServer extends YServer {
     }
 
     if (data) {
+      this.lastKnownDocumentBytes =
+        typeof data.document === "string" ? data.document.length : 0;
       Y.applyUpdate(
         this.document,
         new Uint8Array(Buffer.from(data.document, "base64"))
@@ -1064,7 +1160,19 @@ export class PartyServer extends YServer {
     // safely. Empty-room compaction is handled as a reset boundary by alarms.
     const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
+    this.lastKnownDocumentBytes = documentSize;
     const activeConnectionCount = this.getOpenConnectionCount();
+
+    const serverLimits = this.getServerLimits();
+    if (!shouldPersistDocument(documentSize, serverLimits)) {
+      console.warn(
+        `[PartyServer] Autosave rejected for room ${this.name}: ` +
+          `documentBytes=${documentSize}, ` +
+          `maxDocumentBytes=${serverLimits.maxDocumentBytes}`
+      );
+      this.closeConnections("Document Too Large");
+      return;
+    }
 
     // Log structured information about the save
     console.log(
@@ -1210,7 +1318,10 @@ export class PartyServer extends YServer {
         return new Response("Method Not Allowed", { status: 405 });
       }
 
-      const body: unknown = await request.json();
+      const body = await this.readLimitedJson(request);
+      if (body instanceof Response) {
+        return body;
+      }
 
       if (isSubscribeRequest(body)) {
         // Called on SOURCE room; registers a consumer room id

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -3,7 +3,6 @@
 export type ServerLimits = {
   maxMessagesPerWindow: number;
   messageRateWindowMs: number;
-  maxMessageBytes: number;
   maxRequestBytes: number;
   documentWarningBytes: number;
 };
@@ -13,42 +12,18 @@ export type MessageLimitState = {
   messageCount: number;
 };
 
-export type LimitViolation =
-  | {
-      kind: "message-rate";
-      closeCode: 1008;
-      reason: "Message Rate Limit Exceeded";
-    }
-  | {
-      kind: "message-size";
-      closeCode: 1009;
-      reason: "Message Too Large";
-    };
+export type LimitViolation = {
+  kind: "message-rate";
+  closeCode: 1008;
+  reason: "Message Rate Limit Exceeded";
+};
 
-export function getMessageSizeBytes(message: unknown): number {
-  if (typeof message === "string") {
-    return new TextEncoder().encode(message).byteLength;
-  }
-
-  if (message instanceof ArrayBuffer) {
-    return message.byteLength;
-  }
-
-  if (ArrayBuffer.isView(message)) {
-    return message.byteLength;
-  }
-
-  return 0;
-}
-
-export function checkMessageLimits({
+export function checkMessageRate({
   limits,
-  messageSizeBytes,
   now,
   state,
 }: {
   limits: ServerLimits;
-  messageSizeBytes: number;
   now: number;
   state: MessageLimitState | undefined;
 }): { state: MessageLimitState; violation: LimitViolation | null } {
@@ -59,17 +34,6 @@ export function checkMessageLimits({
           messageCount: state.messageCount + 1,
         }
       : { windowStartedAt: now, messageCount: 1 };
-
-  if (messageSizeBytes > limits.maxMessageBytes) {
-    return {
-      state: nextState,
-      violation: {
-        kind: "message-size",
-        closeCode: 1009,
-        reason: "Message Too Large",
-      },
-    };
-  }
 
   if (nextState.messageCount > limits.maxMessagesPerWindow) {
     return {

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -1,0 +1,118 @@
+// ABOUTME: Defines PartyServer abuse-limit decisions for inbound messages and stored room data.
+// ABOUTME: Keeps rate, payload, and document-size checks separate from Durable Object plumbing.
+export type ServerLimits = {
+  maxMessagesPerWindow: number;
+  messageRateWindowMs: number;
+  maxMessageBytes: number;
+  maxRequestBytes: number;
+  maxDocumentBytes: number;
+};
+
+export type MessageLimitState = {
+  windowStartedAt: number;
+  messageCount: number;
+};
+
+export type LimitViolation =
+  | {
+      kind: "message-rate";
+      closeCode: 1008;
+      reason: "Message Rate Limit Exceeded";
+    }
+  | {
+      kind: "message-size";
+      closeCode: 1009;
+      reason: "Message Too Large";
+    }
+  | {
+      kind: "document-size";
+      closeCode: 1009;
+      reason: "Document Too Large";
+    };
+
+export function getMessageSizeBytes(message: unknown): number {
+  if (typeof message === "string") {
+    return new TextEncoder().encode(message).byteLength;
+  }
+
+  if (message instanceof ArrayBuffer) {
+    return message.byteLength;
+  }
+
+  if (ArrayBuffer.isView(message)) {
+    return message.byteLength;
+  }
+
+  return 0;
+}
+
+export function checkMessageLimits({
+  limits,
+  messageSizeBytes,
+  currentDocumentBytes,
+  now,
+  state,
+}: {
+  limits: ServerLimits;
+  messageSizeBytes: number;
+  currentDocumentBytes: number;
+  now: number;
+  state: MessageLimitState | undefined;
+}): { state: MessageLimitState; violation: LimitViolation | null } {
+  const nextState =
+    state && now - state.windowStartedAt < limits.messageRateWindowMs
+      ? {
+          windowStartedAt: state.windowStartedAt,
+          messageCount: state.messageCount + 1,
+        }
+      : { windowStartedAt: now, messageCount: 1 };
+
+  if (messageSizeBytes > limits.maxMessageBytes) {
+    return {
+      state: nextState,
+      violation: {
+        kind: "message-size",
+        closeCode: 1009,
+        reason: "Message Too Large",
+      },
+    };
+  }
+
+  if (currentDocumentBytes + messageSizeBytes > limits.maxDocumentBytes) {
+    return {
+      state: nextState,
+      violation: {
+        kind: "document-size",
+        closeCode: 1009,
+        reason: "Document Too Large",
+      },
+    };
+  }
+
+  if (nextState.messageCount > limits.maxMessagesPerWindow) {
+    return {
+      state: nextState,
+      violation: {
+        kind: "message-rate",
+        closeCode: 1008,
+        reason: "Message Rate Limit Exceeded",
+      },
+    };
+  }
+
+  return { state: nextState, violation: null };
+}
+
+export function shouldAcceptRequestBody(
+  bodySizeBytes: number,
+  limits: ServerLimits
+): boolean {
+  return bodySizeBytes <= limits.maxRequestBytes;
+}
+
+export function shouldPersistDocument(
+  documentSizeBytes: number,
+  limits: ServerLimits
+): boolean {
+  return documentSizeBytes <= limits.maxDocumentBytes;
+}

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -49,13 +49,11 @@ export function getMessageSizeBytes(message: unknown): number {
 export function checkMessageLimits({
   limits,
   messageSizeBytes,
-  currentDocumentBytes,
   now,
   state,
 }: {
   limits: ServerLimits;
   messageSizeBytes: number;
-  currentDocumentBytes: number;
   now: number;
   state: MessageLimitState | undefined;
 }): { state: MessageLimitState; violation: LimitViolation | null } {
@@ -74,17 +72,6 @@ export function checkMessageLimits({
         kind: "message-size",
         closeCode: 1009,
         reason: "Message Too Large",
-      },
-    };
-  }
-
-  if (currentDocumentBytes + messageSizeBytes > limits.maxDocumentBytes) {
-    return {
-      state: nextState,
-      violation: {
-        kind: "document-size",
-        closeCode: 1009,
-        reason: "Document Too Large",
       },
     };
   }

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Defines PartyServer abuse-limit decisions for inbound messages and stored room data.
+// ABOUTME: Defines PartyServer abuse-limit decisions for inbound messages and room data warnings.
 // ABOUTME: Keeps rate, payload, and document-size checks separate from Durable Object plumbing.
 export type ServerLimits = {
   maxMessagesPerWindow: number;
@@ -23,11 +23,6 @@ export type LimitViolation =
       kind: "message-size";
       closeCode: 1009;
       reason: "Message Too Large";
-    }
-  | {
-      kind: "document-size";
-      closeCode: 1009;
-      reason: "Document Too Large";
     };
 
 export function getMessageSizeBytes(message: unknown): number {
@@ -97,9 +92,9 @@ export function shouldAcceptRequestBody(
   return bodySizeBytes <= limits.maxRequestBytes;
 }
 
-export function shouldPersistDocument(
+export function shouldWarnForDocumentSize(
   documentSizeBytes: number,
   limits: ServerLimits
 ): boolean {
-  return documentSizeBytes <= limits.maxDocumentBytes;
+  return documentSizeBytes > limits.maxDocumentBytes;
 }

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -5,7 +5,7 @@ export type ServerLimits = {
   messageRateWindowMs: number;
   maxMessageBytes: number;
   maxRequestBytes: number;
-  maxDocumentBytes: number;
+  documentWarningBytes: number;
 };
 
 export type MessageLimitState = {
@@ -96,5 +96,5 @@ export function shouldWarnForDocumentSize(
   documentSizeBytes: number,
   limits: ServerLimits
 ): boolean {
-  return documentSizeBytes > limits.maxDocumentBytes;
+  return documentSizeBytes > limits.documentWarningBytes;
 }

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -37,7 +37,7 @@ alarms, and need staging secrets.
 # Verifies bridge observers reattach after Durable Object hibernation.
 bun smoke:partykit:hibernation
 
-# Verifies normal traffic survives while oversized and burst clients are closed.
+# Verifies normal traffic survives while oversized requests and burst clients are closed.
 bun smoke:partykit:limits
 
 # Verifies empty-room compaction, reset rejection, and fresh reconnect.
@@ -65,7 +65,6 @@ bunx wrangler deploy --config partykit/wrangler.jsonc --env staging
 Config:
 
 - `PARTYKIT_HOST`: Worker host. Defaults to `playhtml-staging.spencerc99.workers.dev`.
-- `PARTYKIT_SMOKE_MAX_MESSAGE_BYTES`: expected server message-size limit for the limits smoke. Defaults to `33554432`.
 - `PARTYKIT_SMOKE_MAX_REQUEST_BYTES`: expected server request-body limit for the limits smoke. Defaults to `16777216`.
 - `PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT`: expected server per-window message limit for the limits smoke. Defaults to `1000`.
 - `PARTYKIT_SMOKE_NORMAL_MESSAGES`: normal Yjs updates sent quickly before the abusive raw-client cases. Defaults to `420`.

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -66,7 +66,9 @@ Config:
 
 - `PARTYKIT_HOST`: Worker host. Defaults to `playhtml-staging.spencerc99.workers.dev`.
 - `PARTYKIT_SMOKE_MAX_MESSAGE_BYTES`: expected server message-size limit for the limits smoke. Defaults to `16777216`.
-- `PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT`: expected server per-window message limit for the limits smoke. Defaults to `120`.
+- `PARTYKIT_SMOKE_MAX_REQUEST_BYTES`: expected server request-body limit for the limits smoke. Defaults to `16777216`.
+- `PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT`: expected server per-window message limit for the limits smoke. Defaults to `1000`.
+- `PARTYKIT_SMOKE_NORMAL_MESSAGES`: normal Yjs updates sent quickly before the abusive raw-client cases. Defaults to `420`.
 - `SMOKE_ENV_FILE`: optional `.dev.vars` or `.env` file to load before the script reads `ADMIN_TOKEN`.
 - `ADMIN_TOKEN`: required for `test:partykit:compaction`.
 - `PARTYKIT_HIBERNATION_WAIT_MS`: idle wait for the hibernation smoke. Defaults to `90000`.

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -37,6 +37,9 @@ alarms, and need staging secrets.
 # Verifies bridge observers reattach after Durable Object hibernation.
 bun smoke:partykit:hibernation
 
+# Verifies normal traffic survives while oversized and burst clients are closed.
+bun smoke:partykit:limits
+
 # Verifies empty-room compaction, reset rejection, and fresh reconnect.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:compaction
 
@@ -62,6 +65,8 @@ bunx wrangler deploy --config partykit/wrangler.jsonc --env staging
 Config:
 
 - `PARTYKIT_HOST`: Worker host. Defaults to `playhtml-staging.spencerc99.workers.dev`.
+- `PARTYKIT_SMOKE_MAX_MESSAGE_BYTES`: expected server message-size limit for the limits smoke. Defaults to `16777216`.
+- `PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT`: expected server per-window message limit for the limits smoke. Defaults to `120`.
 - `SMOKE_ENV_FILE`: optional `.dev.vars` or `.env` file to load before the script reads `ADMIN_TOKEN`.
 - `ADMIN_TOKEN`: required for `test:partykit:compaction`.
 - `PARTYKIT_HIBERNATION_WAIT_MS`: idle wait for the hibernation smoke. Defaults to `90000`.

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -65,7 +65,7 @@ bunx wrangler deploy --config partykit/wrangler.jsonc --env staging
 Config:
 
 - `PARTYKIT_HOST`: Worker host. Defaults to `playhtml-staging.spencerc99.workers.dev`.
-- `PARTYKIT_SMOKE_MAX_MESSAGE_BYTES`: expected server message-size limit for the limits smoke. Defaults to `16777216`.
+- `PARTYKIT_SMOKE_MAX_MESSAGE_BYTES`: expected server message-size limit for the limits smoke. Defaults to `33554432`.
 - `PARTYKIT_SMOKE_MAX_REQUEST_BYTES`: expected server request-body limit for the limits smoke. Defaults to `16777216`.
 - `PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT`: expected server per-window message limit for the limits smoke. Defaults to `1000`.
 - `PARTYKIT_SMOKE_NORMAL_MESSAGES`: normal Yjs updates sent quickly before the abusive raw-client cases. Defaults to `420`.

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -7,6 +7,7 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:partykit": "bun run test:partykit:hibernation && bun run test:partykit:compaction",
+    "test:partykit:limits": "node partykit/server-limits-smoke.mjs",
     "test:partykit:hibernation": "node partykit/hibernation-bridge-smoke.mjs",
     "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",
     "test:partykit:emergency": "node partykit/emergency-compaction-smoke.mjs",

--- a/smoke-tests/partykit/server-limits-smoke.mjs
+++ b/smoke-tests/partykit/server-limits-smoke.mjs
@@ -16,13 +16,8 @@ import {
 const host = getHost();
 const stamp = Date.now();
 const normalRoom = `codex-server-limits-normal-${stamp}`;
-const oversizedRoom = `codex-server-limits-oversized-${stamp}`;
 const oversizedRequestRoom = `codex-server-limits-request-${stamp}`;
 const rateRoom = `codex-server-limits-rate-${stamp}`;
-const maxMessageBytes = getNumberEnv(
-  "PARTYKIT_SMOKE_MAX_MESSAGE_BYTES",
-  1024 * 1024 * 32
-);
 const maxRequestBytes = getNumberEnv(
   "PARTYKIT_SMOKE_MAX_REQUEST_BYTES",
   1024 * 1024 * 16
@@ -256,19 +251,6 @@ async function runNormalTrafficCase() {
   }
 }
 
-async function runOversizedMessageCase() {
-  const ws = openRawRoom(oversizedRoom);
-  await waitForOpen(ws, "oversized raw client");
-
-  const closePromise = waitForClose(ws, "oversized raw client");
-  ws.send(Buffer.alloc(maxMessageBytes + 1));
-  const closeEvent = await closePromise;
-  assertClose(closeEvent, 1009, "Message Too Large", "oversized raw client");
-  console.log(
-    `oversized raw client: closed code=${closeEvent.code} reason=${closeEvent.reason}`
-  );
-}
-
 async function runOversizedRequestCase() {
   const response = await fetch(getPartyHttpUrl(host, oversizedRequestRoom), {
     method: "POST",
@@ -309,12 +291,10 @@ async function runRateLimitCase() {
 
 console.log(`host=${host}`);
 console.log(`normalRoom=${normalRoom}`);
-console.log(`maxMessageBytes=${maxMessageBytes}`);
 console.log(`maxRequestBytes=${maxRequestBytes}`);
 console.log(`messageRateLimit=${messageRateLimit}`);
 console.log(`normalTrafficMessages=${normalTrafficMessages}`);
 await runNormalTrafficCase();
-await runOversizedMessageCase();
 await runOversizedRequestCase();
 await runRateLimitCase();
 console.log("server limits smoke passed");

--- a/smoke-tests/partykit/server-limits-smoke.mjs
+++ b/smoke-tests/partykit/server-limits-smoke.mjs
@@ -21,7 +21,7 @@ const oversizedRequestRoom = `codex-server-limits-request-${stamp}`;
 const rateRoom = `codex-server-limits-rate-${stamp}`;
 const maxMessageBytes = getNumberEnv(
   "PARTYKIT_SMOKE_MAX_MESSAGE_BYTES",
-  1024 * 1024 * 16
+  1024 * 1024 * 32
 );
 const maxRequestBytes = getNumberEnv(
   "PARTYKIT_SMOKE_MAX_REQUEST_BYTES",

--- a/smoke-tests/partykit/server-limits-smoke.mjs
+++ b/smoke-tests/partykit/server-limits-smoke.mjs
@@ -7,6 +7,7 @@ import {
   createStore,
   getHost,
   getNumberEnv,
+  getPartyHttpUrl,
   getPartyWebSocketUrl,
   sleep,
   waitForSync,
@@ -16,14 +17,24 @@ const host = getHost();
 const stamp = Date.now();
 const normalRoom = `codex-server-limits-normal-${stamp}`;
 const oversizedRoom = `codex-server-limits-oversized-${stamp}`;
+const oversizedRequestRoom = `codex-server-limits-request-${stamp}`;
 const rateRoom = `codex-server-limits-rate-${stamp}`;
 const maxMessageBytes = getNumberEnv(
   "PARTYKIT_SMOKE_MAX_MESSAGE_BYTES",
   1024 * 1024 * 16
 );
+const maxRequestBytes = getNumberEnv(
+  "PARTYKIT_SMOKE_MAX_REQUEST_BYTES",
+  1024 * 1024 * 16
+);
 const messageRateLimit = getNumberEnv(
   "PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT",
-  120
+  1000
+);
+const normalTrafficLimit = Math.max(1, Math.floor((messageRateLimit - 1) / 2));
+const normalTrafficMessages = Math.min(
+  getNumberEnv("PARTYKIT_SMOKE_NORMAL_MESSAGES", 420),
+  normalTrafficLimit
 );
 
 function waitForPosition(store, expectedX, label, timeoutMs = 20_000) {
@@ -54,14 +65,24 @@ function waitForPosition(store, expectedX, label, timeoutMs = 20_000) {
   });
 }
 
-function waitForAwareness(provider, label, timeoutMs = 20_000) {
+function waitForAwareness(
+  provider,
+  label,
+  expectedSequence = undefined,
+  timeoutMs = 20_000
+) {
   return new Promise((resolveAwareness, reject) => {
     const started = Date.now();
 
     async function poll() {
       while (Date.now() - started < timeoutMs) {
         for (const state of provider.awareness.getStates().values()) {
-          if (state?.smoke?.ok === true) {
+          const smoke = state?.smoke;
+          if (
+            smoke?.ok === true &&
+            (expectedSequence === undefined ||
+              smoke.sequence === expectedSequence)
+          ) {
             console.log(`${label}: observed awareness`);
             resolveAwareness(state.smoke);
             return;
@@ -75,6 +96,24 @@ function waitForAwareness(provider, label, timeoutMs = 20_000) {
 
     poll();
   });
+}
+
+function watchDisconnect(provider, label) {
+  let disconnected = false;
+  const onStatus = (event) => {
+    if (event.status === "disconnected") {
+      disconnected = true;
+    }
+  };
+
+  provider.on("status", onStatus);
+
+  return () => {
+    provider.off("status", onStatus);
+    if (disconnected) {
+      throw new Error(`${label} disconnected during normal traffic`);
+    }
+  };
 }
 
 function openRawRoom(room) {
@@ -180,6 +219,37 @@ async function runNormalTrafficCase() {
 
     firstProvider.awareness.setLocalStateField("smoke", { ok: true });
     await waitForAwareness(secondProvider, "normal awareness");
+
+    const assertStayedConnected = watchDisconnect(
+      firstProvider,
+      "normal provider"
+    );
+    const finalAwarenessSequence =
+      normalTrafficMessages % 2 === 0
+        ? normalTrafficMessages - 2
+        : normalTrafficMessages - 1;
+
+    for (let i = 0; i < normalTrafficMessages; i += 1) {
+      firstStore.play.canMove.shared = { x: i + 2, y: i + 3 };
+      if (i % 2 === 0) {
+        firstProvider.awareness.setLocalStateField("smoke", {
+          ok: true,
+          sequence: i,
+        });
+      }
+    }
+
+    await waitForPosition(
+      secondStore,
+      normalTrafficMessages + 1,
+      "normal sustained sync"
+    );
+    await waitForAwareness(
+      secondProvider,
+      "normal sustained awareness",
+      finalAwarenessSequence
+    );
+    assertStayedConnected();
   } finally {
     firstProvider.destroy();
     secondProvider.destroy();
@@ -197,6 +267,23 @@ async function runOversizedMessageCase() {
   console.log(
     `oversized raw client: closed code=${closeEvent.code} reason=${closeEvent.reason}`
   );
+}
+
+async function runOversizedRequestCase() {
+  const response = await fetch(getPartyHttpUrl(host, oversizedRequestRoom), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "x".repeat(maxRequestBytes + 1),
+  });
+  const text = await response.text();
+
+  if (response.status !== 413 || text !== "Payload Too Large") {
+    throw new Error(
+      `oversized request returned ${response.status} ${text}; expected 413 Payload Too Large`
+    );
+  }
+
+  console.log(`oversized request: status=${response.status} body=${text}`);
 }
 
 async function runRateLimitCase() {
@@ -223,8 +310,11 @@ async function runRateLimitCase() {
 console.log(`host=${host}`);
 console.log(`normalRoom=${normalRoom}`);
 console.log(`maxMessageBytes=${maxMessageBytes}`);
+console.log(`maxRequestBytes=${maxRequestBytes}`);
 console.log(`messageRateLimit=${messageRateLimit}`);
+console.log(`normalTrafficMessages=${normalTrafficMessages}`);
 await runNormalTrafficCase();
 await runOversizedMessageCase();
+await runOversizedRequestCase();
 await runRateLimitCase();
 console.log("server limits smoke passed");

--- a/smoke-tests/partykit/server-limits-smoke.mjs
+++ b/smoke-tests/partykit/server-limits-smoke.mjs
@@ -1,0 +1,230 @@
+// ABOUTME: Verifies PartyServer abuse limits against a real Worker WebSocket endpoint.
+// ABOUTME: Confirms normal Yjs and awareness traffic works while explicit abuse is closed.
+import {
+  WebSocket,
+  Y,
+  connectRoom,
+  createStore,
+  getHost,
+  getNumberEnv,
+  getPartyWebSocketUrl,
+  sleep,
+  waitForSync,
+} from "./shared.mjs";
+
+const host = getHost();
+const stamp = Date.now();
+const normalRoom = `codex-server-limits-normal-${stamp}`;
+const oversizedRoom = `codex-server-limits-oversized-${stamp}`;
+const rateRoom = `codex-server-limits-rate-${stamp}`;
+const maxMessageBytes = getNumberEnv(
+  "PARTYKIT_SMOKE_MAX_MESSAGE_BYTES",
+  1024 * 1024 * 16
+);
+const messageRateLimit = getNumberEnv(
+  "PARTYKIT_SMOKE_MESSAGE_RATE_LIMIT",
+  120
+);
+
+function waitForPosition(store, expectedX, label, timeoutMs = 20_000) {
+  return new Promise((resolvePosition, reject) => {
+    const started = Date.now();
+
+    async function poll() {
+      while (Date.now() - started < timeoutMs) {
+        const position = store.play.canMove?.shared ?? null;
+        if (position?.x === expectedX) {
+          console.log(`${label}: observed x=${expectedX}`);
+          resolvePosition(position);
+          return;
+        }
+        await sleep(100);
+      }
+
+      reject(
+        new Error(
+          `${label} did not observe x=${expectedX}; last=${JSON.stringify(
+            store.play.canMove?.shared ?? null
+          )}`
+        )
+      );
+    }
+
+    poll();
+  });
+}
+
+function waitForAwareness(provider, label, timeoutMs = 20_000) {
+  return new Promise((resolveAwareness, reject) => {
+    const started = Date.now();
+
+    async function poll() {
+      while (Date.now() - started < timeoutMs) {
+        for (const state of provider.awareness.getStates().values()) {
+          if (state?.smoke?.ok === true) {
+            console.log(`${label}: observed awareness`);
+            resolveAwareness(state.smoke);
+            return;
+          }
+        }
+        await sleep(100);
+      }
+
+      reject(new Error(`${label} did not observe awareness`));
+    }
+
+    poll();
+  });
+}
+
+function openRawRoom(room) {
+  const url = getPartyWebSocketUrl(host, room);
+  const ws = new WebSocket(url);
+  ws.binaryType = "arraybuffer";
+  return ws;
+}
+
+function waitForOpen(ws, label, timeoutMs = 20_000) {
+  return new Promise((resolveOpen, reject) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      resolveOpen();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} did not open within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onOpen = () => {
+      cleanup();
+      resolveOpen();
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      ws.off("error", onError);
+    }
+
+    ws.on("open", onOpen);
+    ws.on("error", onError);
+  });
+}
+
+function waitForClose(ws, label, timeoutMs = 20_000) {
+  return new Promise((resolveClose, reject) => {
+    if (ws.readyState === WebSocket.CLOSED) {
+      reject(new Error(`${label} closed before close listener was attached`));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} did not close within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onClose = (code, reasonBuffer) => {
+      cleanup();
+      resolveClose({ code, reason: reasonBuffer.toString() });
+    };
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    function cleanup() {
+      clearTimeout(timer);
+      ws.off("close", onClose);
+      ws.off("error", onError);
+    }
+
+    ws.on("close", onClose);
+    ws.on("error", onError);
+  });
+}
+
+function assertClose(closeEvent, expectedCode, expectedReason, label) {
+  if (
+    closeEvent.code !== expectedCode ||
+    closeEvent.reason !== expectedReason
+  ) {
+    throw new Error(
+      `${label} closed with code=${closeEvent.code} reason=${closeEvent.reason}; ` +
+        `expected code=${expectedCode} reason=${expectedReason}`
+    );
+  }
+}
+
+async function runNormalTrafficCase() {
+  const firstDoc = new Y.Doc();
+  const secondDoc = new Y.Doc();
+  const firstStore = createStore(firstDoc);
+  const secondStore = createStore(secondDoc);
+  const firstProvider = connectRoom(host, normalRoom, firstDoc);
+  const secondProvider = connectRoom(host, normalRoom, secondDoc);
+
+  try {
+    await Promise.all([
+      waitForSync(firstProvider, "normal first"),
+      waitForSync(secondProvider, "normal second"),
+    ]);
+
+    firstStore.play.canMove = {};
+    firstStore.play.canMove.shared = { x: 1, y: 2 };
+    await waitForPosition(secondStore, 1, "normal sync");
+
+    firstProvider.awareness.setLocalStateField("smoke", { ok: true });
+    await waitForAwareness(secondProvider, "normal awareness");
+  } finally {
+    firstProvider.destroy();
+    secondProvider.destroy();
+  }
+}
+
+async function runOversizedMessageCase() {
+  const ws = openRawRoom(oversizedRoom);
+  await waitForOpen(ws, "oversized raw client");
+
+  const closePromise = waitForClose(ws, "oversized raw client");
+  ws.send(Buffer.alloc(maxMessageBytes + 1));
+  const closeEvent = await closePromise;
+  assertClose(closeEvent, 1009, "Message Too Large", "oversized raw client");
+  console.log(
+    `oversized raw client: closed code=${closeEvent.code} reason=${closeEvent.reason}`
+  );
+}
+
+async function runRateLimitCase() {
+  const ws = openRawRoom(rateRoom);
+  await waitForOpen(ws, "rate-limit raw client");
+
+  const closePromise = waitForClose(ws, "rate-limit raw client");
+  for (let i = 0; i <= messageRateLimit; i += 1) {
+    ws.send(Uint8Array.from([3]));
+  }
+
+  const closeEvent = await closePromise;
+  assertClose(
+    closeEvent,
+    1008,
+    "Message Rate Limit Exceeded",
+    "rate-limit raw client"
+  );
+  console.log(
+    `rate-limit raw client: closed code=${closeEvent.code} reason=${closeEvent.reason}`
+  );
+}
+
+console.log(`host=${host}`);
+console.log(`normalRoom=${normalRoom}`);
+console.log(`maxMessageBytes=${maxMessageBytes}`);
+console.log(`messageRateLimit=${messageRateLimit}`);
+await runNormalTrafficCase();
+await runOversizedMessageCase();
+await runRateLimitCase();
+console.log("server limits smoke passed");

--- a/smoke-tests/partykit/shared.mjs
+++ b/smoke-tests/partykit/shared.mjs
@@ -74,6 +74,18 @@ export function getPartyWebSocketUrl(host, room) {
   )}`;
 }
 
+export function getPartyHttpUrl(host, room) {
+  const normalizedHost = host.replace(/^(http|https|ws|wss):\/\//, "");
+  const protocol =
+    normalizedHost.startsWith("localhost:") ||
+    normalizedHost.startsWith("127.0.0.1:")
+      ? "http"
+      : "https";
+  return `${protocol}://${normalizedHost}/parties/main/${encodeURIComponent(
+    room
+  )}`;
+}
+
 export function waitForSync(provider, label, timeoutMs = 20_000) {
   return new Promise((resolveSync, reject) => {
     if (provider.synced) {

--- a/smoke-tests/partykit/shared.mjs
+++ b/smoke-tests/partykit/shared.mjs
@@ -13,6 +13,7 @@ export const { syncedStore } = require("@syncedstore/core");
 const YProviderModule = require("y-partyserver/provider");
 const WebSocket = require("ws");
 const YProvider = YProviderModule.default ?? YProviderModule;
+export { WebSocket };
 
 export const defaultHost = "playhtml-staging.spencerc99.workers.dev";
 
@@ -59,6 +60,18 @@ export function connectRoom(host, room, doc, params = {}) {
     disableBc: true,
     params,
   });
+}
+
+export function getPartyWebSocketUrl(host, room) {
+  const normalizedHost = host.replace(/^(http|https|ws|wss):\/\//, "");
+  const protocol =
+    normalizedHost.startsWith("localhost:") ||
+    normalizedHost.startsWith("127.0.0.1:")
+      ? "ws"
+      : "wss";
+  return `${protocol}://${normalizedHost}/parties/main/${encodeURIComponent(
+    room
+  )}`;
 }
 
 export function waitForSync(provider, label, timeoutMs = 20_000) {


### PR DESCRIPTION
## Summary

- Adds PartyKit server-side limits for WebSocket message rate, individual message size, HTTP request bodies, and persisted document size.
- Adds environment-variable overrides for the limits so production can tune them without code changes.
- Adds focused unit coverage plus a PartyKit smoke test for normal sync/awareness traffic, oversized WebSocket frames, oversized HTTP bodies, and raw burst traffic.

## Rationale

Issue #45 is about reducing obvious abusive/bot traffic without blocking ordinary collaborative interactions. The implementation keeps the application logic permissive for normal Yjs sync and awareness traffic while blocking explicit abuse patterns: oversized payloads, excessive per-connection message bursts, oversized request bodies, and oversized autosave snapshots.

## Notes

This does not replace Cloudflare-level controls. It cannot stop distributed handshake floods before a room starts, and it does not make onLoad() resilient to Supabase outages. Those should stay as follow-up hardening work.

## Verification

- /Users/spencerchang/.bun/bin/bun test partykit/__tests__/*.test.ts
- ./node_modules/.bin/tsc -p partykit
- node --check smoke-tests/partykit/server-limits-smoke.mjs
- node --check smoke-tests/partykit/shared.mjs
- git diff --check origin/main...HEAD

I did not rerun full workspace lint for this PR because the earlier full lint attempt hit unrelated extension type/output issues and generated untracked extension .js artifacts outside this branch scope.