### PR TITLE
Wikipedia article chat + announcement system

### DIFF
--- a/.changeset/presence-replay-on-subscribe.md
+++ b/.changeset/presence-replay-on-subscribe.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+`presence.onPresenceChange` now replays the current presence snapshot to the callback immediately on subscribe, instead of waiting for the next awareness change. Late subscribers previously missed state that peers had already broadcast — for example, a peer who set a presence field before you joined the room would stay invisible to your listener until they changed it again.

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "@playhtml/react": "workspace:*",
         "html2canvas": "^1.4.1",
         "playhtml": "workspace:*",
+        "profane-words": "^1.5.11",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "webextension-polyfill": "^0.12.0",
@@ -152,7 +153,7 @@
     },
     "packages/extension-types": {
       "name": "@playhtml/extension-types",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "devDependencies": {
         "typescript": "^5.0.2",
         "vite": "^7.1.2",

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -12,3 +12,4 @@ Format suggestion: "- short user-facing description (#PR)"
 - Wikipedia chat: a small chat panel on every Wikipedia page lets you talk live with whoever else is reading the same article. Open it from the presence pill or by pressing `/`. You get a random Wikipedia-article name (rerollable); names link to their article and show a hovercard preview on hover. Messages are live-only and never stored.
 - Remote cursors now dim when a person's tab is blurred or hidden, so you can tell who's actively present.
 - Announcements: important updates now surface as a page toast and a dismissible "from spencer" postcard in the popup, so you don't miss new features.
+- Updated the store description to mention the social features (see who's here, Wikipedia chat).

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -12,4 +12,4 @@ Format suggestion: "- short user-facing description (#PR)"
 - Wikipedia chat: a small chat panel on every Wikipedia page lets you talk live with whoever else is reading the same article. Open it from the presence pill or by pressing `/`. You get a random Wikipedia-article name (rerollable); names link to their article and show a hovercard preview on hover. Messages are live-only and never stored.
 - Remote cursors now dim when a person's tab is blurred or hidden, so you can tell who's actively present.
 - Announcements: important updates now surface as a page toast and a dismissible "from spencer" postcard in the popup, so you don't miss new features.
-- Updated the store description to mention the social features (see who's here, Wikipedia chat).
+- Updated the store description to mention the social features (see who's here, Wikipedia chat); added `STORE_LISTING.md` with the full Chrome + Firefox listing copy.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -8,3 +8,7 @@ file back to just the header. Merge that PR to ship.
 
 Format suggestion: "- short user-facing description (#PR)"
 -->
+
+- Wikipedia chat: a small chat panel on every Wikipedia page lets you talk live with whoever else is reading the same article. Open it from the presence pill or by pressing `/`. You get a random Wikipedia-article name (rerollable); names link to their article and show a hovercard preview on hover. Messages are live-only and never stored.
+- Remote cursors now dim when a person's tab is blurred or hidden, so you can tell who's actively present.
+- Announcements: important updates now surface as a page toast and a dismissible "from spencer" postcard in the popup, so you don't miss new features.

--- a/extension/README.md
+++ b/extension/README.md
@@ -2,6 +2,8 @@
 
 A quiet portrait of your time on the internet. This Chrome extension collects traces of how you move, click, scroll, and type across the web, then renders them as living visualizations.
 
+It's also quietly social: see who else is reading the same page, watch their cursors, and — on Wikipedia — chat live with the people there under a random article-name of your choosing. See it in action: [demo on Instagram](https://www.instagram.com/p/DYpRnRAORbE/).
+
 ## Install (closed beta)
 
 1. Download and unzip the extension build

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -1,0 +1,88 @@
+# Store listing copy
+
+Canonical source for the long marketing description shown on the Chrome Web
+Store and Firefox AMO listings. These fields are edited directly in each
+store's developer dashboard (the `wxt submit` flow only uploads the build +
+manifest, not this copy), so this file is the version-controlled record —
+edit here, then paste into the dashboards.
+
+The short manifest description (≤132 chars, shown in search results) lives in
+`wxt.config.ts`, not here.
+
+---
+
+## Chrome Web Store — full description
+
+Chrome renders this field as **plain text** (no markdown, URLs are not
+clickable). Paste exactly as-is.
+
+```
+we were online
+
+A quiet portrait of your time on the internet — and the people quietly there with you.
+
+we were online collects gentle traces of how you move, click, scroll, and type across the web, then renders them as living visualizations: cursor-trail portraits, typing rhythms, the shape of a day's browsing. It's a keepsake of your time online, made from the small motions you never think about.
+
+It's also quietly social. When others with the extension are on the same page, you'll see their cursors drift alongside yours and a small count of who else is here. On Wikipedia, it goes further: a little chat panel lets you talk live with whoever else is reading the same article. Pick a random Wikipedia article as your name (reroll until one feels right), and wander the encyclopedia together. Messages are live-only — nothing is stored.
+
+See it in action: https://www.instagram.com/p/DYpRnRAORbE/
+
+WHAT IT CAPTURES
+- Cursor movement, clicks, and holds
+- Typing cadence and rhythm (text is abstracted by default — we capture the shape of typing, not what you wrote)
+- Navigation: page transitions and screen time
+- Scroll, resize, and zoom
+
+YOUR DATA, YOUR CHOICE
+Collection is local-first — your data stays on your device by default. During setup you choose, per collector, whether to keep things local or share them anonymously to contribute to collective visualizations. Keyboard text is abstracted by default, and personal info (emails, phone numbers) is always redacted. No account, no cross-site ad tracking, no selling data.
+
+ON WIKIPEDIA
+- See who else is reading the same article
+- Chat live with them in a small panel (open it from the presence pill or press /)
+- Your name is a random Wikipedia article — hover anyone's name for a preview
+- Follow another reader's cursor as they wander
+- Chat is ephemeral: messages live only while people are there
+
+we were online is in open beta. It's a small, personal art project about noticing the internet as a place — somewhere we all were, together.
+```
+
+---
+
+## Firefox AMO — full description
+
+AMO supports a limited set of HTML tags, so the demo link can be clickable.
+Paste into the "Description" field with HTML enabled.
+
+```html
+<p><strong>we were online</strong></p>
+
+<p>A quiet portrait of your time on the internet — and the people quietly there with you.</p>
+
+<p>we were online collects gentle traces of how you move, click, scroll, and type across the web, then renders them as living visualizations: cursor-trail portraits, typing rhythms, the shape of a day's browsing. It's a keepsake of your time online, made from the small motions you never think about.</p>
+
+<p>It's also quietly social. When others with the extension are on the same page, you'll see their cursors drift alongside yours and a small count of who else is here. On Wikipedia, it goes further: a little chat panel lets you talk live with whoever else is reading the same article. Pick a random Wikipedia article as your name (reroll until one feels right), and wander the encyclopedia together. Messages are live-only — nothing is stored.</p>
+
+<p>See it in action: <a href="https://www.instagram.com/p/DYpRnRAORbE/">demo on Instagram</a></p>
+
+<p><strong>What it captures</strong></p>
+<ul>
+  <li>Cursor movement, clicks, and holds</li>
+  <li>Typing cadence and rhythm (text is abstracted by default — we capture the shape of typing, not what you wrote)</li>
+  <li>Navigation: page transitions and screen time</li>
+  <li>Scroll, resize, and zoom</li>
+</ul>
+
+<p><strong>Your data, your choice</strong></p>
+<p>Collection is local-first — your data stays on your device by default. During setup you choose, per collector, whether to keep things local or share them anonymously to contribute to collective visualizations. Keyboard text is abstracted by default, and personal info (emails, phone numbers) is always redacted. No account, no cross-site ad tracking, no selling data.</p>
+
+<p><strong>On Wikipedia</strong></p>
+<ul>
+  <li>See who else is reading the same article</li>
+  <li>Chat live with them in a small panel (open it from the presence pill or press /)</li>
+  <li>Your name is a random Wikipedia article — hover anyone's name for a preview</li>
+  <li>Follow another reader's cursor as they wander</li>
+  <li>Chat is ephemeral: messages live only while people are there</li>
+</ul>
+
+<p>we were online is in open beta. It's a small, personal art project about noticing the internet as a place — somewhere we all were, together.</p>
+```

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -17,14 +17,29 @@ Chrome renders this field as **plain text** (no markdown, URLs are not
 clickable). Paste exactly as-is.
 
 ```
-we were online
+A quiet portrait of your time on the internet. Collect traces of where you've been and share them anonymously.
 
 we were online is an online multiplayer world—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Contribute your browsing data to a collective portrait of the Internet and create your own Internet self-portraits.
 
-See it in action: https://www.instagram.com/p/DYpRnRAORbE/
+Cursor trails, keypresses and clicks, scroll patterns, and navigation rhythms, time on pages come to life on the pages you visit and show you how long you've spent on each page.
+
+What it collects (all configurable):
+  - Cursor movement, clicks, and holds
+  - Scroll and viewport changes
+  - Page navigation (screen time)
+  - Keyboard rhythm
+
+What you can do:
+  - View per-site "internet portraits" that visualize your browsing as trail art
+  - Choose three privacy levels: off, local-only, or shared
+  - Configure exactly which data types are collected
 
 See other people (still in development):
-- On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes. See it in action: https://www.instagram.com/p/DYpRnRAORbE/
+- On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes. See it in action https://www.instagram.com/p/DYpRnRAORbE/
+
+Data Collection Policies:
+
+* You choose what is collected and where your data goes, on your device or shared for the purposes of the art project.
 ```
 
 ---
@@ -35,14 +50,34 @@ AMO supports a limited set of HTML tags, so the demo link can be clickable.
 Paste into the "Description" field with HTML enabled.
 
 ```html
-<p><strong>we were online</strong></p>
+<p>A quiet portrait of your time on the internet. Collect traces of where you've been and share them anonymously.</p>
 
 <p>we were online is an online multiplayer world—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Contribute your browsing data to a collective portrait of the Internet and create your own Internet self-portraits.</p>
 
-<p>See it in action: <a href="https://www.instagram.com/p/DYpRnRAORbE/">demo on Instagram</a></p>
+<p>Cursor trails, keypresses and clicks, scroll patterns, and navigation rhythms, time on pages come to life on the pages you visit and show you how long you've spent on each page.</p>
+
+<p><strong>What it collects (all configurable):</strong></p>
+<ul>
+  <li>Cursor movement, clicks, and holds</li>
+  <li>Scroll and viewport changes</li>
+  <li>Page navigation (screen time)</li>
+  <li>Keyboard rhythm</li>
+</ul>
+
+<p><strong>What you can do:</strong></p>
+<ul>
+  <li>View per-site "internet portraits" that visualize your browsing as trail art</li>
+  <li>Choose three privacy levels: off, local-only, or shared</li>
+  <li>Configure exactly which data types are collected</li>
+</ul>
 
 <p><strong>See other people (still in development):</strong></p>
 <ul>
   <li>On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes. <a href="https://www.instagram.com/p/DYpRnRAORbE/">See it in action</a>.</li>
+</ul>
+
+<p><strong>Data Collection Policies:</strong></p>
+<ul>
+  <li>You choose what is collected and where your data goes, on your device or shared for the purposes of the art project.</li>
 </ul>
 ```

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -24,7 +24,7 @@ we were online is an online multiplayer world—part game, artwork, and tool—t
 See it in action: https://www.instagram.com/p/DYpRnRAORbE/
 
 See other people (still in development):
-- On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes.
+- On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes. See it in action: https://www.instagram.com/p/DYpRnRAORbE/
 ```
 
 ---
@@ -43,6 +43,6 @@ Paste into the "Description" field with HTML enabled.
 
 <p><strong>See other people (still in development):</strong></p>
 <ul>
-  <li>On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes.</li>
+  <li>On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes. <a href="https://www.instagram.com/p/DYpRnRAORbE/">See it in action</a>.</li>
 </ul>
 ```

--- a/extension/STORE_LISTING.md
+++ b/extension/STORE_LISTING.md
@@ -19,31 +19,12 @@ clickable). Paste exactly as-is.
 ```
 we were online
 
-A quiet portrait of your time on the internet — and the people quietly there with you.
-
-we were online collects gentle traces of how you move, click, scroll, and type across the web, then renders them as living visualizations: cursor-trail portraits, typing rhythms, the shape of a day's browsing. It's a keepsake of your time online, made from the small motions you never think about.
-
-It's also quietly social. When others with the extension are on the same page, you'll see their cursors drift alongside yours and a small count of who else is here. On Wikipedia, it goes further: a little chat panel lets you talk live with whoever else is reading the same article. Pick a random Wikipedia article as your name (reroll until one feels right), and wander the encyclopedia together. Messages are live-only — nothing is stored.
+we were online is an online multiplayer world—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Contribute your browsing data to a collective portrait of the Internet and create your own Internet self-portraits.
 
 See it in action: https://www.instagram.com/p/DYpRnRAORbE/
 
-WHAT IT CAPTURES
-- Cursor movement, clicks, and holds
-- Typing cadence and rhythm (text is abstracted by default — we capture the shape of typing, not what you wrote)
-- Navigation: page transitions and screen time
-- Scroll, resize, and zoom
-
-YOUR DATA, YOUR CHOICE
-Collection is local-first — your data stays on your device by default. During setup you choose, per collector, whether to keep things local or share them anonymously to contribute to collective visualizations. Keyboard text is abstracted by default, and personal info (emails, phone numbers) is always redacted. No account, no cross-site ad tracking, no selling data.
-
-ON WIKIPEDIA
-- See who else is reading the same article
-- Chat live with them in a small panel (open it from the presence pill or press /)
-- Your name is a random Wikipedia article — hover anyone's name for a preview
-- Follow another reader's cursor as they wander
-- Chat is ephemeral: messages live only while people are there
-
-we were online is in open beta. It's a small, personal art project about noticing the internet as a place — somewhere we all were, together.
+See other people (still in development):
+- On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes.
 ```
 
 ---
@@ -56,33 +37,12 @@ Paste into the "Description" field with HTML enabled.
 ```html
 <p><strong>we were online</strong></p>
 
-<p>A quiet portrait of your time on the internet — and the people quietly there with you.</p>
-
-<p>we were online collects gentle traces of how you move, click, scroll, and type across the web, then renders them as living visualizations: cursor-trail portraits, typing rhythms, the shape of a day's browsing. It's a keepsake of your time online, made from the small motions you never think about.</p>
-
-<p>It's also quietly social. When others with the extension are on the same page, you'll see their cursors drift alongside yours and a small count of who else is here. On Wikipedia, it goes further: a little chat panel lets you talk live with whoever else is reading the same article. Pick a random Wikipedia article as your name (reroll until one feels right), and wander the encyclopedia together. Messages are live-only — nothing is stored.</p>
+<p>we were online is an online multiplayer world—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Contribute your browsing data to a collective portrait of the Internet and create your own Internet self-portraits.</p>
 
 <p>See it in action: <a href="https://www.instagram.com/p/DYpRnRAORbE/">demo on Instagram</a></p>
 
-<p><strong>What it captures</strong></p>
+<p><strong>See other people (still in development):</strong></p>
 <ul>
-  <li>Cursor movement, clicks, and holds</li>
-  <li>Typing cadence and rhythm (text is abstracted by default — we capture the shape of typing, not what you wrote)</li>
-  <li>Navigation: page transitions and screen time</li>
-  <li>Scroll, resize, and zoom</li>
+  <li>On Wikipedia, see others on the same article, chat with them live, watch links grow patina, and follow other cursors down rabbit holes.</li>
 </ul>
-
-<p><strong>Your data, your choice</strong></p>
-<p>Collection is local-first — your data stays on your device by default. During setup you choose, per collector, whether to keep things local or share them anonymously to contribute to collective visualizations. Keyboard text is abstracted by default, and personal info (emails, phone numbers) is always redacted. No account, no cross-site ad tracking, no selling data.</p>
-
-<p><strong>On Wikipedia</strong></p>
-<ul>
-  <li>See who else is reading the same article</li>
-  <li>Chat live with them in a small panel (open it from the presence pill or press /)</li>
-  <li>Your name is a random Wikipedia article — hover anyone's name for a preview</li>
-  <li>Follow another reader's cursor as they wander</li>
-  <li>Chat is ephemeral: messages live only while people are there</li>
-</ul>
-
-<p>we were online is in open beta. It's a small, personal art project about noticing the internet as a place — somewhere we all were, together.</p>
 ```

--- a/extension/package.json
+++ b/extension/package.json
@@ -23,6 +23,7 @@
     "@playhtml/react": "workspace:*",
     "html2canvas": "^1.4.1",
     "playhtml": "workspace:*",
+    "profane-words": "^1.5.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "webextension-polyfill": "^0.12.0"

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -1,0 +1,237 @@
+// ABOUTME: Tests for ChatManager — ring buffer, send/throttle, profanity block, presence wiring.
+// ABOUTME: Uses a fake PresenceAPI to drive onPresenceChange callbacks deterministically.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import browser from "webextension-polyfill";
+import type { PresenceAPI, PresenceView } from "@playhtml/common";
+import { ChatManager } from "../features/ChatManager";
+import { _resetForTest as resetHandle } from "../features/chat-handle";
+
+function setupStorage(value: string | null = null): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  if (value !== null) data["wiki_chat_handle"] = value;
+  vi.mocked(browser.storage.local.get).mockImplementation((keys: any) => {
+    if (typeof keys === "string") return Promise.resolve({ [keys]: data[keys] });
+    if (Array.isArray(keys)) {
+      const out: Record<string, unknown> = {};
+      keys.forEach((k) => {
+        out[k] = data[k];
+      });
+      return Promise.resolve(out);
+    }
+    return Promise.resolve({ ...data });
+  });
+  vi.mocked(browser.storage.local.set).mockImplementation((items: any) => {
+    Object.assign(data, items);
+    return Promise.resolve();
+  });
+  return data;
+}
+
+function makeFakePresence(): {
+  api: PresenceAPI;
+  emit: (presences: Map<string, PresenceView>) => void;
+  getLastSent: () => unknown;
+} {
+  let chatChangeCb: ((p: Map<string, PresenceView>) => void) | null = null;
+  let lastSent: unknown = null;
+  const myIdentity = {
+    publicKey: "self",
+    playerStyle: { colorPalette: ["#c4724e"] },
+  } as any;
+  const api: PresenceAPI = {
+    setMyPresence: (channel, data) => {
+      if (channel === "chat") lastSent = data;
+    },
+    getPresences: () => new Map(),
+    onPresenceChange: (channel, cb) => {
+      if (channel === "chat") chatChangeCb = cb;
+      return () => {};
+    },
+    getMyIdentity: () => myIdentity,
+  };
+  return {
+    api,
+    emit: (p) => chatChangeCb?.(p),
+    getLastSent: () => lastSent,
+  };
+}
+
+function peerView(pid: string, color: string, chat: unknown): PresenceView {
+  return {
+    playerIdentity: {
+      publicKey: pid,
+      playerStyle: { colorPalette: [color] },
+    } as any,
+    cursor: null,
+    isMe: false,
+    chat,
+  } as PresenceView;
+}
+
+describe("ChatManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupStorage("TestHandle");
+    resetHandle();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty state and loads handle on init", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    expect(mgr.getState().messages).toEqual([]);
+    expect(mgr.getState().handle).toBe("TestHandle");
+    expect(mgr.getState().articleTitle).toBe("Octopus");
+    expect(mgr.getState().isOpen).toBe(false);
+    expect(mgr.getState().unread).toBe(false);
+    mgr.destroy();
+  });
+
+  it("send broadcasts via setMyPresence and appends locally", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    mgr.send("hello world");
+    const sent = fake.getLastSent() as any;
+    expect(sent.text).toBe("hello world");
+    expect(sent.name).toBe("TestHandle");
+    expect(typeof sent.id).toBe("string");
+    expect(typeof sent.ts).toBe("number");
+    expect(mgr.getState().messages).toHaveLength(1);
+    expect(mgr.getState().messages[0].text).toBe("hello world");
+    mgr.destroy();
+  });
+
+  it("send blocks profanity and surfaces an error", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    const ok = mgr.send("oh shit");
+    expect(ok).toBe(false);
+    expect(fake.getLastSent()).toBeNull();
+    expect(mgr.getState().sendError).toBeTruthy();
+    expect(mgr.getState().messages).toHaveLength(0);
+    mgr.destroy();
+  });
+
+  it("send silently no-ops on empty/whitespace", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    expect(mgr.send("")).toBe(false);
+    expect(mgr.send("   ")).toBe(false);
+    expect(mgr.send("\n\t")).toBe(false);
+    expect(fake.getLastSent()).toBeNull();
+    expect(mgr.getState().sendError).toBeFalsy();
+    mgr.destroy();
+  });
+
+  it("send caps at 400 chars (truncates)", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    const long = "a".repeat(500);
+    mgr.send(long);
+    const sent = fake.getLastSent() as any;
+    expect(sent.text.length).toBe(400);
+    mgr.destroy();
+  });
+
+  it("send throttles to 1 per 500ms", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    expect(mgr.send("one")).toBe(true);
+    expect(mgr.send("two")).toBe(false);
+    vi.advanceTimersByTime(500);
+    expect(mgr.send("three")).toBe(true);
+    mgr.destroy();
+  });
+
+  it("receives peer messages via onPresenceChange and dedupes by id", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    const msg = { id: "m1", text: "hi", ts: 1000, name: "Peer One" };
+    fake.emit(new Map([["peer-pk", peerView("peer-pk", "#4a9a8a", msg)]]));
+    fake.emit(new Map([["peer-pk", peerView("peer-pk", "#4a9a8a", msg)]]));
+    expect(mgr.getState().messages.filter((m) => m.id === "m1")).toHaveLength(1);
+    mgr.destroy();
+  });
+
+  it("sets unread when a peer message arrives and panel is closed", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    expect(mgr.getState().isOpen).toBe(false);
+    fake.emit(
+      new Map([
+        [
+          "peer-pk",
+          peerView("peer-pk", "#4a9a8a", { id: "m1", text: "hi", ts: 1, name: "P" }),
+        ],
+      ]),
+    );
+    expect(mgr.getState().unread).toBe(true);
+    mgr.toggle();
+    expect(mgr.getState().isOpen).toBe(true);
+    expect(mgr.getState().unread).toBe(false);
+    mgr.destroy();
+  });
+
+  it("ring-buffer caps total messages at 50", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    for (let i = 0; i < 60; i++) {
+      fake.emit(
+        new Map([
+          [
+            `peer-${i}`,
+            peerView(`peer-${i}`, "#aaa", { id: `m${i}`, text: "x", ts: i, name: "P" }),
+          ],
+        ]),
+      );
+    }
+    expect(mgr.getState().messages.length).toBe(50);
+    expect(mgr.getState().messages[0].id).toBe("m10");
+    expect(mgr.getState().messages[49].id).toBe("m59");
+    mgr.destroy();
+  });
+
+  it("subscribe notifies on state changes and unsubscribe stops notifications", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    const seen: number[] = [];
+    const unsub = mgr.subscribe(() => seen.push(mgr.getState().messages.length));
+    mgr.send("a");
+    expect(seen.at(-1)).toBe(1);
+    unsub();
+    mgr.send("b");
+    vi.advanceTimersByTime(1000);
+    mgr.send("c");
+    expect(seen.at(-1)).toBe(1);
+    mgr.destroy();
+  });
+
+  it("reroll updates handle and notifies", async () => {
+    const fake = makeFakePresence();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ title: "Rerolled Name" }),
+    } as Response) as typeof fetch;
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    await mgr.reroll();
+    expect(mgr.getState().handle).toBe("Rerolled Name");
+    mgr.destroy();
+  });
+});

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -28,7 +28,9 @@ function setupStorage(value: string | null = null): Record<string, unknown> {
   return data;
 }
 
