### PR TITLE
presence: aggregate multi-tab awareness entries deterministically

### DIFF
--- a/.changeset/presence-multi-tab.md
+++ b/.changeset/presence-multi-tab.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Fix `playhtml.presence.getPresences()` collapsing multi-tab awareness entries non-deterministically. When a user has the site open in multiple tabs, all tabs share one publicKey (stableId) but have distinct clientIDs. The previous implementation overwrote in iteration order, so a backgrounded tab's `active: false` could clobber the foreground tab's `active: true` in the consumer's view. Self now always reflects the local tab's state; remote peers with multiple tabs are collapsed deterministically (highest clientID wins).

--- a/packages/playhtml/src/__tests__/presence-multitab.test.ts
+++ b/packages/playhtml/src/__tests__/presence-multitab.test.ts
@@ -1,0 +1,133 @@
+// ABOUTME: Tests that createPresenceAPI correctly collapses multiple awareness
+// ABOUTME: entries for the same user (multi-tab) into one deterministic view.
+
+import { describe, it, expect } from "vitest";
+import { createPresenceAPI } from "../presence";
+import type { PlayerIdentity } from "@playhtml/common";
+
+const CURSOR_FIELD = "__playhtml_cursors__";
+const PRESENCE_FIELD = "__presence__";
+
+interface MockAwareness {
+  clientID: number;
+  states: Map<number, Record<string, unknown>>;
+  getStates(): Map<number, Record<string, unknown>>;
+  getLocalState(): Record<string, unknown> | null;
+  setLocalStateField(field: string, value: unknown): void;
+  on(event: string, cb: (...args: unknown[]) => void): void;
+}
+
+function makeAwareness(clientID: number): MockAwareness {
+  const states = new Map<number, Record<string, unknown>>();
+  states.set(clientID, {});
+  return {
+    clientID,
+    states,
+    getStates: () => states,
+    getLocalState: () => states.get(clientID) ?? null,
+    setLocalStateField(field, value) {
+      const cur = states.get(clientID) ?? {};
+      states.set(clientID, { ...cur, [field]: value });
+    },
+    on() {},
+  };
+}
+
+function makeIdentity(publicKey: string): PlayerIdentity {
+  return {
+    publicKey,
+    playerStyle: { colorPalette: ["#000"] },
+  } as PlayerIdentity;
+}
+
+function withCursor(identity: PlayerIdentity, presence?: Record<string, unknown>) {
+  const state: Record<string, unknown> = {
+    [CURSOR_FIELD]: { playerIdentity: identity, cursor: null },
+  };
+  if (presence) state[PRESENCE_FIELD] = presence;
+  return state;
+}
+
+describe("createPresenceAPI multi-tab aggregation", () => {
+  it("collapses two of my tabs into one entry that reflects my local tab's state", () => {
+    // Local tab broadcast active=true; my other tab broadcast active=false.
+    // Reading from the local tab, my entry should show active=true.
+    const awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_me");
+    awareness.states.set(1, withCursor(identity, { active: true }));
+    awareness.states.set(2, withCursor(identity, { active: false }));
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => identity,
+    });
+
+    const presences = api.getPresences();
+    expect(presences.size).toBe(1);
+    const me = presences.get("pk_me")!;
+    expect(me.isMe).toBe(true);
+    expect((me as any).active).toBe(true);
+  });
+
+  it("self entry is deterministic regardless of which clientID iterates last", () => {
+    // Reverse insertion order: remote tab inserted before local. The previous
+    // implementation overwrote self with the later-iterated entry — fixed now.
+    const awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_me");
+    awareness.states.set(2, withCursor(identity, { active: false }));
+    awareness.states.set(1, withCursor(identity, { active: true }));
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => identity,
+    });
+
+    const me = api.getPresences().get("pk_me")!;
+    expect(me.isMe).toBe(true);
+    expect((me as any).active).toBe(true);
+  });
+
+  it("collapses two tabs of a remote peer deterministically (highest clientID wins)", () => {
+    // Remote peer "pk_remote" has two tabs. We pick the highest clientID so
+    // results are stable across calls, independent of Map iteration order.
+    const awareness = makeAwareness(1);
+    const localIdentity = makeIdentity("pk_me");
+    const remoteIdentity = makeIdentity("pk_remote");
+    awareness.states.set(5, withCursor(remoteIdentity, { page: "/old" }));
+    awareness.states.set(7, withCursor(remoteIdentity, { page: "/new" }));
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => localIdentity,
+    });
+
+    const remote = api.getPresences().get("pk_remote")!;
+    expect(remote.isMe).toBe(false);
+    expect((remote as any).page).toBe("/new");
+
+    // Insertion order swapped — result must be identical.
+    awareness.states.clear();
+    awareness.states.set(1, {});
+    awareness.states.set(7, withCursor(remoteIdentity, { page: "/new" }));
+    awareness.states.set(5, withCursor(remoteIdentity, { page: "/old" }));
+    const remoteAgain = api.getPresences().get("pk_remote")!;
+    expect((remoteAgain as any).page).toBe("/new");
+  });
+
+  it("single-tab users are unaffected", () => {
+    const awareness = makeAwareness(1);
+    const localIdentity = makeIdentity("pk_me");
+    awareness.states.set(1, withCursor(localIdentity, { active: true }));
+    awareness.states.set(2, withCursor(makeIdentity("pk_other"), { active: false }));
+
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => localIdentity,
+    });
+
+    const presences = api.getPresences();
+    expect(presences.size).toBe(2);
+    expect((presences.get("pk_me") as any).active).toBe(true);
+    expect((presences.get("pk_other") as any).active).toBe(false);
+  });
+});

