### PR TITLE
walking-together: session home page + Rhizome history

### DIFF
--- a/smoke-tests/smoke.spec.ts
+++ b/smoke-tests/smoke.spec.ts
@@ -26,6 +26,9 @@ const PAGES: { path: string; skip?: string }[] = [
   { path: "/events/gray-area/" },
   { path: "/events/if-then/" },
   { path: "/events/walking-together/" },
+  // The session experience (list links here with ?session=<id>). Smoke-test
+  // the active session so a broken session page is caught.
+  { path: "/events/walking-together/session.html?session=2026-06-06-byod" },
   { path: "/docs/" },
 ];
 

--- a/website/events/walking-together/__tests__/sessions.test.ts
+++ b/website/events/walking-together/__tests__/sessions.test.ts
@@ -1,13 +1,15 @@
-// ABOUTME: Tests session config helpers — resolution from URL and room derivation.
-// ABOUTME: Verifies fallback to the latest active session when ?session is absent.
+// ABOUTME: Tests session config helpers — URL resolution, room derivation, overrides.
+// ABOUTME: Verifies unknown/absent sessions resolve to null (page redirects to home).
 
 import { describe, it, expect } from "vitest";
 import {
   SESSIONS,
   sessionRoom,
+  roomForSession,
   defaultSession,
   findSession,
-  resolveSessionId,
+  parseSessionId,
+  resolveSession,
 } from "../sessions";
 
 describe("sessions", () => {
@@ -28,10 +30,29 @@ describe("sessions", () => {
     expect(findSession("does-not-exist")).toBeUndefined();
   });
 
-  it("resolveSessionId reads ?session and falls back when absent/unknown", () => {
+  it("parseSessionId returns the raw param or null", () => {
+    expect(parseSessionId("?session=foo")).toBe("foo");
+    expect(parseSessionId("")).toBeNull();
+    expect(parseSessionId("?other=1")).toBeNull();
+  });
+
+  it("resolveSession returns the session for a known id", () => {
     const known = SESSIONS[0].id;
-    expect(resolveSessionId(`?session=${known}`)).toBe(known);
-    expect(resolveSessionId("")).toBe(defaultSession().id);
-    expect(resolveSessionId("?session=bogus")).toBe(defaultSession().id);
+    expect(resolveSession(`?session=${known}`)?.id).toBe(known);
+  });
+
+  it("resolveSession returns null when absent or unknown (page redirects home)", () => {
+    expect(resolveSession("")).toBeNull();
+    expect(resolveSession("?session=bogus")).toBeNull();
+  });
+
+  it("roomForSession uses the explicit override when set, else derives", () => {
+    const rhizome = findSession("2025-04-30-rhizome")!;
+    expect(rhizome.room).toBe("/events/walking-together/");
+    expect(roomForSession(rhizome)).toBe("/events/walking-together/");
+
+    const byod = findSession("2026-06-06-byod")!;
+    expect(byod.room).toBeUndefined();
+    expect(roomForSession(byod)).toBe("walking-together-2026-06-06-byod");
   });
 });

--- a/website/events/walking-together/index.html
+++ b/website/events/walking-together/index.html
@@ -15,9 +15,6 @@
     <title>walking together on the internet</title>
   </head>
   <body>
-    <!-- <div id="reactContent"></div>
-    <script type="module" src="./one.tsx"></script> -->
-
     <main
       style="
         height: 100vh;
@@ -28,10 +25,9 @@
     >
       <div style="max-width: 400px">
         <h1>walking together on the internet</h1>
-        <p id="session-subtitle"></p>
       </div>
       <div id="react"></div>
     </main>
   </body>
-  <script type="module" src="./walking-together.tsx"></script>
+  <script type="module" src="./index.tsx"></script>
 </html>

--- a/website/events/walking-together/index.tsx
+++ b/website/events/walking-together/index.tsx
@@ -3,6 +3,9 @@ import React from "react";
 import { SESSIONS } from "./sessions";
 import "./walking-together.scss";
 
+/** Home / index for walking-together: lists every session. The bare
+ * /events/walking-together/ URL lands here; people pick a session to join,
+ * which opens the session experience at session.html?session=<id>. */
 function Home() {
   const sessions = [...SESSIONS].sort((a, b) => b.date.localeCompare(a.date));
   return (
@@ -10,7 +13,7 @@ function Home() {
       <ul>
         {sessions.map((s) => (
           <li key={s.id} className={s.archived ? "archived" : "active"}>
-            <a href={`./index.html?session=${s.id}`}>{s.label}</a>
+            <a href={`./session.html?session=${s.id}`}>{s.label}</a>
             <span className="session-date">{s.date}</span>
             {s.archived ? (
               <span className="session-tag">archived (read-only)</span>

--- a/website/events/walking-together/session.html
+++ b/website/events/walking-together/session.html
@@ -25,14 +25,10 @@
     >
       <div style="max-width: 400px">
         <h1>walking together on the internet</h1>
-        <p>
-          with <a href="https://naiveweekly.com">kristoffer tjalve</a> &
-          <a href="https://spencer.place">spencer chang</a>, with
-          <a href="https://rhizome.org/">rhizome</a>
-        </p>
+        <p id="session-subtitle"></p>
       </div>
       <div id="react"></div>
     </main>
   </body>
-  <script type="module" src="./home.tsx"></script>
+  <script type="module" src="./walking-together.tsx"></script>
 </html>

--- a/website/events/walking-together/sessions.ts
+++ b/website/events/walking-together/sessions.ts
@@ -16,6 +16,15 @@ export interface WorkshopSession {
   archived: boolean;
   /** Credits line shown under the title on the session page. */
   subtitle: SubtitleSegment[];
+  /**
+   * Optional explicit playhtml room string, used verbatim instead of the
+   * derived `walking-together-<id>` room. Set this for sessions whose data
+   * lives in a room that predates this id scheme — e.g. the original Rhizome
+   * event, whose shared URLs live in the pre-v2 pathname-based room. The value
+   * is the un-prefixed room string; playhtml prepends the host (so
+   * `/events/walking-together/` resolves to the live `playhtml.fun-...` room).
+   */
+  room?: string;
 }
 
 export const SESSIONS: WorkshopSession[] = [
@@ -24,6 +33,10 @@ export const SESSIONS: WorkshopSession[] = [
     label: "walking together (Rhizome)",
     date: "2025-04-30",
     archived: true,
+    // The original Rhizome event ran before the session system, on the
+    // default pathname-based room. Point at it so the archived view shows the
+    // real shared URLs from that day.
+    room: "/events/walking-together/",
     subtitle: [
       "with ",
       { text: "kristoffer tjalve", href: "https://naiveweekly.com" },
@@ -46,12 +59,20 @@ export const SESSIONS: WorkshopSession[] = [
   },
 ];
 
-/** Playhtml room id for a session. */
+/** Derived playhtml room string for a session id. */
 export function sessionRoom(id: string): string {
   return `walking-together-${id}`;
 }
 
-/** The latest non-archived session — the fallback when no ?session is given. */
+/**
+ * The playhtml room string for a session — its explicit `room` override when
+ * set (e.g. the legacy Rhizome room), otherwise the derived id-based room.
+ */
+export function roomForSession(session: WorkshopSession): string {
+  return session.room ?? sessionRoom(session.id);
+}
+
+/** The latest non-archived session. */
 export function defaultSession(): WorkshopSession {
   const active = SESSIONS.filter((s) => !s.archived);
   if (active.length === 0) {
@@ -65,12 +86,20 @@ export function findSession(id: string): WorkshopSession | undefined {
 }
 
 /**
- * Resolve the session id from a location search string (e.g. "?session=foo").
- * Falls back to the default session when the param is absent or unknown.
+ * Raw `?session=` value from a location search string, or null when absent.
+ * Does not validate against SESSIONS — callers decide how to handle unknowns.
  */
-export function resolveSessionId(search: string): string {
-  const params = new URLSearchParams(search);
-  const id = params.get("session");
-  if (id && findSession(id)) return id;
-  return defaultSession().id;
+export function parseSessionId(search: string): string | null {
+  return new URLSearchParams(search).get("session");
+}
+
+/**
+ * Resolve a session from a location search string. Returns the matching
+ * session, or null when the param is absent or names an unknown session —
+ * the session page treats null as "redirect to the home list".
+ */
+export function resolveSession(search: string): WorkshopSession | null {
+  const id = parseSessionId(search);
+  if (!id) return null;
+  return findSession(id) ?? null;
 }

--- a/website/events/walking-together/walking-together.tsx
+++ b/website/events/walking-together/walking-together.tsx
@@ -7,10 +7,10 @@ import {
 } from "@playhtml/react";
 import { useStickyState } from "../../hooks/useStickyState";
 import {
-  resolveSessionId,
-  sessionRoom,
-  findSession,
+  resolveSession,
+  roomForSession,
   type SubtitleSegment,
+  type WorkshopSession,
 } from "./sessions";
 import { isAdmin } from "./admin";
 import { PortraitOverlay } from "./PortraitOverlay";
@@ -38,8 +38,12 @@ interface SharedURL {
   timestamp: number;
 }
 
-const SESSION_ID = resolveSessionId(window.location.search);
-const SESSION = findSession(SESSION_ID);
+// Resolve the session from ?session=<id>. An absent or unknown session sends
+// the visitor back to the home list rather than silently joining some room.
+const SESSION = resolveSession(window.location.search);
+if (!SESSION) {
+  window.location.replace("./index.html");
+}
 const IS_ARCHIVED = SESSION?.archived ?? false;
 
 // Element id for the shared roster store. Set as an explicit `id` on the
@@ -356,11 +360,11 @@ export const GroupActivityDisplay = withSharedState(
   },
 );
 
-function Main() {
+function Main({ session }: { session: WorkshopSession }) {
   return (
     <PlayProvider
       initOptions={{
-        room: sessionRoom(SESSION_ID),
+        room: roomForSession(session),
         cursors: { enabled: true, coordinateMode: "relative" },
       }}
     >
@@ -392,9 +396,16 @@ function SessionSubtitle({ segments }: { segments: SubtitleSegment[] }) {
   );
 }
 
-ReactDOM.render(<Main />, document.getElementById("react"));
+// Only mount when a valid session resolved; otherwise the redirect above is
+// already navigating away.
+if (SESSION) {
+  ReactDOM.render(<Main session={SESSION} />, document.getElementById("react"));
 
-const subtitleRoot = document.getElementById("session-subtitle");
-if (subtitleRoot && SESSION) {
-  ReactDOM.render(<SessionSubtitle segments={SESSION.subtitle} />, subtitleRoot);
+  const subtitleRoot = document.getElementById("session-subtitle");
+  if (subtitleRoot) {
+    ReactDOM.render(
+      <SessionSubtitle segments={SESSION.subtitle} />,
+      subtitleRoot,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Makes `/events/walking-together/` land on a session list instead of silently joining a room, and recovers the original Rhizome event's data.

- **Index = home.** Bare `/events/walking-together/` now renders the session list (`index.tsx`). The per-session experience moved to `session.html` + `walking-together.tsx`, reached via `session.html?session=<id>`. (Previously the bare URL dropped you straight into the latest active session's room.)
- **Unknown/absent `?session` redirects** to the home list rather than falling into a default room.
- **Per-session room override.** New optional `room?` on `WorkshopSession`. The archived Rhizome session points at its original pre-v2 room (`/events/walking-together/`) so its read-only view shows the real shared URLs from that day (confirmed that room holds ~16KB of real data in Supabase). Other sessions keep the derived `walking-together-<id>` room.
- Helpers reworked: `resolveSession` (nullable), `parseSessionId`, `roomForSession`, with unit tests.
- Smoke test now covers the session page too.

## Test Plan

- [x] Unit: `bunx vitest run --config website/vitest.config.mts website/events/walking-together/__tests__/` (sessions/admin/roster/portraitData — all pass)
- [x] Type-check at baseline (no new errors)
- [x] `bun run build-site` produces `index.html` (list) + `session.html`, no `home.html`
- [x] Browser-verified against the build: bare URL → list; links → `session.html?session=`; valid session loads; unknown session redirects to home
- [ ] **Post-deploy check (reviewer):** on `playhtml.fun`, confirm the archived Rhizome session shows the original April-2025 shared URLs. The room override is host-prefixed, so this only resolves to the real room on the production host (localhost gets a different prefix).

Builds on the roster-bloat fix + footgun docs already on main.