-function makeFakePresence(): {
+function makeFakePresence(
+  initialPresences: Map<string, PresenceView> = new Map(),
+): {
   api: PresenceAPI;
   emit: (presences: Map<string, PresenceView>) => void;
   getLastSent: () => unknown;
@@ -59,7 +61,11 @@ function makeFakePresence(): {
     },
     getPresences: () => new Map(),
     onPresenceChange: (channel, cb) => {
-      if (channel === "chat") chatChangeCb = cb;
+      if (channel === "chat") {
+        chatChangeCb = cb;
+        // Mirror the real API: replay the current snapshot on subscribe.
+        cb(initialPresences);
+      }
       return () => {};
     },
     getMyIdentity: () => myIdentity,
@@ -177,6 +183,42 @@ describe("ChatManager", () => {
     fake.emit(new Map([["peer-pk", peerView("peer-pk", "#4a9a8a", msg)]]));
     fake.emit(new Map([["peer-pk", peerView("peer-pk", "#4a9a8a", msg)]]));
     expect(mgr.getState().messages.filter((m) => m.id === "m1")).toHaveLength(1);
+    mgr.destroy();
+  });
+
+  it("ignores the subscribe-time replay snapshot (live-session only)", async () => {
+    // A late joiner subscribes and the presence API replays the current
+    // snapshot — peers' latest messages. We must NOT seed the panel from it
+    // (presence can't represent coherent history). Panel stays empty until a
+    // fresh message arrives.
+    const preExisting = new Map<string, PresenceView>([
+      ["peer-a", peerView("peer-a", "#4a9a8a", { id: "old-a", text: "earlier", ts: 1, name: "A" })],
+      ["peer-b", peerView("peer-b", "#d4b85c", { id: "old-b", text: "also earlier", ts: 2, name: "B" })],
+    ]);
+    const fake = makeFakePresence(preExisting);
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    // Nothing from the replay should be in the panel.
+    expect(mgr.getState().messages).toHaveLength(0);
+    expect(mgr.getState().unread).toBe(false);
+
+    // A genuinely new message after we joined DOES appear.
+    fake.emit(
+      new Map([
+        ["peer-a", peerView("peer-a", "#4a9a8a", { id: "new-a", text: "live now", ts: 3, name: "A" })],
+      ]),
+    );
+    expect(mgr.getState().messages).toHaveLength(1);
+    expect(mgr.getState().messages[0].text).toBe("live now");
+
+    // And a peer re-broadcasting one of the pre-existing (already-seen) ids
+    // is NOT re-appended.
+    fake.emit(
+      new Map([
+        ["peer-a", peerView("peer-a", "#4a9a8a", { id: "old-a", text: "earlier", ts: 1, name: "A" })],
+      ]),
+    );
+    expect(mgr.getState().messages).toHaveLength(1);
     mgr.destroy();
   });
 

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -41,7 +41,21 @@ function makeFakePresence(): {
   } as any;
   const api: PresenceAPI = {
     setMyPresence: (channel, data) => {
-      if (channel === "chat") lastSent = data;
+      if (channel === "chat") {
+        lastSent = data;
+        // Mimic Y.js awareness: setLocalStateField fires listeners synchronously.
+        // This is what caused the dedupe-before-optimistic-append bug.
+        const ownView: PresenceView = {
+          playerIdentity: {
+            publicKey: "self",
+            playerStyle: { colorPalette: ["#c4724e"] },
+          } as any,
+          cursor: null,
+          isMe: true,
+          chat: data,
+        } as PresenceView;
+        chatChangeCb?.(new Map([["self", ownView]]));
+      }
     },
     getPresences: () => new Map(),
     onPresenceChange: (channel, cb) => {

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -242,6 +242,31 @@ describe("ChatManager", () => {
     mgr.destroy();
   });
 
+  it("openOrFocus opens when closed and bumps focusNonce", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    expect(mgr.getState().isOpen).toBe(false);
+    const before = mgr.getState().focusNonce;
+    mgr.openOrFocus();
+    expect(mgr.getState().isOpen).toBe(true);
+    expect(mgr.getState().focusNonce).toBe(before + 1);
+    mgr.destroy();
+  });
+
+  it("openOrFocus does NOT close an open panel — only bumps focusNonce", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+    mgr.toggle(); // open
+    expect(mgr.getState().isOpen).toBe(true);
+    const before = mgr.getState().focusNonce;
+    mgr.openOrFocus();
+    expect(mgr.getState().isOpen).toBe(true); // stays open
+    expect(mgr.getState().focusNonce).toBe(before + 1);
+    mgr.destroy();
+  });
+
   it("ring-buffer caps total messages at 50", async () => {
     const fake = makeFakePresence();
     const mgr = new ChatManager(fake.api, "Octopus");

--- a/extension/src/__tests__/announcement-storage.test.ts
+++ b/extension/src/__tests__/announcement-storage.test.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Tests for announcement seen-state storage and candidate filtering.
+// ABOUTME: Verifies forward-only state, URL gating, and shippedAt ordering.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import browser from "webextension-polyfill";
+import {
+  getState,
+  setState,
+  getToastCandidates,
+  getPostcardCandidates,
+} from "../announcements/announcement-storage";
+import { ANNOUNCEMENTS } from "../announcements/announcements";
+
+function setupStorage(): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  vi.mocked(browser.storage.local.get).mockImplementation((keys: any) => {
+    if (typeof keys === "string") return Promise.resolve({ [keys]: data[keys] });
+    if (Array.isArray(keys)) {
+      const out: Record<string, unknown> = {};
+      keys.forEach((k) => {
+        out[k] = data[k];
+      });
+      return Promise.resolve(out);
+    }
+    return Promise.resolve({ ...data });
+  });
+  vi.mocked(browser.storage.local.set).mockImplementation((items: any) => {
+    Object.assign(data, items);
+    return Promise.resolve();
+  });
+  return data;
+}
+
+describe("announcement-storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupStorage();
+  });
+
+  it("getState returns undefined for unseen", async () => {
+    expect(await getState("nope")).toBeUndefined();
+  });
+
+  it("setState writes and getState reads", async () => {
+    await setState("a", "toast-shown");
+    expect(await getState("a")).toBe("toast-shown");
+    await setState("a", "dismissed");
+    expect(await getState("a")).toBe("dismissed");
+  });
+
+  it("setState is forward-only: dismissed cannot downgrade to toast-shown", async () => {
+    await setState("a", "dismissed");
+    await setState("a", "toast-shown");
+    expect(await getState("a")).toBe("dismissed");
+  });
+
+  it("getToastCandidates excludes already-seen announcements", async () => {
+    const first = ANNOUNCEMENTS[0];
+    if (!first) return; // guard if list is empty in a future state
+    const url = "https://en.wikipedia.org/wiki/Octopus";
+    const before = await getToastCandidates(url);
+    if (!first.relevantUrl || first.relevantUrl.test(url)) {
+      expect(before.some((a) => a.id === first.id)).toBe(true);
+    }
+    await setState(first.id, "toast-shown");
+    const after = await getToastCandidates(url);
+    expect(after.some((a) => a.id === first.id)).toBe(false);
+  });
+
+  it("getToastCandidates respects relevantUrl gating", async () => {
+    const first = ANNOUNCEMENTS[0];
+    if (!first || !first.relevantUrl) return;
+    const offTarget = "https://example.com/";
+    const onTarget = "https://en.wikipedia.org/wiki/Anything";
+    const offResults = await getToastCandidates(offTarget);
+    const onResults = await getToastCandidates(onTarget);
+    expect(offResults.some((a) => a.id === first.id)).toBe(false);
+    expect(onResults.some((a) => a.id === first.id)).toBe(true);
+  });
+
+  it("getPostcardCandidates excludes only dismissed, includes toast-shown", async () => {
+    const first = ANNOUNCEMENTS[0];
+    if (!first) return;
+    expect((await getPostcardCandidates()).some((a) => a.id === first.id)).toBe(true);
+    await setState(first.id, "toast-shown");
+    expect((await getPostcardCandidates()).some((a) => a.id === first.id)).toBe(true);
+    await setState(first.id, "dismissed");
+    expect((await getPostcardCandidates()).some((a) => a.id === first.id)).toBe(false);
+  });
+});

