### PR TITLE
Fix guestbook mock dots

### DIFF
--- a/extension/website/src/components/AuraGuestbook.module.scss
+++ b/extension/website/src/components/AuraGuestbook.module.scss
@@ -15,7 +15,7 @@
   margin-bottom: 16px;
 }
 
-// --- Visitor dots — rendered pile colors, drawn on one canvas ---
+// --- Visitor dots — guestbook colors, drawn on one canvas ---
 
 .visitorOrbs {
   // Break out of the section's max-width and side padding so the band runs

--- a/extension/website/src/components/AuraGuestbook.tsx
+++ b/extension/website/src/components/AuraGuestbook.tsx
@@ -12,8 +12,9 @@ import {
 import { withSharedState, usePlayContext } from "@playhtml/react";
 import { containsProfanity } from "@movement/profanity";
 import {
+  getGuestbookDotColors,
   getLoopedEntryIndex,
-  getPileDotColors,
+  getRenderedPileCardIndexes,
   type GuestbookEntry,
 } from "./auraGuestbookData";
 import styles from "./AuraGuestbook.module.scss";
@@ -55,6 +56,15 @@ function getAgeFilter(timestamp: number): string {
 function seededRandom(seed: number): number {
   const x = Math.sin(seed * 127.1 + seed * 311.7) * 43758.5453;
   return x - Math.floor(x);
+}
+
+function getMockDotColors(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => {
+    const hue = Math.floor(seededRandom(index + 11) * 360);
+    const saturation = Math.floor(60 + seededRandom(index + 23) * 25);
+    const lightness = Math.floor(45 + seededRandom(index + 37) * 18);
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+  });
 }
 
 // Cards cluster near center first, spreading outward as the pile grows
@@ -238,8 +248,8 @@ function layoutOrbs(
   return { dots, width };
 }
 
-// Visitor dots — every unique rendered pile color, drawn on one canvas so the
-// glow scales without compositing a box-shadow per DOM node.
+// Visitor dots — every unique guestbook color, drawn on one canvas so the glow
+// scales without compositing a box-shadow per DOM node.
 // Hovering a dot reports its color up so the matching pile cards can lift.
 const VisitorOrbs = memo(function VisitorOrbs({
   dotColors,
@@ -476,13 +486,15 @@ export const AuraGuestbook = withSharedState(
       [entries],
     );
 
-    // The pile area is fixed-size; only the most recent cards are ever visible
-    // (older ones are fully buried). Render a window of the newest entries,
-    // keeping real indices so the expanded carousel still spans every entry.
-    const visiblePileCards = useMemo(() => {
-      const start = Math.max(0, sortedEntries.length - PILE_RENDER_LIMIT);
-      return sortedEntries.slice(start).map((entry, offset) => {
-        const index = start + offset;
+    // The pile area is fixed-size; only the most recent cards are visible while
+    // resting. A hovered dot can surface one buried card with the same color.
+    const renderedPileCards = useMemo(() => {
+      return getRenderedPileCardIndexes(
+        sortedEntries,
+        PILE_RENDER_LIMIT,
+        hoveredColor,
+      ).map((index) => {
+        const entry = sortedEntries[index];
         const { rotation, spreadX, spreadY } = getCardTransform(
           entry.timestamp,
           index,
@@ -497,10 +509,23 @@ export const AuraGuestbook = withSharedState(
           textureClass: getTextureClass(index),
         };
       });
-    }, [sortedEntries]);
-    const pileDotColors = useMemo(
-      () => getPileDotColors(sortedEntries, PILE_RENDER_LIMIT),
+    }, [sortedEntries, hoveredColor]);
+    const guestbookDotColors = useMemo(
+      () => getGuestbookDotColors(sortedEntries),
       [sortedEntries],
+    );
+    const mockDotColors = useMemo(() => {
+      const mockDotsParam = new URLSearchParams(window.location.search).get(
+        "mockDots",
+      );
+      if (mockDotsParam === null) return [];
+      const mockDotCount = Number(mockDotsParam);
+      if (!Number.isInteger(mockDotCount) || mockDotCount <= 0) return [];
+      return getMockDotColors(mockDotCount);
+    }, []);
+    const dotColors = useMemo(
+      () => [...guestbookDotColors, ...mockDotColors],
+      [guestbookDotColors, mockDotColors],
     );
 
     // Earliest timestamp per visitor color, for the dot hover tooltip
@@ -599,7 +624,7 @@ export const AuraGuestbook = withSharedState(
         {/* Visitor dots above heading */}
 
         <VisitorOrbs
-          dotColors={pileDotColors}
+          dotColors={dotColors}
           hoveredColor={hoveredColor}
           onHoverColor={setHoveredColor}
           firstVisitByColor={firstVisitByColor}
@@ -611,7 +636,7 @@ export const AuraGuestbook = withSharedState(
               expandedIndex !== null ? styles.pileDimmed : ""
             }`}
           >
-            {visiblePileCards.map(
+            {renderedPileCards.map(
               ({
                 entry,
                 index,

--- a/extension/website/src/components/__tests__/AuraGuestbook.test.ts
+++ b/extension/website/src/components/__tests__/AuraGuestbook.test.ts
@@ -1,8 +1,12 @@
 // ABOUTME: Tests for guestbook card pile and visitor dot data selection.
-// ABOUTME: Verifies hoverable dot colors stay backed by rendered cards.
+// ABOUTME: Verifies visitor dots can cover the full guestbook without rendering every card.
 
 import { describe, expect, it } from "vitest";
-import { getLoopedEntryIndex, getPileDotColors } from "../auraGuestbookData";
+import {
+  getGuestbookDotColors,
+  getLoopedEntryIndex,
+  getRenderedPileCardIndexes,
+} from "../auraGuestbookData";
 
 function entry(color: string, timestamp: number) {
   return {
@@ -13,33 +17,82 @@ function entry(color: string, timestamp: number) {
   };
 }
 
-describe("getPileDotColors", () => {
-  it("returns newest unique colors from the rendered pile window", () => {
+describe("getGuestbookDotColors", () => {
+  it("returns every unique visitor color newest first", () => {
     const entries = Array.from({ length: 123 }, (_, index) =>
       entry(`hsl(${index}, 60%, 50%)`, index),
     );
 
-    const colors = getPileDotColors(entries, 120);
+    const colors = getGuestbookDotColors(entries);
 
-    expect(colors).toHaveLength(120);
+    expect(colors).toHaveLength(123);
     expect(colors.slice(0, 3)).toEqual([
       "hsl(122, 60%, 50%)",
       "hsl(121, 60%, 50%)",
       "hsl(120, 60%, 50%)",
     ]);
-    expect(colors).not.toContain("hsl(0, 60%, 50%)");
-    expect(colors).not.toContain("hsl(1, 60%, 50%)");
-    expect(colors).not.toContain("hsl(2, 60%, 50%)");
+    expect(colors.slice(-3)).toEqual([
+      "hsl(2, 60%, 50%)",
+      "hsl(1, 60%, 50%)",
+      "hsl(0, 60%, 50%)",
+    ]);
   });
 
-  it("deduplicates repeated colors by the newest rendered card", () => {
+  it("deduplicates repeated colors by the newest visit", () => {
     const entries = [
       entry("#c4724e", 1),
       entry("#4a9a8a", 2),
       entry("#c4724e", 3),
     ];
 
-    expect(getPileDotColors(entries, 120)).toEqual(["#c4724e", "#4a9a8a"]);
+    expect(getGuestbookDotColors(entries)).toEqual(["#c4724e", "#4a9a8a"]);
+  });
+});
+
+describe("getRenderedPileCardIndexes", () => {
+  it("keeps the resting pile capped to the newest cards", () => {
+    const entries = Array.from({ length: 5 }, (_, index) =>
+      entry(`#color-${index}`, index),
+    );
+
+    expect(getRenderedPileCardIndexes(entries, 3, null)).toEqual([2, 3, 4]);
+  });
+
+  it("adds a buried card when its visitor dot is hovered", () => {
+    const entries = Array.from({ length: 5 }, (_, index) =>
+      entry(`#color-${index}`, index),
+    );
+
+    expect(getRenderedPileCardIndexes(entries, 3, "#color-0")).toEqual([
+      2,
+      3,
+      4,
+      0,
+    ]);
+  });
+
+  it("does not duplicate a card that is already in the rendered pile", () => {
+    const entries = Array.from({ length: 5 }, (_, index) =>
+      entry(`#color-${index}`, index),
+    );
+
+    expect(getRenderedPileCardIndexes(entries, 3, "#color-4")).toEqual([
+      2,
+      3,
+      4,
+    ]);
+  });
+
+  it("does not render a card for a dot color without an entry", () => {
+    const entries = Array.from({ length: 5 }, (_, index) =>
+      entry(`#color-${index}`, index),
+    );
+
+    expect(getRenderedPileCardIndexes(entries, 3, "#mock-color")).toEqual([
+      2,
+      3,
+      4,
+    ]);
   });
 });
 

--- a/extension/website/src/components/auraGuestbookData.ts
+++ b/extension/website/src/components/auraGuestbookData.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Data helpers for the aura guestbook card pile and visitor dots.
-// ABOUTME: Keeps dot colors aligned with the cards rendered on the corkboard.
+// ABOUTME: Keeps visitor colors and card indexes stable for the corkboard.
 
 export interface GuestbookEntry {
   name: string;
@@ -8,16 +8,12 @@ export interface GuestbookEntry {
   timestamp: number;
 }
 
-export function getPileDotColors(
-  entries: GuestbookEntry[],
-  pileLimit: number,
-): string[] {
+export function getGuestbookDotColors(entries: GuestbookEntry[]): string[] {
   const sortedEntries = [...entries].sort((a, b) => a.timestamp - b.timestamp);
-  const start = Math.max(0, sortedEntries.length - pileLimit);
   const seen = new Set<string>();
   const colors: string[] = [];
 
-  for (const entry of sortedEntries.slice(start).reverse()) {
+  for (const entry of sortedEntries.reverse()) {
     if (!seen.has(entry.color)) {
       seen.add(entry.color);
       colors.push(entry.color);
@@ -25,6 +21,33 @@ export function getPileDotColors(
   }
 
   return colors;
+}
+
+export function getRenderedPileCardIndexes(
+  sortedEntries: GuestbookEntry[],
+  pileLimit: number,
+  hoveredColor: string | null,
+): number[] {
+  const start = Math.max(0, sortedEntries.length - pileLimit);
+  const indexes: number[] = [];
+
+  for (let index = start; index < sortedEntries.length; index++) {
+    indexes.push(index);
+  }
+
+  if (hoveredColor === null) return indexes;
+  if (indexes.some((index) => sortedEntries[index].color === hoveredColor)) {
+    return indexes;
+  }
+
+  for (let index = sortedEntries.length - 1; index >= 0; index--) {
+    if (sortedEntries[index].color === hoveredColor) {
+      indexes.push(index);
+      break;
+    }
+  }
+
+  return indexes;
 }
 
 export function getLoopedEntryIndex(


### PR DESCRIPTION
## Summary
- Restore `?mockDots=` support for validating guestbook dot density.
- Draw real visitor dots from all unique guestbook colors instead of only the rendered card window.
- Keep the resting card pile capped, while temporarily surfacing one buried real card when its dot is hovered.

## Root Cause
The prior hover-card fix tied visitor dots to the capped rendered pile and removed the mock-dot path. On desktop, mock validation could collapse the canvas to a tiny empty band.

## Verification
- `/Users/spencerchang/.bun/bin/bunx vitest run extension/website/src/components/__tests__/AuraGuestbook.test.ts --environment jsdom --config extension/website/vite.config.ts`
- `/Users/spencerchang/.bun/bin/bun run build` from `extension/website`
- `git diff --check`
- Browser validation with `?mockDots=300`: 1280px viewport, 1447.625px dot band, 346676 painted canvas pixels.