### PR TITLE
Filter stale Wikipedia portal targets

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -8,3 +8,5 @@ file back to just the header. Merge that PR to ship.
 
 Format suggestion: "- short user-facing description (#PR)"
 -->
+
+- Make the Wikipedia jump portal ignore stale page presence so it only sends you to currently active readers.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -10,3 +10,4 @@ Format suggestion: "- short user-facing description (#PR)"
 -->
 
 - Make the Wikipedia jump portal ignore stale page presence so it only sends you to currently active readers.
+- Keep Wikipedia chat handle article previews in sync after rerolling or changing your name.

--- a/extension/src/__tests__/PresenceCountPill.test.ts
+++ b/extension/src/__tests__/PresenceCountPill.test.ts
@@ -1,0 +1,139 @@
+// ABOUTME: Tests for the Wikipedia presence count pill and portal target selection.
+// ABOUTME: Verifies domain-lobby pages only advertise useful live destinations.
+
+import type { PresenceAPI, PlayerIdentity } from "@playhtml/common";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PresenceCountPill } from "../features/PresenceCountPill";
+
+function setLocation(href: string) {
+  const url = new URL(href);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      href: url.href,
+      pathname: url.pathname,
+      origin: url.origin,
+      hostname: url.hostname,
+      hash: url.hash,
+    },
+  });
+}
+
+function identity(publicKey: string): PlayerIdentity {
+  return {
+    publicKey,
+    playerStyle: { colorPalette: ["#4a9a8a"] },
+  } as PlayerIdentity;
+}
+
+function presenceApi(myKey: string, presences: Map<string, any>): PresenceAPI {
+  return {
+    setMyPresence: vi.fn(),
+    getPresences: () => presences,
+    onPresenceChange: vi.fn(() => () => {}),
+    getMyIdentity: () => identity(myKey),
+  };
+}
+
+describe("PresenceCountPill", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+    setLocation("https://en.wikipedia.org/wiki/Current");
+  });
+
+  it("does not show the jump portal for stale lobby pages", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
+    setLocation("https://en.wikipedia.org/wiki/Current");
+
+    const pagePresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+      ]),
+    );
+    const lobbyPresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+        [
+          "peer",
+          {
+            isMe: false,
+            playerIdentity: identity("peer"),
+            page: {
+              url: "https://en.wikipedia.org/wiki/Stale",
+              title: "Stale",
+              lastSeenAt: Date.now() - 60_000,
+            },
+          },
+        ],
+      ]),
+    );
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(
+      document.querySelector('button[title="jump to someone"]'),
+    ).toBeNull();
+
+    pill.destroy();
+  });
+
+  it("jumps to a fresh lobby page instead of a stale one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    setLocation("https://en.wikipedia.org/wiki/Current");
+
+    const pagePresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+      ]),
+    );
+    const lobbyPresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+        [
+          "stale-peer",
+          {
+            isMe: false,
+            playerIdentity: identity("stale-peer"),
+            page: {
+              url: "https://en.wikipedia.org/wiki/Stale",
+              title: "Stale",
+              lastSeenAt: Date.now() - 60_000,
+            },
+          },
+        ],
+        [
+          "fresh-peer",
+          {
+            isMe: false,
+            playerIdentity: identity("fresh-peer"),
+            page: {
+              url: "https://en.wikipedia.org/wiki/Fresh",
+              title: "Fresh",
+              lastSeenAt: Date.now(),
+            },
+          },
+        ],
+      ]),
+    );
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    document
+      .querySelector<HTMLButtonElement>('button[title="jump to someone"]')
+      ?.click();
+
+    expect(window.location.href).toBe("https://en.wikipedia.org/wiki/Fresh");
+
+    pill.destroy();
+  });
+});