--- a/extension/src/__tests__/chat-echo-renderer.test.ts
+++ b/extension/src/__tests__/chat-echo-renderer.test.ts
@@ -1,0 +1,93 @@
+// ABOUTME: Tests for chat-echo-renderer — bubble lifecycle, dedupe per pid, 3s expiry.
+// ABOUTME: Bubbles are inside a closed shadow root; we query the shadow root directly.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ChatEchoRenderer } from "../features/chat-echo-renderer";
+
+function makeFakeCursorClient(positions: Record<string, { x: number; y: number }>) {
+  return {
+    getCursorPresences: () => {
+      const m = new Map();
+      for (const [pid, pos] of Object.entries(positions)) {
+        m.set(pid, {
+          cursor: { x: pos.x, y: pos.y, pointer: "mouse" },
+          playerIdentity: { publicKey: pid },
+        });
+      }
+      return m;
+    },
+  };
+}
+
+function clearBody(): void {
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+}
+
+function queryBubbles(): NodeListOf<Element> {
+  const host = document.getElementById("wewere-chat-echo-host");
+  if (!host) return document.querySelectorAll("__never__");
+  const shadow = (host as HTMLElement & { shadowRoot: ShadowRoot | null }).shadowRoot;
+  if (!shadow) {
+    return host.querySelectorAll("[data-chat-echo]");
+  }
+  return shadow.querySelectorAll("[data-chat-echo]");
+}
+
+describe("ChatEchoRenderer", () => {
+  let renderer: ChatEchoRenderer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearBody();
+  });
+
+  afterEach(() => {
+    renderer?.destroy();
+    vi.useRealTimers();
+  });
+
+  it("creates a bubble for an echo and removes it after 3s", () => {
+    const cursorClient = makeFakeCursorClient({ "peer-1": { x: 100, y: 100 } });
+    renderer = new ChatEchoRenderer(cursorClient);
+    renderer.setEcho("peer-1", "hello", "#4a9a8a");
+    expect(queryBubbles().length).toBe(1);
+    vi.advanceTimersByTime(3100);
+    vi.runOnlyPendingTimers();
+    expect(queryBubbles().length).toBe(0);
+  });
+
+  it("replaces a prior echo for the same pid (resets timer)", () => {
+    const cursorClient = makeFakeCursorClient({ "peer-1": { x: 100, y: 100 } });
+    renderer = new ChatEchoRenderer(cursorClient);
+    renderer.setEcho("peer-1", "first", "#4a9a8a");
+    vi.advanceTimersByTime(2000);
+    renderer.setEcho("peer-1", "second", "#4a9a8a");
+    const bubbles = queryBubbles();
+    expect(bubbles.length).toBe(1);
+    expect(bubbles[0].textContent).toBe("second");
+    vi.advanceTimersByTime(2000);
+    vi.runOnlyPendingTimers();
+    expect(queryBubbles().length).toBe(1);
+    vi.advanceTimersByTime(1100);
+    vi.runOnlyPendingTimers();
+    expect(queryBubbles().length).toBe(0);
+  });
+
+  it("no-ops silently when the pid has no cursor presence", () => {
+    const cursorClient = makeFakeCursorClient({});
+    renderer = new ChatEchoRenderer(cursorClient);
+    renderer.setEcho("missing-peer", "hello", "#c4724e");
+    expect(queryBubbles().length).toBe(0);
+  });
+
+  it("destroy removes the shadow host from the document", () => {
+    const cursorClient = makeFakeCursorClient({ "peer-1": { x: 100, y: 100 } });
+    renderer = new ChatEchoRenderer(cursorClient);
+    renderer.setEcho("peer-1", "hi", "#000");
+    expect(document.getElementById("wewere-chat-echo-host")).not.toBeNull();
+    renderer.destroy();
+    expect(document.getElementById("wewere-chat-echo-host")).toBeNull();
+  });
+});

--- a/extension/src/__tests__/chat-echo-renderer.test.ts
+++ b/extension/src/__tests__/chat-echo-renderer.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for chat-echo-renderer — bubble lifecycle, dedupe per pid, 3s expiry.
-// ABOUTME: Bubbles are inside a closed shadow root; we query the shadow root directly.
+// ABOUTME: Bubbles live inside the renderer's shadow root; tests query via the host element.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ChatEchoRenderer } from "../features/chat-echo-renderer";

--- a/extension/src/__tests__/chat-handle.test.ts
+++ b/extension/src/__tests__/chat-handle.test.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Tests for the chat-handle module — storage, roll, reroll, profanity filter.
+// ABOUTME: Mocks browser.storage.local with an in-memory backing store and globalThis.fetch.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import browser from "webextension-polyfill";
+import { getOrCreateHandle, rerollHandle, _resetForTest } from "../features/chat-handle";
+
+const STORAGE_KEY = "wiki_chat_handle";
+
+function setupStorage(): { data: Record<string, unknown> } {
+  const data: Record<string, unknown> = {};
+  vi.mocked(browser.storage.local.get).mockImplementation((keys: any) => {
+    if (typeof keys === "string") return Promise.resolve({ [keys]: data[keys] });
+    if (Array.isArray(keys)) {
+      const out: Record<string, unknown> = {};
+      keys.forEach((k) => { out[k] = data[k]; });
+      return Promise.resolve(out);
+    }
+    return Promise.resolve({ ...data });
+  });
+  vi.mocked(browser.storage.local.set).mockImplementation((items: any) => {
+    Object.assign(data, items);
+    return Promise.resolve();
+  });
+  return { data };
+}
+
+function mockFetchOnce(title: string) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ title }),
+  } as Response);
+}
+
+describe("chat-handle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupStorage();
+    _resetForTest();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns stored handle if present", async () => {
+    const { data } = setupStorage();
+    data[STORAGE_KEY] = "Tundra Swan";
+    _resetForTest();
+    const handle = await getOrCreateHandle();
+    expect(handle).toBe("Tundra Swan");
+  });
+
+  it("rolls a new handle on miss and persists it", async () => {
+    globalThis.fetch = mockFetchOnce("Pyotr Stolypin") as typeof fetch;
+    const handle = await getOrCreateHandle();
+    expect(handle).toBe("Pyotr Stolypin");
+    expect(browser.storage.local.set).toHaveBeenCalledWith({ [STORAGE_KEY]: "Pyotr Stolypin" });
+  });
+
+  it("retries on profane rolls and returns a clean one", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ title: "Shit Article" }) } as Response)
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ title: "Octopus" }) } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+    const handle = await getOrCreateHandle();
+    expect(handle).toBe("Octopus");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to Anonymous after 5 profane rolls", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ title: "shit" }),
+    } as Response);
+    globalThis.fetch = fetchMock as typeof fetch;
+    const handle = await getOrCreateHandle();
+    expect(handle).toBe("Anonymous");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("falls back to Anonymous on network failure", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("net down")) as typeof fetch;
+    const handle = await getOrCreateHandle();
+    expect(handle).toBe("Anonymous");
+  });
+
+  it("rerollHandle ignores stored value and refetches", async () => {
+    const { data } = setupStorage();
+    data[STORAGE_KEY] = "Old Name";
+    _resetForTest();
+    globalThis.fetch = mockFetchOnce("New Name") as typeof fetch;
+    const handle = await rerollHandle();
+    expect(handle).toBe("New Name");
+    expect(browser.storage.local.set).toHaveBeenCalledWith({ [STORAGE_KEY]: "New Name" });
+  });
+});

--- a/extension/src/__tests__/wiki-summary.test.ts
+++ b/extension/src/__tests__/wiki-summary.test.ts
@@ -1,0 +1,101 @@
+// ABOUTME: Tests for the Wikipedia summary fetch/cache module.
+// ABOUTME: Verifies caching, in-flight dedupe, and graceful failure handling.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  fetchWikiSummary,
+  getCachedSummary,
+  wikipediaUrlForTitle,
+  titleToPath,
+  _clearSummaryCacheForTest,
+} from "../features/wiki-summary";
+
+function okResponse(body: unknown): Response {
+  return { ok: true, json: () => Promise.resolve(body) } as Response;
+}
+
+describe("wiki-summary", () => {
+  beforeEach(() => {
+    _clearSummaryCacheForTest();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("titleToPath turns spaces into underscores and encodes", () => {
+    expect(titleToPath("Pyotr Stolypin")).toBe("Pyotr_Stolypin");
+    expect(titleToPath("C++")).toBe("C%2B%2B");
+  });
+
+  it("wikipediaUrlForTitle builds an en.wikipedia.org article URL", () => {
+    expect(wikipediaUrlForTitle("Octopus")).toBe("https://en.wikipedia.org/wiki/Octopus");
+  });
+
+  it("fetches and normalizes a summary", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      okResponse({
+        title: "Octopus",
+        description: "eight-limbed mollusc",
+        extract: "The octopus is a soft-bodied mollusc.",
+        thumbnail: { source: "https://img/oct.jpg", width: 320, height: 200 },
+        content_urls: { desktop: { page: "https://en.wikipedia.org/wiki/Octopus" } },
+      }),
+    ) as typeof fetch;
+
+    const s = await fetchWikiSummary("Octopus");
+    expect(s).not.toBeNull();
+    expect(s!.title).toBe("Octopus");
+    expect(s!.description).toBe("eight-limbed mollusc");
+    expect(s!.extract).toContain("soft-bodied");
+    expect(s!.thumbnail?.source).toBe("https://img/oct.jpg");
+    expect(s!.url).toBe("https://en.wikipedia.org/wiki/Octopus");
+  });
+
+  it("caches the result so a second call does not refetch", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      okResponse({ title: "Octopus", extract: "x" }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await fetchWikiSummary("Octopus");
+    await fetchWikiSummary("Octopus");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(getCachedSummary("Octopus")).not.toBeNull();
+  });
+
+  it("dedupes concurrent in-flight requests for the same title", async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise<Response>((res) => {
+        resolveFetch = res;
+      }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const p1 = fetchWikiSummary("Octopus");
+    const p2 = fetchWikiSummary("Octopus");
+    resolveFetch(okResponse({ title: "Octopus", extract: "x" }));
+    await Promise.all([p1, p2]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null and caches null on a non-ok response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false } as Response) as typeof fetch;
+    const s = await fetchWikiSummary("Nonexistent");
+    expect(s).toBeNull();
+    expect(getCachedSummary("Nonexistent")).toBeNull();
+  });
+
+  it("returns null on a fetch rejection (network error)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("offline")) as typeof fetch;
+    const s = await fetchWikiSummary("Octopus");
+    expect(s).toBeNull();
+  });
+
+  it("returns null when the payload has no usable extract", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      okResponse({ title: "Disambig", extract: "" }),
+    ) as typeof fetch;
+    expect(await fetchWikiSummary("Disambig")).toBeNull();
+  });
+});

--- a/extension/src/announcements/AnnouncementPostcard.tsx
+++ b/extension/src/announcements/AnnouncementPostcard.tsx
@@ -1,0 +1,67 @@
+// ABOUTME: Postcard-styled announcement card shown in the extension popup home.
+// ABOUTME: Slight hand-tilt, envelope chrome, title + body + optional CTA, dismissible.
+
+import { useState } from "react";
+import type { Announcement } from "./announcements";
+
+interface Props {
+  announcement: Announcement;
+  tiltDeg: number; // -2..+2 for visual variety in a stack
+  onDismiss: (id: string) => void;
+  onCtaClick: (id: string, href: string) => void;
+}
+
+export function AnnouncementPostcard({ announcement, tiltDeg, onDismiss, onCtaClick }: Props) {
+  const [exiting, setExiting] = useState(false);
+
+  function handleDismiss() {
+    setExiting(true);
+    setTimeout(() => onDismiss(announcement.id), 200);
+  }
+
+  function handleCta(e: React.MouseEvent) {
+    if (!announcement.cta) return;
+    e.preventDefault();
+    onCtaClick(announcement.id, announcement.cta.href);
+    setExiting(true);
+    setTimeout(() => onDismiss(announcement.id), 200);
+  }
+
+  return (
+    <article
+      className={`announcement-postcard ${exiting ? "is-exiting" : ""}`}
+      style={{ transform: `rotate(${tiltDeg}deg)` }}
+    >
+      <header className="announcement-postcard__chrome">
+        <span className="announcement-postcard__from">
+          <span className="announcement-postcard__envelope" aria-hidden>
+            ✉
+          </span>{" "}
+          from spencer
+        </span>
+        <button
+          type="button"
+          className="announcement-postcard__close"
+          aria-label="dismiss"
+          onClick={handleDismiss}
+        >
+          ×
+        </button>
+      </header>
+      <div className="announcement-postcard__rule" />
+      <h3 className="announcement-postcard__title">{announcement.title}</h3>
+      <p className="announcement-postcard__body">{announcement.body}</p>
+      {announcement.cta ? (
+        <a
+          className="announcement-postcard__cta"
+          href={announcement.cta.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleCta}
+        >
+          {announcement.cta.label}
+        </a>
+      ) : null}
+    </article>
+  );
+}

--- a/extension/src/announcements/AnnouncementPostcard.tsx
+++ b/extension/src/announcements/AnnouncementPostcard.tsx
@@ -1,66 +1,96 @@
-// ABOUTME: Postcard-styled announcement card shown in the extension popup home.
-// ABOUTME: Slight hand-tilt, envelope chrome, title + body + optional CTA, dismissible.
+// ABOUTME: Letter-styled announcement notification shown in the extension popup home.
+// ABOUTME: Collapsed by default (dot + subject); click to expand into body + CTA + dismiss.
 
 import { useState } from "react";
 import type { Announcement } from "./announcements";
 
 interface Props {
   announcement: Announcement;
-  tiltDeg: number; // -2..+2 for visual variety in a stack
   onDismiss: (id: string) => void;
   onCtaClick: (id: string, href: string) => void;
 }
 
