### PR TITLE
prevent stacked milestone toasts

### DIFF
--- a/extension/src/__tests__/content-milestone-toast.test.ts
+++ b/extension/src/__tests__/content-milestone-toast.test.ts
@@ -1,0 +1,130 @@
+// ABOUTME: Regression tests for milestone toast handling in the content script.
+// ABOUTME: Verifies repeated milestone messages replace the visible injected UI.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        get: vi.fn().mockImplementation((keys: string | string[]) => {
+          if (!Array.isArray(keys)) return Promise.resolve({});
+
+          return Promise.resolve(
+            Object.fromEntries(
+              keys
+                .filter((key) => key.startsWith("migration_v1_done_"))
+                .map((key) => [key, true]),
+            ),
+          );
+        }),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+      },
+    },
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      sendMessage: vi.fn().mockResolvedValue({}),
+      onMessage: {
+        addListener: vi.fn(),
+      },
+    },
+    tabs: {
+      query: vi.fn().mockResolvedValue([{ id: 1, url: "https://example.com" }]),
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    },
+  },
+}));
+
+vi.mock("../flags", () => ({
+  FLAGS: { COPRESENCE: false },
+}));
+
+vi.mock("playhtml", () => ({
+  playhtml: {
+    init: vi.fn().mockResolvedValue(undefined),
+    createPageData: vi.fn(),
+    createPresenceRoom: vi.fn(),
+    presence: {},
+    cursorClient: {},
+  },
+}));
+
+vi.mock("../collectors/CollectorManager", () => ({
+  CollectorManager: class {
+    registerCollector = vi.fn();
+    init = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn();
+    pauseAll = vi.fn();
+    resumeAll = vi.fn();
+    getCollectorStatuses = vi.fn(() => []);
+    disableCollector = vi.fn().mockResolvedValue(undefined);
+    enableCollector = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock("../collectors/CursorCollector", () => ({
+  CursorCollector: class {},
+}));
+
+vi.mock("../collectors/NavigationCollector", () => ({
+  NavigationCollector: class {},
+}));
+
+vi.mock("../collectors/ViewportCollector", () => ({
+  ViewportCollector: class {},
+}));
+
+vi.mock("../collectors/KeyboardCollector", () => ({
+  KeyboardCollector: class {},
+}));
+
+const milestone = {
+  type: "sitesExplored",
+  threshold: 10,
+  displayValue: "10",
+  copy: "You crossed 10 sites.",
+  ctaLabel: "see your portrait",
+  ctaAction: "OPEN_PORTRAIT",
+  period: "alltime",
+} as const;
+
+describe("content milestone toasts", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 0));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    document.body.innerHTML = "";
+  });
+
+  it("replaces the existing milestone toast when another milestone arrives", async () => {
+    const browser = (await import("webextension-polyfill")).default;
+    const contentScript = (await import("../entrypoints/content")).default as {
+      main: () => void;
+    };
+
+    contentScript.main();
+
+    const addListener = vi.mocked(browser.runtime.onMessage.addListener);
+    const listener = addListener.mock.calls[0][0];
+    const sendResponse = vi.fn();
+
+    listener({ type: "SHOW_MILESTONE", milestone }, {}, sendResponse);
+
+    expect(document.body.childElementCount).toBe(1);
+
+    listener(
+      {
+        type: "SHOW_MILESTONE",
+        milestone: { ...milestone, copy: "You crossed another milestone." },
+      },
+      {},
+      sendResponse,
+    );
+
+    expect(document.body.childElementCount).toBe(1);
+  });
+});