--- a/extension/src/__tests__/WikiArticleLink.test.tsx
+++ b/extension/src/__tests__/WikiArticleLink.test.tsx
@@ -1,0 +1,92 @@
+// ABOUTME: Tests for WikiArticleLink hovercard behavior across article title changes.
+// ABOUTME: Verifies the preview follows chat handle rerolls and page-name adoption.
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _clearSummaryCacheForTest } from "../features/wiki-summary";
+import { WikiArticleLink } from "../components/WikiArticleLink";
+
+function okResponse(title: string, extract: string): Response {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ title, extract }),
+  } as Response;
+}
+
+async function renderLink(title: string) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<WikiArticleLink title={title} />);
+  });
+
+  return { container, root };
+}
+
+async function hover(container: HTMLElement) {
+  const link = container.querySelector("a");
+  expect(link).toBeInstanceOf(HTMLAnchorElement);
+
+  await act(async () => {
+    link?.dispatchEvent(
+      new MouseEvent("mouseover", { bubbles: true, cancelable: true }),
+    );
+    vi.advanceTimersByTime(350);
+    await Promise.resolve();
+  });
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe("WikiArticleLink", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _clearSummaryCacheForTest();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("shows the new article preview after the title changes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okResponse("Octopus", "Old preview"))
+      .mockResolvedValueOnce(okResponse("Cuttlefish", "New preview"));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { container, root } = await renderLink("Octopus");
+
+    try {
+      await hover(container);
+      expect(container.querySelector(".wiki-hovercard__title")?.textContent).toBe(
+        "Octopus",
+      );
+
+      await act(async () => {
+        root.render(<WikiArticleLink title="Cuttlefish" />);
+      });
+      await hover(container);
+
+      expect(container.querySelector(".wiki-hovercard__title")?.textContent).toBe(
+        "Cuttlefish",
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+});

--- a/extension/src/components/WikiArticleLink.tsx
+++ b/extension/src/components/WikiArticleLink.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: A Wikipedia article link that shows a hovercard preview on hover.
 // ABOUTME: Builds its own card from the page/summary REST API (Wikipedia's native popup can't reach our shadow DOM).
 
-import { useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import {
   fetchWikiSummary,
   getCachedSummary,
@@ -42,6 +42,13 @@ export function WikiArticleLink({ title, className }: Props) {
     openTimer.current = null;
     closeTimer.current = null;
   }, []);
+
+  useEffect(() => {
+    clearTimers();
+    setSummary(getCachedSummary(title));
+    setOpen(false);
+    setPos(null);
+  }, [clearTimers, title]);
 
   const computePos = useCallback((): CardPos | null => {
     const rect = anchorRef.current?.getBoundingClientRect();

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -8,7 +8,13 @@ import { FollowManager } from "../features/FollowManager";
 export interface WikiPresenceFields {
   navigatingTo?: { url: string; title: string } | null;
   following?: string | null;
-  page?: { url: string; title: string; color: string; pid?: string } | null;
+  page?: {
+    url: string;
+    title: string;
+    color: string;
+    pid?: string;
+    lastSeenAt?: number;
+  } | null;
 }
 
 export type WikiPresenceView = PresenceView & WikiPresenceFields;
@@ -273,14 +279,26 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   let lobbyPresence = deps.presence; // fallback to page presence if lobby unavailable
   if (typeof deps.createPresenceRoom === "function") {
     const lobby = deps.createPresenceRoom("lobby");
-    lobby.presence.setMyPresence("page", {
-      url: location.href,
-      title: document.title.replace(/ - Wikipedia$/, ""),
-      color: deps.playerColor,
-      pid: lobby.presence.getMyIdentity().publicKey,
-    });
+    const publishLobbyPage = () => {
+      lobby.presence.setMyPresence("page", {
+        url: location.href,
+        title: document.title.replace(/ - Wikipedia$/, ""),
+        color: deps.playerColor,
+        pid: lobby.presence.getMyIdentity().publicKey,
+        lastSeenAt: Date.now(),
+      });
+    };
+    publishLobbyPage();
+    const lobbyHeartbeat = window.setInterval(publishLobbyPage, 10_000);
+    window.addEventListener("focus", publishLobbyPage);
+    document.addEventListener("visibilitychange", publishLobbyPage);
     lobbyPresence = lobby.presence;
-    cleanups.push(() => lobby.destroy());
+    cleanups.push(() => {
+      window.clearInterval(lobbyHeartbeat);
+      window.removeEventListener("focus", publishLobbyPage);
+      document.removeEventListener("visibilitychange", publishLobbyPage);
+      lobby.destroy();
+    });
   }
 
   // === Tab-focus dimming for remote cursors ===

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -11,6 +11,8 @@ const PORTAL_SVG = `<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
   <circle cx="7" cy="7" r="1" fill="currentColor" opacity="0.6"/>
 </svg>`;
 
+const LOBBY_PAGE_TTL_MS = 30_000;
+
 export class PresenceCountPill {
   private element: HTMLElement | null = null;
   private jumpBtn: HTMLElement | null = null;
@@ -33,11 +35,10 @@ export class PresenceCountPill {
 
       const myKey = this.getMyPublicKey(pagePresences, lobbyPresences);
       const pageOtherKeys = this.uniqueOtherKeys(pagePresences, myKey);
-      const lobbyOtherKeys = this.uniqueOtherKeys(lobbyPresences, myKey);
+      const lobbyOtherPageKeys = this.uniqueOtherPageKeys(lobbyPresences, myKey);
 
       const pageOthers = pageOtherKeys.size;
-      const lobbyOthers = lobbyOtherKeys.size;
-      const elsewhere = Math.max(0, lobbyOthers - pageOthers);
+      const elsewhere = lobbyOtherPageKeys.size;
       const fingerprint = `${pageOthers}:${elsewhere}`;
 
       if (fingerprint !== this.lastFingerprint) {
@@ -98,6 +99,40 @@ export class PresenceCountPill {
       if (p.isMe) return;
       const key = this.pidOf(p);
       if (key && myKey && key === myKey) return;
+      keys.add(key ?? `conn:${connectionId}`);
+    });
+    return keys;
+  }
+
+  private isFreshLobbyPage(
+    page: WikiPresenceView["page"],
+  ): page is NonNullable<WikiPresenceView["page"]> {
+    if (!page?.url || typeof page.lastSeenAt !== "number") return false;
+    return Date.now() - page.lastSeenAt <= LOBBY_PAGE_TTL_MS;
+  }
+
+  private isCurrentPageUrl(url: string): boolean {
+    try {
+      const candidate = new URL(url, location.href);
+      const current = new URL(location.href);
+      return (
+        candidate.origin === current.origin &&
+        candidate.pathname === current.pathname &&
+        candidate.search === current.search
+      );
+    } catch {
+      return url === location.href;
+    }
+  }
+
+  private uniqueOtherPageKeys(presences: Map<string, any>, myKey: string | null): Set<string> {
+    const keys = new Set<string>();
+    presences.forEach((p, connectionId) => {
+      if (p.isMe) return;
+      const key = this.pidOf(p);
+      if (key && myKey && key === myKey) return;
+      const page = (p as WikiPresenceView).page;
+      if (!this.isFreshLobbyPage(page) || this.isCurrentPageUrl(page.url)) return;
       keys.add(key ?? `conn:${connectionId}`);
     });
     return keys;
@@ -266,10 +301,9 @@ export class PresenceCountPill {
     const lobbyPresences = this.lobbyPresence.getPresences();
     const myKey = this.getMyPublicKey(pagePresences, lobbyPresences);
     const pageOtherKeys = this.uniqueOtherKeys(pagePresences, myKey);
-    const lobbyOtherKeys = this.uniqueOtherKeys(lobbyPresences, myKey);
+    const lobbyOtherPageKeys = this.uniqueOtherPageKeys(lobbyPresences, myKey);
     const pageOthers = pageOtherKeys.size;
-    const lobbyOthers = lobbyOtherKeys.size;
-    const elsewhere = Math.max(0, lobbyOthers - pageOthers);
+    const elsewhere = lobbyOtherPageKeys.size;
     this.lastFingerprint = "";
     this.render(pageOthers, elsewhere, pagePresences, pageOtherKeys, myKey);
   }
@@ -323,12 +357,11 @@ export class PresenceCountPill {
       const key = this.pidOf(p);
       // Same human in another tab — skip so we don't teleport to our own pages.
       if (key && myKey && key === myKey) return;
+      const page = (p as WikiPresenceView).page;
+      if (!this.isFreshLobbyPage(page) || this.isCurrentPageUrl(page.url)) return;
       if (key && seenKeys.has(key)) return;
       if (key) seenKeys.add(key);
-      const page = (p as WikiPresenceView).page;
-      if (page?.url && page.url !== location.href) {
-        otherPages.push({ url: page.url, title: page.title });
-      }
+      otherPages.push({ url: page.url, title: page.title });
     });
 
     if (otherPages.length === 0) {


### PR DESCRIPTION
## Summary

- Add a heartbeat timestamp to Wikipedia lobby page presence.
- Filter the jump portal's count and target selection to fresh lobby pages only.
- Add regression coverage for stale lobby entries and mixed stale/fresh portal targets.

## Root Cause

The Wikipedia lobby advertised each tab's page.url once, and the jump portal treated that URL as valid indefinitely. During tab close, navigation, or reconnect windows, stale lobby entries could still be selected, sending someone to a page where no live peer was present.

## Validation

- bun run test --run PresenceCountPill.test.ts wikipedia-article-name.test.ts ChatManager.test.ts chat-echo-renderer.test.ts wiki-summary.test.ts (35 tests passed)
- git diff --check origin/main...HEAD