--- a/packages/playhtml/src/presence.ts
+++ b/packages/playhtml/src/presence.ts
@@ -147,16 +147,41 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
     const awareness = getAwareness();
     const states = awareness.getStates();
     const myClientId = awareness.clientID;
+    const mySelfStableId = getSelfStableId();
     let selfSeen = false;
 
+    // Multiple tabs of the same user share a publicKey (stableId) but have
+    // distinct clientIDs. When collapsing into one entry per stableId:
+    //  - For self: always prefer the local clientID's state so the consumer
+    //    sees what THIS tab broadcast, not a non-deterministic other tab.
+    //  - For remote peers: prefer the highest clientID, a stable tiebreaker
+    //    that avoids flapping based on Map iteration order.
+    const winningClientIdByStableId = new Map<string, number>();
     states.forEach((state: Record<string, unknown>, clientId: number) => {
-      const isMe = clientId === myClientId;
-      if (isMe) selfSeen = true;
-
       const stableId = getStableIdForAwareness(state, clientId);
-      const view = buildViewFromState(state, isMe);
-      presences.set(stableId, view);
+      const isSelf = stableId === mySelfStableId;
+      const existing = winningClientIdByStableId.get(stableId);
+      if (existing === undefined) {
+        winningClientIdByStableId.set(stableId, clientId);
+        return;
+      }
+      // Self always wins via the local clientID
+      if (isSelf && clientId === myClientId) {
+        winningClientIdByStableId.set(stableId, clientId);
+        return;
+      }
+      if (isSelf && existing === myClientId) return;
+      // Remote: highest clientID wins
+      if (clientId > existing) winningClientIdByStableId.set(stableId, clientId);
     });
+
+    for (const [stableId, clientId] of winningClientIdByStableId) {
+      const state = states.get(clientId);
+      if (!state) continue;
+      const isMe = stableId === mySelfStableId;
+      if (isMe) selfSeen = true;
+      presences.set(stableId, buildViewFromState(state, isMe));
+    }
 
     // Ensure self is always present even if awareness hasn't synced
     if (!selfSeen) {
@@ -164,7 +189,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
       const view = buildViewFromState(localState, true);
       // Use identity for playerIdentity since cursor state may not be set
       view.playerIdentity = deps.getPlayerIdentity();
-      presences.set(getSelfStableId(), view);
+      presences.set(mySelfStableId, view);
     }
 
     return presences;


### PR DESCRIPTION
## Summary

When a user has the site open in multiple tabs, every tab shares one `publicKey` (stableId) but has its own clientID in awareness. `getPresences()` was collapsing them via `presences.set(stableId, view)` in iteration order — so a backgrounded tab's `active: false` could overwrite the foreground tab's `active: true`, non-deterministically across calls. The reporter (Spencer's website Stats trinket) saw his own dot stuck faded because a second open tab won the collapse.

This PR collapses multiple awareness entries per stableId with a deterministic policy:
- **Self**: the local clientID's state always wins, so consumers see what THIS tab broadcast.
- **Remote peers**: highest clientID wins — a stable tiebreaker that doesn't depend on Map iteration order. (Not perfect — we don't know which of a remote user's tabs is "primary" — but at least it stops flapping.)

Single-tab users are unaffected.

## Test plan

- [x] Added `presence-multitab.test.ts` with 4 cases: self-with-multiple-tabs, iteration-order independence, remote multi-tab determinism, single-tab regression.
- [x] Verified all 3 new cases fail on `main` and pass with the fix.
- [x] Full `bun run test` in `packages/playhtml` — 178 tests pass.