### PR TITLE
Fix chat hovercard clipping + add 'be this page' name picker

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -8,3 +8,5 @@ file back to just the header. Merge that PR to ship.
 
 Format suggestion: "- short user-facing description (#PR)"
 -->
+
+- Wikipedia chat: article-name hovercards now stay on-screen near the viewport edge instead of getting cut off. The reroll affordance is a dice icon, and on real article pages a pin-icon button lets you adopt the article you're reading as your name.

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -267,6 +267,25 @@ describe("ChatManager", () => {
     mgr.destroy();
   });
 
+  it("useCurrentPage adopts the current article as the handle", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus", "Octopus");
+    await mgr.init();
+    await mgr.useCurrentPage();
+    expect(mgr.getState().handle).toBe("Octopus");
+    mgr.destroy();
+  });
+
+  it("useCurrentPage is a no-op when not on an article (currentArticleName null)", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Wikipedia home", null);
+    await mgr.init();
+    const before = mgr.getState().handle;
+    await mgr.useCurrentPage();
+    expect(mgr.getState().handle).toBe(before);
+    mgr.destroy();
+  });
+
   it("ring-buffer caps total messages at 50", async () => {
     const fake = makeFakePresence();
     const mgr = new ChatManager(fake.api, "Octopus");

--- a/extension/src/__tests__/wikipedia-article-name.test.ts
+++ b/extension/src/__tests__/wikipedia-article-name.test.ts
@@ -1,0 +1,53 @@
+// ABOUTME: Tests for currentWikipediaArticleName — which pages can be adopted as a chat handle.
+// ABOUTME: The main page and namespace pages must return null so "be this page" doesn't appear there.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { currentWikipediaArticleName } from "../custom-sites/wikipedia";
+
+function setLocation(href: string) {
+  const url = new URL(href);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: url.href,
+      pathname: url.pathname,
+      origin: url.origin,
+      hostname: url.hostname,
+    },
+  });
+}
+
+describe("currentWikipediaArticleName", () => {
+  afterEach(() => {
+    setLocation("https://en.wikipedia.org/");
+  });
+
+  it("returns the title on a real article", () => {
+    setLocation("https://en.wikipedia.org/wiki/Octopus");
+    expect(currentWikipediaArticleName()).toBe("Octopus");
+  });
+
+  it("decodes underscores and percent-encoding", () => {
+    setLocation("https://en.wikipedia.org/wiki/Pyotr_Stolypin");
+    expect(currentWikipediaArticleName()).toBe("Pyotr Stolypin");
+  });
+
+  it("returns null on the main page (/wiki/Main_Page)", () => {
+    setLocation("https://en.wikipedia.org/wiki/Main_Page");
+    expect(currentWikipediaArticleName()).toBeNull();
+  });
+
+  it("returns null on the bare root and /wiki/", () => {
+    setLocation("https://en.wikipedia.org/");
+    expect(currentWikipediaArticleName()).toBeNull();
+    setLocation("https://en.wikipedia.org/wiki/");
+    expect(currentWikipediaArticleName()).toBeNull();
+  });
+
+  it("returns null on namespace pages (Special:/Talk:)", () => {
+    setLocation("https://en.wikipedia.org/wiki/Special:RecentChanges");
+    expect(currentWikipediaArticleName()).toBeNull();
+    setLocation("https://en.wikipedia.org/wiki/Talk:Octopus");
+    expect(currentWikipediaArticleName()).toBeNull();
+  });
+});

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -10,11 +10,13 @@ interface ChatPanelProps {
   handle: string;
   myColor: string;
   articleTitle: string;
+  currentArticleName: string | null;
   sendError: string | null;
   focusNonce: number;
   onSend: (text: string) => void;
   onClose: () => void;
   onReroll: () => void;
+  onUsePage: () => void;
   onClearError: () => void;
 }
 