--- a/extension/src/__tests__/participant.test.ts
+++ b/extension/src/__tests__/participant.test.ts
@@ -34,6 +34,7 @@ describe("participant storage fallbacks", () => {
 
   it("uses a stable in-memory sid when browser.storage.session is unavailable", async () => {
     installCryptoWithoutRandomUuid();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.doMock("webextension-polyfill", () => ({
       default: {
         storage: {
@@ -50,10 +51,15 @@ describe("participant storage fallbacks", () => {
 
     expect(first.startsWith("sid_")).toBe(true);
     expect(first).toBe(second);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      "[Participant] browser.storage.session unavailable; using in-memory session id",
+    );
   });
 
   it("falls back to generated participant id without crypto.randomUUID", async () => {
     installCryptoWithoutRandomUuid();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.doMock("webextension-polyfill", () => ({
       default: {
         storage: {
@@ -69,5 +75,7 @@ describe("participant storage fallbacks", () => {
 
     expect(pid.startsWith("pk_temp_")).toBe(true);
     expect(pid.length).toBeGreaterThan("pk_temp_".length + 8);
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith("Failed to get participant ID:", expect.any(Error));
   });
 });

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -1032,6 +1032,7 @@ export default defineContentScript({
     let extensionInstance: PlayHTMLExtension | null = null;
     let collectorManager: CollectorManager | null = null;
     let overlayUI: InjectedReactUI | null = null;
+    let milestoneToastUI: InjectedReactUI | null = null;
     let overlayVisible = false;
 
     const toggleHistoricalOverlay = async () => {
@@ -1198,6 +1199,8 @@ export default defineContentScript({
     });
 
     const showMilestoneToast = (milestone: MilestoneToastData): void => {
+      milestoneToastUI?.destroy();
+
       let ui: InjectedReactUI | null = null;
 
       const handleCta = (action: MilestoneToastData["ctaAction"]) => {
@@ -1213,6 +1216,9 @@ export default defineContentScript({
 
       const handleDismiss = () => {
         ui?.destroy();
+        if (milestoneToastUI === ui) {
+          milestoneToastUI = null;
+        }
         ui = null;
       };
 
@@ -1231,6 +1237,7 @@ export default defineContentScript({
           fontUrl: MILESTONE_TOAST_FONT_URL,
         },
       );
+      milestoneToastUI = ui;
     };
 
     // Listen for messages from popup/devtools

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -12,6 +12,8 @@
       "@@/*": ["./*"],
       "~~": ["."],
       "~~/*": ["./*"],
+      "@extension": ["./src"],
+      "@extension/*": ["./src/*"],
       "@movement/*": ["./website/shared/*"]
     }
   },

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -6,9 +6,21 @@ import { fileURLToPath } from "url";
 
 const rootDir = fileURLToPath(new URL(".", import.meta.url));
 const setupFile = fileURLToPath(new URL("./vitest.setup.ts", import.meta.url));
+const extensionSource = fileURLToPath(new URL("./src", import.meta.url));
+const playhtmlSource = fileURLToPath(new URL("../packages/playhtml/src/index.ts", import.meta.url));
+const extensionTypesSource = fileURLToPath(
+  new URL("../packages/extension-types/src/index.ts", import.meta.url),
+);
 
 export default defineConfig({
   root: rootDir,
+  resolve: {
+    alias: {
+      "@extension": extensionSource,
+      playhtml: playhtmlSource,
+      "@playhtml/extension-types": extensionTypesSource,
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,3 +1,6 @@
+// ABOUTME: WXT build configuration for the browser extension.
+// ABOUTME: Defines manifest metadata, output settings, and Vite aliases.
+
 import { defineConfig } from "wxt";
 import path from "path";
 
@@ -44,6 +47,7 @@ export default defineConfig({
     },
     resolve: {
       alias: {
+        "@extension": path.resolve(__dirname, "src"),
         "@movement": path.resolve(__dirname, "website/shared"),
       },
     },


### PR DESCRIPTION
## Summary
- Keep a single active milestone toast instance in the content script and destroy the previous toast before showing another one.
- Add a regression test that sends two milestone messages and verifies only one injected toast host remains.
- Align extension test/build aliases for @extension and workspace package source resolution.

## Root Cause
The content script stored the injected milestone toast UI handle inside showMilestoneToast, so each SHOW_MILESTONE message lost access to the previous toast and left it mounted underneath the next one.

## Validation
- bun run test --run from extension passed: 11 files, 120 tests.
- bun run build from extension passed using Homebrew Node in PATH; build still reports the existing Sass @import deprecation warning from website/shared/portrait-styles.scss.