### PR TITLE
extension: align guestbook dots and loop navigation

### DIFF
--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -99,6 +99,7 @@ const ANIMATION_SETTINGS = {
   animationSpeed: 1.0,
   clickMinRadius: 10,
   clickMaxRadius: 30,
+  clickCoreRadius: 3,
   clickMinDuration: 600,
   clickMaxDuration: 1200,
   clickExpansionDuration: 400,

--- a/extension/website/src/components/AuraGuestbook.module.scss
+++ b/extension/website/src/components/AuraGuestbook.module.scss
@@ -15,7 +15,7 @@
   margin-bottom: 16px;
 }
 
-// --- Visitor dots — every visitor, drawn on one canvas ---
+// --- Visitor dots — rendered pile colors, drawn on one canvas ---
 
 .visitorOrbs {
   // Break out of the section's max-width and side padding so the band runs

--- a/extension/website/src/components/AuraGuestbook.tsx
+++ b/extension/website/src/components/AuraGuestbook.tsx
@@ -11,14 +11,8 @@ import {
 } from "react";
 import { withSharedState, usePlayContext } from "@playhtml/react";
 import { containsProfanity } from "@movement/profanity";
+import { getPileDotColors, type GuestbookEntry } from "./auraGuestbookData";
 import styles from "./AuraGuestbook.module.scss";
-
-interface GuestbookEntry {
-  name: string;
-  color: string;
-  message: string;
-  timestamp: number;
-}
 
 const MAX_MESSAGE_LENGTH = 400;
 const MAX_NAME_LENGTH = 20;
@@ -240,21 +234,20 @@ function layoutOrbs(
   return { dots, width };
 }
 
-// Visitor dots — every unique visitor, drawn on one canvas so the glow scales
-// to thousands of dots without compositing a box-shadow per DOM node.
+// Visitor dots — every unique rendered pile color, drawn on one canvas so the
+// glow scales without compositing a box-shadow per DOM node.
 // Hovering a dot reports its color up so the matching pile cards can lift.
 const VisitorOrbs = memo(function VisitorOrbs({
-  entries,
+  dotColors,
   hoveredColor,
   onHoverColor,
   firstVisitByColor,
 }: {
-  entries: GuestbookEntry[];
+  dotColors: string[];
   hoveredColor: string | null;
   onHoverColor: (color: string | null) => void;
   firstVisitByColor: Map<string, number>;
 }) {
-  const { cursors } = usePlayContext();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -265,40 +258,9 @@ const VisitorOrbs = memo(function VisitorOrbs({
     text: string;
   } | null>(null);
 
-  const allColors = useMemo(() => {
-    const seen = new Set<string>();
-    const colors: string[] = [];
-    if (cursors.color) {
-      seen.add(cursors.color);
-      colors.push(cursors.color);
-    }
-    const sorted = [...entries].sort((a, b) => b.timestamp - a.timestamp);
-    for (const entry of sorted) {
-      if (!seen.has(entry.color)) {
-        seen.add(entry.color);
-        colors.push(entry.color);
-      }
-    }
-    // Dev preview: append synthetic visitor colors so the dot band can be
-    // inspected with realistic density. Enable with ?mockDots=300 in the URL.
-    if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search);
-      const mockCount = parseInt(params.get("mockDots") ?? "", 10);
-      if (Number.isFinite(mockCount) && mockCount > 0) {
-        for (let i = 0; i < mockCount; i++) {
-          const hue = Math.floor(seededRandom(i + 1) * 360);
-          const sat = 55 + Math.floor(seededRandom(i + 2) * 35);
-          const light = 50 + Math.floor(seededRandom(i + 3) * 20);
-          colors.push(`hsl(${hue}, ${sat}%, ${light}%)`);
-        }
-      }
-    }
-    return colors;
-  }, [entries, cursors.color]);
-
   const { dots, width: bandWidth } = useMemo(
-    () => layoutOrbs(allColors, bandHeight),
-    [allColors, bandHeight],
+    () => layoutOrbs(dotColors, bandHeight),
+    [dotColors, bandHeight],
   );
 
   // Track the viewport's height so layout matches the visible band.
@@ -532,6 +494,10 @@ export const AuraGuestbook = withSharedState(
         };
       });
     }, [sortedEntries]);
