### PR TITLE
Reduce Cloudflare cost from extension-owned rooms

### DIFF
--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -2,7 +2,12 @@
 // ABOUTME: Guards high-traffic sites from extension-owned rooms unless explicitly supported.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { initCustomSite, shouldEnableCursorsForHostname } from "../custom-sites";
+import {
+  getCustomSiteSettingsForHostname,
+  initCustomSite,
+  resolveCustomSiteSettingsForHostname,
+  shouldEnableCursorsForHostname,
+} from "../custom-sites";
 import { initWikipedia } from "../custom-sites/wikipedia";
 import { shouldStartExtensionPresence } from "../entrypoints/content/presencePolicy";
 
@@ -77,6 +82,34 @@ describe("shouldEnableCursors", () => {
     expect(shouldEnableCursorsForHostname("wikipedia.org.example.com")).toBe(
       false,
     );
+  });
+});
+
+describe("custom site settings", () => {
+  it("uses default supported-site settings for Wikipedia", () => {
+    expect(getCustomSiteSettingsForHostname("en.wikipedia.org")).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: false },
+    });
+  });
+
+  it("does not return settings for unsupported high-traffic sites", () => {
+    expect(getCustomSiteSettingsForHostname("www.youtube.com")).toBeNull();
+  });
+
+  it("allows explicit site settings to override room options", () => {
+    const settings = resolveCustomSiteSettingsForHostname("videos.example", [
+      {
+        matches: (hostname) => hostname === "videos.example",
+        init: async () => null,
+        settings: { defaultRoomOptions: { includeSearch: true } },
+      },
+    ]);
+
+    expect(settings).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: true },
+    });
   });
 });
 

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -51,5 +51,13 @@ describe("shouldEnableCursors", () => {
 
   it("enables cursors for Wikipedia", () => {
     expect(shouldEnableCursorsForHostname("en.wikipedia.org")).toBe(true);
+    expect(shouldEnableCursorsForHostname("wikipedia.org")).toBe(true);
+  });
+
+  it("does not enable cursors for Wikipedia lookalike domains", () => {
+    expect(shouldEnableCursorsForHostname("fakewikipedia.org")).toBe(false);
+    expect(shouldEnableCursorsForHostname("wikipedia.org.example.com")).toBe(
+      false,
+    );
   });
 });

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -1,9 +1,27 @@
 // ABOUTME: Verifies when the extension is allowed to create PlayHTML presence rooms.
 // ABOUTME: Guards high-traffic sites from extension-owned rooms unless explicitly supported.
 
-import { describe, expect, it } from "vitest";
-import { shouldEnableCursorsForHostname } from "../custom-sites";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initCustomSite, shouldEnableCursorsForHostname } from "../custom-sites";
+import { initWikipedia } from "../custom-sites/wikipedia";
 import { shouldStartExtensionPresence } from "../entrypoints/content/presencePolicy";