-export function AnnouncementPostcard({ announcement, tiltDeg, onDismiss, onCtaClick }: Props) {
+// Format the shippedAt timestamp like "MAY 2026" for the cancellation watermark.
+function formatPostmark(ts: number): string {
+  const d = new Date(ts);
+  const month = d.toLocaleString("en-US", { month: "short" }).toUpperCase();
+  const year = d.getFullYear();
+  return `${month} ${year}`;
+}
+
+export function AnnouncementPostcard({ announcement, onDismiss, onCtaClick }: Props) {
+  const [expanded, setExpanded] = useState(false);
   const [exiting, setExiting] = useState(false);
 
-  function handleDismiss() {
+  function handleDismiss(e?: React.MouseEvent) {
+    e?.stopPropagation();
     setExiting(true);
     setTimeout(() => onDismiss(announcement.id), 200);
+  }
+
+  function handleCardClick() {
+    if (!expanded) setExpanded(true);
   }
 
   function handleCta(e: React.MouseEvent) {
     if (!announcement.cta) return;
     e.preventDefault();
+    e.stopPropagation();
     onCtaClick(announcement.id, announcement.cta.href);
     setExiting(true);
     setTimeout(() => onDismiss(announcement.id), 200);
   }
 
+  const postmark = formatPostmark(announcement.shippedAt);
+
   return (
     <article
-      className={`announcement-postcard ${exiting ? "is-exiting" : ""}`}
-      style={{ transform: `rotate(${tiltDeg}deg)` }}
+      className={`announcement-postcard ${exiting ? "is-exiting" : ""} ${
+        expanded ? "is-expanded" : "is-collapsed"
+      }`}
+      onClick={handleCardClick}
+      role="button"
+      aria-expanded={expanded}
+      aria-label={expanded ? undefined : `open: ${announcement.title}`}
     >
-      <header className="announcement-postcard__chrome">
-        <span className="announcement-postcard__from">
-          <span className="announcement-postcard__envelope" aria-hidden>
-            ✉
-          </span>{" "}
-          from spencer
+      <div className="announcement-postcard__cancel" aria-hidden>
+        <span className="announcement-postcard__cancel-mark">wwo</span>
+        <span className="announcement-postcard__cancel-arc" />
+        <span className="announcement-postcard__cancel-date">{postmark}</span>
+      </div>
+
+      <div className="announcement-postcard__row">
+        <span className="announcement-postcard__dot-slot" aria-hidden>
+          <span className="announcement-postcard__dot" />
         </span>
-        <button
-          type="button"
-          className="announcement-postcard__close"
-          aria-label="dismiss"
-          onClick={handleDismiss}
-        >
-          ×
-        </button>
-      </header>
-      <div className="announcement-postcard__rule" />
-      <h3 className="announcement-postcard__title">{announcement.title}</h3>
-      <p className="announcement-postcard__body">{announcement.body}</p>
-      {announcement.cta ? (
-        <a
-          className="announcement-postcard__cta"
-          href={announcement.cta.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={handleCta}
-        >
-          {announcement.cta.label}
-        </a>
+        <h3 className="announcement-postcard__title">{announcement.title}</h3>
+        {expanded ? (
+          <button
+            type="button"
+            className="announcement-postcard__close"
+            aria-label="dismiss"
+            onClick={handleDismiss}
+          >
+            ×
+          </button>
+        ) : null}
+      </div>
+
+      {expanded ? (
+        <div className="announcement-postcard__body-wrap">
+          <p className="announcement-postcard__body">{announcement.body}</p>
+          {announcement.cta ? (
+            <a
+              className="announcement-postcard__cta"
+              href={announcement.cta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handleCta}
+            >
+              {announcement.cta.label}
+            </a>
+          ) : null}
+        </div>
       ) : null}
     </article>
   );

--- a/extension/src/announcements/AnnouncementToast.tsx
+++ b/extension/src/announcements/AnnouncementToast.tsx
@@ -1,0 +1,83 @@
+// ABOUTME: System-styled toast surfacing a new announcement on a matching page.
+// ABOUTME: Click anywhere → opens CTA + dismisses; × dismisses; auto-dismiss after 8s (paused on hover).
+
+import { useEffect, useRef, useState } from "react";
+import type { Announcement } from "./announcements";
+
+const AUTO_DISMISS_MS = 8000;
+
+interface Props {
+  announcement: Announcement;
+  onShown: (id: string) => void;
+  onDismiss: () => void;
+  onCtaClick: (id: string, href: string) => void;
+}
+
+export function AnnouncementToast({ announcement, onShown, onDismiss, onCtaClick }: Props) {
+  const [exiting, setExiting] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    onShown(announcement.id);
+    armTimer();
+    return () => clearTimer();
+  }, []);
+
+  function clearTimer() {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }
+
+  function armTimer() {
+    clearTimer();
+    timerRef.current = window.setTimeout(() => {
+      dismiss();
+    }, AUTO_DISMISS_MS);
+  }
+
+  function dismiss() {
+    if (exiting) return;
+    setExiting(true);
+    setTimeout(onDismiss, 200);
+  }
+
+  function handleClick() {
+    if (announcement.cta) {
+      onCtaClick(announcement.id, announcement.cta.href);
+    }
+    dismiss();
+  }
+
+  function handleClose(e: React.MouseEvent) {
+    e.stopPropagation();
+    dismiss();
+  }
+
+  return (
+    <div
+      className={`announcement-toast ${exiting ? "is-exiting" : ""}`}
+      onClick={handleClick}
+      onMouseEnter={clearTimer}
+      onMouseLeave={armTimer}
+      role="alert"
+    >
+      <div className="announcement-toast__chrome">
+        <span className="announcement-toast__title">{announcement.title}</span>
+        <button
+          type="button"
+          className="announcement-toast__close"
+          aria-label="dismiss"
+          onClick={handleClose}
+        >
+          ×
+        </button>
+      </div>
+      <p className="announcement-toast__body">{announcement.body}</p>
+      {announcement.cta ? (
+        <span className="announcement-toast__cta">{announcement.cta.label}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/extension/src/announcements/AnnouncementToast.tsx
+++ b/extension/src/announcements/AnnouncementToast.tsx
@@ -43,22 +43,13 @@ export function AnnouncementToast({ announcement, onShown, onDismiss, onCtaClick
     setTimeout(onDismiss, 200);
   }
 
-  function handleClick() {
-    // Toast fires only on pages matching relevantUrl, so the feature is
-    // already reachable here — no need to send people elsewhere via CTA.
-    // (CTA still appears on the popup postcard for users who land there first.)
-    dismiss();
-  }
-
-  function handleClose(e: React.MouseEvent) {
-    e.stopPropagation();
+  function handleClose() {
     dismiss();
   }
 
   return (
     <div
       className={`announcement-toast ${exiting ? "is-exiting" : ""}`}
-      onClick={handleClick}
       onMouseEnter={clearTimer}
       onMouseLeave={armTimer}
       role="alert"

--- a/extension/src/announcements/AnnouncementToast.tsx
+++ b/extension/src/announcements/AnnouncementToast.tsx
@@ -44,9 +44,9 @@ export function AnnouncementToast({ announcement, onShown, onDismiss, onCtaClick
   }
 
   function handleClick() {
-    if (announcement.cta) {
-      onCtaClick(announcement.id, announcement.cta.href);
-    }
+    // Toast fires only on pages matching relevantUrl, so the feature is
+    // already reachable here — no need to send people elsewhere via CTA.
+    // (CTA still appears on the popup postcard for users who land there first.)
     dismiss();
   }
 
@@ -64,7 +64,10 @@ export function AnnouncementToast({ announcement, onShown, onDismiss, onCtaClick
       role="alert"
     >
       <div className="announcement-toast__chrome">
-        <span className="announcement-toast__title">{announcement.title}</span>
+        <span className="announcement-toast__title">
+          <span className="announcement-toast__new-badge">NEW</span>
+          {announcement.title}
+        </span>
         <button
           type="button"
           className="announcement-toast__close"
@@ -75,9 +78,6 @@ export function AnnouncementToast({ announcement, onShown, onDismiss, onCtaClick
         </button>
       </div>
       <p className="announcement-toast__body">{announcement.body}</p>
-      {announcement.cta ? (
-        <span className="announcement-toast__cta">{announcement.cta.label}</span>
-      ) : null}
     </div>
   );
 }

--- a/extension/src/announcements/PostcardStack.tsx
+++ b/extension/src/announcements/PostcardStack.tsx
@@ -1,0 +1,50 @@
+// ABOUTME: Stack of pending announcement postcards rendered at top of popup home.
+// ABOUTME: Loads candidates from storage, hides itself when empty, alternates tilt.
+
+import { useEffect, useState, useCallback } from "react";
+import { AnnouncementPostcard } from "./AnnouncementPostcard";
+import { getPostcardCandidates, setState } from "./announcement-storage";
+import type { Announcement } from "./announcements";
+import "./announcements.scss";
+
+const TILT_PATTERN = [-1.6, 1.4, -0.9, 1.1];
+
+export function PostcardStack() {
+  const [items, setItems] = useState<Announcement[]>([]);
+
+  const load = useCallback(async () => {
+    setItems(await getPostcardCandidates());
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onDismiss = useCallback(
+    async (id: string) => {
+      await setState(id, "dismissed");
+      setItems((prev) => prev.filter((a) => a.id !== id));
+    },
+    [],
+  );
+
+  const onCtaClick = useCallback((_id: string, href: string) => {
+    window.open(href, "_blank", "noopener,noreferrer");
+  }, []);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="announcement-stack">
+      {items.map((a, i) => (
+        <AnnouncementPostcard
+          key={a.id}
+          announcement={a}
+          tiltDeg={TILT_PATTERN[i % TILT_PATTERN.length]}
+          onDismiss={onDismiss}
+          onCtaClick={onCtaClick}
+        />
+      ))}
+    </div>
+  );
+}

--- a/extension/src/announcements/PostcardStack.tsx
+++ b/extension/src/announcements/PostcardStack.tsx
@@ -7,8 +7,6 @@ import { getPostcardCandidates, setState } from "./announcement-storage";
 import type { Announcement } from "./announcements";
 import "./announcements.scss";
 
-const TILT_PATTERN = [-1.6, 1.4, -0.9, 1.1];
-
 export function PostcardStack() {
   const [items, setItems] = useState<Announcement[]>([]);
 
@@ -36,11 +34,10 @@ export function PostcardStack() {
 
   return (
     <div className="announcement-stack">
-      {items.map((a, i) => (
+      {items.map((a) => (
         <AnnouncementPostcard
           key={a.id}
           announcement={a}
-          tiltDeg={TILT_PATTERN[i % TILT_PATTERN.length]}
           onDismiss={onDismiss}
           onCtaClick={onCtaClick}
         />

--- a/extension/src/announcements/announcement-storage.ts
+++ b/extension/src/announcements/announcement-storage.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Per-announcement seen-state stored in browser.storage.local.
+// ABOUTME: Forward-only state machine: undefined → "toast-shown" → "dismissed".
+
+import browser from "webextension-polyfill";
+import { ANNOUNCEMENTS, type Announcement } from "./announcements";
+
+export type AnnouncementState = "toast-shown" | "dismissed";
+
+const KEY_PREFIX = "announcement_seen_";
+
+function key(id: string): string {
+  return `${KEY_PREFIX}${id}`;
+}
+
+export async function getState(id: string): Promise<AnnouncementState | undefined> {
+  const stored = (await browser.storage.local.get(key(id))) as Record<string, unknown>;
+  const v = stored[key(id)];
+  if (v === "toast-shown" || v === "dismissed") return v;
+  return undefined;
+}
+
+// Forward-only: dismissed locks in; toast-shown only writes if currently undefined.
+export async function setState(id: string, next: AnnouncementState): Promise<void> {
+  const current = await getState(id);
+  if (current === "dismissed") return;
+  if (current === "toast-shown" && next === "toast-shown") return;
+  await browser.storage.local.set({ [key(id)]: next });
+}
+
+function urlMatches(a: Announcement, url: string): boolean {
+  if (!a.relevantUrl) return true;
+  return a.relevantUrl.test(url);
+}
+
+function byShippedAtDesc(a: Announcement, b: Announcement): number {
+  return b.shippedAt - a.shippedAt;
+}
+
+export async function getToastCandidates(url: string): Promise<Announcement[]> {
+  const out: Announcement[] = [];
+  for (const a of ANNOUNCEMENTS) {
+    if (!urlMatches(a, url)) continue;
+    const s = await getState(a.id);
+    if (s === undefined) out.push(a);
+  }
+  return out.sort(byShippedAtDesc);
+}
+
+export async function getPostcardCandidates(): Promise<Announcement[]> {
+  const out: Announcement[] = [];
+  for (const a of ANNOUNCEMENTS) {
+    const s = await getState(a.id);
+    if (s !== "dismissed") out.push(a);
+  }
+  return out.sort(byShippedAtDesc);
+}

--- a/extension/src/announcements/announcements.scss
+++ b/extension/src/announcements/announcements.scss
@@ -1,54 +1,134 @@
 // ABOUTME: Styles for announcement postcards (popup) and toasts (content scripts).
-// ABOUTME: Warm linen aged-paper postcard, plain warm-tone toast distinct from the postcard.
+// ABOUTME: Letter-notification — pulsing dot, subject-only collapsed row, wwo cancellation watermark.
 
 .announcement-stack {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 14px 12px 4px;
+  gap: 10px;
+  padding: 12px 12px 0;
+  // Load Source Serif 4 italic for the "wwo" cancellation mark. This affects
+  // the popup document head; safe here because the popup is our own page.
+  @import url("https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@1,8..60,200..400&display=swap");
 }
 
 .announcement-postcard {
   position: relative;
   background: #f5f0e8;
-  border: 1px solid rgba(90, 78, 65, 0.18);
-  border-radius: 4px;
-  padding: 10px 12px 12px;
-  box-shadow:
-    1px 2px 0 rgba(90, 78, 65, 0.08),
-    3px 6px 14px rgba(0, 0, 0, 0.07);
-  transition: transform 200ms ease, opacity 200ms ease;
+  border: 1px solid rgba(90, 78, 65, 0.22);
+  border-radius: 3px;
+  padding: 8px 88px 9px 10px; // 88px right padding reserves room for cancellation mark
+  cursor: pointer;
   font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
   color: #3d3833;
+  box-shadow:
+    0 1px 0 rgba(90, 78, 65, 0.06),
+    0 3px 8px rgba(0, 0, 0, 0.05);
   background-image: linear-gradient(
     180deg,
-    rgba(255, 252, 246, 0.4) 0%,
-    rgba(245, 240, 232, 0) 30%
+    rgba(255, 253, 247, 0.6) 0%,
+    rgba(245, 240, 232, 0) 25%
   );
+  transition:
+    background-color 200ms ease,
+    transform 200ms ease,
+    opacity 200ms ease;
+
+  &:hover {
+    background-color: #f0eadb;
+  }
 
   &.is-exiting {
     opacity: 0;
-    transform: translateY(-8px) rotate(0deg) !important;
+    transform: translateY(-8px);
   }
 
-  &__chrome {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 10.5px;
-    color: #8a8279;
+  &.is-expanded {
+    cursor: default;
   }
 
-  &__from {
+  &__cancel {
+    position: absolute;
+    right: 10px;
+    top: 6px;
+    width: 72px;
+    text-align: center;
+    pointer-events: none;
+    line-height: 1;
+    transform: rotate(-5deg);
+    transform-origin: center;
+    color: rgba(90, 78, 65, 0.3);
+  }
+
+  &__cancel-mark {
+    display: block;
+    font-family: "Source Serif 4", Georgia, serif;
+    font-style: italic;
+    font-weight: 200;
+    font-size: 14px;
     letter-spacing: 0.02em;
   }
 
-  &__envelope {
-    font-size: 11px;
-    margin-right: 1px;
+  &__cancel-arc {
+    display: block;
+    margin: 2px auto 0;
+    width: 36px;
+    height: 4px;
+    border-top: 1px solid rgba(90, 78, 65, 0.22);
+    border-radius: 50%;
+    transform: scaleY(0.6);
+  }
+
+  &__cancel-date {
+    display: block;
+    margin-top: 2px;
+    font-family: "Martian Mono", ui-monospace, monospace;
+    font-size: 7px;
+    letter-spacing: 0.12em;
+    color: rgba(90, 78, 65, 0.32);
+    white-space: nowrap;
+  }
+
+  &__row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 16px;
+  }
+
+  &__dot-slot {
+    flex: 0 0 auto;
+    width: 14px;
+    height: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, #d8835d 0%, #c4724e 55%, #9a4f30 100%);
+    box-shadow: 0 1px 1.5px rgba(154, 79, 48, 0.35);
+    animation: announcement-dot-pulse 2.4s ease-in-out infinite;
+  }
+
+  &__title {
+    flex: 1 1 auto;
+    min-width: 0;
+    margin: 0;
+    font-family: "Lora", "Atkinson Hyperlegible", serif;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1.25;
+    color: #3d3833;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &__close {
+    flex: 0 0 auto;
     background: none;
     border: none;
     cursor: pointer;
@@ -62,45 +142,54 @@
     }
   }
 
-  &__rule {
-    height: 1px;
-    margin: 6px 0 8px;
-    background: repeating-linear-gradient(
-      90deg,
-      rgba(90, 78, 65, 0.25) 0 3px,
-      transparent 3px 6px
-    );
-  }
-
-  &__title {
-    margin: 0 0 4px;
-    font-size: 13px;
-    font-weight: 700;
-    color: #3d3833;
-    font-family: "Lora", "Atkinson Hyperlegible", serif;
+  &__body-wrap {
+    margin-top: 6px;
+    padding-left: 22px; // align under the title (dot slot + gap)
+    animation: announcement-body-in 180ms ease;
   }
 
   &__body {
-    margin: 0 0 10px;
-    font-size: 12px;
+    margin: 0 0 8px;
+    font-size: 11.5px;
     line-height: 1.45;
     color: #3d3833;
   }
 
   &__cta {
     display: inline-block;
-    background: rgba(196, 114, 78, 0.12);
-    border: 1px solid rgba(196, 114, 78, 0.35);
     color: #c4724e;
-    padding: 4px 10px;
-    border-radius: 4px;
-    font-size: 12px;
+    font-size: 11.5px;
     font-weight: 600;
-    text-decoration: none;
-    transition: background 120ms ease, color 120ms ease;
+    text-decoration: underline;
+    text-decoration-color: rgba(196, 114, 78, 0.4);
+    text-underline-offset: 2px;
     &:hover {
-      background: rgba(196, 114, 78, 0.2);
-      color: #b35a35;
+      text-decoration-color: #c4724e;
     }
+  }
+}
+
+@keyframes announcement-dot-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 1px 1.5px rgba(154, 79, 48, 0.35),
+      0 0 0 0 rgba(196, 114, 78, 0.45);
+  }
+  50% {
+    box-shadow:
+      0 1px 1.5px rgba(154, 79, 48, 0.35),
+      0 0 0 5px rgba(196, 114, 78, 0);
+  }
+}
+
+@keyframes announcement-body-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/extension/src/announcements/announcements.scss
+++ b/extension/src/announcements/announcements.scss
@@ -1,0 +1,106 @@
+// ABOUTME: Styles for announcement postcards (popup) and toasts (content scripts).
+// ABOUTME: Warm linen aged-paper postcard, plain warm-tone toast distinct from the postcard.
+
+.announcement-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 12px 4px;
+}
+
+.announcement-postcard {
+  position: relative;
+  background: #f5f0e8;
+  border: 1px solid rgba(90, 78, 65, 0.18);
+  border-radius: 4px;
+  padding: 10px 12px 12px;
+  box-shadow:
+    1px 2px 0 rgba(90, 78, 65, 0.08),
+    3px 6px 14px rgba(0, 0, 0, 0.07);
+  transition: transform 200ms ease, opacity 200ms ease;
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  color: #3d3833;
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 252, 246, 0.4) 0%,
+    rgba(245, 240, 232, 0) 30%
+  );
+
+  &.is-exiting {
+    opacity: 0;
+    transform: translateY(-8px) rotate(0deg) !important;
+  }
+
+  &__chrome {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 10.5px;
+    color: #8a8279;
+  }
+
+  &__from {
+    letter-spacing: 0.02em;
+  }
+
+  &__envelope {
+    font-size: 11px;
+    margin-right: 1px;
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #b8b0a6;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0 2px;
+    transition: color 120ms ease;
+    &:hover {
+      color: #3d3833;
+    }
+  }
+
+  &__rule {
+    height: 1px;
+    margin: 6px 0 8px;
+    background: repeating-linear-gradient(
+      90deg,
+      rgba(90, 78, 65, 0.25) 0 3px,
+      transparent 3px 6px
+    );
+  }
+
+  &__title {
+    margin: 0 0 4px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #3d3833;
+    font-family: "Lora", "Atkinson Hyperlegible", serif;
+  }
+
+  &__body {
+    margin: 0 0 10px;
+    font-size: 12px;
+    line-height: 1.45;
+    color: #3d3833;
+  }
+
+  &__cta {
+    display: inline-block;
+    background: rgba(196, 114, 78, 0.12);
+    border: 1px solid rgba(196, 114, 78, 0.35);
+    color: #c4724e;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 120ms ease, color 120ms ease;
+    &:hover {
+      background: rgba(196, 114, 78, 0.2);
+      color: #b35a35;
+    }
+  }
+}

--- a/extension/src/announcements/announcements.ts
+++ b/extension/src/announcements/announcements.ts
@@ -17,10 +17,10 @@ export const ANNOUNCEMENTS: Announcement[] = [
   {
     id: "wiki-chat-2026-05",
     shippedAt: Date.parse("2026-05-27T00:00:00Z"),
-    title: "New: chat on Wikipedia",
-    body: "A small chat panel now lives on every page. Talk to whoever else is reading the same article & find a favorite article for your name :) enjoy and let me know if you have any thoughts!",
+    title: "Chat on Wikipedia!",
+    body: "A small chat panel now lives on every page so you can talk to others there. Happy rabbitholing!",
     cta: {
-      label: "try it on today's featured →",
+      label: "try on today's featured article →",
       href: "https://en.wikipedia.org/wiki/Wikipedia:Today%27s_featured_article",
     },
     relevantUrl: /^https?:\/\/([a-z]+\.)?wikipedia\.org\//,

--- a/extension/src/announcements/announcements.ts
+++ b/extension/src/announcements/announcements.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Build-time list of extension announcements shown via toast + popup postcard.
+// ABOUTME: Newest first. Each announcement has a stable id used as a storage key.
+
+export interface Announcement {
+  id: string;
+  shippedAt: number;
+  title: string;
+  body: string;
+  cta?: {
+    label: string;
+    href: string;
+  };
+  relevantUrl?: RegExp;
+}
+
+export const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: "wiki-chat-2026-05",
+    shippedAt: Date.parse("2026-05-27T00:00:00Z"),
+    title: "New: chat on Wikipedia",
+    body: "A small chat panel now lives on every page. Talk to whoever else is reading the same article & find a favorite article for your name :) enjoy and let me know if you have any thoughts!",
+    cta: {
+      label: "try it on today's featured →",
+      href: "https://en.wikipedia.org/wiki/Wikipedia:Today%27s_featured_article",
+    },
+    relevantUrl: /^https?:\/\/([a-z]+\.)?wikipedia\.org\//,
+  },
+];

--- a/extension/src/announcements/inject-toast.ts
+++ b/extension/src/announcements/inject-toast.ts
@@ -21,7 +21,6 @@ const TOAST_CSS = `
   color: #3d3833;
   font-size: 12px;
   z-index: 2147483640;
-  cursor: pointer;
   transform: translateY(0);
   opacity: 1;
   transition: transform 200ms ease, opacity 200ms ease;

--- a/extension/src/announcements/inject-toast.ts
+++ b/extension/src/announcements/inject-toast.ts
@@ -1,0 +1,105 @@
+// ABOUTME: One-shot toast injector — mounts the highest-priority unseen announcement for the current url.
+// ABOUTME: Use from a content script; no-op if everything's been seen or the page doesn't match.
+
+import { injectShadowReact } from "../entrypoints/content/inject-ui";
+import { AnnouncementToast } from "./AnnouncementToast";
+import { getToastCandidates, setState } from "./announcement-storage";
+
+const TOAST_CSS = `
+:host { all: initial; }
+.announcement-toast {
+  position: fixed;
+  bottom: 16px;
+  left: 16px;
+  width: 320px;
+  background: #faf7f2;
+  border: 1px solid rgba(90, 78, 65, 0.2);
+  border-radius: 6px;
+  box-shadow: 2px 4px 14px rgba(0,0,0,0.12);
+  padding: 10px 12px;
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  color: #3d3833;
+  font-size: 12px;
+  z-index: 2147483640;
+  cursor: pointer;
+  transform: translateY(0);
+  opacity: 1;
+  transition: transform 200ms ease, opacity 200ms ease;
+}
+.announcement-toast.is-exiting {
+  transform: translateY(8px);
+  opacity: 0;
+}
+.announcement-toast__chrome {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.announcement-toast__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: #3d3833;
+  font-family: "Lora", "Atkinson Hyperlegible", serif;
+  line-height: 1.25;
+}
+.announcement-toast__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #b8b0a6;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.announcement-toast__close:hover { color: #3d3833; }
+.announcement-toast__body {
+  margin: 6px 0 8px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.announcement-toast__cta {
+  display: inline-block;
+  color: #c4724e;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: rgba(196, 114, 78, 0.4);
+  text-underline-offset: 2px;
+}
+`;
+
+export async function maybeInjectAnnouncementToast(): Promise<(() => void) | null> {
+  const url = location.href;
+  const candidates = await getToastCandidates(url);
+  const next = candidates[0];
+  if (!next) return null;
+
+  let ui: { destroy: () => void } | null = null;
+  ui = injectShadowReact(
+    AnnouncementToast as any,
+    {
+      announcement: next,
+      onShown: (id: string) => {
+        void setState(id, "toast-shown");
+      },
+      onDismiss: () => {
+        ui?.destroy();
+        ui = null;
+      },
+      onCtaClick: (_id: string, href: string) => {
+        window.open(href, "_blank", "noopener,noreferrer");
+      },
+    },
+    {
+      hostId: "wewere-announcement-toast-host",
+      hostStyle:
+        "position:fixed;bottom:0;left:0;width:0;height:0;pointer-events:auto;z-index:2147483640;",
+      css: TOAST_CSS,
+    },
+  );
+
+  return () => {
+    ui?.destroy();
+    ui = null;
+  };
+}

--- a/extension/src/announcements/inject-toast.ts
+++ b/extension/src/announcements/inject-toast.ts
@@ -42,6 +42,25 @@ const TOAST_CSS = `
   color: #3d3833;
   font-family: "Lora", "Atkinson Hyperlegible", serif;
   line-height: 1.25;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.announcement-toast__new-badge {
+  display: inline-block;
+  font-family: "Martian Mono", ui-monospace, monospace;
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  background: #c4724e;
+  color: #faf7f2;
+  padding: 1.5px 5px 1px;
+  border-radius: 2px;
+  animation: toast-new-pulse 1.4s ease-in-out infinite;
+}
+@keyframes toast-new-pulse {
+  0%, 100% { background: #c4724e; box-shadow: 0 0 0 0 rgba(196, 114, 78, 0.5); }
+  50%      { background: #d8835d; box-shadow: 0 0 0 4px rgba(196, 114, 78, 0); }
 }
 .announcement-toast__close {
   background: none;

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -1,0 +1,124 @@
+// ABOUTME: Floating AIM-style chat panel rendered above the Wikipedia presence pill.
+// ABOUTME: Pure presentational React — receives messages and handlers from ChatManager.
+
+import { useEffect, useRef, useState } from "react";
+import type { ChatMessageView } from "../features/ChatManager";
+
+interface ChatPanelProps {
+  messages: ChatMessageView[];
+  handle: string;
+  myColor: string;
+  articleTitle: string;
+  sendError: string | null;
+  onSend: (text: string) => void;
+  onClose: () => void;
+  onReroll: () => void;
+  onClearError: () => void;
+}
+
+const MAX_MESSAGE_LENGTH = 400;
+const SOFT_COUNTER_AT = 380;
+
+export function ChatPanel({
+  messages,
+  handle,
+  myColor,
+  articleTitle,
+  sendError,
+  onSend,
+  onClose,
+  onReroll,
+  onClearError,
+}: ChatPanelProps) {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight;
+  }, [messages]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  function attemptSend() {
+    const v = value.trim();
+    if (v.length === 0) return;
+    onSend(value);
+    setValue("");
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      attemptSend();
+    }
+  }
+
+  function onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = e.target.value.slice(0, MAX_MESSAGE_LENGTH);
+    setValue(next);
+    if (sendError) onClearError();
+  }
+
+  const showCounter = value.length >= SOFT_COUNTER_AT;
+
+  return (
+    <div className="chat-panel" role="dialog" aria-label={`chat for ${articleTitle}`}>
+      <div className="chat-titlebar">
+        <span className="chat-title-text">chat · {articleTitle}</span>
+        <button
+          type="button"
+          className="chat-close"
+          aria-label="close chat"
+          onClick={onClose}
+        >
+          ×
+        </button>
+      </div>
+      <div className="chat-name-strip">
+        <span className="you-dot" style={{ background: myColor }} />
+        <span className="you-label">
+          you're <strong>{handle}</strong>
+        </span>
+        <button type="button" className="chat-reroll" onClick={onReroll}>
+          reroll
+        </button>
+      </div>
+      <div className="chat-body" ref={bodyRef}>
+        {messages.map((m) => (
+          <div className="chat-msg" key={m.id}>
+            <span className="chat-msg-dot" style={{ background: m.color }} />
+            <span className="chat-msg-who">{m.name}</span>{" "}
+            <span className="chat-msg-body">{m.text}</span>
+          </div>
+        ))}
+      </div>
+      {sendError ? <div className="chat-error">{sendError}</div> : null}
+      <div className={`chat-input-row ${sendError ? "has-error" : ""}`}>
+        <span className="you-dot" style={{ background: myColor }} />
+        <textarea
+          ref={inputRef}
+          className="chat-input"
+          placeholder="say something…"
+          value={value}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+          rows={1}
+        />
+        {showCounter ? (
+          <span className="chat-counter">{MAX_MESSAGE_LENGTH - value.length}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -91,6 +91,7 @@ export function ChatPanel({
       <div className="chat-name-strip">
         <span className="you-dot" style={{ background: myColor }} />
         <span className="you-label">
+          chatting as{" "}
           {handle === "Anonymous" ? (
             <strong>{handle}</strong>
           ) : (

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -19,6 +19,11 @@ interface ChatPanelProps {
 const MAX_MESSAGE_LENGTH = 400;
 const SOFT_COUNTER_AT = 380;
 
+function wikipediaUrlForTitle(title: string): string {
+  // Wikipedia article URLs use underscores for spaces; the rest is path-encoded.
+  return `https://en.wikipedia.org/wiki/${encodeURIComponent(title.replace(/ /g, "_"))}`;
+}
+
 export function ChatPanel({
   messages,
   handle,
@@ -88,7 +93,19 @@ export function ChatPanel({
       <div className="chat-name-strip">
         <span className="you-dot" style={{ background: myColor }} />
         <span className="you-label">
-          you're <strong>{handle}</strong>
+          you're{" "}
+          {handle === "Anonymous" ? (
+            <strong>{handle}</strong>
+          ) : (
+            <a
+              className="chat-handle-link"
+              href={wikipediaUrlForTitle(handle)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {handle}
+            </a>
+          )}
         </span>
         <button type="button" className="chat-reroll" onClick={onReroll}>
           reroll

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -11,6 +11,7 @@ interface ChatPanelProps {
   myColor: string;
   articleTitle: string;
   sendError: string | null;
+  focusNonce: number;
   onSend: (text: string) => void;
   onClose: () => void;
   onReroll: () => void;
@@ -26,6 +27,7 @@ export function ChatPanel({
   myColor,
   articleTitle,
   sendError,
+  focusNonce,
   onSend,
   onClose,
   onReroll,
@@ -39,6 +41,12 @@ export function ChatPanel({
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // Focus the input whenever the manager bumps the nonce (e.g. "/" pressed
+  // while the panel is open but the input isn't focused).
+  useEffect(() => {
+    if (focusNonce > 0) inputRef.current?.focus();
+  }, [focusNonce]);
 
   useEffect(() => {
     if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight;

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -80,20 +80,20 @@ export function ChatPanel({
   return (
     <div className="chat-panel" role="dialog" aria-label={`chat for ${articleTitle}`}>
       <div className="chat-titlebar">
-        <span className="chat-title-text">chat · {articleTitle}</span>
+        <span className="chat-title-text">chatting on {articleTitle}</span>
         <button
           type="button"
           className="chat-close"
-          aria-label="close chat"
+          aria-label="minimize chat"
+          title="minimize"
           onClick={onClose}
         >
-          ×
+          –
         </button>
       </div>
       <div className="chat-name-strip">
         <span className="you-dot" style={{ background: myColor }} />
         <span className="you-label">
-          you're{" "}
           {handle === "Anonymous" ? (
             <strong>{handle}</strong>
           ) : (

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { ChatMessageView } from "../features/ChatManager";
+import { WikiArticleLink } from "./WikiArticleLink";
 
 interface ChatPanelProps {
   messages: ChatMessageView[];
@@ -19,11 +20,6 @@ interface ChatPanelProps {
 const MAX_MESSAGE_LENGTH = 400;
 const SOFT_COUNTER_AT = 380;
 
-function wikipediaUrlForTitle(title: string): string {
-  // Wikipedia article URLs use underscores for spaces; the rest is path-encoded.
-  return `https://en.wikipedia.org/wiki/${encodeURIComponent(title.replace(/ /g, "_"))}`;
-}
-
 export function ChatPanel({
   messages,
   handle,
@@ -36,6 +32,7 @@ export function ChatPanel({
   onClearError,
 }: ChatPanelProps) {
   const [value, setValue] = useState("");
+  const [inputFocused, setInputFocused] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
@@ -97,14 +94,7 @@ export function ChatPanel({
           {handle === "Anonymous" ? (
             <strong>{handle}</strong>
           ) : (
-            <a
-              className="chat-handle-link"
-              href={wikipediaUrlForTitle(handle)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {handle}
-            </a>
+            <WikiArticleLink className="chat-handle-link" title={handle} />
           )}
         </span>
         <button type="button" className="chat-reroll" onClick={onReroll}>
@@ -115,7 +105,7 @@ export function ChatPanel({
         {messages.map((m) => (
           <div className="chat-msg" key={m.id}>
             <span className="chat-msg-dot" style={{ background: m.color }} />
-            <span className="chat-msg-who">{m.name}</span>{" "}
+            <WikiArticleLink className="chat-msg-who" title={m.name} />{" "}
             <span className="chat-msg-body">{m.text}</span>
           </div>
         ))}
@@ -126,10 +116,12 @@ export function ChatPanel({
         <textarea
           ref={inputRef}
           className="chat-input"
-          placeholder="say something…"
+          placeholder={inputFocused ? "say something…" : "press / to chat"}
           value={value}
           onChange={onChange}
           onKeyDown={onKeyDown}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
           rows={1}
         />
         {showCounter ? (

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -11,6 +11,7 @@ import { PortraitCard } from "./PortraitCard";
 import { CollectorIcon } from "./icons";
 import "./InternetPortraitHome.scss";
 import { FLAGS } from "../flags";
+import { PostcardStack } from "../announcements/PostcardStack";
 
 interface Props {
   playerIdentity: PlayerIdentity | null;
@@ -181,6 +182,7 @@ export function InternetPortraitHome({
 
   return (
     <div className="portrait-home">
+      <PostcardStack />
       <header className="portrait-home__header">
         <div className="portrait-home__header-row">
           <h1 className="portrait-home__wordmark">we were online</h1>

--- a/extension/src/components/WikiArticleLink.tsx
+++ b/extension/src/components/WikiArticleLink.tsx
@@ -1,0 +1,94 @@
+// ABOUTME: A Wikipedia article link that shows a hovercard preview on hover.
+// ABOUTME: Builds its own card from the page/summary REST API (Wikipedia's native popup can't reach our shadow DOM).
+
+import { useRef, useState, useCallback } from "react";
+import {
+  fetchWikiSummary,
+  getCachedSummary,
+  wikipediaUrlForTitle,
+  type WikiSummary,
+} from "../features/wiki-summary";
+
+const HOVER_OPEN_DELAY_MS = 350;
+const HOVER_CLOSE_DELAY_MS = 150;
+
+interface Props {
+  title: string;
+  className?: string;
+}
+
+export function WikiArticleLink({ title, className }: Props) {
+  const [summary, setSummary] = useState<WikiSummary | null | undefined>(() =>
+    getCachedSummary(title),
+  );
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; bottom: number } | null>(null);
+  const anchorRef = useRef<HTMLAnchorElement | null>(null);
+  const openTimer = useRef<number | null>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (openTimer.current !== null) window.clearTimeout(openTimer.current);
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    openTimer.current = null;
+    closeTimer.current = null;
+  }, []);
+
+  const onEnter = useCallback(() => {
+    clearTimers();
+    openTimer.current = window.setTimeout(() => {
+      // Anchor the fixed-position card just above the link so it escapes the
+      // panel's scrolling/clipping body.
+      const rect = anchorRef.current?.getBoundingClientRect();
+      if (rect) {
+        setPos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 });
+      }
+      setOpen(true);
+      if (summary === undefined) {
+        void fetchWikiSummary(title).then((s) => setSummary(s));
+      }
+    }, HOVER_OPEN_DELAY_MS);
+  }, [clearTimers, summary, title]);
+
+  const onLeave = useCallback(() => {
+    clearTimers();
+    closeTimer.current = window.setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
+  }, [clearTimers]);
+
+  return (
+    <span className="wiki-link-wrap" onMouseEnter={onEnter} onMouseLeave={onLeave}>
+      <a
+        ref={anchorRef}
+        className={className}
+        href={wikipediaUrlForTitle(title)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {title}
+      </a>
+      {open && summary && pos ? (
+        <span
+          className="wiki-hovercard"
+          role="tooltip"
+          style={{ left: `${pos.left}px`, bottom: `${pos.bottom}px` }}
+        >
+          {summary.thumbnail ? (
+            <img
+              className="wiki-hovercard__thumb"
+              src={summary.thumbnail.source}
+              alt=""
+              loading="lazy"
+            />
+          ) : null}
+          <span className="wiki-hovercard__text">
+            <span className="wiki-hovercard__title">{summary.title}</span>
+            {summary.description ? (
+              <span className="wiki-hovercard__desc">{summary.description}</span>
+            ) : null}
+            <span className="wiki-hovercard__extract">{summary.extract}</span>
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -92,7 +92,61 @@ const CHAT_PANEL_CSS = `
 .chat-msg { margin-bottom: 3px; word-wrap: break-word; }
 .chat-msg-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; vertical-align: middle; margin-right: 4px; }
 .chat-msg-who { color: #5a4e41; font-weight: 600; }
+a.chat-msg-who {
+  text-decoration: underline;
+  text-decoration-color: rgba(90, 78, 65, 0.3);
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+a.chat-msg-who:hover { color: #5b8db8; text-decoration-color: #5b8db8; }
 .chat-msg-body { color: #3d3833; }
+
+/* Wikipedia hovercard for article-name links */
+.wiki-link-wrap { position: relative; }
+.wiki-hovercard {
+  position: fixed;
+  z-index: 2147483646;
+  width: 240px;
+  max-height: 220px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #faf7f2;
+  border: 1px solid rgba(90, 78, 65, 0.25);
+  border-radius: 5px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  color: #3d3833;
+  pointer-events: none;
+}
+.wiki-hovercard__thumb {
+  width: 100%;
+  height: 96px;
+  object-fit: cover;
+  display: block;
+  border-bottom: 1px solid rgba(90, 78, 65, 0.12);
+}
+.wiki-hovercard__text { padding: 7px 9px 9px; display: flex; flex-direction: column; gap: 2px; }
+.wiki-hovercard__title {
+  font-family: "Lora", "Atkinson Hyperlegible", serif;
+  font-weight: 700;
+  font-size: 12.5px;
+}
+.wiki-hovercard__desc {
+  font-size: 10px;
+  color: #8a8279;
+  font-style: italic;
+}
+.wiki-hovercard__extract {
+  font-size: 11px;
+  line-height: 1.4;
+  color: #3d3833;
+  margin-top: 2px;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
 .chat-error {
   padding: 3px 8px;
   background: rgba(196, 114, 78, 0.08);
@@ -138,6 +192,16 @@ export function wikipediaPageLabel(): string {
   // Fallback to <title> with trailing " - Wikipedia" stripped
   const title = document.title.replace(/ - Wikipedia$/, "").trim();
   return title.length > 0 ? title : "Wikipedia";
+}
+
+// True when a keyboard event target is a text input the user is typing into,
+// so we don't hijack keys like "/" out from under them.
+function isEditableTarget(el: HTMLElement | null): boolean {
+  if (!el) return false;
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (el.isContentEditable) return true;
+  return false;
 }
 
 // Matches /wiki/ArticleName but not /wiki/Special: /wiki/Talk: etc.
@@ -306,6 +370,22 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     panelUI = null;
     chatManager.destroy();
   });
+
+  // "/" toggles the chat — unless the user is typing somewhere (including our
+  // own chat input, where "/" should type a slash). When the panel is open and
+  // focused, the panel's own Esc handler closes it; "/" inside the input types.
+  function onSlashKey(e: KeyboardEvent) {
+    if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
+    const target = e.target as HTMLElement | null;
+    if (isEditableTarget(target)) return;
+    // Events originating inside our chat panel's shadow root are retargeted to
+    // the shadow host at the document level — guard against that too.
+    if (target && target.id === "wewere-chat-panel-host") return;
+    e.preventDefault();
+    chatManager.toggle();
+  }
+  document.addEventListener("keydown", onSlashKey);
+  cleanups.push(() => document.removeEventListener("keydown", onSlashKey));
 
   // Cursor-anchored echo bubble for each message
   if (deps.cursorClient) {

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -61,6 +61,17 @@ const CHAT_PANEL_CSS = `
   display: flex; align-items: center; gap: 5px;
 }
 .chat-name-strip .you-label strong { color: #3d3833; font-weight: 600; }
+.chat-name-strip .chat-handle-link {
+  color: #3d3833;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: rgba(91, 141, 184, 0.5);
+  text-underline-offset: 2px;
+}
+.chat-name-strip .chat-handle-link:hover {
+  text-decoration-color: #5b8db8;
+  color: #5b8db8;
+}
 .chat-name-strip .chat-reroll {
   margin-left: auto;
   background: none; border: none; cursor: pointer;

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -335,6 +335,7 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
       myColor: s.myColor,
       articleTitle: s.articleTitle,
       sendError: s.sendError,
+      focusNonce: s.focusNonce,
       onSend: (text: string) => { chatManager.send(text); },
       onClose: () => { chatManager.close(); },
       onReroll: () => { void chatManager.reroll(); },
@@ -371,9 +372,9 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     chatManager.destroy();
   });
 
-  // "/" toggles the chat — unless the user is typing somewhere (including our
-  // own chat input, where "/" should type a slash). When the panel is open and
-  // focused, the panel's own Esc handler closes it; "/" inside the input types.
+  // "/" opens the chat (or focuses its input if already open) — never closes
+  // it. Closing is Esc or the minimize button. Ignored while typing anywhere,
+  // including our own chat input, where "/" should just type a slash.
   function onSlashKey(e: KeyboardEvent) {
     if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
     const target = e.target as HTMLElement | null;
@@ -382,7 +383,7 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     // the shadow host at the document level — guard against that too.
     if (target && target.id === "wewere-chat-panel-host") return;
     e.preventDefault();
-    chatManager.toggle();
+    chatManager.openOrFocus();
   }
   document.addEventListener("keydown", onSlashKey);
   cleanups.push(() => document.removeEventListener("keydown", onSlashKey));

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -51,8 +51,10 @@ const CHAT_PANEL_CSS = `
 .chat-title-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
 .chat-close {
   background: none; border: none; cursor: pointer;
-  color: #8a8279; font-size: 14px; line-height: 1; padding: 0 2px;
+  color: #8a8279; font-size: 16px; line-height: 1; padding: 0 4px;
+  font-weight: 700;
 }
+.chat-close:hover { color: #3d3833; }
 .chat-name-strip {
   padding: 3px 8px;
   border-bottom: 1px solid rgba(90, 78, 65, 0.06);
@@ -118,6 +120,26 @@ const CHAT_PANEL_CSS = `
 .chat-counter { font-size: 10px; color: #b8b0a6; }
 `;
 
+// Human-readable label for the current Wikipedia page, used as the chat
+// room title. Handles articles, main page, and namespace pages like
+// Special:RecentChanges or Talk:Octopus.
+export function wikipediaPageLabel(): string {
+  const path = location.pathname;
+  // Main page: en.wikipedia.org/, /wiki/Main_Page, /wiki/, /wiki/Wikipedia:Main_Page
+  if (path === "/" || path === "/wiki/" || /\/wiki\/(Main_Page|Wikipedia:Main_Page)$/.test(path)) {
+    return "Wikipedia home";
+  }
+  const match = path.match(/\/wiki\/(.+)$/);
+  if (match) {
+    const raw = decodeURIComponent(match[1]).replace(/_/g, " ");
+    // Namespace pages like "Special:RecentChanges" or "Talk:Octopus" — keep the prefix
+    return raw;
+  }
+  // Fallback to <title> with trailing " - Wikipedia" stripped
+  const title = document.title.replace(/ - Wikipedia$/, "").trim();
+  return title.length > 0 ? title : "Wikipedia";
+}
+
 // Matches /wiki/ArticleName but not /wiki/Special: /wiki/Talk: etc.
 export function isWikiArticleUrl(url: string): boolean {
   try {
@@ -169,13 +191,62 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     cleanups.push(() => lobby.destroy());
   }
 
+  // === Tab-focus dimming for remote cursors ===
+  // Broadcast our own focused state so peers can dim our cursor when our tab
+  // isn't active. Receive peers' focused state and feed it to a getCursorStyle
+  // closure that dims unfocused cursors.
+  const unfocusedPeers = new Set<string>();
+
+  function broadcastFocused() {
+    const focused = document.hasFocus() && document.visibilityState === "visible";
+    deps.presence.setMyPresence("focused", focused);
+  }
+
+  if (deps.cursorClient) {
+    const cursorClient = deps.cursorClient;
+    cursorClient.configure({
+      getCursorStyle: (presence: any) => {
+        const pid = presence?.playerIdentity?.publicKey;
+        if (pid && unfocusedPeers.has(pid)) {
+          return { opacity: "0.3", filter: "grayscale(0.7)" };
+        }
+        return {};
+      },
+    });
+
+    const unsubFocused = deps.presence.onPresenceChange("focused", (presences) => {
+      const myPid = deps.presence.getMyIdentity().publicKey;
+      unfocusedPeers.clear();
+      presences.forEach((view, pid) => {
+        if (pid === myPid) return;
+        const raw = (view as Record<string, unknown>).focused;
+        // Treat missing/undefined as focused (be lenient — peer may not broadcast)
+        if (raw === false) unfocusedPeers.add(pid);
+      });
+      // Re-apply styles so peers that came back into focus get their dim cleared
+      // and peers that just blurred get dimmed.
+      cursorClient.refreshCursorStyles?.();
+    });
+    cleanups.push(unsubFocused);
+
+    broadcastFocused();
+    window.addEventListener("focus", broadcastFocused);
+    window.addEventListener("blur", broadcastFocused);
+    document.addEventListener("visibilitychange", broadcastFocused);
+    cleanups.push(() => {
+      window.removeEventListener("focus", broadcastFocused);
+      window.removeEventListener("blur", broadcastFocused);
+      document.removeEventListener("visibilitychange", broadcastFocused);
+    });
+  }
+
   // === Chat: per-article live chat (manager first, pill wired to it) ===
   const { ChatManager } = await import("../features/ChatManager");
   const { ChatEchoRenderer } = await import("../features/chat-echo-renderer");
   const { injectShadowReact } = await import("../entrypoints/content/inject-ui");
   const { ChatPanel } = await import("../components/ChatPanel");
 
-  const articleTitle = document.title.replace(/ - Wikipedia$/, "");
+  const articleTitle = wikipediaPageLabel();
   const chatManager = new ChatManager(deps.presence, articleTitle);
   await chatManager.init();
 

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -13,6 +13,100 @@ export interface WikiPresenceFields {
 
 export type WikiPresenceView = PresenceView & WikiPresenceFields;
 
+const CHAT_PANEL_CSS = `
+:host { all: initial; }
+.chat-panel {
+  width: 240px;
+  max-height: 280px;
+  background: #faf7f2;
+  border: 1px solid rgba(90, 78, 65, 0.2);
+  border-radius: 6px;
+  box-shadow: 2px 4px 14px rgba(0,0,0,0.1);
+  overflow: hidden;
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  font-size: 12px;
+  color: #3d3833;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+.chat-panel::after {
+  content: "";
+  position: absolute;
+  right: 16px;
+  bottom: -6px;
+  width: 10px; height: 10px;
+  background: #faf7f2;
+  border-right: 1px solid rgba(90, 78, 65, 0.2);
+  border-bottom: 1px solid rgba(90, 78, 65, 0.2);
+  transform: rotate(45deg);
+}
+.chat-titlebar {
+  background: rgba(196, 114, 78, 0.08);
+  border-bottom: 1px solid rgba(90, 78, 65, 0.1);
+  padding: 5px 8px;
+  font-size: 11px;
+  display: flex; justify-content: space-between; align-items: center;
+}
+.chat-title-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
+.chat-close {
+  background: none; border: none; cursor: pointer;
+  color: #8a8279; font-size: 14px; line-height: 1; padding: 0 2px;
+}
+.chat-name-strip {
+  padding: 3px 8px;
+  border-bottom: 1px solid rgba(90, 78, 65, 0.06);
+  font-size: 11px;
+  color: #8a8279;
+  display: flex; align-items: center; gap: 5px;
+}
+.chat-name-strip .you-label strong { color: #3d3833; font-weight: 600; }
+.chat-name-strip .chat-reroll {
+  margin-left: auto;
+  background: none; border: none; cursor: pointer;
+  color: #5b8db8; font-size: 11px; padding: 0; font-family: inherit;
+}
+.you-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.chat-body {
+  padding: 6px 8px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  font-size: 12px;
+  line-height: 1.45;
+  min-height: 60px;
+  max-height: 180px;
+}
+.chat-msg { margin-bottom: 3px; word-wrap: break-word; }
+.chat-msg-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; vertical-align: middle; margin-right: 4px; }
+.chat-msg-who { color: #5a4e41; font-weight: 600; }
+.chat-msg-body { color: #3d3833; }
+.chat-error {
+  padding: 3px 8px;
+  background: rgba(196, 114, 78, 0.08);
+  color: #c4724e;
+  font-size: 11px;
+  border-top: 1px solid rgba(196, 114, 78, 0.2);
+}
+.chat-input-row {
+  border-top: 1px solid rgba(90, 78, 65, 0.1);
+  padding: 4px 8px;
+  background: #f5f0e8;
+  display: flex; align-items: center; gap: 5px;
+}
+.chat-input-row.has-error { background: rgba(196, 114, 78, 0.05); }
+.chat-input {
+  flex: 1 1 auto;
+  border: none; background: transparent; outline: none;
+  font-family: inherit; font-size: 12px; color: #3d3833;
+  resize: none;
+  min-height: 18px;
+  max-height: 60px;
+  line-height: 1.4;
+}
+.chat-input::placeholder { color: #b8b0a6; }
+.chat-counter { font-size: 10px; color: #b8b0a6; }
+`;
+
 // Matches /wiki/ArticleName but not /wiki/Special: /wiki/Talk: etc.
 export function isWikiArticleUrl(url: string): boolean {
   try {
@@ -64,11 +158,90 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     cleanups.push(() => lobby.destroy());
   }
 
-  // Ambient presence count + jump-to-someone
+  // === Chat: per-article live chat (manager first, pill wired to it) ===
+  const { ChatManager } = await import("../features/ChatManager");
+  const { ChatEchoRenderer } = await import("../features/chat-echo-renderer");
+  const { injectShadowReact } = await import("../entrypoints/content/inject-ui");
+  const { ChatPanel } = await import("../components/ChatPanel");
+
+  const articleTitle = document.title.replace(/ - Wikipedia$/, "");
+  const chatManager = new ChatManager(deps.presence, articleTitle);
+  await chatManager.init();
+
+  // Ambient presence count + jump-to-someone + chat toggle
   const { PresenceCountPill } = await import("../features/PresenceCountPill");
-  const presencePill = new PresenceCountPill(deps.presence, lobbyPresence);
+  const presencePill = new PresenceCountPill(
+    deps.presence,
+    lobbyPresence,
+    () => chatManager.toggle(),
+  );
   presencePill.init();
   cleanups.push(() => presencePill.destroy());
+
+  // Mount the chat panel only while open; tear down when closed.
+  let panelUI: { render: (props: any) => void; destroy: () => void } | null = null;
+
+  function buildPanelProps() {
+    const s = chatManager.getState();
+    return {
+      messages: s.messages,
+      handle: s.handle,
+      myColor: s.myColor,
+      articleTitle: s.articleTitle,
+      sendError: s.sendError,
+      onSend: (text: string) => { chatManager.send(text); },
+      onClose: () => { chatManager.close(); },
+      onReroll: () => { void chatManager.reroll(); },
+      onClearError: () => { chatManager.clearError(); },
+    };
+  }
+
+  function syncPanel() {
+    const state = chatManager.getState();
+    if (state.isOpen && !panelUI) {
+      panelUI = injectShadowReact(ChatPanel as any, buildPanelProps(), {
+        hostId: "wewere-chat-panel-host",
+        hostStyle: "position:fixed;bottom:48px;right:16px;z-index:2147483639;",
+        css: CHAT_PANEL_CSS,
+      });
+    } else if (state.isOpen && panelUI) {
+      panelUI.render(buildPanelProps());
+    } else if (!state.isOpen && panelUI) {
+      panelUI.destroy();
+      panelUI = null;
+    }
+  }
+
+  const unsubChat = chatManager.subscribe(() => {
+    const state = chatManager.getState();
+    presencePill.setChatOpen(state.isOpen);
+    presencePill.setChatUnread(state.unread);
+    syncPanel();
+  });
+  cleanups.push(unsubChat);
+  cleanups.push(() => {
+    panelUI?.destroy();
+    panelUI = null;
+    chatManager.destroy();
+  });
+
+  // Cursor-anchored echo bubble for each message
+  if (deps.cursorClient) {
+    const echoRenderer = new ChatEchoRenderer(deps.cursorClient);
+    const unsubEcho = deps.presence.onPresenceChange("chat", (presences) => {
+      presences.forEach((view, pid) => {
+        const raw = (view as Record<string, unknown>).chat;
+        if (!raw || typeof raw !== "object") return;
+        const m = raw as Record<string, unknown>;
+        if (typeof m.text !== "string" || typeof m.id !== "string") return;
+        const color =
+          (view as any).playerIdentity?.playerStyle?.colorPalette?.[0] ?? "#c4724e";
+        echoRenderer.setEcho(pid, m.text, color);
+      });
+    });
+    cleanups.push(unsubEcho);
+    cleanups.push(() => echoRenderer.destroy());
+  }
 
   // Broadcast navigatingTo on Wikipedia article link clicks.
   // Only delay navigation when someone is following — solo users get instant clicks.

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -1014,6 +1014,16 @@ export default defineContentScript({
             console.error("[we-were-online] initCustomSite failed:", err);
           }
         }
+
+        // Surface any pending announcements as a toast (no-op if all seen / no match)
+        try {
+          const { maybeInjectAnnouncementToast } = await import(
+            "../announcements/inject-toast"
+          );
+          await maybeInjectAnnouncementToast();
+        } catch (err) {
+          console.error("[we-were-online] announcement toast failed:", err);
+        }
       }
 
       private listenForPresenceCount() {

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -52,6 +52,12 @@ export class ChatManager {
   private unsubPresence: (() => void) | null = null;
   private lastSendAt = 0;
   private seenIds = new Set<string>();
+  // onPresenceChange replays the current snapshot on subscribe. We intentionally
+  // do NOT seed the panel from it: presence holds only each peer's latest
+  // message, so a replay would reconstruct an incoherent partial transcript
+  // (missing any earlier messages a peer overwrote). Chat stays live-session
+  // only — we mark replayed ids as seen so they don't double-append later.
+  private seededInitialSnapshot = false;
 
   constructor(
     private presence: PresenceAPI,
@@ -153,6 +159,18 @@ export class ChatManager {
   }
 
   private onPresences(presences: Map<string, PresenceView>): void {
+    // First call is the subscribe-time replay. Mark every message currently in
+    // presence as seen but do NOT append — chat is live-session only and the
+    // replay can't represent coherent history (see seededInitialSnapshot note).
+    if (!this.seededInitialSnapshot) {
+      this.seededInitialSnapshot = true;
+      presences.forEach((view) => {
+        const raw = (view as Record<string, unknown>)[CHAT_CHANNEL];
+        if (isChatMessage(raw)) this.seenIds.add(raw.id);
+      });
+      return;
+    }
+
     const myPid = this.presence.getMyIdentity().publicKey;
     let unreadFromBatch = false;
     presences.forEach((view, pid) => {

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -1,0 +1,188 @@
+// ABOUTME: Orchestrator for Wikipedia article chat — state store, presence wiring, send/throttle.
+// ABOUTME: React panel and echo renderer are mounted separately in wikipedia.ts using this manager.
+
+import type { PresenceAPI, PresenceView } from "@playhtml/common";
+import { containsProfanity } from "@movement/profanity";
+import { getOrCreateHandle, rerollHandle } from "./chat-handle";
+
+const CHAT_CHANNEL = "chat";
+const MAX_MESSAGE_LENGTH = 400;
+const SEND_THROTTLE_MS = 500;
+const RING_BUFFER_SIZE = 50;
+
+export type ChatMessageBroadcast = {
+  id: string;
+  text: string;
+  ts: number;
+  name: string;
+};
+
+export type ChatMessageView = ChatMessageBroadcast & {
+  pid: string;
+  color: string;
+  isMe: boolean;
+};
+
+export type ChatManagerState = {
+  messages: ChatMessageView[];
+  handle: string;
+  articleTitle: string;
+  isOpen: boolean;
+  unread: boolean;
+  sendError: string | null;
+  myColor: string;
+};
+
+type Listener = () => void;
+
+function isChatMessage(v: unknown): v is ChatMessageBroadcast {
+  if (!v || typeof v !== "object") return false;
+  const m = v as Record<string, unknown>;
+  return (
+    typeof m.id === "string" &&
+    typeof m.text === "string" &&
+    typeof m.ts === "number" &&
+    typeof m.name === "string"
+  );
+}
+
+export class ChatManager {
+  private state: ChatManagerState;
+  private listeners = new Set<Listener>();
+  private unsubPresence: (() => void) | null = null;
+  private lastSendAt = 0;
+  private seenIds = new Set<string>();
+
+  constructor(
+    private presence: PresenceAPI,
+    articleTitle: string,
+  ) {
+    const myIdentity = presence.getMyIdentity();
+    const myColor = myIdentity.playerStyle?.colorPalette?.[0] ?? "#8a8279";
+    this.state = {
+      messages: [],
+      handle: "Anonymous",
+      articleTitle,
+      isOpen: false,
+      unread: false,
+      sendError: null,
+      myColor,
+    };
+  }
+
+  async init(): Promise<void> {
+    const handle = await getOrCreateHandle();
+    this.setState({ handle });
+    this.unsubPresence = this.presence.onPresenceChange(CHAT_CHANNEL, (presences) => {
+      this.onPresences(presences);
+    });
+  }
+
+  destroy(): void {
+    this.unsubPresence?.();
+    this.unsubPresence = null;
+    this.listeners.clear();
+  }
+
+  getState(): ChatManagerState {
+    return this.state;
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  send(text: string): boolean {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return false;
+    const capped = trimmed.slice(0, MAX_MESSAGE_LENGTH);
+    if (containsProfanity(capped)) {
+      this.setState({ sendError: "this won't send — mind the language" });
+      return false;
+    }
+    const now = Date.now();
+    if (now - this.lastSendAt < SEND_THROTTLE_MS) return false;
+    this.lastSendAt = now;
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${now}-${Math.random().toString(36).slice(2)}`;
+    const msg: ChatMessageBroadcast = {
+      id,
+      text: capped,
+      ts: now,
+      name: this.state.handle,
+    };
+    this.presence.setMyPresence(CHAT_CHANNEL, msg);
+    const myPid = this.presence.getMyIdentity().publicKey;
+    this.appendMessage({
+      ...msg,
+      pid: myPid,
+      color: this.state.myColor,
+      isMe: true,
+    });
+    if (this.state.sendError !== null) this.setState({ sendError: null });
+    return true;
+  }
+
+  clearError(): void {
+    if (this.state.sendError !== null) this.setState({ sendError: null });
+  }
+
+  toggle(): void {
+    if (this.state.isOpen) {
+      this.setState({ isOpen: false });
+    } else {
+      this.setState({ isOpen: true, unread: false });
+    }
+  }
+
+  close(): void {
+    if (this.state.isOpen) this.setState({ isOpen: false });
+  }
+
+  async reroll(): Promise<void> {
+    const fresh = await rerollHandle();
+    this.setState({ handle: fresh });
+  }
+
+  private onPresences(presences: Map<string, PresenceView>): void {
+    const myPid = this.presence.getMyIdentity().publicKey;
+    let unreadFromBatch = false;
+    presences.forEach((view, pid) => {
+      const raw = (view as Record<string, unknown>)[CHAT_CHANNEL];
+      if (!isChatMessage(raw)) return;
+      if (this.seenIds.has(raw.id)) return;
+      const isMe = pid === myPid;
+      if (isMe) {
+        this.seenIds.add(raw.id);
+        return;
+      }
+      const color = view.playerIdentity?.playerStyle?.colorPalette?.[0] ?? "#8a8279";
+      this.appendMessage({ ...raw, pid, color, isMe: false });
+      if (!this.state.isOpen) unreadFromBatch = true;
+    });
+    if (unreadFromBatch && !this.state.unread) {
+      this.setState({ unread: true });
+    }
+  }
+
+  private appendMessage(msg: ChatMessageView): void {
+    if (this.seenIds.has(msg.id)) return;
+    this.seenIds.add(msg.id);
+    const next = [...this.state.messages, msg];
+    while (next.length > RING_BUFFER_SIZE) {
+      const evicted = next.shift();
+      if (evicted) this.seenIds.delete(evicted.id);
+    }
+    this.setState({ messages: next });
+  }
+
+  private setState(patch: Partial<ChatManagerState>): void {
+    this.state = { ...this.state, ...patch };
+    this.listeners.forEach((l) => l());
+  }
+}

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -116,14 +116,17 @@ export class ChatManager {
       ts: now,
       name: this.state.handle,
     };
-    this.presence.setMyPresence(CHAT_CHANNEL, msg);
     const myPid = this.presence.getMyIdentity().publicKey;
+    // Append locally BEFORE broadcasting: setMyPresence synchronously fires
+    // awareness listeners which would otherwise mark our own id as "seen"
+    // before our optimistic append runs, causing it to be deduped away.
     this.appendMessage({
       ...msg,
       pid: myPid,
       color: this.state.myColor,
       isMe: true,
     });
+    this.presence.setMyPresence(CHAT_CHANNEL, msg);
     if (this.state.sendError !== null) this.setState({ sendError: null });
     return true;
   }

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -31,6 +31,10 @@ export type ChatManagerState = {
   unread: boolean;
   sendError: string | null;
   myColor: string;
+  // Increments whenever the input should be (re)focused — e.g. pressing "/"
+  // while the panel is already open but the input isn't focused. The panel
+  // watches this and focuses its textarea on change.
+  focusNonce: number;
 };
 
 type Listener = () => void;
@@ -73,6 +77,7 @@ export class ChatManager {
       unread: false,
       sendError: null,
       myColor,
+      focusNonce: 0,
     };
   }
 
@@ -146,6 +151,16 @@ export class ChatManager {
       this.setState({ isOpen: false });
     } else {
       this.setState({ isOpen: true, unread: false });
+    }
+  }
+
+  // Pressing "/" should open the panel if closed, or just focus the input if
+  // it's already open — never close it (closing is Esc / the minimize button).
+  openOrFocus(): void {
+    if (this.state.isOpen) {
+      this.setState({ focusNonce: this.state.focusNonce + 1 });
+    } else {
+      this.setState({ isOpen: true, unread: false, focusNonce: this.state.focusNonce + 1 });
     }
   }
 

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -17,10 +17,13 @@ export class PresenceCountPill {
   private cleanups: (() => void)[] = [];
   private lastFingerprint = "";
   private isHidden = false;
+  private chatOpen = false;
+  private chatUnread = false;
 
   constructor(
     private presence: PresenceAPI,
     private lobbyPresence: PresenceAPI,
+    private chatToggle?: () => void,
   ) {}
 
   init(): void {
@@ -184,6 +187,91 @@ export class PresenceCountPill {
     } else {
       this.jumpBtn = null;
     }
+
+    // Chat segment
+    if (this.chatToggle) {
+      const sep = document.createElement("span");
+      Object.assign(sep.style, { opacity: "0.35", margin: "0 1px" });
+      sep.textContent = "\u00b7";
+      this.element.appendChild(sep);
+      this.element.appendChild(this.createChatSegment());
+    }
+
+    // Pill border accent when chat is open
+    this.element.style.borderColor = this.chatOpen
+      ? "rgba(196, 114, 78, 0.4)"
+      : "rgba(90, 78, 65, 0.15)";
+  }
+
+  private createChatSegment(): HTMLElement {
+    const seg = document.createElement("span");
+    Object.assign(seg.style, {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "3px",
+      cursor: "pointer",
+      padding: "1px 5px",
+      borderRadius: "8px",
+      transition: "background 120ms ease, color 120ms ease",
+      pointerEvents: "auto",
+    });
+    if (this.chatOpen) {
+      seg.style.background = "rgba(196, 114, 78, 0.15)";
+      seg.style.color = "#c4724e";
+    }
+
+    const icon = document.createElement("span");
+    icon.textContent = "\u25a4"; // small square with horizontal lines
+    icon.style.fontSize = "11px";
+    seg.appendChild(icon);
+
+    const label = document.createElement("span");
+    label.textContent = "chat";
+    seg.appendChild(label);
+
+    if (this.chatUnread) {
+      const dot = document.createElement("span");
+      Object.assign(dot.style, {
+        width: "5px",
+        height: "5px",
+        borderRadius: "50%",
+        background: "#c4724e",
+        display: "inline-block",
+        marginLeft: "2px",
+      });
+      seg.appendChild(dot);
+    }
+
+    seg.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.chatToggle?.();
+    });
+    return seg;
+  }
+
+  setChatOpen(open: boolean): void {
+    if (open === this.chatOpen) return;
+    this.chatOpen = open;
+    this.rerender();
+  }
+
+  setChatUnread(unread: boolean): void {
+    if (unread === this.chatUnread) return;
+    this.chatUnread = unread;
+    this.rerender();
+  }
+
+  private rerender(): void {
+    const pagePresences = this.presence.getPresences();
+    const lobbyPresences = this.lobbyPresence.getPresences();
+    const myKey = this.getMyPublicKey(pagePresences, lobbyPresences);
+    const pageOtherKeys = this.uniqueOtherKeys(pagePresences, myKey);
+    const lobbyOtherKeys = this.uniqueOtherKeys(lobbyPresences, myKey);
+    const pageOthers = pageOtherKeys.size;
+    const lobbyOthers = lobbyOtherKeys.size;
+    const elsewhere = Math.max(0, lobbyOthers - pageOthers);
+    this.lastFingerprint = "";
+    this.render(pageOthers, elsewhere, pagePresences, pageOtherKeys, myKey);
   }
 
   private createDot(color: string): HTMLElement {

--- a/extension/src/features/chat-echo-renderer.ts
+++ b/extension/src/features/chat-echo-renderer.ts
@@ -1,0 +1,154 @@
+// ABOUTME: Renders chat-message echo bubbles anchored to a peer's cursor for ~3 seconds.
+// ABOUTME: Reads cursor positions from CursorClient.getCursorPresences() and repositions on rAF.
+
+const ECHO_TTL_MS = 3000;
+const BUBBLE_OFFSET_X = 12;
+const BUBBLE_OFFSET_Y = -28;
+
+interface MinimalCursorClient {
+  getCursorPresences(): Map<
+    string,
+    {
+      cursor: { x: number; y: number; pointer: string } | null;
+      playerIdentity: { publicKey: string };
+    }
+  >;
+}
+
+interface EchoEntry {
+  msg: string;
+  color: string;
+  expiresAt: number;
+  node: HTMLElement;
+}
+
+const CSS = `
+:host { all: initial; }
+.layer {
+  position: fixed;
+  top: 0; left: 0;
+  width: 0; height: 0;
+  pointer-events: none;
+  z-index: 2147483641;
+}
+.bubble {
+  position: absolute;
+  background: #faf7f2;
+  border: 1px solid currentColor;
+  border-radius: 10px;
+  padding: 3px 8px;
+  font-family: "Atkinson Hyperlegible", system-ui, sans-serif;
+  font-size: 12px;
+  white-space: nowrap;
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.92;
+  transition: opacity 200ms ease;
+}
+`;
+
+export class ChatEchoRenderer {
+  private host: HTMLElement;
+  private shadow: ShadowRoot;
+  private layer: HTMLElement;
+  private entries = new Map<string, EchoEntry>();
+  private rafId: number | null = null;
+  private destroyed = false;
+
+  constructor(private cursorClient: MinimalCursorClient) {
+    this.host = document.createElement("div");
+    this.host.id = "wewere-chat-echo-host";
+    this.host.style.cssText =
+      "position:fixed;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483641;";
+    this.shadow = this.host.attachShadow({ mode: "open" });
+    const styleEl = document.createElement("style");
+    styleEl.textContent = CSS;
+    this.shadow.appendChild(styleEl);
+    const layer = document.createElement("div");
+    layer.className = "layer";
+    this.shadow.appendChild(layer);
+    this.layer = layer;
+    document.body.appendChild(this.host);
+  }
+
+  setEcho(pid: string, msg: string, color: string): void {
+    if (this.destroyed) return;
+    const presences = this.cursorClient.getCursorPresences();
+    const peer = presences.get(pid);
+    if (!peer || !peer.cursor) {
+      const existing = this.entries.get(pid);
+      if (existing) {
+        existing.node.remove();
+        this.entries.delete(pid);
+      }
+      return;
+    }
+    const existing = this.entries.get(pid);
+    if (existing) {
+      existing.node.remove();
+      this.entries.delete(pid);
+    }
+    const bubble = document.createElement("div");
+    bubble.className = "bubble";
+    bubble.dataset.chatEcho = pid;
+    bubble.style.color = color;
+    bubble.style.borderColor = color;
+    bubble.textContent = msg;
+    bubble.style.left = `${peer.cursor.x + BUBBLE_OFFSET_X}px`;
+    bubble.style.top = `${peer.cursor.y + BUBBLE_OFFSET_Y}px`;
+    this.layer.appendChild(bubble);
+    const entry: EchoEntry = {
+      msg,
+      color,
+      expiresAt: Date.now() + ECHO_TTL_MS,
+      node: bubble,
+    };
+    this.entries.set(pid, entry);
+    this.ensureLoop();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    this.entries.forEach((e) => e.node.remove());
+    this.entries.clear();
+    this.host.remove();
+  }
+
+  private ensureLoop(): void {
+    if (this.rafId != null) return;
+    const tick = () => {
+      this.rafId = null;
+      if (this.destroyed) return;
+      const now = Date.now();
+      const presences = this.cursorClient.getCursorPresences();
+      const expired: string[] = [];
+      this.entries.forEach((entry, pid) => {
+        if (now >= entry.expiresAt) {
+          expired.push(pid);
+          return;
+        }
+        const peer = presences.get(pid);
+        if (!peer || !peer.cursor) {
+          expired.push(pid);
+          return;
+        }
+        entry.node.style.left = `${peer.cursor.x + BUBBLE_OFFSET_X}px`;
+        entry.node.style.top = `${peer.cursor.y + BUBBLE_OFFSET_Y}px`;
+      });
+      expired.forEach((pid) => {
+        const entry = this.entries.get(pid);
+        entry?.node.remove();
+        this.entries.delete(pid);
+      });
+      if (this.entries.size > 0) {
+        this.rafId = requestAnimationFrame(tick);
+      }
+    };
+    this.rafId = requestAnimationFrame(tick);
+  }
+}

--- a/extension/src/features/chat-handle.ts
+++ b/extension/src/features/chat-handle.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Random Wikipedia-article handle for chat. Persists to browser.storage.local.
+// ABOUTME: Filters profane rolls; falls back to "Anonymous" on persistent failure.
+
+import browser from "webextension-polyfill";
+import { containsProfanity } from "@movement/profanity";
+
+const STORAGE_KEY = "wiki_chat_handle";
+const RANDOM_URL = "https://en.wikipedia.org/api/rest_v1/page/random/summary";
+const MAX_ROLL_RETRIES = 5;
+const FALLBACK = "Anonymous";
+
+let cached: string | null = null;
+
+export function _resetForTest(): void {
+  cached = null;
+}
+
+async function rollOnce(): Promise<string | null> {
+  try {
+    const res = await fetch(RANDOM_URL);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { title?: string };
+    if (typeof data.title !== "string" || data.title.length === 0) return null;
+    return data.title;
+  } catch {
+    return null;
+  }
+}
+
+async function rollHandle(): Promise<string> {
+  for (let i = 0; i < MAX_ROLL_RETRIES; i++) {
+    const title = await rollOnce();
+    if (title && !containsProfanity(title)) return title;
+  }
+  return FALLBACK;
+}
+
+export async function getOrCreateHandle(): Promise<string> {
+  if (cached) return cached;
+  const stored = (await browser.storage.local.get(STORAGE_KEY)) as Record<string, unknown>;
+  const existing = stored[STORAGE_KEY];
+  if (typeof existing === "string" && existing.length > 0) {
+    cached = existing;
+    return existing;
+  }
+  const fresh = await rollHandle();
+  cached = fresh;
+  await browser.storage.local.set({ [STORAGE_KEY]: fresh });
+  return fresh;
+}
+
+export async function rerollHandle(): Promise<string> {
+  const fresh = await rollHandle();
+  cached = fresh;
+  await browser.storage.local.set({ [STORAGE_KEY]: fresh });
+  return fresh;
+}

--- a/extension/src/features/wiki-summary.ts
+++ b/extension/src/features/wiki-summary.ts
@@ -1,0 +1,83 @@
+// ABOUTME: Fetches + caches Wikipedia article summaries for chat hovercards.
+// ABOUTME: Wraps the same REST endpoint Wikipedia's own Page Previews use.
+
+export interface WikiSummary {
+  title: string;
+  description?: string;
+  extract: string;
+  thumbnail?: { source: string; width: number; height: number };
+  url: string;
+}
+
+const SUMMARY_BASE = "https://en.wikipedia.org/api/rest_v1/page/summary/";
+
+// Cache per title for the lifetime of the page. Stores resolved summaries and
+// in-flight promises so concurrent hovers dedupe to a single request, and
+// `null` for titles known to have no usable summary (404, etc.).
+const cache = new Map<string, WikiSummary | null>();
+const inflight = new Map<string, Promise<WikiSummary | null>>();
+
+export function titleToPath(title: string): string {
+  return encodeURIComponent(title.replace(/ /g, "_"));
+}
+
+export function wikipediaUrlForTitle(title: string): string {
+  return `https://en.wikipedia.org/wiki/${titleToPath(title)}`;
+}
+
+export function getCachedSummary(title: string): WikiSummary | null | undefined {
+  return cache.get(title);
+}
+
+export async function fetchWikiSummary(title: string): Promise<WikiSummary | null> {
+  if (cache.has(title)) return cache.get(title) ?? null;
+  const existing = inflight.get(title);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<WikiSummary | null> => {
+    try {
+      const res = await fetch(`${SUMMARY_BASE}${titleToPath(title)}`);
+      if (!res.ok) {
+        cache.set(title, null);
+        return null;
+      }
+      const data = (await res.json()) as Record<string, any>;
+      if (typeof data.extract !== "string" || data.extract.length === 0) {
+        cache.set(title, null);
+        return null;
+      }
+      const summary: WikiSummary = {
+        title: typeof data.title === "string" ? data.title : title,
+        description: typeof data.description === "string" ? data.description : undefined,
+        extract: data.extract,
+        thumbnail:
+          data.thumbnail && typeof data.thumbnail.source === "string"
+            ? {
+                source: data.thumbnail.source,
+                width: Number(data.thumbnail.width) || 0,
+                height: Number(data.thumbnail.height) || 0,
+              }
+            : undefined,
+        url:
+          data.content_urls?.desktop?.page ??
+          wikipediaUrlForTitle(title),
+      };
+      cache.set(title, summary);
+      return summary;
+    } catch {
+      cache.set(title, null);
+      return null;
+    } finally {
+      inflight.delete(title);
+    }
+  })();
+
+  inflight.set(title, promise);
+  return promise;
+}
+
+// Test seam — reset module cache between tests.
+export function _clearSummaryCacheForTest(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -22,9 +22,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@extension": extensionSource,
+      "@movement": movementSharedDir,
       playhtml: playhtmlSource,
       "@playhtml/extension-types": extensionTypesSource,
-      "@movement": movementSharedDir,
     },
   },
   test: {
@@ -33,8 +33,8 @@ export default defineConfig({
     exclude: ["node_modules/**", "dist/**", ".output/**"],
     setupFiles: [setupFile],
     include: [
-      "src/__tests__/**/*.test.ts",
-      "src/__tests__/**/*.test.tsx",
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
       "website/shared/**/*.test.ts",
       "website/shared/**/*.test.tsx",
     ],

--- a/extension/website/privacy.html
+++ b/extension/website/privacy.html
@@ -161,6 +161,18 @@
       Supabase's managed infrastructure with encryption at rest.
     </p>
 
+    <h2>Real-time presence and chat</h2>
+    <p>
+      When other people with the extension are on the same page as you (currently
+      Wikipedia articles), the extension shows their cursors and lets you chat
+      with them in a small panel anchored to the presence pill. Cursor positions
+      and chat messages travel over a real-time PartyKit room. They are
+      <strong>not stored on our servers</strong>, are not linked to your
+      identity in any persistent record, and are gone once everyone leaves the
+      page. Your chat handle is a randomly chosen Wikipedia article title kept
+      only in your browser's local storage.
+    </p>
+
     <h2>How your data is used</h2>
     <p>Your data is used solely to:</p>
     <ul>

--- a/extension/website/shared/__tests__/profanity.test.ts
+++ b/extension/website/shared/__tests__/profanity.test.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Tests for the shared profanity-check utility.
+// ABOUTME: Verifies word-boundary matching and case-insensitive behavior.
+
+import { describe, it, expect } from "vitest";
+import { containsProfanity } from "../profanity";
+
+describe("containsProfanity", () => {
+  it("returns false for clean strings", () => {
+    expect(containsProfanity("hello world")).toBe(false);
+    expect(containsProfanity("octopuses have three hearts")).toBe(false);
+    expect(containsProfanity("")).toBe(false);
+  });
+
+  it("matches with word boundaries (case-insensitive)", () => {
+    expect(containsProfanity("oh shit")).toBe(true);
+    expect(containsProfanity("OH SHIT")).toBe(true);
+    expect(containsProfanity("Shit happens")).toBe(true);
+  });
+
+  it("does not flag inner substrings of unrelated words", () => {
+    expect(containsProfanity("classic literature")).toBe(false);
+    expect(containsProfanity("assassin")).toBe(false);
+  });
+});

--- a/extension/website/shared/profanity.ts
+++ b/extension/website/shared/profanity.ts
@@ -1,0 +1,11 @@
+// ABOUTME: Shared profanity check using the `profane-words` word list.
+// ABOUTME: Matches with word boundaries (case-insensitive) to avoid substring false positives.
+
+import words from "profane-words";
+
+export function containsProfanity(text: string): boolean {
+  return words.some((word) => {
+    const regex = new RegExp(`\\b${word}\\b`, "gi");
+    return regex.test(text);
+  });
+}

--- a/extension/website/src/components/AuraGuestbook.tsx
+++ b/extension/website/src/components/AuraGuestbook.tsx
@@ -3,7 +3,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { withSharedState, usePlayContext } from "@playhtml/react";
-import words from "profane-words";
+import { containsProfanity } from "@movement/profanity";
 import styles from "./AuraGuestbook.module.scss";
 
 interface GuestbookEntry {
@@ -21,13 +21,6 @@ const LOCALSTORAGE_KEY = "wewere-guestbook-submitted";
 const TEXTURE_CLASSES = ["textureA", "textureB", "textureC"] as const;
 function getTextureClass(index: number): string {
   return TEXTURE_CLASSES[index % TEXTURE_CLASSES.length];
-}
-
-function containsProfanity(text: string): boolean {
-  return words.some((word) => {
-    const regex = new RegExp(`\\b${word}\\b`, "gi");
-    return regex.test(text);
-  });
 }
 
 // Aging via desaturation + dimming instead of opacity

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   manifest: {
     name: "we were online",
     description:
-      "A quiet portrait of your time on the internet. Collect traces of where you've been and share them anonymously.",
+      "A quiet portrait of your time online. See who else is here, chat on Wikipedia, and collect traces of where you've been.",
     permissions: ["storage", "tabs", "alarms", "idle", "unlimitedStorage"],
     host_permissions: ["http://*/*", "https://*/*"],
     action: {

--- a/packages/playhtml/src/__tests__/presence.test.ts
+++ b/packages/playhtml/src/__tests__/presence.test.ts
@@ -55,4 +55,26 @@ describe("playhtml.presence", () => {
     expect(unsub).toBeTypeOf("function");
     unsub();
   });
+
+  it("onPresenceChange replays the current snapshot to a late subscriber", () => {
+    // A consumer that subscribes AFTER presence was already set must still
+    // receive the current state — not wait for the next change. This is the
+    // bug behind cursors that were already idle/unfocused before a peer
+    // loaded the page never getting dimmed.
+    playhtml.presence.setMyPresence("focus-replay", false);
+
+    let received: Map<string, unknown> | null = null;
+    const unsub = playhtml.presence.onPresenceChange("focus-replay", (presences) => {
+      received = presences as Map<string, unknown>;
+    });
+
+    expect(received).not.toBeNull();
+    const self = Array.from((received as unknown as Map<string, any>).values()).find(
+      (p) => p.isMe,
+    )!;
+    expect(self["focus-replay"]).toBe(false);
+
+    unsub();
+    playhtml.presence.setMyPresence("focus-replay", null);
+  });
 });

--- a/packages/playhtml/src/presence.ts
+++ b/packages/playhtml/src/presence.ts
@@ -199,8 +199,22 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
     ): () => void {
       ensureIdentityWritten();
       const id = String(nextListenerId++);
-      listeners.set(id, { channel, callback, lastFingerprint: "" });
+      // Seed lastFingerprint with the current channel state so the listener
+      // isn't re-fired redundantly on the next awareness change if nothing
+      // actually changed for this channel.
+      const currentStates = getAwareness().getStates() as Map<
+        number,
+        Record<string, unknown>
+      >;
+      const initialFingerprint = channelFingerprint(currentStates, channel);
+      listeners.set(id, { channel, callback, lastFingerprint: initialFingerprint });
       attachAwarenessListener();
+
+      // Replay the current snapshot immediately so late subscribers receive
+      // existing peer state instead of waiting for the next change. Consumers
+      // assume "subscribe = current state + future changes"; without this, a
+      // peer who set their state before we subscribed stays invisible to us.
+      callback(buildPresences());
 
       return () => {
         listeners.delete(id);


### PR DESCRIPTION
## Summary

Adds a live, per-article chat to Wikipedia pages, an in-extension announcement system to surface it, and a core presence fix that both rely on.

### Wikipedia chat
- A small chat panel on every Wikipedia page lets you talk live with whoever else is reading the same article. Open it from the presence pill or by pressing `/` (ignored while typing).
- You get a random Wikipedia-article handle (rerollable, profanity-filtered). The handle and every message author's name link to their article and show a **hovercard preview** on hover — built from the same `page/summary` REST API Wikipedia's own Page Previews use (their native popup can't reach into our shadow DOM).
- Messages are **live-session only**: they ride the existing per-page presence room and are never persisted. Joining shows an empty panel; messages appear in order as they're sent. Profanity-filtered (shared `containsProfanity` with the guestbook), 400-char cap, 500ms send throttle.
- Your latest message echoes by your cursor for ~3s.
- Remote cursors now dim when a person's tab is blurred/hidden so you can tell who's actively present.

### Announcement system
- Important updates surface as a bottom-left page **toast** (flashing NEW badge; dismiss via × only) on pages matching the announcement's `relevantUrl`, plus a dismissible **"from spencer" postcard** in the popup (collapsed → click to expand → body + CTA). Single forward-only seen-state per announcement (`unseen → toast-shown → dismissed`).
- First announcement: the Wikipedia chat launch.

### Core fix (`playhtml`)
- `presence.onPresenceChange` now replays the current snapshot to late subscribers instead of only firing on the next change. Without this, peers who'd already broadcast state before you subscribed stayed invisible — which is why cursors that were already blurred at page load never dimmed. Covered by a changeset.

## Testing
- [ ] Extension suite: 159 tests pass (`bun run -C extension test`)
- [ ] Core suite: 175 tests pass (`bun run -C packages/playhtml test`)
- [ ] Extension builds clean (`bun run -C extension build`)
- [ ] Manual: chat panel opens via pill + `/`; messages exchange live between two browsers; cursor echo appears; hovercards load; toast + postcard show and dismiss correctly

## Notes
- **Docs split correctly across the two release flows:** core change → `.changeset/presence-replay-on-subscribe.md` (changesets); extension changes → `extension/PENDING.md` bullets (the new extension release-PR flow).
- ChatPanel render tests were attempted but the workspace's React 18/19 hoist split breaks `@testing-library/react` in the test env; deferred rather than destabilize the build. The fetch/cache logic (`wiki-summary`) and all manager/storage logic are unit-tested.


<img width="304" height="232" alt="image" src="https://github.com/user-attachments/assets/a94cdeba-debf-417a-8528-d44c672bf400" />