+    const pileDotColors = useMemo(
+      () => getPileDotColors(sortedEntries, PILE_RENDER_LIMIT),
+      [sortedEntries],
+    );
 
     // Earliest timestamp per visitor color, for the dot hover tooltip
     const firstVisitByColor = useMemo(() => {
@@ -629,7 +595,7 @@ export const AuraGuestbook = withSharedState(
         {/* Visitor dots above heading */}
 
         <VisitorOrbs
-          entries={entries}
+          dotColors={pileDotColors}
           hoveredColor={hoveredColor}
           onHoverColor={setHoveredColor}
           firstVisitByColor={firstVisitByColor}

--- a/extension/website/src/components/AuraGuestbook.tsx
+++ b/extension/website/src/components/AuraGuestbook.tsx
@@ -11,7 +11,11 @@ import {
 } from "react";
 import { withSharedState, usePlayContext } from "@playhtml/react";
 import { containsProfanity } from "@movement/profanity";
-import { getPileDotColors, type GuestbookEntry } from "./auraGuestbookData";
+import {
+  getLoopedEntryIndex,
+  getPileDotColors,
+  type GuestbookEntry,
+} from "./auraGuestbookData";
 import styles from "./AuraGuestbook.module.scss";
 
 const MAX_MESSAGE_LENGTH = 400;
@@ -523,14 +527,14 @@ export const AuraGuestbook = withSharedState(
         if (expandedIndex === null) return;
         if (e.key === "ArrowRight" || e.key === "ArrowDown") {
           e.preventDefault();
-          if (expandedIndex < sortedEntries.length - 1) {
-            setExpandedIndex(expandedIndex + 1);
-          }
+          setExpandedIndex(
+            getLoopedEntryIndex(expandedIndex, sortedEntries.length, 1),
+          );
         } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
           e.preventDefault();
-          if (expandedIndex > 0) {
-            setExpandedIndex(expandedIndex - 1);
-          }
+          setExpandedIndex(
+            getLoopedEntryIndex(expandedIndex, sortedEntries.length, -1),
+          );
         } else if (e.key === "Escape") {
           setExpandedIndex(null);
         }

--- a/extension/website/src/components/CoffeeMachine.tsx
+++ b/extension/website/src/components/CoffeeMachine.tsx
@@ -1,8 +1,8 @@
 // ABOUTME: Interactive coffee machine + cortado for the essay marginalia.
 // ABOUTME: Shared state tracks phase and counts; play events trigger animations across clients.
 
-import { useEffect, useState, useCallback, useContext, useRef } from "react";
-import { withSharedState, PlayContext } from "@playhtml/react";
+import { useEffect, useState, useCallback, useRef } from "react";
+import { withSharedState, usePlayContext } from "@playhtml/react";
 import styles from "./CoffeeMachine.module.scss";
 
 type Phase = "idle" | "ready";
@@ -30,13 +30,13 @@ export const CoffeeMachine = withSharedState<CoffeeData, any, CoffeeMachineProps
       dispatchPlayEvent,
       registerPlayEventListener,
       removePlayEventListener,
-    } = useContext(PlayContext);
+    } = usePlayContext();
 
     // Local animation state layered on top of the shared phase
     const [animating, setAnimating] = useState<"brewing" | "drinking" | null>(
       null,
     );
-    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
       return () => {

--- a/extension/website/src/components/__tests__/AuraGuestbook.test.ts
+++ b/extension/website/src/components/__tests__/AuraGuestbook.test.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Tests for guestbook card pile and visitor dot data selection.
+// ABOUTME: Verifies hoverable dot colors stay backed by rendered cards.
+
+import { describe, expect, it } from "vitest";
+import { getPileDotColors } from "../auraGuestbookData";
+
+function entry(color: string, timestamp: number) {
+  return {
+    name: `person-${timestamp}`,
+    color,
+    message: `message ${timestamp}`,
+    timestamp,
+  };
+}
+
+describe("getPileDotColors", () => {
+  it("returns newest unique colors from the rendered pile window", () => {
+    const entries = Array.from({ length: 123 }, (_, index) =>
+      entry(`hsl(${index}, 60%, 50%)`, index),
+    );
+
+    const colors = getPileDotColors(entries, 120);
+
+    expect(colors).toHaveLength(120);
+    expect(colors.slice(0, 3)).toEqual([
+      "hsl(122, 60%, 50%)",
+      "hsl(121, 60%, 50%)",
+      "hsl(120, 60%, 50%)",
+    ]);
+    expect(colors).not.toContain("hsl(0, 60%, 50%)");
+    expect(colors).not.toContain("hsl(1, 60%, 50%)");
+    expect(colors).not.toContain("hsl(2, 60%, 50%)");
+  });
+
+  it("deduplicates repeated colors by the newest rendered card", () => {
+    const entries = [
+      entry("#c4724e", 1),
+      entry("#4a9a8a", 2),
+      entry("#c4724e", 3),
+    ];
+
+    expect(getPileDotColors(entries, 120)).toEqual(["#c4724e", "#4a9a8a"]);
+  });
+});

--- a/extension/website/src/components/__tests__/AuraGuestbook.test.ts
+++ b/extension/website/src/components/__tests__/AuraGuestbook.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies hoverable dot colors stay backed by rendered cards.
 
 import { describe, expect, it } from "vitest";
-import { getPileDotColors } from "../auraGuestbookData";
+import { getLoopedEntryIndex, getPileDotColors } from "../auraGuestbookData";
 
 function entry(color: string, timestamp: number) {
   return {
@@ -40,5 +40,19 @@ describe("getPileDotColors", () => {
     ];
 
     expect(getPileDotColors(entries, 120)).toEqual(["#c4724e", "#4a9a8a"]);
+  });
+});
+
+describe("getLoopedEntryIndex", () => {
+  it("wraps forward from the last entry to the first", () => {
+    expect(getLoopedEntryIndex(2, 3, 1)).toBe(0);
+  });
+
+  it("wraps backward from the first entry to the last", () => {
+    expect(getLoopedEntryIndex(0, 3, -1)).toBe(2);
+  });
+
+  it("keeps the current index when there are no entries", () => {
+    expect(getLoopedEntryIndex(0, 0, 1)).toBe(0);
   });
 });

--- a/extension/website/src/components/auraGuestbookData.ts
+++ b/extension/website/src/components/auraGuestbookData.ts
@@ -26,3 +26,12 @@ export function getPileDotColors(
 
   return colors;
 }
+
+export function getLoopedEntryIndex(
+  currentIndex: number,
+  entryCount: number,
+  direction: number,
+): number {
+  if (entryCount === 0) return currentIndex;
+  return (currentIndex + direction + entryCount) % entryCount;
+}

--- a/extension/website/src/components/auraGuestbookData.ts
+++ b/extension/website/src/components/auraGuestbookData.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Data helpers for the aura guestbook card pile and visitor dots.
+// ABOUTME: Keeps dot colors aligned with the cards rendered on the corkboard.
+
+export interface GuestbookEntry {
+  name: string;
+  color: string;
+  message: string;
+  timestamp: number;
+}
+
+export function getPileDotColors(
+  entries: GuestbookEntry[],
+  pileLimit: number,
+): string[] {
+  const sortedEntries = [...entries].sort((a, b) => a.timestamp - b.timestamp);
+  const start = Math.max(0, sortedEntries.length - pileLimit);
+  const seen = new Set<string>();
+  const colors: string[] = [];
+
+  for (const entry of sortedEntries.slice(start).reverse()) {
+    if (!seen.has(entry.color)) {
+      seen.add(entry.color);
+      colors.push(entry.color);
+    }
+  }
+
+  return colors;
+}


### PR DESCRIPTION
## Summary
- align guestbook visitor dots with the rendered card pile so each hoverable dot can lift a visible card
- make expanded guestbook arrow-key navigation wrap around at the ends
- cover the dot selection and looping index logic with focused tests

## Verification
- /Users/spencerchang/.bun/bin/bunx vitest run extension/website/src/components/__tests__/AuraGuestbook.test.ts --environment jsdom --config extension/website/vite.config.ts
- /Users/spencerchang/.bun/bin/bun run build in extension/website
- git diff --check

Note: extension/website lint still fails on existing cross-package unused-local errors in packages/common and packages/playhtml.