+
+vi.mock("../custom-sites/wikipedia", () => ({
+  initWikipedia: vi.fn(() => null),
+}));
+
+const customSiteDeps = {
+  createPageData: vi.fn(),
+  createPresenceRoom: vi.fn(),
+  presence: {} as any,
+  cursorClient: {},
+  playerColor: "#4a9a8a",
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe("shouldStartExtensionPresence", () => {
   it("does not start an extension-owned room when native PlayHTML exists", () => {
@@ -59,5 +77,23 @@ describe("shouldEnableCursors", () => {
     expect(shouldEnableCursorsForHostname("wikipedia.org.example.com")).toBe(
       false,
     );
+  });
+});
+
+describe("initCustomSite", () => {
+  it("initializes Wikipedia site modules for supported Wikipedia hosts", async () => {
+    vi.stubGlobal("location", { hostname: "en.wikipedia.org" });
+
+    await initCustomSite(customSiteDeps);
+
+    expect(initWikipedia).toHaveBeenCalledWith(customSiteDeps);
+  });
+
+  it("does not initialize site modules for Wikipedia lookalike domains", async () => {
+    vi.stubGlobal("location", { hostname: "fakewikipedia.org" });
+
+    await expect(initCustomSite(customSiteDeps)).resolves.toBeNull();
+
+    expect(initWikipedia).not.toHaveBeenCalled();
   });
 });

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Verifies when the extension is allowed to create PlayHTML presence rooms.
+// ABOUTME: Guards high-traffic sites from extension-owned rooms unless explicitly supported.
+
+import { describe, expect, it } from "vitest";
+import { shouldEnableCursorsForHostname } from "../custom-sites";
+import { shouldStartExtensionPresence } from "../entrypoints/content/presencePolicy";
+
+describe("shouldStartExtensionPresence", () => {
+  it("does not start an extension-owned room when native PlayHTML exists", () => {
+    expect(
+      shouldStartExtensionPresence({
+        nativePlayhtmlDetected: true,
+        cursorsEnabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not start an extension-owned room on pages without explicit cursor support", () => {
+    expect(
+      shouldStartExtensionPresence({
+        nativePlayhtmlDetected: false,
+        cursorsEnabled: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("starts an extension-owned room only for explicit cursor sites", () => {
+    expect(
+      shouldStartExtensionPresence({
+        nativePlayhtmlDetected: false,
+        cursorsEnabled: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldEnableCursors", () => {
+  it("leaves high-traffic domains disabled unless they get explicit support", () => {
+    const highTrafficPages = [
+      "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "https://www.google.com/search?q=playhtml",
+      "https://x.com/home",
+      "https://www.reddit.com/r/webdev/",
+      "https://www.tiktok.com/@example/video/123",
+    ];
+
+    for (const url of highTrafficPages) {
+      expect(shouldEnableCursorsForHostname(new URL(url).hostname)).toBe(false);
+    }
+  });
+
+  it("enables cursors for Wikipedia", () => {
+    expect(shouldEnableCursorsForHostname("en.wikipedia.org")).toBe(true);
+  });
+});

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -17,7 +17,7 @@ export function shouldEnableCursors(): boolean {
 }
 
 export function shouldEnableCursorsForHostname(hostname: string): boolean {
-  return hostname.endsWith("wikipedia.org");
+  return hostname === "wikipedia.org" || hostname.endsWith(".wikipedia.org");
 }
 
 export async function initCustomSite(deps: CustomSiteDeps): Promise<(() => void) | null> {

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -23,7 +23,7 @@ export function shouldEnableCursorsForHostname(hostname: string): boolean {
 export async function initCustomSite(deps: CustomSiteDeps): Promise<(() => void) | null> {
   const hostname = location.hostname;
 
-  if (hostname.endsWith("wikipedia.org")) {
+  if (shouldEnableCursorsForHostname(hostname)) {
     const { initWikipedia } = await import("./wikipedia");
     return initWikipedia(deps);
   }

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -13,7 +13,11 @@ export interface CustomSiteDeps {
 
 // Returns true if the current domain should have collaborative cursors enabled.
 export function shouldEnableCursors(): boolean {
-  return location.hostname.endsWith("wikipedia.org");
+  return shouldEnableCursorsForHostname(location.hostname);
+}
+
+export function shouldEnableCursorsForHostname(hostname: string): boolean {
+  return hostname.endsWith("wikipedia.org");
 }
 
 export async function initCustomSite(deps: CustomSiteDeps): Promise<(() => void) | null> {

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Each site module initializes domain-specific collaborative features.
 
 import type { PageDataChannel, PresenceAPI, PresenceRoom } from "@playhtml/common";
+import type { InitOptions } from "../../../packages/playhtml/src/index";
 
 export interface CustomSiteDeps {
   createPageData: <T>(name: string, defaultValue: T) => PageDataChannel<T>;
@@ -11,18 +12,14 @@ export interface CustomSiteDeps {
   playerColor: string;
 }
 
-interface DefaultRoomOptions {
-  includeSearch: boolean;
-}
-
 export interface CustomSiteSettings {
   cursorsEnabled: boolean;
-  defaultRoomOptions: DefaultRoomOptions;
+  defaultRoomOptions: NonNullable<InitOptions["defaultRoomOptions"]>;
 }
 
 interface CustomSiteSettingsOverride {
   cursorsEnabled?: boolean;
-  defaultRoomOptions?: Partial<DefaultRoomOptions>;
+  defaultRoomOptions?: Partial<CustomSiteSettings["defaultRoomOptions"]>;
 }
 
 export interface CustomSitePolicy {

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -11,22 +11,94 @@ export interface CustomSiteDeps {
   playerColor: string;
 }
 
+interface DefaultRoomOptions {
+  includeSearch: boolean;
+}
+
+export interface CustomSiteSettings {
+  cursorsEnabled: boolean;
+  defaultRoomOptions: DefaultRoomOptions;
+}
+
+interface CustomSiteSettingsOverride {
+  cursorsEnabled?: boolean;
+  defaultRoomOptions?: Partial<DefaultRoomOptions>;
+}
+
+export interface CustomSitePolicy {
+  matches: (hostname: string) => boolean;
+  init: (deps: CustomSiteDeps) => Promise<(() => void) | null>;
+  settings?: CustomSiteSettingsOverride;
+}
+
+const DEFAULT_CUSTOM_SITE_SETTINGS: CustomSiteSettings = {
+  cursorsEnabled: true,
+  defaultRoomOptions: { includeSearch: false },
+};
+
+function isWikipediaHostname(hostname: string): boolean {
+  return hostname === "wikipedia.org" || hostname.endsWith(".wikipedia.org");
+}
+
+const CUSTOM_SITE_POLICIES: CustomSitePolicy[] = [
+  {
+    matches: isWikipediaHostname,
+    init: async (deps) => {
+      const { initWikipedia } = await import("./wikipedia");
+      return initWikipedia(deps);
+    },
+  },
+];
+
+function mergeCustomSiteSettings(
+  settings?: CustomSiteSettingsOverride,
+): CustomSiteSettings {
+  return {
+    cursorsEnabled:
+      settings?.cursorsEnabled ?? DEFAULT_CUSTOM_SITE_SETTINGS.cursorsEnabled,
+    defaultRoomOptions: {
+      ...DEFAULT_CUSTOM_SITE_SETTINGS.defaultRoomOptions,
+      ...settings?.defaultRoomOptions,
+    },
+  };
+}
+
+export function resolveCustomSiteSettingsForHostname(
+  hostname: string,
+  policies: CustomSitePolicy[],
+): CustomSiteSettings | null {
+  const policy = policies.find((candidate) => candidate.matches(hostname));
+  if (!policy) return null;
+
+  return mergeCustomSiteSettings(policy.settings);
+}
+
+export function getCustomSiteSettingsForHostname(
+  hostname: string,
+): CustomSiteSettings | null {
+  return resolveCustomSiteSettingsForHostname(hostname, CUSTOM_SITE_POLICIES);
+}
+
+export function getCustomSiteSettings(): CustomSiteSettings | null {
+  return getCustomSiteSettingsForHostname(location.hostname);
+}
+
 // Returns true if the current domain should have collaborative cursors enabled.
 export function shouldEnableCursors(): boolean {
-  return shouldEnableCursorsForHostname(location.hostname);
+  return getCustomSiteSettings()?.cursorsEnabled ?? false;
 }
 
 export function shouldEnableCursorsForHostname(hostname: string): boolean {
-  return hostname === "wikipedia.org" || hostname.endsWith(".wikipedia.org");
+  return getCustomSiteSettingsForHostname(hostname)?.cursorsEnabled ?? false;
 }
 
 export async function initCustomSite(deps: CustomSiteDeps): Promise<(() => void) | null> {
   const hostname = location.hostname;
+  const policy = CUSTOM_SITE_POLICIES.find((candidate) =>
+    candidate.matches(hostname)
+  );
 
-  if (shouldEnableCursorsForHostname(hostname)) {
-    const { initWikipedia } = await import("./wikipedia");
-    return initWikipedia(deps);
-  }
+  if (policy) return policy.init(deps);
 
   return null;
 }

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -19,6 +19,7 @@ import { KeyboardCollector } from "../collectors/KeyboardCollector";
 import { VERBOSE } from "../config";
 import { getFaviconUrl, getPageTitle } from "../utils/pageMetadata";
 import { FLAGS } from "../flags";
+import { shouldStartExtensionPresence } from "./content/presencePolicy";
 
 export default defineContentScript({
   matches: ["<all_urls>"],
@@ -982,11 +983,19 @@ export default defineContentScript({
           return;
         }
 
-        // Initialize PlayHTML — cursors only enabled on supported sites (e.g. Wikipedia)
+        // Initialize PlayHTML only for sites with explicit extension cursor support.
         const { initCustomSite, shouldEnableCursors } = await import(
           "../custom-sites"
         );
         const enableCursors = shouldEnableCursors();
+        if (
+          !shouldStartExtensionPresence({
+            nativePlayhtmlDetected: false,
+            cursorsEnabled: enableCursors,
+          })
+        ) {
+          return;
+        }
 
         const { playhtml } = await import("playhtml");
         await playhtml.init({

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -984,10 +984,11 @@ export default defineContentScript({
         }
 
         // Initialize PlayHTML only for sites with explicit extension cursor support.
-        const { initCustomSite, shouldEnableCursors } = await import(
+        const { getCustomSiteSettings, initCustomSite } = await import(
           "../custom-sites"
         );
-        const enableCursors = shouldEnableCursors();
+        const customSiteSettings = getCustomSiteSettings();
+        const enableCursors = customSiteSettings?.cursorsEnabled ?? false;
         if (
           !shouldStartExtensionPresence({
             nativePlayhtmlDetected: false,
@@ -999,7 +1000,7 @@ export default defineContentScript({
 
         const { playhtml } = await import("playhtml");
         await playhtml.init({
-          defaultRoomOptions: { includeSearch: false },
+          defaultRoomOptions: customSiteSettings?.defaultRoomOptions,
           cursors: {
             enabled: enableCursors,
             playerIdentity: this.playerIdentity,

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -999,6 +999,7 @@ export default defineContentScript({
 
         const { playhtml } = await import("playhtml");
         await playhtml.init({
+          defaultRoomOptions: { includeSearch: false },
           cursors: {
             enabled: enableCursors,
             playerIdentity: this.playerIdentity,

--- a/extension/src/entrypoints/content/presencePolicy.ts
+++ b/extension/src/entrypoints/content/presencePolicy.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Decides when the extension should create its own PlayHTML presence connection.
+// ABOUTME: Keeps broad content-script injection from opening rooms on unsupported sites.
+
+export type ExtensionPresenceDecision = {
+  nativePlayhtmlDetected: boolean;
+  cursorsEnabled: boolean;
+};
+
+export function shouldStartExtensionPresence({
+  nativePlayhtmlDetected,
+  cursorsEnabled,
+}: ExtensionPresenceDecision): boolean {
+  return !nativePlayhtmlDetected && cursorsEnabled;
+}

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "bun:test";
 import { DEFAULT_MESSAGE_RATE_LIMIT } from "../const";
 import {
   checkMessageRate,
+  isDurableObjectOverloadError,
   shouldAcceptRequestBody,
   shouldWarnForDocumentSize,
   type ServerLimits,
@@ -123,5 +124,22 @@ describe("shouldWarnForDocumentSize", () => {
   it("warns when autosave snapshots exceed the configured document threshold", () => {
     expect(shouldWarnForDocumentSize(30, limits)).toBe(false);
     expect(shouldWarnForDocumentSize(31, limits)).toBe(true);
+  });
+});
+
+describe("isDurableObjectOverloadError", () => {
+  it("matches Cloudflare queued-request overload errors", () => {
+    expect(
+      isDurableObjectOverloadError(
+        new Error("Durable Object is overloaded. Requests queued for too long."),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated route errors", () => {
+    expect(isDurableObjectOverloadError(new Error("boom"))).toBe(false);
+    expect(isDurableObjectOverloadError("Durable Object is overloaded")).toBe(
+      false,
+    );
   });
 });

--- a/partykit/__tests__/serverLimits.test.ts
+++ b/partykit/__tests__/serverLimits.test.ts
@@ -128,6 +128,14 @@ describe("shouldWarnForDocumentSize", () => {
 });
 
 describe("isDurableObjectOverloadError", () => {
+  it("matches errors with Cloudflare's overload marker", () => {
+    const error = Object.assign(new Error("worker overloaded"), {
+      overloaded: true,
+    });
+
+    expect(isDurableObjectOverloadError(error)).toBe(true);
+  });
+
   it("matches Cloudflare queued-request overload errors", () => {
     expect(
       isDurableObjectOverloadError(
@@ -136,8 +144,25 @@ describe("isDurableObjectOverloadError", () => {
     ).toBe(true);
   });
 
+  it("matches other documented Durable Object overload messages", () => {
+    const messages = [
+      "Durable Object is overloaded. Too many requests queued.",
+      "Durable Object is overloaded. Too much data queued.",
+      "Durable Object is overloaded. Too many requests for the same object within a 10 second window.",
+    ];
+
+    for (const message of messages) {
+      expect(isDurableObjectOverloadError(new Error(message))).toBe(true);
+    }
+  });
+
   it("does not match unrelated route errors", () => {
     expect(isDurableObjectOverloadError(new Error("boom"))).toBe(false);
+    expect(
+      isDurableObjectOverloadError(
+        Object.assign(new Error("boom"), { overloaded: false }),
+      ),
+    ).toBe(false);
     expect(isDurableObjectOverloadError("Durable Object is overloaded")).toBe(
       false,
     );

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -1206,6 +1206,11 @@ export class PartyServer extends YServer {
       );
     }
 
+    // Log structured information about the save
+    console.log(
+      `[PartyServer] Autosave: room=${this.name}, size=${documentSize} bytes (${(documentSize / 1024 / 1024).toFixed(2)} MB), resetEpoch=${docResetEpoch ?? serverResetEpoch ?? "none"}`
+    );
+
     // Save the document to the database
     const { data: _data, error } = await supabase.from("documents").upsert(
       {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -706,6 +706,10 @@ export class PartyServer extends YServer {
     const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
     await this.setEmptyRoomCompactAfter(compactAfter);
     await this.scheduleNextAlarm();
+
+    console.log(
+      `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
+    );
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -1220,6 +1224,9 @@ export class PartyServer extends YServer {
 
     if (!error) {
       if (this.consumeCompactionAutosave(documentBase64)) {
+        console.log(
+          `[PartyServer] Compaction autosave completed: room=${this.name}`
+        );
         return;
       }
     }
@@ -1286,6 +1293,9 @@ export class PartyServer extends YServer {
       })
     ) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
+      console.log(
+        `[PartyServer] Emergency compaction skipped: room=${this.name}, ${documentSize} -> ${compactedDocument.afterSize} bytes, nextCheckAt=${recheckAfter}`
+      );
       return false;
     }
 
@@ -1756,6 +1766,9 @@ export class PartyServer extends YServer {
         )
       ) {
         await this.clearEmptyRoomCompactAfter();
+        console.log(
+          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes`
+        );
         return;
       }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -47,6 +47,7 @@ import {
 } from "./request";
 import {
   checkMessageRate,
+  isDurableObjectOverloadError,
   shouldAcceptRequestBody,
   shouldWarnForDocumentSize,
   type MessageLimitState,
@@ -1965,9 +1966,22 @@ export class PartyServer extends YServer {
 export default {
   // Set up your fetch handler to use configured Servers
   async fetch(request: Request, env: Env): Promise<Response> {
-    return (
-      (await routePartykitRequest(request, env)) ||
-      new Response("Not Found", { status: 404 })
-    );
+    try {
+      return (
+        (await routePartykitRequest(request, env)) ||
+        new Response("Not Found", { status: 404 })
+      );
+    } catch (error) {
+      if (isDurableObjectOverloadError(error)) {
+        return new Response("Service Busy", {
+          status: 503,
+          headers: {
+            "Retry-After": "5",
+          },
+        });
+      }
+
+      throw error;
+    }
   },
 } satisfies ExportedHandler<Env>;

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -706,10 +706,6 @@ export class PartyServer extends YServer {
     const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
     await this.setEmptyRoomCompactAfter(compactAfter);
     await this.scheduleNextAlarm();
-
-    console.log(
-      `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
-    );
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -1206,11 +1202,6 @@ export class PartyServer extends YServer {
       );
     }
 
-    // Log structured information about the save
-    console.log(
-      `[PartyServer] Autosave: room=${this.name}, size=${documentSize} bytes (${(documentSize / 1024 / 1024).toFixed(2)} MB), resetEpoch=${docResetEpoch ?? serverResetEpoch ?? "none"}`
-    );
-
     // Save the document to the database
     const { data: _data, error } = await supabase.from("documents").upsert(
       {
@@ -1225,15 +1216,10 @@ export class PartyServer extends YServer {
         `[PartyServer] Autosave failed for room ${this.name}:`,
         error
       );
-    } else {
-      console.log(`[PartyServer] Autosave succeeded for room ${this.name}`);
     }
 
     if (!error) {
       if (this.consumeCompactionAutosave(documentBase64)) {
-        console.log(
-          `[PartyServer] Compaction autosave completed: room=${this.name}`
-        );
         return;
       }
     }
@@ -1300,9 +1286,6 @@ export class PartyServer extends YServer {
       })
     ) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
-      console.log(
-        `[PartyServer] Emergency compaction skipped: room=${this.name}, ${documentSize} -> ${compactedDocument.afterSize} bytes, nextCheckAt=${recheckAfter}`
-      );
       return false;
     }
 
@@ -1492,15 +1475,10 @@ export class PartyServer extends YServer {
             headers: { "content-type": "application/json" },
           });
         }
-        const beforeSize = encodeDocToBase64(yDoc).length;
         const ORIGIN = originKind === "consumer" ? ORIGIN_C2S : ORIGIN_S2C;
         yDoc.transact(
           () => this.assignPlaySubtrees(yDoc, subtreesToApply),
           ORIGIN
-        );
-        const afterSize = encodeDocToBase64(yDoc).length;
-        console.log(
-          `[Bridge] Applied subtrees from ${sender} (${originKind}). Size: ${beforeSize} -> ${afterSize}`
         );
 
         // If this is a SOURCE room receiving from a CONSUMER, immediately fanout to other consumers (excluding sender if provided)
@@ -1778,9 +1756,6 @@ export class PartyServer extends YServer {
         )
       ) {
         await this.clearEmptyRoomCompactAfter();
-        console.log(
-          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes`
-        );
         return;
       }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -980,9 +980,6 @@ export class PartyServer extends YServer {
 
     const url = new URL(ctx.request.url);
     const connectionId = connection.id;
-    console.log(
-      `[PartyServer] onConnect: connectionId=${connectionId}, room=${this.name}`
-    );
 
     const clientResetEpoch = parseClientResetEpoch(
       url.searchParams.get("clientResetEpoch")
@@ -998,10 +995,6 @@ export class PartyServer extends YServer {
       );
       serverResetEpoch = null;
     }
-
-    console.log(
-      `[PartyServer] Epoch check: client=${clientResetEpoch}, server=${serverResetEpoch}, connectionId=${connectionId}`
-    );
 
     if (
       serverResetEpoch !== null &&
@@ -1021,10 +1014,6 @@ export class PartyServer extends YServer {
     }
 
     this.setConnectionAcceptedResetEpoch(connection, serverResetEpoch);
-
-    console.log(
-      `[PartyServer] Proceeding with normal Y.js connection setup for connectionId=${connectionId}`
-    );
 
     await this.clearEmptyRoomCompactAfter();
 

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -18,6 +18,9 @@ export type LimitViolation = {
   reason: "Message Rate Limit Exceeded";
 };
 
+const DURABLE_OBJECT_OVERLOAD_MESSAGE =
+  "Durable Object is overloaded. Requests queued for too long.";
+
 export function checkMessageRate({
   limits,
   now,
@@ -61,4 +64,11 @@ export function shouldWarnForDocumentSize(
   limits: ServerLimits
 ): boolean {
   return documentSizeBytes > limits.documentWarningBytes;
+}
+
+export function isDurableObjectOverloadError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes(DURABLE_OBJECT_OVERLOAD_MESSAGE)
+  );
 }

--- a/partykit/serverLimits.ts
+++ b/partykit/serverLimits.ts
@@ -19,7 +19,11 @@ export type LimitViolation = {
 };
 
 const DURABLE_OBJECT_OVERLOAD_MESSAGE =
-  "Durable Object is overloaded. Requests queued for too long.";
+  "Durable Object is overloaded.";
+
+type DurableObjectError = Error & {
+  overloaded?: unknown;
+};
 
 export function checkMessageRate({
   limits,
@@ -69,6 +73,7 @@ export function shouldWarnForDocumentSize(
 export function isDurableObjectOverloadError(error: unknown): boolean {
   return (
     error instanceof Error &&
-    error.message.includes(DURABLE_OBJECT_OVERLOAD_MESSAGE)
+    ((error as DurableObjectError).overloaded === true ||
+      error.message.startsWith(DURABLE_OBJECT_OVERLOAD_MESSAGE))
   );
 }


### PR DESCRIPTION
## Summary

- Gate extension-owned PlayHTML startup so it only runs for explicitly supported cursor sites when no native PlayHTML instance is present.
- Keep high-traffic sites like YouTube, Google, X, Reddit, and TikTok disabled in the extension policy, while retaining Wikipedia support with stricter hostname matching.
- Catch known Durable Object overload errors at the Worker boundary and return `503 Service Busy` with `Retry-After` instead of letting overloads escape as Worker exceptions.
- Remove routine PartyKit connection, successful epoch-check, normal autosave, and bridge-apply logs while keeping warnings/errors and compaction/reset signal.

## Rationale

The Cloudflare cost spike was driven by extension-created rooms on high-traffic pages, especially YouTube `/watch`, plus large volumes of low-signal Worker/Durable Object logs. The extension fix prevents new supported builds from initializing PlayHTML on those pages, and the PartyKit overload handling reduces noisy exception logging when existing/old clients still hit overloaded Durable Objects.

## Validation

- `bun run test run src/__tests__/presencePolicy.test.ts`
- `bun test partykit/__tests__/serverLimits.test.ts`
- `bunx tsc -p partykit`
- `git diff --check origin/main...HEAD`

## Code review

Requested a pre-merge code review using the `superpowers:requesting-code-review` workflow. Result: no Critical or Important issues. Minor non-blocking suggestion: add a future boundary-level test for the Worker overload `503 Service Busy` response.

## Notes

This branch was recreated from current `origin/main` and cherry-picked to keep the PR scoped to the Cloudflare cost/logging fixes only.