@@ -26,11 +28,13 @@ export function ChatPanel({
   handle,
   myColor,
   articleTitle,
+  currentArticleName,
   sendError,
   focusNonce,
   onSend,
   onClose,
   onReroll,
+  onUsePage,
   onClearError,
 }: ChatPanelProps) {
   const [value, setValue] = useState("");
@@ -106,9 +110,29 @@ export function ChatPanel({
             <WikiArticleLink className="chat-handle-link" title={handle} />
           )}
         </span>
-        <button type="button" className="chat-reroll" onClick={onReroll}>
-          reroll
-        </button>
+        <span className="chat-name-actions">
+          {currentArticleName && handle !== currentArticleName ? (
+            <button type="button" className="chat-be-page" onClick={onUsePage}>
+              be this page
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="chat-reroll-dice"
+            onClick={onReroll}
+            aria-label="reroll name"
+            title="reroll name"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden>
+              <rect x="1.5" y="1.5" width="13" height="13" rx="3" stroke="currentColor" stroke-width="1.4" />
+              <circle cx="5" cy="5" r="1.1" fill="currentColor" />
+              <circle cx="11" cy="5" r="1.1" fill="currentColor" />
+              <circle cx="8" cy="8" r="1.1" fill="currentColor" />
+              <circle cx="5" cy="11" r="1.1" fill="currentColor" />
+              <circle cx="11" cy="11" r="1.1" fill="currentColor" />
+            </svg>
+          </button>
+        </span>
       </div>
       <div className="chat-body" ref={bodyRef}>
         {messages.map((m) => (

--- a/extension/src/components/ChatPanel.tsx
+++ b/extension/src/components/ChatPanel.tsx
@@ -112,8 +112,22 @@ export function ChatPanel({
         </span>
         <span className="chat-name-actions">
           {currentArticleName && handle !== currentArticleName ? (
-            <button type="button" className="chat-be-page" onClick={onUsePage}>
-              be this page
+            <button
+              type="button"
+              className="chat-be-page"
+              onClick={onUsePage}
+              aria-label="be this page"
+              title="be this page"
+            >
+              <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden>
+                <path
+                  d="M8 1.5c-2.6 0-4.5 2-4.5 4.5 0 3.1 4.5 8 4.5 8s4.5-4.9 4.5-8c0-2.5-1.9-4.5-4.5-4.5z"
+                  stroke="currentColor"
+                  stroke-width="1.4"
+                  stroke-linejoin="round"
+                />
+                <circle cx="8" cy="6" r="1.6" fill="currentColor" />
+              </svg>
             </button>
           ) : null}
           <button

--- a/extension/src/components/WikiArticleLink.tsx
+++ b/extension/src/components/WikiArticleLink.tsx
@@ -11,6 +11,15 @@ import {
 
 const HOVER_OPEN_DELAY_MS = 350;
 const HOVER_CLOSE_DELAY_MS = 150;
+// Keep in sync with .wiki-hovercard width in wikipedia.ts CHAT_PANEL_CSS.
+const HOVERCARD_WIDTH = 240;
+const HOVERCARD_MAX_HEIGHT = 220;
+const VIEWPORT_MARGIN = 8;
+const ANCHOR_GAP = 6;
+
+type CardPos =
+  | { left: number; bottom: number; top?: undefined }
+  | { left: number; top: number; bottom?: undefined };
 
 interface Props {
   title: string;
@@ -22,7 +31,7 @@ export function WikiArticleLink({ title, className }: Props) {
     getCachedSummary(title),
   );
   const [open, setOpen] = useState(false);
-  const [pos, setPos] = useState<{ left: number; bottom: number } | null>(null);
+  const [pos, setPos] = useState<CardPos | null>(null);
   const anchorRef = useRef<HTMLAnchorElement | null>(null);
   const openTimer = useRef<number | null>(null);
   const closeTimer = useRef<number | null>(null);
@@ -34,21 +43,36 @@ export function WikiArticleLink({ title, className }: Props) {
     closeTimer.current = null;
   }, []);
 
+  const computePos = useCallback((): CardPos | null => {
+    const rect = anchorRef.current?.getBoundingClientRect();
+    if (!rect) return null;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+
+    // Horizontal: prefer the link's left edge, but clamp so the full card
+    // stays within the viewport (this is what was getting cut off on the
+    // right-anchored chat panel).
+    const maxLeft = vw - HOVERCARD_WIDTH - VIEWPORT_MARGIN;
+    const left = Math.max(VIEWPORT_MARGIN, Math.min(rect.left, maxLeft));
+
+    // Vertical: prefer above the link; flip below if there isn't room.
+    const spaceAbove = rect.top;
+    if (spaceAbove >= HOVERCARD_MAX_HEIGHT + ANCHOR_GAP) {
+      return { left, bottom: vh - rect.top + ANCHOR_GAP };
+    }
+    return { left, top: rect.bottom + ANCHOR_GAP };
+  }, []);
+
   const onEnter = useCallback(() => {
     clearTimers();
     openTimer.current = window.setTimeout(() => {
-      // Anchor the fixed-position card just above the link so it escapes the
-      // panel's scrolling/clipping body.
-      const rect = anchorRef.current?.getBoundingClientRect();
-      if (rect) {
-        setPos({ left: rect.left, bottom: window.innerHeight - rect.top + 6 });
-      }
+      setPos(computePos());
       setOpen(true);
       if (summary === undefined) {
         void fetchWikiSummary(title).then((s) => setSummary(s));
       }
     }, HOVER_OPEN_DELAY_MS);
-  }, [clearTimers, summary, title]);
+  }, [clearTimers, computePos, summary, title]);
 
   const onLeave = useCallback(() => {
     clearTimers();
@@ -70,7 +94,11 @@ export function WikiArticleLink({ title, className }: Props) {
         <span
           className="wiki-hovercard"
           role="tooltip"
-          style={{ left: `${pos.left}px`, bottom: `${pos.bottom}px` }}
+          style={
+            pos.bottom !== undefined
+              ? { left: `${pos.left}px`, bottom: `${pos.bottom}px` }
+              : { left: `${pos.left}px`, top: `${pos.top}px` }
+          }
         >
           {summary.thumbnail ? (
             <img

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -80,11 +80,11 @@ const CHAT_PANEL_CSS = `
   flex: 0 0 auto;
 }
 .chat-name-strip .chat-be-page {
-  background: none; border: none; cursor: pointer;
-  color: #5b8db8; font-size: 11px; padding: 0; font-family: inherit;
-  white-space: nowrap;
+  background: none; border: none; cursor: pointer; padding: 0;
+  color: #8a8279; display: inline-flex; align-items: center;
+  transition: color 120ms ease;
 }
-.chat-name-strip .chat-be-page:hover { color: #3d6f96; text-decoration: underline; }
+.chat-name-strip .chat-be-page:hover { color: #5b8db8; }
 .chat-name-strip .chat-reroll-dice {
   background: none; border: none; cursor: pointer; padding: 0;
   color: #8a8279; display: inline-flex; align-items: center;
@@ -210,8 +210,14 @@ export function wikipediaPageLabel(): string {
 // can be offered as a "be this page" handle). null on the main page, namespace
 // pages (Special:/Talk:/etc.), and anything that isn't an article.
 export function currentWikipediaArticleName(): string | null {
+  const path = location.pathname;
+  // The main page is a "/wiki/" URL with no namespace colon, so isWikiArticleUrl
+  // treats it as an article — exclude it explicitly (matches wikipediaPageLabel).
+  if (path === "/" || path === "/wiki/" || /\/wiki\/(Main_Page|Wikipedia:Main_Page)$/.test(path)) {
+    return null;
+  }
   if (!isWikiArticleUrl(location.href)) return null;
-  const match = location.pathname.match(/\/wiki\/(.+)$/);
+  const match = path.match(/\/wiki\/(.+)$/);
   if (!match) return null;
   return decodeURIComponent(match[1]).replace(/_/g, " ");
 }

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -74,11 +74,23 @@ const CHAT_PANEL_CSS = `
   text-decoration-color: #5b8db8;
   color: #5b8db8;
 }
-.chat-name-strip .chat-reroll {
+.chat-name-strip .chat-name-actions {
   margin-left: auto;
+  display: inline-flex; align-items: center; gap: 8px;
+  flex: 0 0 auto;
+}
+.chat-name-strip .chat-be-page {
   background: none; border: none; cursor: pointer;
   color: #5b8db8; font-size: 11px; padding: 0; font-family: inherit;
+  white-space: nowrap;
 }
+.chat-name-strip .chat-be-page:hover { color: #3d6f96; text-decoration: underline; }
+.chat-name-strip .chat-reroll-dice {
+  background: none; border: none; cursor: pointer; padding: 0;
+  color: #8a8279; display: inline-flex; align-items: center;
+  transition: color 120ms ease;
+}
+.chat-name-strip .chat-reroll-dice:hover { color: #5b8db8; }
 .you-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
 .chat-body {
   padding: 6px 8px;
@@ -192,6 +204,16 @@ export function wikipediaPageLabel(): string {
   // Fallback to <title> with trailing " - Wikipedia" stripped
   const title = document.title.replace(/ - Wikipedia$/, "").trim();
   return title.length > 0 ? title : "Wikipedia";
+}
+
+// The current page's article title, but only when it's a real article (so it
+// can be offered as a "be this page" handle). null on the main page, namespace
+// pages (Special:/Talk:/etc.), and anything that isn't an article.
+export function currentWikipediaArticleName(): string | null {
+  if (!isWikiArticleUrl(location.href)) return null;
+  const match = location.pathname.match(/\/wiki\/(.+)$/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]).replace(/_/g, " ");
 }
 
 // True when a keyboard event target is a text input the user is typing into,
@@ -311,7 +333,11 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   const { ChatPanel } = await import("../components/ChatPanel");
 
   const articleTitle = wikipediaPageLabel();
-  const chatManager = new ChatManager(deps.presence, articleTitle);
+  const chatManager = new ChatManager(
+    deps.presence,
+    articleTitle,
+    currentWikipediaArticleName(),
+  );
   await chatManager.init();
 
   // Ambient presence count + jump-to-someone + chat toggle
@@ -334,11 +360,13 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
       handle: s.handle,
       myColor: s.myColor,
       articleTitle: s.articleTitle,
+      currentArticleName: s.currentArticleName,
       sendError: s.sendError,
       focusNonce: s.focusNonce,
       onSend: (text: string) => { chatManager.send(text); },
       onClose: () => { chatManager.close(); },
       onReroll: () => { void chatManager.reroll(); },
+      onUsePage: () => { void chatManager.useCurrentPage(); },
       onClearError: () => { chatManager.clearError(); },
     };
   }

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -3,7 +3,7 @@
 
 import type { PresenceAPI, PresenceView } from "@playhtml/common";
 import { containsProfanity } from "@movement/profanity";
-import { getOrCreateHandle, rerollHandle } from "./chat-handle";
+import { getOrCreateHandle, rerollHandle, setHandle } from "./chat-handle";
 
 const CHAT_CHANNEL = "chat";
 const MAX_MESSAGE_LENGTH = 400;
@@ -27,6 +27,9 @@ export type ChatManagerState = {
   messages: ChatMessageView[];
   handle: string;
   articleTitle: string;
+  // The current page's article title when it's a real article (so the user can
+  // adopt it as their handle via "be this page"); null on non-article pages.
+  currentArticleName: string | null;
   isOpen: boolean;
   unread: boolean;
   sendError: string | null;
@@ -66,6 +69,7 @@ export class ChatManager {
   constructor(
     private presence: PresenceAPI,
     articleTitle: string,
+    currentArticleName: string | null = null,
   ) {
     const myIdentity = presence.getMyIdentity();
     const myColor = myIdentity.playerStyle?.colorPalette?.[0] ?? "#8a8279";
@@ -73,6 +77,7 @@ export class ChatManager {
       messages: [],
       handle: "Anonymous",
       articleTitle,
+      currentArticleName,
       isOpen: false,
       unread: false,
       sendError: null,
@@ -171,6 +176,15 @@ export class ChatManager {
   async reroll(): Promise<void> {
     const fresh = await rerollHandle();
     this.setState({ handle: fresh });
+  }
+
+  // Adopt the current article as the handle ("be this page"). No-op when not
+  // on an article.
+  async useCurrentPage(): Promise<void> {
+    const name = this.state.currentArticleName;
+    if (!name) return;
+    const next = await setHandle(name);
+    this.setState({ handle: next });
   }
 
   private onPresences(presences: Map<string, PresenceView>): void {

--- a/extension/src/features/chat-handle.ts
+++ b/extension/src/features/chat-handle.ts
@@ -55,3 +55,16 @@ export async function rerollHandle(): Promise<string> {
   await browser.storage.local.set({ [STORAGE_KEY]: fresh });
   return fresh;
 }
+
+// Adopt a specific article title as the handle (e.g. "be this page"). Falls
+// back to a reroll if the chosen title is empty or profane, so we never
+// persist an unusable name.
+export async function setHandle(title: string): Promise<string> {
+  const trimmed = title.trim();
+  if (trimmed.length === 0 || containsProfanity(trimmed)) {
+    return rerollHandle();
+  }
+  cached = trimmed;
+  await browser.storage.local.set({ [STORAGE_KEY]: trimmed });
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

Two fixes to the Wikipedia chat that shipped in #142.

1. **Hovercard clipping** — the article-name hovercard (fixed 240px) was getting cut off at the right edge of the viewport, since the chat panel sits bottom-right. It now clamps its horizontal position so the full card stays on-screen, and flips below the link when there isn't enough room above.

2. **"be this page" name picker** — alongside reroll (now a dice icon with a tooltip), you can adopt the article you're currently reading as your chat name. The "be this page" link only appears on real article pages and hides when you're already named that page. `setHandle` reuses the existing profanity check and falls back to a reroll if the chosen title is unusable.

## Test plan
- [ ] `bun run -C extension test` — 169 pass (incl. 2 new `useCurrentPage` cases)
- [ ] `bun run -C extension build` — clean
- [ ] Manual: hover an article name when the panel is bottom-right → card stays fully on screen; hover a link low in the viewport → card flips below
- [ ] Manual: on an article, click "be this page" → handle becomes that article; on the main page / Special: page, "be this page" is absent
- [ ] Manual: dice icon rerolls; tooltip reads "reroll name"

## Notes
- PENDING.md bullet added for the extension release flow.