### PR TITLE
Automate Edge extension releases

### DIFF
--- a/.github/workflows/extension-release-prep.yml
+++ b/.github/workflows/extension-release-prep.yml
@@ -151,7 +151,7 @@ jobs:
 
           - Bumps \`extension/package.json\` to **$VERSION**
           - Moves bullets from \`PENDING.md\` into \`CHANGELOG.md\`
-          - Triggers the Extension Release workflow on merge → builds Chrome + Firefox zips, submits to both stores, tags \`@playhtml/extension@$VERSION\`
+          - Triggers the Extension Release workflow on merge → builds Chrome + Firefox zips, submits to Chrome, Edge, and Firefox, tags \`@playhtml/extension@$VERSION\`
 
           ## Changes in this release
 

--- a/.github/workflows/extension-release-prep.yml
+++ b/.github/workflows/extension-release-prep.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Check for pending changes
         id: pending
         run: |
@@ -107,6 +112,7 @@ jobs:
             pkg.version = process.env.VERSION;
             fs.writeFileSync('extension/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
+          bun install --lockfile-only
 
           DATE=$(date -u +%Y-%m-%d)
           {
@@ -133,7 +139,7 @@ jobs:
           -->
           TEMPLATE_EOF
 
-          git add extension/package.json extension/CHANGELOG.md extension/PENDING.md
+          git add extension/package.json extension/CHANGELOG.md extension/PENDING.md bun.lock
           git commit -m "extension: release v$VERSION"
           git push --force origin "$RELEASE_BRANCH"
 
@@ -150,6 +156,7 @@ jobs:
           Auto-generated release PR for the extension. Merging this:
 
           - Bumps \`extension/package.json\` to **$VERSION**
+          - Updates \`bun.lock\` for the extension package version
           - Moves bullets from \`PENDING.md\` into \`CHANGELOG.md\`
           - Triggers the Extension Release workflow on merge → builds Chrome + Firefox zips, submits to Chrome, Edge, and Firefox, tags \`@playhtml/extension@$VERSION\`
 

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -18,6 +18,10 @@ on:
         description: "Skip Chrome submission"
         type: boolean
         default: false
+      skip-edge:
+        description: "Skip Edge submission"
+        type: boolean
+        default: false
       skip-firefox:
         description: "Skip Firefox submission"
         type: boolean
@@ -88,6 +92,7 @@ jobs:
     env:
       DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
       SKIP_CHROME: ${{ inputs.skip-chrome && 'true' || 'false' }}
+      SKIP_EDGE: ${{ inputs.skip-edge && 'true' || 'false' }}
       SKIP_FIREFOX: ${{ inputs.skip-firefox && 'true' || 'false' }}
       VERSION: ${{ needs.guard.outputs.version }}
     steps:
@@ -114,7 +119,7 @@ jobs:
         run: bun run build-packages
 
       - name: Build Chrome zip
-        if: env.SKIP_CHROME != 'true'
+        if: env.SKIP_CHROME != 'true' || env.SKIP_EDGE != 'true'
         working-directory: extension
         run: |
           WXT_OUT_DIR=publish bun run zip
@@ -149,6 +154,10 @@ jobs:
           CHROME_DEPLOY_PERCENTAGE: ${{ secrets.CHROME_DEPLOY_PERCENTAGE }}
           CHROME_REVIEW_EXEMPTION: ${{ secrets.CHROME_REVIEW_EXEMPTION }}
           CHROME_SKIP_SUBMIT_REVIEW: ${{ secrets.CHROME_SKIP_SUBMIT_REVIEW }}
+          EDGE_PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+          EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          EDGE_API_KEY: ${{ secrets.EDGE_API_KEY }}
+          EDGE_CERTIFICATION_NOTES: ${{ secrets.EDGE_CERTIFICATION_NOTES }}
           FIREFOX_EXTENSION_ID: ${{ secrets.FIREFOX_EXTENSION_ID }}
           FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
@@ -162,6 +171,14 @@ jobs:
               exit 1
             fi
             node scripts/submitChrome.mjs
+          fi
+
+          if [ "$SKIP_EDGE" != "true" ]; then
+            if [ -z "$CHROME_ZIP" ]; then
+              echo "Chrome zip was not found for Edge submission."
+              exit 1
+            fi
+            EDGE_ZIP="$CHROME_ZIP" node scripts/submitEdge.mjs
           fi
 
           if [ "$SKIP_FIREFOX" != "true" ]; then

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -116,7 +116,9 @@ jobs:
       - name: Build Chrome zip
         if: env.SKIP_CHROME != 'true'
         working-directory: extension
-        run: WXT_OUT_DIR=publish bun run zip
+        run: |
+          WXT_OUT_DIR=publish bun run zip
+          node scripts/validateExtensionBuild.mjs publish/chrome-mv3
 
       - name: Build Firefox zip
         if: env.SKIP_FIREFOX != 'true'

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
     },
     "extension": {
       "name": "@playhtml/extension",
-      "version": "0.1.14",
+      "version": "0.1.16",
       "dependencies": {
         "@playhtml/common": "workspace:*",
         "@playhtml/extension-types": "workspace:*",

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -33,8 +33,9 @@ changesets release-PR flow but on a separate cadence.
   on every prep cycle so the PR always reflects current `main`.
 - Merging that PR to `main` triggers `.github/workflows/extension-release.yml`,
   which builds Chrome + Firefox zips, submits Chrome through
-  `scripts/submitChrome.mjs`, submits Firefox through `wxt submit`, and pushes
-  a `@playhtml/extension@x.y.z` tag.
+  `scripts/submitChrome.mjs`, submits Edge through `scripts/submitEdge.mjs`,
+  submits Firefox through `wxt submit`, and pushes a
+  `@playhtml/extension@x.y.z` tag.
 
 **To bump minor or major instead of patch:** edit `extension/package.json`
 on the release branch directly (in the GitHub PR UI is fine). The prep
@@ -68,6 +69,12 @@ Firefox AMO:
 - `FIREFOX_EXTENSION_ID`
 - `FIREFOX_JWT_ISSUER` — from addons.mozilla.org → Developer Hub → Manage API Keys
 - `FIREFOX_JWT_SECRET`
+
+Microsoft Edge Add-ons:
+- `EDGE_PRODUCT_ID` — Partner Center product ID GUID
+- `EDGE_CLIENT_ID` — from Microsoft Edge → Publish API
+- `EDGE_API_KEY` — from Microsoft Edge → Publish API
+- `EDGE_CERTIFICATION_NOTES` — optional notes sent with the submission
 
 **Manual fallback:** The local `./release.sh` continues to work as an escape
 hatch (uses `.env.submit` instead of GitHub secrets, requires a manual

--- a/extension/release.sh
+++ b/extension/release.sh
@@ -60,6 +60,8 @@ echo "  chrome:  ${CHROME_ZIP}"
 echo "  firefox: ${FIREFOX_ZIP}"
 echo "  sources: ${SOURCES_ZIP}"
 
+node scripts/validateExtensionBuild.mjs "${PUBLISH_DIR}/chrome-mv3"
+
 echo "Submitting to stores..."
 if [ "$SKIP_CHROME" -eq 0 ]; then
   if [ -n "$DRY_RUN" ]; then

--- a/extension/release.sh
+++ b/extension/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# ABOUTME: Build both browser zips into ./publish and submit to Chrome + Firefox stores.
-# ABOUTME: Usage: ./release.sh [--dry-run] [--skip-firefox] [--skip-chrome]
+# ABOUTME: Build browser zips into ./publish and submit to extension stores.
+# ABOUTME: Usage: ./release.sh [--dry-run] [--skip-chrome] [--skip-edge] [--skip-firefox]
 
 set -euo pipefail
 
@@ -10,11 +10,13 @@ cd "$SCRIPT_DIR"
 DRY_RUN=""
 SKIP_FIREFOX=0
 SKIP_CHROME=0
+SKIP_EDGE=0
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN="--dry-run" ;;
     --skip-firefox) SKIP_FIREFOX=1 ;;
     --skip-chrome) SKIP_CHROME=1 ;;
+    --skip-edge) SKIP_EDGE=1 ;;
     *) echo "Unknown arg: $arg"; exit 1 ;;
   esac
 done
@@ -24,8 +26,9 @@ if [ ! -f ".env.submit" ]; then
   exit 1
 fi
 
+set -a; . ./.env.submit; set +a
+
 if [ "$SKIP_CHROME" -eq 0 ]; then
-  set -a; . ./.env.submit; set +a
   TOKEN_PROBE=$(curl -s -X POST https://oauth2.googleapis.com/token \
     -d "client_id=${CHROME_CLIENT_ID}" \
     -d "client_secret=${CHROME_CLIENT_SECRET}" \
@@ -68,6 +71,14 @@ if [ "$SKIP_CHROME" -eq 0 ]; then
     DRY_RUN=true CHROME_ZIP="${CHROME_ZIP}" node scripts/submitChrome.mjs
   else
     CHROME_ZIP="${CHROME_ZIP}" node scripts/submitChrome.mjs
+  fi
+fi
+
+if [ "$SKIP_EDGE" -eq 0 ]; then
+  if [ -n "$DRY_RUN" ]; then
+    DRY_RUN=true EDGE_ZIP="${CHROME_ZIP}" node scripts/submitEdge.mjs
+  else
+    EDGE_ZIP="${CHROME_ZIP}" node scripts/submitEdge.mjs
   fi
 fi
 

--- a/extension/scripts/submitEdge.mjs
+++ b/extension/scripts/submitEdge.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// ABOUTME: Submits Microsoft Edge Add-ons extension zips and checks operation status.
+// ABOUTME: Used by CI and local release scripts to update the Edge store package.
+import fs from "node:fs/promises";
+
+const EDGE_API_ROOT = "https://api.addons.microsoftedge.microsoft.com";
+const DEFAULT_CERTIFICATION_NOTES = "Automated extension release.";
+
+function booleanEnv(value) {
+  if (value == null || value === "") return false;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+}
+
+function requireEnv(env, name) {
+  const value = env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function formatBody(body) {
+  if (body == null) return "";
+  if (typeof body === "string") return body;
+  return JSON.stringify(body);
+}
+
+function edgeHeaders(env, extra = {}) {
+  return {
+    authorization: `ApiKey ${requireEnv(env, "EDGE_API_KEY")}`,
+    "x-clientid": requireEnv(env, "EDGE_CLIENT_ID"),
+    ...extra,
+  };
+}
+
+function uploadUrl(productId) {
+  return `${EDGE_API_ROOT}/v1/products/${productId}/submissions/draft/package`;
+}
+
+function uploadStatusUrl(productId, operationId) {
+  return `${EDGE_API_ROOT}/v1/products/${productId}/submissions/draft/package/operations/${operationId}`;
+}
+
+function publishUrl(productId) {
+  return `${EDGE_API_ROOT}/v1/products/${productId}/submissions`;
+}
+
+function publishStatusUrl(productId, operationId) {
+  return `${EDGE_API_ROOT}/v1/products/${productId}/submissions/operations/${operationId}`;
+}
+
+function operationIdFromLocation(location) {
+  if (!location) throw new Error("Edge response did not include an operation location");
+  const segments = location.split("/").filter(Boolean);
+  const operationId = segments.at(-1);
+  if (!operationId) throw new Error(`Edge response included an invalid operation location: ${location}`);
+  return operationId;
+}
+
+async function ensureEdgeResponseAccepted(action, response) {
+  const body = await readResponseBody(response);
+
+  if (!response.ok) {
+    const detail = formatBody(body);
+    throw new Error(
+      `Edge ${action} failed: ${response.status} ${response.statusText}${detail ? `\n${detail}` : ""}`,
+    );
+  }
+
+  return body;
+}
+
+async function waitForEdgeOperation({
+  action,
+  operationUrl,
+  env,
+  fetchImpl,
+  sleepImpl,
+}) {
+  const pollLimit = Number(env.EDGE_POLL_LIMIT || 10);
+  const pollIntervalMs = Number(env.EDGE_POLL_INTERVAL_MS || 5000);
+
+  for (let attempt = 1; attempt <= pollLimit; attempt += 1) {
+    const response = await fetchImpl(operationUrl, {
+      method: "GET",
+      headers: edgeHeaders(env),
+    });
+    const body = await ensureEdgeResponseAccepted(`${action} status`, response);
+    const status = body?.status;
+
+    if (status === "Succeeded") {
+      console.log(`Edge ${action} succeeded.`);
+      return body;
+    }
+
+    if (status && status !== "InProgress") {
+      throw new Error(`Edge ${action} failed with status: ${status}`);
+    }
+
+    if (attempt < pollLimit) await sleepImpl(pollIntervalMs);
+  }
+
+  throw new Error(`Edge ${action} did not finish after ${pollLimit} status checks`);
+}
+
+export async function submitEdge({
+  env = process.env,
+  fetchImpl = fetch,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  const zipPath = requireEnv(env, "EDGE_ZIP");
+  const productId = requireEnv(env, "EDGE_PRODUCT_ID");
+  requireEnv(env, "EDGE_CLIENT_ID");
+  requireEnv(env, "EDGE_API_KEY");
+  const dryRun = booleanEnv(env.DRY_RUN);
+
+  await fs.stat(zipPath);
+  console.log(`Edge zip: ${zipPath}`);
+
+  if (dryRun) {
+    console.log("DRY RUN: Edge inputs are present; skipped upload and publish.");
+    return;
+  }
+
+  const zip = await fs.readFile(zipPath);
+  const uploadResponse = await fetchImpl(uploadUrl(productId), {
+    method: "POST",
+    headers: edgeHeaders(env, {
+      "content-type": "application/zip",
+      "content-length": String(zip.byteLength),
+    }),
+    body: zip,
+  });
+  await ensureEdgeResponseAccepted("upload", uploadResponse);
+  const uploadOperationId = operationIdFromLocation(uploadResponse.headers.get("location"));
+
+  await waitForEdgeOperation({
+    action: "upload",
+    operationUrl: uploadStatusUrl(productId, uploadOperationId),
+    env,
+    fetchImpl,
+    sleepImpl,
+  });
+
+  const publishResponse = await fetchImpl(publishUrl(productId), {
+    method: "POST",
+    headers: edgeHeaders(env, {
+      "content-type": "application/json",
+    }),
+    body: JSON.stringify({
+      notes: env.EDGE_CERTIFICATION_NOTES || DEFAULT_CERTIFICATION_NOTES,
+    }),
+  });
+  await ensureEdgeResponseAccepted("publish", publishResponse);
+  const publishOperationId = operationIdFromLocation(publishResponse.headers.get("location"));
+
+  await waitForEdgeOperation({
+    action: "publish",
+    operationUrl: publishStatusUrl(productId, publishOperationId),
+    env,
+    fetchImpl,
+    sleepImpl,
+  });
+
+  console.log("Edge will update the live store package after Add-ons review approval.");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  submitEdge().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/extension/scripts/submitEdge.test.mjs
+++ b/extension/scripts/submitEdge.test.mjs
@@ -1,0 +1,134 @@
+// ABOUTME: Verifies Microsoft Edge Add-ons submit API request handling.
+// ABOUTME: Covers release automation behavior without calling external APIs.
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test, vi } from "vitest";
+
+import { submitEdge } from "./submitEdge.mjs";
+
+const tempDirs = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  const removals = tempDirs
+    .splice(0)
+    .map((dir) => rm(dir, { recursive: true, force: true }));
+  await Promise.all(removals);
+});
+
+async function writeTempZip() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "submit-edge-"));
+  tempDirs.push(dir);
+  const zipPath = path.join(dir, "extension.zip");
+  await writeFile(zipPath, "zip");
+  return zipPath;
+}
+
+test("dry run validates Edge inputs without calling the API", async () => {
+  const logs = [];
+  vi.spyOn(console, "log").mockImplementation((message) => logs.push(String(message)));
+
+  await submitEdge({
+    env: {
+      DRY_RUN: "true",
+      EDGE_ZIP: await writeTempZip(),
+      EDGE_PRODUCT_ID: "edge-product-id",
+      EDGE_CLIENT_ID: "edge-client-id",
+      EDGE_API_KEY: "edge-api-key",
+    },
+    fetchImpl: async () => {
+      throw new Error("fetch should not be called");
+    },
+  });
+
+  expect(logs).toContain("DRY RUN: Edge inputs are present; skipped upload and publish.");
+});
+
+test("uploads, polls, publishes, and polls an Edge submission", async () => {
+  const requests = [];
+
+  await submitEdge({
+    env: {
+      EDGE_ZIP: await writeTempZip(),
+      EDGE_PRODUCT_ID: "edge-product-id",
+      EDGE_CLIENT_ID: "edge-client-id",
+      EDGE_API_KEY: "edge-api-key",
+      EDGE_CERTIFICATION_NOTES: "Release notes for certification.",
+      EDGE_POLL_INTERVAL_MS: "0",
+    },
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options });
+
+      if (requests.length === 1) {
+        return new Response("", {
+          status: 202,
+          statusText: "Accepted",
+          headers: {
+            location:
+              "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions/draft/package/operations/upload-operation",
+          },
+        });
+      }
+
+      if (requests.length === 2) {
+        return new Response(JSON.stringify({ status: "Succeeded" }), {
+          status: 202,
+          statusText: "Accepted",
+          headers: {
+            "content-type": "application/json",
+          },
+        });
+      }
+
+      if (requests.length === 3) {
+        return new Response("", {
+          status: 202,
+          statusText: "Accepted",
+          headers: {
+            location:
+              "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions/operations/publish-operation",
+          },
+        });
+      }
+
+      return new Response(JSON.stringify({ status: "Succeeded" }), {
+        status: 202,
+        statusText: "Accepted",
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+    },
+    sleepImpl: async () => {},
+  });
+
+  expect(requests).toHaveLength(4);
+  expect(requests[0].url).toBe(
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions/draft/package",
+  );
+  expect(requests[0].options.method).toBe("POST");
+  expect(requests[0].options.headers.authorization).toBe("ApiKey edge-api-key");
+  expect(requests[0].options.headers["x-clientid"]).toBe("edge-client-id");
+  expect(requests[0].options.headers["content-type"]).toBe("application/zip");
+
+  expect(requests[1].url).toBe(
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions/draft/package/operations/upload-operation",
+  );
+  expect(requests[1].options.method).toBe("GET");
+
+  expect(requests[2].url).toBe(
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions",
+  );
+  expect(requests[2].options.method).toBe("POST");
+  expect(requests[2].options.headers["content-type"]).toBe("application/json");
+  expect(requests[2].options.body).toBe(
+    JSON.stringify({ notes: "Release notes for certification." }),
+  );
+
+  expect(requests[3].url).toBe(
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/edge-product-id/submissions/operations/publish-operation",
+  );
+  expect(requests[3].options.method).toBe("GET");
+});

--- a/extension/scripts/validateExtensionBuild.mjs
+++ b/extension/scripts/validateExtensionBuild.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// ABOUTME: Validates built extension manifests against files in the output directory.
+// ABOUTME: Catches store-facing package errors before upload automation submits zips.
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function collectManifestResources(manifest) {
+  const resources = [];
+
+  for (const script of manifest.content_scripts ?? []) {
+    resources.push(...(script.js ?? []));
+    resources.push(...(script.css ?? []));
+  }
+
+  for (const group of manifest.web_accessible_resources ?? []) {
+    resources.push(...(group.resources ?? []));
+  }
+
+  return resources;
+}
+
+export async function validateExtensionBuild(buildDir) {
+  const manifestPath = path.join(buildDir, "manifest.json");
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+  const resources = collectManifestResources(manifest);
+  const missingResources = [];
+
+  for (const resource of resources) {
+    try {
+      await fs.stat(path.join(buildDir, resource));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      missingResources.push(resource);
+    }
+  }
+
+  if (missingResources.length > 0) {
+    throw new Error(
+      `Extension build references missing files:\n${missingResources
+        .map((resource) => `  - ${resource}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  validateExtensionBuild(process.argv[2] ?? "publish/chrome-mv3").catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/extension/scripts/validateExtensionBuild.test.mjs
+++ b/extension/scripts/validateExtensionBuild.test.mjs
@@ -1,0 +1,64 @@
+// ABOUTME: Covers extension build validation for manifest-referenced files.
+// ABOUTME: Protects release uploads from store package validation failures.
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, expect, test } from "vitest";
+
+import { validateExtensionBuild } from "./validateExtensionBuild.mjs";
+
+const tempDirs = [];
+
+afterEach(async () => {
+  const removals = tempDirs
+    .splice(0)
+    .map((dir) => rm(dir, { recursive: true, force: true }));
+  await Promise.all(removals);
+});
+
+async function makeBuildDir(manifest) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "extension-build-"));
+  tempDirs.push(dir);
+  await mkdir(path.join(dir, "content-scripts"), { recursive: true });
+  await writeFile(path.join(dir, "manifest.json"), JSON.stringify(manifest));
+  return dir;
+}
+
+test("throws when manifest resources are missing from the build directory", async () => {
+  const dir = await makeBuildDir({
+    manifest_version: 3,
+    content_scripts: [
+      {
+        js: ["content-scripts/content.js"],
+      },
+    ],
+    web_accessible_resources: [
+      {
+        resources: ["content-scripts/content.css"],
+        matches: ["<all_urls>"],
+      },
+    ],
+  });
+  await writeFile(path.join(dir, "content-scripts/content.js"), "");
+
+  await expect(validateExtensionBuild(dir)).rejects.toThrow(
+    /content-scripts\/content\.css/,
+  );
+});
+
+test("passes when manifest resources exist in the build directory", async () => {
+  const dir = await makeBuildDir({
+    manifest_version: 3,
+    content_scripts: [
+      {
+        js: ["content-scripts/content.js"],
+        css: ["content-scripts/content.css"],
+      },
+    ],
+  });
+  await writeFile(path.join(dir, "content-scripts/content.js"), "");
+  await writeFile(path.join(dir, "content-scripts/content.css"), "");
+
+  await expect(validateExtensionBuild(dir)).resolves.toBeUndefined();
+});

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Main content script injected into every web page.
 // ABOUTME: Initializes playhtml copresence, data collectors, and domain-specific features.
+import "./content/style.css";
 import browser from "webextension-polyfill";
 import {
   MILESTONE_DURATION_MS,

--- a/extension/src/entrypoints/content/style.css
+++ b/extension/src/entrypoints/content/style.css
@@ -1,5 +1,5 @@
-/* ABOUTME: Content script stylesheet — injected via manifest into every page.
-/* ABOUTME: Only contains styles for elements that must affect the host page directly (e.g. element picker outlines). */
+/* ABOUTME: Content script stylesheet injected via manifest into every page. */
+/* ABOUTME: Only contains styles that must affect host page elements directly. */
 /* All extension-owned UI (toasts, overlays) uses Shadow DOM with inline styles — see content.ts. */
 
 .playhtml-extension-element-picker {


### PR DESCRIPTION
## Summary
- package the content script CSS so store validators find the manifest-referenced file
- add a build validator for manifest-referenced extension files
- add Microsoft Edge Add-ons API submission to local and GitHub extension release flows

## Verification
- `bun run build-packages`
- `WXT_OUT_DIR=publish bun run zip && node scripts/validateExtensionBuild.mjs publish/chrome-mv3`
- `bunx vitest run` in `extension` (25 files, 183 tests)
- parsed `.github/workflows/extension-release.yml` and `.github/workflows/extension-release-prep.yml` as YAML