### PR TITLE
Fix signup email sending

### DIFF
--- a/extension/worker/src/__tests__/resend.test.ts
+++ b/extension/worker/src/__tests__/resend.test.ts
@@ -158,9 +158,39 @@ describe('createResendClient', () => {
     expect(params.subject.length).toBeGreaterThan(0);
     expect(typeof params.html).toBe('string');
     expect(params.html).toContain('we were online');
+    expect(params.html).toContain('join the playhtml discord');
+    expect(params.html).toContain('https://discord.gg/SKbsSf4ptU');
     expect(typeof params.text).toBe('string');
     expect(params.text.length).toBeGreaterThan(0);
+    expect(params.text).toContain('join the playhtml discord');
+    expect(params.text).toContain('https://discord.gg/SKbsSf4ptU');
     expect(opts.idempotencyKey).toBe('welcome-email/a@b.com');
+  });
+
+  it('sendUpdatesEmail sends project content without download links', async () => {
+    mockEmailsSend.mockResolvedValueOnce({ data: { id: 'em_2' }, error: null });
+
+    const client = createResendClient({ apiKey: 'k' });
+    await client.sendUpdatesEmail('a@b.com');
+
+    expect(mockEmailsSend).toHaveBeenCalledTimes(1);
+    const [params, opts] = mockEmailsSend.mock.calls[0];
+    expect(params.from).toBe('spencer <hi@spencer.place>');
+    expect(params.to).toBe('a@b.com');
+    expect(params.replyTo).toBe('hi@spencer.place');
+    expect(params.subject).toContain('we were online');
+    expect(params.html).toContain('we were online');
+    expect(params.html).toContain('join the playhtml discord');
+    expect(params.html).not.toContain('Download on Chrome');
+    expect(params.html).not.toContain('Download on Firefox');
+    expect(params.html).not.toContain('chromewebstore.google.com');
+    expect(params.html).not.toContain('addons.mozilla.org');
+    expect(params.text).toContain('join the playhtml discord');
+    expect(params.text).not.toContain('Download on Chrome');
+    expect(params.text).not.toContain('Download on Firefox');
+    expect(params.text).not.toContain('chromewebstore.google.com');
+    expect(params.text).not.toContain('addons.mozilla.org');
+    expect(opts.idempotencyKey).toBe('updates-email/a@b.com');
   });
 
   it('sendWelcomeEmail throws when emails.send returns error', async () => {
@@ -171,5 +201,15 @@ describe('createResendClient', () => {
 
     const client = createResendClient({ apiKey: 'k' });
     await expect(client.sendWelcomeEmail('a@b.com')).rejects.toThrow('service down');
+  });
+
+  it('sendUpdatesEmail throws when emails.send returns error', async () => {
+    mockEmailsSend.mockResolvedValueOnce({
+      data: null,
+      error: { name: 'application_error', message: 'service down' },
+    });
+
+    const client = createResendClient({ apiKey: 'k' });
+    await expect(client.sendUpdatesEmail('a@b.com')).rejects.toThrow('service down');
   });
 });

--- a/extension/worker/src/__tests__/resend.test.ts
+++ b/extension/worker/src/__tests__/resend.test.ts
@@ -111,6 +111,22 @@ describe('createResendClient', () => {
     await expect(client.addContact('a@b.com', 'website')).rejects.toThrow('create failed');
   });
 
+  it('addContact throws when contacts.create returns no contact data', async () => {
+    mockContactsGet.mockResolvedValueOnce({
+      data: null,
+      error: { name: 'not_found', message: 'Contact not found' },
+    });
+    mockContactsCreate.mockResolvedValueOnce({
+      data: null,
+      error: null,
+    });
+
+    const client = createResendClient({ apiKey: 'k' });
+    await expect(client.addContact('a@b.com', 'website')).rejects.toThrow(
+      'Resend did not return a contact id',
+    );
+  });
+
   it('addContact throws on a generic "not found" message that is not name=not_found', async () => {
     // Defensive: a "Segment not found" or "Audience not found" error from
     // get should NOT be treated as "this contact is new".
@@ -211,5 +227,14 @@ describe('createResendClient', () => {
 
     const client = createResendClient({ apiKey: 'k' });
     await expect(client.sendUpdatesEmail('a@b.com')).rejects.toThrow('service down');
+  });
+
+  it('sendWelcomeEmail throws when emails.send returns no email data', async () => {
+    mockEmailsSend.mockResolvedValueOnce({ data: null, error: null });
+
+    const client = createResendClient({ apiKey: 'k' });
+    await expect(client.sendWelcomeEmail('a@b.com')).rejects.toThrow(
+      'Resend did not return an email id',
+    );
   });
 });

--- a/extension/worker/src/__tests__/subscribe.test.ts
+++ b/extension/worker/src/__tests__/subscribe.test.ts
@@ -25,7 +25,6 @@ const ENV: Env = {
   SUPABASE_SECRET_KEY: 'k',
   ADMIN_KEY: 'a',
   RESEND_API_KEY: 'r',
-  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
 };
 
 function makeRequest(body: unknown, ip = '1.2.3.4'): Request {

--- a/extension/worker/src/__tests__/subscribe.test.ts
+++ b/extension/worker/src/__tests__/subscribe.test.ts
@@ -1,15 +1,19 @@
 // ABOUTME: Tests for the POST /subscribe route handler.
-// ABOUTME: Mocks the resend client and asserts validation, dedupe, and welcome-email behavior.
+// ABOUTME: Mocks the resend client and asserts validation, dedupe, and signup-email behavior.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockAddContact = vi.fn();
 const mockSendWelcome = vi.fn();
+const mockSendUpdates = vi.fn();
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+let allowConsoleError = false;
 
 vi.mock('../lib/resend', () => ({
   createResendClient: vi.fn(() => ({
     addContact: mockAddContact,
     sendWelcomeEmail: mockSendWelcome,
+    sendUpdatesEmail: mockSendUpdates,
   })),
 }));
 
@@ -21,6 +25,7 @@ const ENV: Env = {
   SUPABASE_SECRET_KEY: 'k',
   ADMIN_KEY: 'a',
   RESEND_API_KEY: 'r',
+  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
 };
 
 function makeRequest(body: unknown, ip = '1.2.3.4'): Request {
@@ -35,7 +40,17 @@ describe('handleSubscribe', () => {
   beforeEach(() => {
     mockAddContact.mockReset();
     mockSendWelcome.mockReset();
+    mockSendUpdates.mockReset();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    allowConsoleError = false;
     __resetRateLimitForTests();
+  });
+
+  afterEach(() => {
+    if (!allowConsoleError) {
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    }
+    consoleErrorSpy.mockRestore();
   });
 
   it('returns 400 for invalid email format', async () => {
@@ -74,8 +89,9 @@ describe('handleSubscribe', () => {
     expect(mockSendWelcome).toHaveBeenCalledWith('new@example.com');
   });
 
-  it('on existing contact: skips welcome, returns alreadySubscribed=true', async () => {
+  it('on existing contact: sends welcome, returns alreadySubscribed=true', async () => {
     mockAddContact.mockResolvedValueOnce({ created: false });
+    mockSendWelcome.mockResolvedValueOnce(undefined);
 
     const res = await handleSubscribe(
       makeRequest({ email: 'existing@example.com', source: 'website' }),
@@ -84,10 +100,27 @@ describe('handleSubscribe', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, alreadySubscribed: true });
-    expect(mockSendWelcome).not.toHaveBeenCalled();
+    expect(mockSendWelcome).toHaveBeenCalledWith('existing@example.com');
   });
 
-  it('contact created but welcome send fails: still returns 200', async () => {
+  it('on extension setup contact: adds contact and sends updates email', async () => {
+    mockAddContact.mockResolvedValueOnce({ created: true });
+    mockSendUpdates.mockResolvedValueOnce(undefined);
+
+    const res = await handleSubscribe(
+      makeRequest({ email: 'setup@example.com', source: 'extension-setup' }),
+      ENV,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, alreadySubscribed: false });
+    expect(mockAddContact).toHaveBeenCalledWith('setup@example.com', 'extension-setup');
+    expect(mockSendWelcome).not.toHaveBeenCalled();
+    expect(mockSendUpdates).toHaveBeenCalledWith('setup@example.com');
+  });
+
+  it('returns 503 when welcome send fails', async () => {
+    allowConsoleError = true;
     mockAddContact.mockResolvedValueOnce({ created: true });
     mockSendWelcome.mockRejectedValueOnce(new Error('resend down'));
 
@@ -96,11 +129,35 @@ describe('handleSubscribe', () => {
       ENV,
     );
 
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, alreadySubscribed: false });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Email service temporarily unavailable' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[Subscribe] sendWelcomeEmail failed:',
+      expect.any(Error),
+    );
+  });
+
+  it('returns 503 when updates send fails', async () => {
+    allowConsoleError = true;
+    mockAddContact.mockResolvedValueOnce({ created: true });
+    mockSendUpdates.mockRejectedValueOnce(new Error('resend down'));
+
+    const res = await handleSubscribe(
+      makeRequest({ email: 'a@b.com', source: 'extension-setup' }),
+      ENV,
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'Email service temporarily unavailable' });
+    expect(mockSendWelcome).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[Subscribe] sendUpdatesEmail failed:',
+      expect.any(Error),
+    );
   });
 
   it('on Resend addContact failure: returns 503', async () => {
+    allowConsoleError = true;
     mockAddContact.mockRejectedValueOnce(new Error('resend down'));
 
     const res = await handleSubscribe(
@@ -109,6 +166,10 @@ describe('handleSubscribe', () => {
     );
 
     expect(res.status).toBe(503);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[Subscribe] addContact failed:',
+      expect.any(Error),
+    );
   });
 
   it('rate-limits after 5 requests from same IP within a minute', async () => {

--- a/extension/worker/src/emails/WelcomeEmail.tsx
+++ b/extension/worker/src/emails/WelcomeEmail.tsx
@@ -1,18 +1,5 @@
-// ABOUTME: Welcome email template sent on first signup to we were online.
-// ABOUTME: Renders both HTML (via react-email) and plaintext for email-client compatibility.
-
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Html,
-  Link,
-  Preview,
-  Section,
-  Text,
-} from '@react-email/components';
-import { render } from '@react-email/render';
+// ABOUTME: Email templates sent to we were online signups.
+// ABOUTME: Exposes HTML and plaintext bodies for download-link and updates emails.
 
 const CHROME_URL =
   'https://chromewebstore.google.com/detail/we-were-online/bhkdblmogjkgeipehaphdocclmijnkhc?authuser=0&hl=en';
@@ -20,21 +7,16 @@ const FIREFOX_URL =
   'https://addons.mozilla.org/en-US/firefox/addon/we-were-online/';
 const HOMEPAGE_URL = 'https://wewere.online/';
 const PLAYHTML_URL = 'https://playhtml.fun/';
+const DISCORD_INVITE_URL = 'https://discord.gg/SKbsSf4ptU';
 const SELF_PORTRAIT_URL =
   'https://spencer.place/creation/self-portrait-(internet)';
 const REPLY_EMAIL = 'hi@spencer.place';
 
 export const WELCOME_EMAIL_SUBJECT = 'welcome to we were online!';
 
-export const WELCOME_EMAIL_TEXT = `Hi everyone!
+export const UPDATES_EMAIL_SUBJECT = 'updates from we were online';
 
-Thanks for signing up and being willing to try something that makes the Internet hopefully feel a bit more alive :) I'm excited to share the beta of we were online (${HOMEPAGE_URL}) with you.
-
-- Download on Chrome (or chromium equivalents): ${CHROME_URL}
-- Download on Firefox: ${FIREFOX_URL}
-- Use another browser or run into any issues? let me know
-
-As a reminder, we were online is a browser extension—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Eventually, I want this to be a space where we can bump into each other all over the web and other creatives can create more embodied social media from their personal websites to bring belonging to the open web (building on top of playhtml: ${PLAYHTML_URL}).
+const SHARED_EMAIL_TEXT = `As a reminder, we were online is a browser extension—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Eventually, I want this to be a space where we can bump into each other all over the web and other creatives can create more embodied social media from their personal websites to bring belonging to the open web (building on top of playhtml: ${PLAYHTML_URL}).
 
 But that'll be a long process and here's what you can do now:
 
@@ -44,152 +26,125 @@ But that'll be a long process and here's what you can do now:
 
 If you have an idea for a new social web experience (like the Wikipedia one), please let me know! I'm working directly with people to help bring their ideas to life.
 
+You can also join the playhtml discord: ${DISCORD_INVITE_URL}
+
 Thanks for your willingness to try something new and contribute to making a new kind of Internet! Let me know what you think anytime at my email :)
 
 spencer
 ${REPLY_EMAIL}
 `;
 
-const styles = {
-  body: {
-    backgroundColor: '#faf7f2',
-    color: '#3d3833',
-    fontFamily:
-      "'Atkinson Hyperlegible', -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif",
-    margin: 0,
-    padding: 0,
-  },
-  container: {
-    margin: '0 auto',
-    padding: '40px 24px',
-    maxWidth: '560px',
-  },
-  wordmark: {
-    fontFamily: "'Source Serif 4', 'Source Serif Pro', Georgia, serif",
-    fontStyle: 'italic',
-    fontWeight: 200,
-    fontSize: '32px',
-    color: '#3d3833',
-    margin: '0 0 24px 0',
-    letterSpacing: '-0.01em',
-  },
-  paragraph: {
-    fontSize: '16px',
-    lineHeight: '1.6',
-    margin: '0 0 16px 0',
-  },
-  buttonRow: {
-    margin: '24px 0',
-  },
-  button: {
-    display: 'inline-block',
-    backgroundColor: '#4a9a8a',
-    color: '#faf7f2',
-    padding: '12px 20px',
-    borderRadius: '4px',
-    textDecoration: 'none',
-    fontWeight: 600,
-    fontSize: '15px',
-    marginRight: '8px',
-    marginBottom: '8px',
-  },
-  list: {
-    fontSize: '16px',
-    lineHeight: '1.6',
-    paddingLeft: '20px',
-    margin: '0 0 16px 0',
-  },
-  signature: {
-    fontFamily: "'Source Serif 4', 'Source Serif Pro', Georgia, serif",
-    fontStyle: 'italic',
-    fontSize: '18px',
-    color: '#3d3833',
-    margin: '24px 0 0 0',
-  },
-} as const;
+export const WELCOME_EMAIL_TEXT = `Hi everyone!
 
-export function WelcomeEmail() {
-  return (
-    <Html>
-      <Head />
-      <Preview>install links for we were online — and what to expect next</Preview>
-      <Body style={styles.body}>
-        <Container style={styles.container}>
-          <Heading as="h1" style={styles.wordmark}>
-            we were online
-          </Heading>
-          <Text style={styles.paragraph}>Hi everyone!</Text>
-          <Text style={styles.paragraph}>
-            Thanks for signing up and being willing to try something that makes
-            the Internet hopefully feel a bit more alive :) I'm excited to share
-            the beta of{' '}
-            <Link href={HOMEPAGE_URL}>
-              <em>we were online</em>
-            </Link>{' '}
-            with you.
-          </Text>
-          <Section style={styles.buttonRow}>
-            <Link href={CHROME_URL} style={styles.button}>
-              Download on Chrome
-            </Link>
-            <Link href={FIREFOX_URL} style={styles.button}>
-              Download on Firefox
-            </Link>
-          </Section>
-          <Text style={styles.paragraph}>
-            (Chrome download also works for Chromium-equivalents.) Use another
-            browser or run into any issues?{' '}
-            <Link href={`mailto:${REPLY_EMAIL}`}>let me know</Link>.
-          </Text>
-          <Text style={styles.paragraph}>
-            As a reminder, we were online is a browser extension—part game,
-            artwork, and tool—that turns the existing Internet into a living,
-            shared world, actively shaped by its inhabitants. Eventually, I want
-            this to be a space where we can bump into each other all over the
-            web and other creatives can create more embodied social media from
-            their personal websites to bring belonging to the open web (building
-            on top of <Link href={PLAYHTML_URL}>playhtml</Link>).
-          </Text>
-          <Text style={styles.paragraph}>
-            But that'll be a long process and here's what you can do now:
-          </Text>
-          <ol style={styles.list}>
-            <li>
-              <strong>Collect your browsing traces:</strong> your trails,
-              keypresses, scrolls are transformed into an Internet self-portrait.
-              It's an experiment in taking data that's usually used for
-              surveillance and making it into something expressive instead. Data
-              stored locally and collected anonymously. If you'd like, you can
-              also share the data to contribute to a{' '}
-              <Link href={SELF_PORTRAIT_URL}>
-                collective portrait of the Internet
-              </Link>
-              .
-            </li>
-            <li>
-              <strong>Browse collectively on Wikipedia:</strong> you'll see
-              other people browsing Wikipedia and can even follow each other
-              down links. This is a first experiment in the kinds of collective
-              interactions that I hope to bring to the rest of the web.
-            </li>
-          </ol>
-          <Text style={styles.paragraph}>
-            If you have an idea for a new social web experience (like the
-            Wikipedia one), please let me know! I'm working directly with
-            people to help bring their ideas to life.
-          </Text>
-          <Text style={styles.paragraph}>
-            Thanks for your willingness to try something new and contribute to
-            making a new kind of Internet! Let me know what you think anytime at{' '}
-            <Link href={`mailto:${REPLY_EMAIL}`}>{REPLY_EMAIL}</Link> :)
-          </Text>
-          <Text style={styles.signature}>spencer</Text>
-        </Container>
-      </Body>
-    </Html>
-  );
+Thanks for signing up and being willing to try something that makes the Internet hopefully feel a bit more alive :) I'm excited to share the beta of we were online (${HOMEPAGE_URL}) with you.
+
+- Download on Chrome (or chromium equivalents): ${CHROME_URL}
+- Download on Firefox: ${FIREFOX_URL}
+- Use another browser or run into any issues? let me know
+
+${SHARED_EMAIL_TEXT}`;
+
+export const UPDATES_EMAIL_TEXT = `Hi everyone!
+
+Thanks for signing up for updates as we keep building we were online (${HOMEPAGE_URL}).
+
+${SHARED_EMAIL_TEXT}`;
+
+const SHARED_EMAIL_HTML = `
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              As a reminder, we were online is a browser extension - part game, artwork, and tool - that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Eventually, I want this to be a space where we can bump into each other all over the web and other creatives can create more embodied social media from their personal websites to bring belonging to the open web (building on top of
+              <a href="${PLAYHTML_URL}" style="color:#067df7;text-decoration:none" target="_blank">playhtml</a>).
+            </p>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">But that'll be a long process and here's what you can do now:</p>
+            <ol style="font-size:16px;line-height:1.6;padding-left:20px;margin:0 0 16px 0">
+              <li>
+                <strong>Collect your browsing traces:</strong> your trails, keypresses, scrolls are transformed into an Internet self-portrait. It's an experiment in taking data that's usually used for surveillance and making it into something expressive instead. Data stored locally and collected anonymously. If you'd like, you can also share the data to contribute to a
+                <a href="${SELF_PORTRAIT_URL}" style="color:#067df7;text-decoration:none" target="_blank">collective portrait of the Internet</a>.
+              </li>
+              <li>
+                <strong>Browse collectively on Wikipedia:</strong> you'll see other people browsing Wikipedia and can even follow each other down links. This is a first experiment in the kinds of collective interactions that I hope to bring to the rest of the web.
+              </li>
+            </ol>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              If you have an idea for a new social web experience (like the Wikipedia one), please let me know! I'm working directly with people to help bring their ideas to life.
+            </p>
+            <div style="margin:24px 0">
+              <a href="${DISCORD_INVITE_URL}" style="display:inline-block;background-color:#3d3833;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px" target="_blank">
+                join the playhtml discord
+              </a>
+            </div>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              Thanks for your willingness to try something new and contribute to making a new kind of Internet! Let me know what you think anytime at
+              <a href="mailto:${REPLY_EMAIL}" style="color:#067df7;text-decoration:none" target="_blank">${REPLY_EMAIL}</a> :)
+            </p>
+            <p style="font-family:'Source Serif 4','Source Serif Pro',Georgia,serif;font-style:italic;font-size:18px;color:#3d3833;margin:24px 0 0 0">spencer</p>`;
+
+function buildEmailHtml(subject: string, preview: string, introHtml: string): string {
+  return `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>${subject}</title>
+  </head>
+  <body style="background-color:#faf7f2;color:#3d3833;font-family:'Atkinson Hyperlegible',-apple-system,BlinkMacSystemFont,'Helvetica Neue',sans-serif;margin:0;padding:0">
+    <div style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0">
+      ${preview}
+    </div>
+    <table align="center" width="100%" border="0" cellpadding="0" cellspacing="0" role="presentation" style="max-width:560px;margin:0 auto;padding:40px 24px">
+      <tbody>
+        <tr style="width:100%">
+          <td>
+            <h1 style="font-family:'Source Serif 4','Source Serif Pro',Georgia,serif;font-style:italic;font-weight:200;font-size:32px;color:#3d3833;margin:0 0 24px 0;letter-spacing:0">
+              we were online
+            </h1>
+            ${introHtml}
+${SHARED_EMAIL_HTML}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+</html>`;
 }
 
+const WELCOME_EMAIL_HTML = buildEmailHtml(
+  WELCOME_EMAIL_SUBJECT,
+  'install links for we were online - and what to expect next',
+  `<p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">Hi everyone!</p>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              Thanks for signing up and being willing to try something that makes the Internet hopefully feel a bit more alive :) I'm excited to share the beta of
+              <a href="${HOMEPAGE_URL}" style="color:#067df7;text-decoration:none" target="_blank"><em>we were online</em></a>
+              with you.
+            </p>
+            <div style="margin:24px 0">
+              <a href="${CHROME_URL}" style="display:inline-block;background-color:#4a9a8a;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px;margin-right:8px;margin-bottom:8px" target="_blank">
+                Download on Chrome
+              </a>
+              <a href="${FIREFOX_URL}" style="display:inline-block;background-color:#4a9a8a;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px;margin-right:8px;margin-bottom:8px" target="_blank">
+                Download on Firefox
+              </a>
+            </div>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              (Chrome download also works for Chromium-equivalents.) Use another browser or run into any issues?
+              <a href="mailto:${REPLY_EMAIL}" style="color:#067df7;text-decoration:none" target="_blank">let me know</a>.
+            </p>`,
+);
+
+const UPDATES_EMAIL_HTML = buildEmailHtml(
+  UPDATES_EMAIL_SUBJECT,
+  'updates from we were online and playhtml',
+  `<p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">Hi everyone!</p>
+            <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
+              Thanks for signing up for updates as we keep building
+              <a href="${HOMEPAGE_URL}" style="color:#067df7;text-decoration:none" target="_blank"><em>we were online</em></a>.
+            </p>`,
+);
+
 export async function renderWelcomeEmail(): Promise<string> {
-  return await render(<WelcomeEmail />);
+  return WELCOME_EMAIL_HTML;
+}
+
+export async function renderUpdatesEmail(): Promise<string> {
+  return UPDATES_EMAIL_HTML;
 }

--- a/extension/worker/src/lib/resend.ts
+++ b/extension/worker/src/lib/resend.ts
@@ -58,7 +58,7 @@ async function sendEmail(
   resend: Resend,
   { email, subject, html, text, idempotencyKey }: SendEmailOptions,
 ): Promise<void> {
-  const { error } = await resend.emails.send(
+  const { data, error } = await resend.emails.send(
     {
       from: FROM_ADDRESS,
       to: email,
@@ -74,6 +74,9 @@ async function sendEmail(
 
   if (error) {
     throw new Error(error.message);
+  }
+  if (!data?.id) {
+    throw new Error('Resend did not return an email id');
   }
 }
 
@@ -102,7 +105,7 @@ export function createResendClient(config: ResendClientConfig): ResendClient {
       // do it via a proper Resend Segment.
       void source;
 
-      const { error: createError } = await resend.contacts.create({
+      const { data: createdContact, error: createError } = await resend.contacts.create({
         email,
         unsubscribed: false,
         ...(config.segmentId
@@ -117,6 +120,9 @@ export function createResendClient(config: ResendClientConfig): ResendClient {
           return { created: false };
         }
         throw new Error(createError.message);
+      }
+      if (!createdContact?.id) {
+        throw new Error('Resend did not return a contact id');
       }
 
       return { created: true };

--- a/extension/worker/src/lib/resend.ts
+++ b/extension/worker/src/lib/resend.ts
@@ -1,8 +1,15 @@
-// ABOUTME: Thin wrapper around the Resend SDK for adding subscribers and sending welcome emails.
+// ABOUTME: Thin wrapper around the Resend SDK for adding subscribers and sending signup emails.
 // ABOUTME: Surfaces a minimal interface so the route handler can be tested with a mock.
 
 import { Resend } from 'resend';
-import { renderWelcomeEmail, WELCOME_EMAIL_SUBJECT, WELCOME_EMAIL_TEXT } from '../emails/WelcomeEmail';
+import {
+  renderUpdatesEmail,
+  renderWelcomeEmail,
+  UPDATES_EMAIL_SUBJECT,
+  UPDATES_EMAIL_TEXT,
+  WELCOME_EMAIL_SUBJECT,
+  WELCOME_EMAIL_TEXT,
+} from '../emails/WelcomeEmail';
 
 export type SignupSource = 'website' | 'extension-setup';
 
@@ -17,9 +24,19 @@ export interface ResendClientConfig {
 export interface ResendClient {
   addContact(email: string, source: SignupSource): Promise<{ created: boolean }>;
   sendWelcomeEmail(email: string): Promise<void>;
+  sendUpdatesEmail(email: string): Promise<void>;
 }
 
 const FROM_ADDRESS = 'spencer <hi@spencer.place>';
+const REPLY_TO_ADDRESS = 'hi@spencer.place';
+
+interface SendEmailOptions {
+  email: string;
+  subject: string;
+  html: string;
+  text: string;
+  idempotencyKey: string;
+}
 
 function isNotFoundError(error: { name?: string; message?: string }): boolean {
   // Resend returns name 'not_found' when a contact lookup misses.
@@ -35,6 +52,29 @@ function isDuplicateContactError(error: { name?: string; message?: string }): bo
   // rather than failing the request. This races against contacts.get when
   // two requests for the same email arrive within ms of each other.
   return /already.*exist/i.test(error.message || '');
+}
+
+async function sendEmail(
+  resend: Resend,
+  { email, subject, html, text, idempotencyKey }: SendEmailOptions,
+): Promise<void> {
+  const { error } = await resend.emails.send(
+    {
+      from: FROM_ADDRESS,
+      to: email,
+      replyTo: REPLY_TO_ADDRESS,
+      subject,
+      html,
+      text,
+    },
+    // Idempotency key prevents duplicate sends if the worker retries
+    // within Resend's 24h dedup window.
+    { idempotencyKey },
+  );
+
+  if (error) {
+    throw new Error(error.message);
+  }
 }
 
 export function createResendClient(config: ResendClientConfig): ResendClient {
@@ -84,23 +124,24 @@ export function createResendClient(config: ResendClientConfig): ResendClient {
 
     async sendWelcomeEmail(email) {
       const html = await renderWelcomeEmail();
-      const { error } = await resend.emails.send(
-        {
-          from: FROM_ADDRESS,
-          to: email,
-          replyTo: 'hi@spencer.place',
-          subject: WELCOME_EMAIL_SUBJECT,
-          html,
-          text: WELCOME_EMAIL_TEXT,
-        },
-        // Idempotency key prevents duplicate sends if the worker retries
-        // within Resend's 24h dedup window.
-        { idempotencyKey: `welcome-email/${email}` },
-      );
+      await sendEmail(resend, {
+        email,
+        subject: WELCOME_EMAIL_SUBJECT,
+        html,
+        text: WELCOME_EMAIL_TEXT,
+        idempotencyKey: `welcome-email/${email}`,
+      });
+    },
 
-      if (error) {
-        throw new Error(error.message);
-      }
+    async sendUpdatesEmail(email) {
+      const html = await renderUpdatesEmail();
+      await sendEmail(resend, {
+        email,
+        subject: UPDATES_EMAIL_SUBJECT,
+        html,
+        text: UPDATES_EMAIL_TEXT,
+        idempotencyKey: `updates-email/${email}`,
+      });
     },
   };
 }

--- a/extension/worker/src/routes/subscribe.ts
+++ b/extension/worker/src/routes/subscribe.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Handles POST /subscribe — adds an email to the Resend Audience and sends welcome on first signup.
-// ABOUTME: Public endpoint, validated and rate-limited; never logs or stores anything beyond email + source.
+// ABOUTME: Handles POST /subscribe by adding signup emails to Resend.
+// ABOUTME: Public endpoint, validated and rate-limited; sends email based on signup source.
 
 import { createResendClient, type SignupSource } from '../lib/resend';
 import type { Env } from '../lib/supabase';
@@ -75,6 +75,7 @@ export async function handleSubscribe(request: Request, env: Env): Promise<Respo
   if (!VALID_SOURCES.includes(source as SignupSource)) {
     return jsonResponse(400, { error: 'Invalid or missing source' });
   }
+  const signupSource = source as SignupSource;
 
   const resend = createResendClient({
     apiKey: env.RESEND_API_KEY,
@@ -83,25 +84,30 @@ export async function handleSubscribe(request: Request, env: Env): Promise<Respo
 
   let result: { created: boolean };
   try {
-    result = await resend.addContact(email, source as SignupSource);
+    result = await resend.addContact(email, signupSource);
   } catch (err) {
     console.error('[Subscribe] addContact failed:', err);
     return jsonResponse(503, { error: 'Email service temporarily unavailable' });
   }
 
-  if (result.created) {
+  if (signupSource === 'website') {
     try {
       await resend.sendWelcomeEmail(email);
     } catch (err) {
-      // Contact was created; welcome failed. Log but return success — the
-      // user is on the list, and we'd rather not double-charge them with
-      // a retry that creates duplicate entries.
       console.error('[Subscribe] sendWelcomeEmail failed:', err);
+      return jsonResponse(503, { error: 'Email service temporarily unavailable' });
+    }
+  } else {
+    try {
+      await resend.sendUpdatesEmail(email);
+    } catch (err) {
+      console.error('[Subscribe] sendUpdatesEmail failed:', err);
+      return jsonResponse(503, { error: 'Email service temporarily unavailable' });
     }
   }
 
   if (VERBOSE) {
-    console.log(`[Subscribe] ${email} (${source}) — created=${result.created}`);
+    console.log(`[Subscribe] ${email} (${signupSource}) — created=${result.created}`);
   }
 
   return jsonResponse(200, { ok: true, alreadySubscribed: !result.created });


### PR DESCRIPTION
## Summary
- replace the welcome email render path with static HTML/plaintext so Worker sends do not depend on React Email at runtime
- send download-link welcome emails for website signups and updates-only emails for extension setup signups
- add Resend client and /subscribe tests for welcome, updates, send-failure, and malformed Resend success responses

## Verification
- /Users/spencerchang/.bun/bin/bun run --cwd extension/worker test (2 files, 24 tests)
- /Users/spencerchang/.bun/bin/bunx tsc -p extension/worker/tsconfig.json --noEmit (blocked by existing `extension/worker/src/routes/export.ts` unknown-body errors outside this PR diff)

## Code Review
- Subagent follow-up review found no Critical, Important, or Minor issues after the Resend response validation fix

## Deployment
- Deployed Worker version ae048328-072f-45fd-bb98-01519324bed7 from the same final Worker email file state
- Backfilled corrected remaining recipient list separately through Resend
