### PR TITLE
walking-together: session home page, Rhizome history, keyed-map roster + soak test

### DIFF
--- a/apps/docs/src/content/docs/data/data-essentials.md
+++ b/apps/docs/src/content/docs/data/data-essentials.md
@@ -218,31 +218,36 @@ const Roster = withSharedState({ defaultData: { entries: [] } }, ({ data, setDat
 });
 ```
 
-Each write changes `data.entries`, which re-runs the effect, which writes again. Worse, because the data is a CRDT, **two readers writing concurrently both land** (the merge appends rather than overwrites) — so the loop never converges to a stable value the guard can catch. A single buggy element like this grew one production room to 1.2 million CRDT operations / 23 MB and took the room offline.
+Each write changes `data.entries`, which re-runs the effect, which writes again. Worse, because the data is a CRDT, **two readers writing concurrently both land** — and with the **replacement form** (`setData({ entries: [...] })`) over an **array**, concurrent writes append rather than overwrite, so the loop never converges to a stable value the guard can catch. A single buggy element like this grew one production room to 1.2 million CRDT operations / 23 MB and took the room offline.
 
-The fix has two parts:
-
-1. **Don't depend on the data you write.** Read the latest value through a ref so the effect only fires on the inputs that should actually trigger a write (here, the local user's own identity), not on every change to the shared list.
-2. **Make the write idempotent — key by a unique id, last-write-wins.** Rebuild from a `Map` keyed by id so re-running the write can never duplicate, and so it self-heals any duplicates a concurrent merge introduced.
+**The strongest fix is the data model: store collections that must stay unique as a keyed map, and upsert in place with the mutator form.**
 
 ```tsx
-const Roster = withSharedState({ defaultData: { entries: [] } }, ({ data, setData }) => {
+// entries is keyed by id, not an array
+const Roster = withSharedState({ defaultData: { entries: {} } }, ({ data, setData }) => {
   const me = useMe(); // { id, name } — the only thing that should trigger a write
-  const entriesRef = useRef(data.entries);
-  entriesRef.current = data.entries;
+  const ref = useRef(data.entries);
+  ref.current = data.entries;
 
   useEffect(() => {
-    const byId = new Map(entriesRef.current.map((e) => [e.id, e]));
-    const existing = byId.get(me.id);
-    if (existing && existing.name === me.name && byId.size === entriesRef.current.length) {
-      return; // already correct and duplicate-free — skip the write entirely
-    }
-    byId.set(me.id, me);
-    setData({ entries: [...byId.values()] });
+    const existing = ref.current[me.id];
+    if (existing && existing.name === me.name) return; // already correct
+    // Keyed mutator write — assigning entries[id] overwrites in place. Writing
+    // the same id N times can never duplicate, and concurrent writes from two
+    // clients merge cleanly (maps are last-write-wins per key). Idempotent by
+    // construction — the loop, even if it fired, could not grow the doc.
+    setData((draft) => { draft.entries[me.id] = me; });
   }, [me.id, me.name]); // depends on local identity, NOT on data.entries
   return <div />;
 });
 ```
+
+Two reinforcing rules at work here:
+
+1. **Prefer a keyed map + mutator-form upsert over an array + replacement-form rewrite.** The keyed write is idempotent and merge-safe; the array rewrite is neither. This alone defuses the runaway.
+2. **Still don't depend on the data you write.** Read it through a ref so the effect fires only on the inputs that should trigger a write (the local user's identity), not on every change to the shared collection. Belt-and-suspenders on top of the keyed model.
+
+If you genuinely need an array (order matters and there's no natural key), then you must both (a) read via a ref as above and (b) make the write converge — dedupe by id into a `Map` and write the deduped result — but a keyed map is almost always the better shape.
 
 The same rule applies to vanilla `updateElement`: never call `setData` from inside `updateElement` (which runs on every data change) without a guard that provably converges. When in doubt, write only from explicit user events, not from reactive callbacks.
 

--- a/claude-plugin/skills/building-playhtml-elements/SKILL.md
+++ b/claude-plugin/skills/building-playhtml-elements/SKILL.md
@@ -89,19 +89,18 @@ useEffect(() => {
 }, [data.entries]);                            // …re-runs because entries changed
 ```
 
-Fix — two parts, both required:
-1. **Don't depend on the data you write.** Read it through a ref; key the effect on the inputs that should actually trigger a write (e.g. the local user's identity), NOT on the shared array.
-2. **Make the write idempotent** — key by unique id via a `Map` (last-write-wins) so re-running can't duplicate and self-heals concurrent dupes.
+Strongest fix — **model unique collections as a keyed map and upsert in place with the mutator form.** A keyed write is idempotent (same id overwrites, never appends) and merge-safe (maps are last-write-wins per key), so even if the effect loops it cannot grow the doc:
 
 ```tsx
-const entriesRef = useRef(data.entries); entriesRef.current = data.entries;
+// entries is keyed by id, not an array
+const ref = useRef(data.entries); ref.current = data.entries;
 useEffect(() => {
-  const byId = new Map(entriesRef.current.map((e) => [e.id, e]));
-  if (byId.get(me.id)?.name === me.name && byId.size === entriesRef.current.length) return;
-  byId.set(me.id, me);
-  setData({ entries: [...byId.values()] });
-}, [me.id, me.name]); // local identity only
+  if (ref.current[me.id]?.name === me.name) return;       // already correct
+  setData((draft) => { draft.entries[me.id] = me; });      // keyed, idempotent, merge-safe
+}, [me.id, me.name]); // local identity only — NOT data.entries
 ```
+
+Two reinforcing rules: (1) prefer keyed-map + mutator upsert over array + replacement rewrite; (2) read the data through a ref so the effect depends on local identity, not the shared collection. If you truly need an array, you must both read via ref AND dedupe-by-id into a Map before writing — but a keyed map is almost always the right shape.
 
 Rule of thumb: **write shared data from explicit user events, not from reactive callbacks.** If you must write from a callback, prove it converges. Full explanation: https://playhtml.fun/docs/data/data-essentials/#7-never-write-shared-data-from-code-that-re-runs-when-that-data-changes
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",
     "smoke:partykit:emergency": "cd smoke-tests && bun run test:partykit:emergency",
     "smoke:partykit:transient": "cd smoke-tests && bun run test:partykit:transient",
+    "smoke:partykit:soak": "cd smoke-tests && bun run test:partykit:soak",
     "generate-types": "bunx wrangler types --config partykit/wrangler.jsonc --include-runtime=false"
   },
   "overrides": {

--- a/packages/playhtml/src/__tests__/main.nested-data.test.ts
+++ b/packages/playhtml/src/__tests__/main.nested-data.test.ts
@@ -361,4 +361,38 @@ describe("playhtml SyncedStore CRDT behavior", () => {
       });
     }).toThrow();
   });
+
+  it("keyed-map upsert is idempotent — re-writing the same key never duplicates", async () => {
+    // This is the merge-safe pattern for collections that must stay unique by
+    // key (e.g. a participant roster). Modeling entries as a keyed object and
+    // assigning by id means writing the same id N times overwrites rather than
+    // appends — structurally immune to the runaway-append bug that grows the
+    // doc when a write loop fires repeatedly.
+    const tag = "can-mirror";
+    const el = setupSimpleElement(tag, "e-roster");
+    const handler = playhtml.elementHandlers!.get(tag)!.get("e-roster")!;
+
+    // Seed a nested keyed map.
+    handler.setData((draft: any) => {
+      draft.attributes.entries = {};
+    });
+    await waitForSync();
+
+    // Upsert the same key many times — as a write loop would.
+    for (let i = 0; i < 50; i++) {
+      handler.setData((draft: any) => {
+        draft.attributes.entries["pk_a"] = { name: `n${i}` };
+      });
+    }
+    // And a second distinct key once.
+    handler.setData((draft: any) => {
+      draft.attributes.entries["pk_b"] = { name: "b" };
+    });
+    await waitForSync();
+
+    const entries = handler.data.attributes.entries;
+    expect(Object.keys(entries).sort()).toEqual(["pk_a", "pk_b"]);
+    expect(entries["pk_a"]).toEqual({ name: "n49" }); // last write wins
+    expect(entries["pk_b"]).toEqual({ name: "b" });
+  });
 });

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -52,9 +52,24 @@ SUPABASE_URL=http://127.0.0.1:9 SUPABASE_KEY=bad ADMIN_TOKEN=dev \
   --var SUPABASE_LOAD_TIMEOUT_MS:100
 PARTYKIT_HOST=localhost:1999 bun smoke:partykit:transient
 
+# Simulates many participants upserting a keyed roster; asserts the room
+# document stays bounded and no client is dropped (regression guard for the
+# write-loop / doc-bloat incident). Tunables: PARTYKIT_SOAK_CLIENTS,
+# PARTYKIT_SOAK_UPSERTS_PER_CLIENT, PARTYKIT_SOAK_MAX_STRUCT_ITEMS.
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:soak
+
 # Runs the standard PartyKit checks.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit
 ```
+
+The soak test is the regression guard for the runaway-write incident
+(a self-triggering effect over an array roster grew a room to ~1.2M Yjs ops /
+23MB and crashed the Durable Object). It connects N clients, has each
+repeatedly re-upsert its own keyed entry (what a re-rendering effect does), and
+fails if the roster doesn't converge to N unique entries, if the document grows
+past the struct-item ceiling, or if any client is disconnected (a 503/overloaded
+DO drops sockets). Run it against staging after any change to the roster data
+model or the server's persistence/limit logic.
 
 The emergency smoke expects the deployed Worker to use a low threshold, so it
 can exercise the reset path without sending a production-sized document. One

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -12,6 +12,7 @@
     "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",
     "test:partykit:emergency": "node partykit/emergency-compaction-smoke.mjs",
     "test:partykit:transient": "node partykit/supabase-transient-smoke.mjs",
+    "test:partykit:soak": "node partykit/multi-client-soak-smoke.mjs",
     "install-browsers": "playwright install chromium --with-deps"
   },
   "devDependencies": {

--- a/smoke-tests/partykit/multi-client-soak-smoke.mjs
+++ b/smoke-tests/partykit/multi-client-soak-smoke.mjs
@@ -1,0 +1,182 @@
+// ABOUTME: Simulates many participants writing a keyed roster and asserts the
+// ABOUTME: room document stays bounded and every client stays connected (no DO overload).
+//
+// This is the regression guard for the June 2026 walking-together incident: a
+// self-triggering write loop over an array roster grew one room to ~1.2M Yjs
+// ops / 23MB and crashed the Durable Object (503), taking cursors down with it.
+// The fix models the roster as a keyed map upserted in place (idempotent,
+// merge-safe). This soak exercises that pattern under concurrency and fails if
+// the document grows unboundedly or the server stops accepting connections.
+
+import {
+  Y,
+  connectRoom,
+  createStore,
+  getHost,
+  getNumberEnv,
+  getPartyHttpUrl,
+  loadSmokeEnv,
+  sleep,
+  waitForSync,
+} from "./shared.mjs";
+
+const loadedEnvFile = loadSmokeEnv();
+const host = getHost();
+const adminToken = process.env.ADMIN_TOKEN;
+const room = `codex-multi-client-soak-${Date.now()}`;
+const elementId = "soak-roster";
+
+// Tunables (env-overridable). Defaults model a real workshop: ~8 participants,
+// each re-upserting their entry many times (as a re-rendering effect would).
+const clientCount = getNumberEnv("PARTYKIT_SOAK_CLIENTS", 8);
+const upsertsPerClient = getNumberEnv("PARTYKIT_SOAK_UPSERTS_PER_CLIENT", 200);
+const upsertIntervalMs = getNumberEnv("PARTYKIT_SOAK_UPSERT_INTERVAL_MS", 10);
+// A correct keyed-map roster for N clients holds N entries and a bounded number
+// of Yjs structs. The append-bug produced ~clientCount * upserts structs; a
+// keyed map produces roughly clientCount entries + per-write overwrite ops that
+// Yjs largely supersedes. Ceiling is generous but far below the runaway curve.
+const maxStructItems = getNumberEnv(
+  "PARTYKIT_SOAK_MAX_STRUCT_ITEMS",
+  Math.max(5_000, clientCount * upsertsPerClient * 0.25)
+);
+const syncTimeoutMs = getNumberEnv("PARTYKIT_SOAK_SYNC_TIMEOUT_MS", 30_000);
+
+if (!adminToken) {
+  throw new Error(
+    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file."
+  );
+}
+
+function totalStructItems(doc) {
+  let total = 0;
+  for (const arr of doc.store.clients.values()) total += arr.length;
+  return total;
+}
+
+function ensureRosterMap(store) {
+  store.play[elementId] ??= {};
+  store.play[elementId].entries ??= {};
+  return store.play[elementId].entries;
+}
+
+// Inspect via getPartyHttpUrl so this works against both localhost (http) and
+// staging (https) — the shared inspectRoom helper hardcodes https.
+async function inspectSoakRoom() {
+  const response = await fetch(`${getPartyHttpUrl(host, room)}/admin/inspect`, {
+    headers: { Authorization: `Bearer ${adminToken}` },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`inspect failed ${response.status}: ${text}`);
+  }
+  return JSON.parse(text);
+}
+
+/** Mimics RosterAdmin's keyed-map upsert: assign entries[pid] in place. */
+function upsertEntry(store, pid, name, color) {
+  const entries = ensureRosterMap(store);
+  entries[pid] = { pid, name, color };
+}
+
+async function run() {
+  console.log(
+    `[soak] host=${host} room=${room} clients=${clientCount} upserts/client=${upsertsPerClient} envFile=${loadedEnvFile ?? "none"}`
+  );
+
+  const clients = [];
+  for (let i = 0; i < clientCount; i += 1) {
+    const doc = new Y.Doc();
+    const store = createStore(doc);
+    const provider = connectRoom(host, room, doc);
+    clients.push({ i, doc, store, provider, pid: `pk_soak_${i}`, dropped: false });
+    provider.on("status", (event) => {
+      if (event.status === "disconnected") {
+        clients[i].dropped = true;
+      }
+    });
+  }
+
+  try {
+    await Promise.all(
+      clients.map((c) => waitForSync(c.provider, `soak client ${c.i}`, syncTimeoutMs))
+    );
+    console.log(`[soak] all ${clientCount} clients synced`);
+
+    // Each client repeatedly upserts ITS OWN entry — exactly what a
+    // re-rendering effect does. With the keyed map this must converge to
+    // clientCount entries and a bounded doc.
+    for (let round = 0; round < upsertsPerClient; round += 1) {
+      for (const c of clients) {
+        upsertEntry(c.store, c.pid, `name-${round}`, "#4a9a8a");
+      }
+      if (upsertIntervalMs > 0) await sleep(upsertIntervalMs);
+    }
+
+    // Let the final state settle/sync.
+    await sleep(3_000);
+
+    // Assert no client was dropped (a 503/overloaded DO disconnects clients).
+    const dropped = clients.filter((c) => c.dropped).map((c) => c.i);
+    if (dropped.length > 0) {
+      throw new Error(
+        `clients disconnected during soak (DO overload?): ${dropped.join(", ")}`
+      );
+    }
+
+    // Assert the roster converged to exactly clientCount unique entries on a
+    // representative client.
+    const sample = clients[0];
+    const entries = sample.store.play[elementId]?.entries ?? {};
+    const entryCount = Object.keys(entries).length;
+    if (entryCount !== clientCount) {
+      throw new Error(
+        `roster did not converge: expected ${clientCount} entries, got ${entryCount}`
+      );
+    }
+
+    // Assert the document stayed bounded. This is the load-bearing check —
+    // the append-bug would blow far past maxStructItems.
+    const structItems = totalStructItems(sample.doc);
+    console.log(
+      `[soak] converged: entries=${entryCount} structItems=${structItems} (ceiling=${maxStructItems})`
+    );
+    if (structItems > maxStructItems) {
+      throw new Error(
+        `document grew unbounded: ${structItems} struct items exceeds ceiling ${maxStructItems}`
+      );
+    }
+
+    // Confirm the server is still responsive (not wedged) via admin inspect.
+    // Best-effort: in local transient mode (no persistence) the inspect has no
+    // persisted doc to report, so a 404 there is not a failure. Against staging
+    // it cross-checks that the server sees the same converged roster. A 503
+    // here WOULD indicate an overloaded DO — surface that distinctly.
+    try {
+      const inspected = await inspectSoakRoom();
+      const serverEntries = inspected?.ydoc?.play?.[elementId]?.entries ?? {};
+      const serverEntryCount = Object.keys(serverEntries).length;
+      console.log(`[soak] server inspect ok: entries=${serverEntryCount}`);
+      if (serverEntryCount !== clientCount) {
+        throw new Error(
+          `server roster mismatch: expected ${clientCount}, got ${serverEntryCount}`
+        );
+      }
+    } catch (err) {
+      if (/\b503\b|overload|Service Busy/i.test(err.message)) {
+        throw new Error(`server overloaded during soak: ${err.message}`);
+      }
+      console.warn(
+        `[soak] server inspect skipped (non-fatal, e.g. transient/local): ${err.message}`
+      );
+    }
+
+    console.log("[soak] PASS — room stayed bounded and responsive");
+  } finally {
+    for (const c of clients) c.provider.destroy();
+  }
+}
+
+run().catch((err) => {
+  console.error("[soak] FAIL:", err.message);
+  process.exitCode = 1;
+});

--- a/smoke-tests/smoke.spec.ts
+++ b/smoke-tests/smoke.spec.ts
@@ -26,6 +26,9 @@ const PAGES: { path: string; skip?: string }[] = [
   { path: "/events/gray-area/" },
   { path: "/events/if-then/" },
   { path: "/events/walking-together/" },
+  // The session experience (list links here with ?session=<id>). Smoke-test
+  // the active session so a broken session page is caught.
+  { path: "/events/walking-together/session.html?session=2026-06-06-byod" },
   { path: "/docs/" },
 ];
 

--- a/website/events/walking-together/__tests__/roster.test.ts
+++ b/website/events/walking-together/__tests__/roster.test.ts
@@ -1,7 +1,13 @@
-// ABOUTME: Tests roster upsert — unique pids, last-write-wins, self-healing dupes.
+// ABOUTME: Tests the keyed-map roster helpers — pids, entries, current-check.
 
 import { describe, it, expect } from "vitest";
-import { upsertRoster, rosterIsCurrent, type RosterEntry } from "../roster";
+import {
+  rosterPids,
+  rosterEntries,
+  rosterEntryIsCurrent,
+  type Roster,
+  type RosterEntry,
+} from "../roster";
 
 const e = (pid: string, name = "n", color = "#000"): RosterEntry => ({
   pid,
@@ -9,50 +15,44 @@ const e = (pid: string, name = "n", color = "#000"): RosterEntry => ({
   color,
 });
 
-describe("upsertRoster", () => {
-  it("adds a new participant", () => {
-    expect(upsertRoster([], e("pk_a"))).toEqual([e("pk_a")]);
+describe("roster (keyed map)", () => {
+  it("rosterPids returns the distinct pids", () => {
+    const r: Roster = { pk_a: e("pk_a"), pk_b: e("pk_b") };
+    expect(rosterPids(r).sort()).toEqual(["pk_a", "pk_b"]);
   });
 
-  it("never duplicates an existing pid — updates in place", () => {
-    const next = upsertRoster([e("pk_a", "old", "#111")], e("pk_a", "new", "#222"));
-    expect(next).toEqual([e("pk_a", "new", "#222")]);
-    expect(next.filter((x) => x.pid === "pk_a")).toHaveLength(1);
+  it("rosterPids is empty for an empty roster", () => {
+    expect(rosterPids({})).toEqual([]);
   });
 
-  it("keeps distinct pids and dedupes to one entry each", () => {
-    const next = upsertRoster([e("pk_a"), e("pk_b")], e("pk_c"));
-    expect(next.map((x) => x.pid).sort()).toEqual(["pk_a", "pk_b", "pk_c"]);
+  it("rosterEntries returns the entry values", () => {
+    const r: Roster = { pk_a: e("pk_a", "alice") };
+    expect(rosterEntries(r)).toEqual([e("pk_a", "alice")]);
   });
 
-  it("self-heals a roster that already contains duplicate pids", () => {
-    // Simulates the bug's accumulated state: same pid written many times.
-    const dupes = [e("pk_a", "a1"), e("pk_a", "a2"), e("pk_a", "a3"), e("pk_b")];
-    const next = upsertRoster(dupes, e("pk_a", "latest"));
-    expect(next).toHaveLength(2);
-    expect(next.find((x) => x.pid === "pk_a")).toEqual(e("pk_a", "latest"));
-    expect(next.find((x) => x.pid === "pk_b")).toEqual(e("pk_b"));
-  });
-});
-
-describe("rosterIsCurrent", () => {
-  it("is true when the entry already matches and there are no dupes", () => {
-    expect(rosterIsCurrent([e("pk_a", "n", "#000")], e("pk_a", "n", "#000"))).toBe(
-      true,
-    );
+  it("rosterEntryIsCurrent is true when the entry already matches", () => {
+    const r: Roster = { pk_a: e("pk_a", "alice", "#111") };
+    expect(rosterEntryIsCurrent(r, e("pk_a", "alice", "#111"))).toBe(true);
   });
 
-  it("is false when the entry is missing", () => {
-    expect(rosterIsCurrent([e("pk_b")], e("pk_a"))).toBe(false);
+  it("rosterEntryIsCurrent is false when missing", () => {
+    expect(rosterEntryIsCurrent({}, e("pk_a"))).toBe(false);
   });
 
-  it("is false when name or color differs", () => {
-    expect(rosterIsCurrent([e("pk_a", "old")], e("pk_a", "new"))).toBe(false);
+  it("rosterEntryIsCurrent is false when name or color differs", () => {
+    const r: Roster = { pk_a: e("pk_a", "old") };
+    expect(rosterEntryIsCurrent(r, e("pk_a", "new"))).toBe(false);
   });
 
-  it("is false when duplicates exist (forces a healing write)", () => {
-    expect(
-      rosterIsCurrent([e("pk_a"), e("pk_a")], e("pk_a")),
-    ).toBe(false);
+  it("tolerates a legacy array-shaped roster (re-keys by pid)", () => {
+    // A room persisted under the old array shape should still read correctly.
+    const legacy = [e("pk_a", "alice"), e("pk_b", "bob")] as unknown as Roster;
+    expect(rosterPids(legacy).sort()).toEqual(["pk_a", "pk_b"]);
+    expect(rosterEntries(legacy)).toEqual([e("pk_a", "alice"), e("pk_b", "bob")]);
+  });
+
+  it("treats undefined/empty roster as empty", () => {
+    expect(rosterPids(undefined)).toEqual([]);
+    expect(rosterEntries(undefined)).toEqual([]);
   });
 });

--- a/website/events/walking-together/__tests__/sessions.test.ts
+++ b/website/events/walking-together/__tests__/sessions.test.ts
@@ -1,13 +1,15 @@
-// ABOUTME: Tests session config helpers — resolution from URL and room derivation.
-// ABOUTME: Verifies fallback to the latest active session when ?session is absent.
+// ABOUTME: Tests session config helpers — URL resolution, room derivation, overrides.
+// ABOUTME: Verifies unknown/absent sessions resolve to null (page redirects to home).
 
 import { describe, it, expect } from "vitest";
 import {
   SESSIONS,
   sessionRoom,
+  roomForSession,
   defaultSession,
   findSession,
-  resolveSessionId,
+  parseSessionId,
+  resolveSession,
 } from "../sessions";
 
 describe("sessions", () => {
@@ -28,10 +30,29 @@ describe("sessions", () => {
     expect(findSession("does-not-exist")).toBeUndefined();
   });
 
-  it("resolveSessionId reads ?session and falls back when absent/unknown", () => {
+  it("parseSessionId returns the raw param or null", () => {
+    expect(parseSessionId("?session=foo")).toBe("foo");
+    expect(parseSessionId("")).toBeNull();
+    expect(parseSessionId("?other=1")).toBeNull();
+  });
+
+  it("resolveSession returns the session for a known id", () => {
     const known = SESSIONS[0].id;
-    expect(resolveSessionId(`?session=${known}`)).toBe(known);
-    expect(resolveSessionId("")).toBe(defaultSession().id);
-    expect(resolveSessionId("?session=bogus")).toBe(defaultSession().id);
+    expect(resolveSession(`?session=${known}`)?.id).toBe(known);
+  });
+
+  it("resolveSession returns null when absent or unknown (page redirects home)", () => {
+    expect(resolveSession("")).toBeNull();
+    expect(resolveSession("?session=bogus")).toBeNull();
+  });
+
+  it("roomForSession uses the explicit override when set, else derives", () => {
+    const rhizome = findSession("2025-04-30-rhizome")!;
+    expect(rhizome.room).toBe("/events/walking-together/");
+    expect(roomForSession(rhizome)).toBe("/events/walking-together/");
+
+    const byod = findSession("2026-06-06-byod")!;
+    expect(byod.room).toBeUndefined();
+    expect(roomForSession(byod)).toBe("walking-together-2026-06-06-byod");
   });
 });

--- a/website/events/walking-together/index.html
+++ b/website/events/walking-together/index.html
@@ -15,9 +15,6 @@
     <title>walking together on the internet</title>
   </head>
   <body>
-    <!-- <div id="reactContent"></div>
-    <script type="module" src="./one.tsx"></script> -->
-
     <main
       style="
         height: 100vh;
@@ -28,10 +25,9 @@
     >
       <div style="max-width: 400px">
         <h1>walking together on the internet</h1>
-        <p id="session-subtitle"></p>
       </div>
       <div id="react"></div>
     </main>
   </body>
-  <script type="module" src="./walking-together.tsx"></script>
+  <script type="module" src="./index.tsx"></script>
 </html>

--- a/website/events/walking-together/index.tsx
+++ b/website/events/walking-together/index.tsx
@@ -3,6 +3,9 @@ import React from "react";
 import { SESSIONS } from "./sessions";
 import "./walking-together.scss";
 
+/** Home / index for walking-together: lists every session. The bare
+ * /events/walking-together/ URL lands here; people pick a session to join,
+ * which opens the session experience at session.html?session=<id>. */
 function Home() {
   const sessions = [...SESSIONS].sort((a, b) => b.date.localeCompare(a.date));
   return (
@@ -10,7 +13,7 @@ function Home() {
       <ul>
         {sessions.map((s) => (
           <li key={s.id} className={s.archived ? "archived" : "active"}>
-            <a href={`./index.html?session=${s.id}`}>{s.label}</a>
+            <a href={`./session.html?session=${s.id}`}>{s.label}</a>
             <span className="session-date">{s.date}</span>
             {s.archived ? (
               <span className="session-tag">archived (read-only)</span>

--- a/website/events/walking-together/roster.ts
+++ b/website/events/walking-together/roster.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Session participant roster types and the pure upsert used by RosterAdmin.
-// ABOUTME: Keyed by unique pid (last write wins) so concurrent writes can't duplicate.
+// ABOUTME: Session participant roster types and helpers, keyed by pid.
+// ABOUTME: A keyed map (not an array) so upserts are idempotent and merge-safe.
 
 export interface RosterEntry {
   pid: string;
@@ -8,36 +8,55 @@ export interface RosterEntry {
 }
 
 /**
- * Upsert a participant into the roster, keyed by `pid`. Rebuilds the list from
- * a pid->entry map (last write wins), which both inserts/updates the given
- * participant and self-heals any duplicate entries already present. The result
- * preserves insertion order of first appearance, with the upserted entry taking
- * the latest name/color.
+ * The roster is a map keyed by participant id. Modeling it as a keyed object —
+ * rather than an array — means upserting a participant is a single keyed write
+ * (`entries[pid] = entry`) that overwrites in place. Writing the same pid any
+ * number of times can never duplicate, and concurrent writes from different
+ * clients merge cleanly (Yjs maps are last-write-wins per key, vs. arrays which
+ * append). This is the structural defense against the runaway-append bug that
+ * previously grew the room document until it crashed the sync server.
  */
-export function upsertRoster(
-  entries: RosterEntry[],
-  entry: RosterEntry,
+export type Roster = Record<string, RosterEntry>;
+
+/**
+ * Coerce a stored roster value into the keyed-map shape. Tolerates a legacy
+ * array value (the pre-keyed-map format) by re-keying it by pid, so a room
+ * persisted under the old shape reads correctly instead of producing junk
+ * numeric keys. New writes always use the keyed map.
+ */
+function normalizeRoster(value: Roster | RosterEntry[] | undefined): Roster {
+  if (!value) return {};
+  if (Array.isArray(value)) {
+    const map: Roster = {};
+    for (const e of value) if (e && e.pid) map[e.pid] = e;
+    return map;
+  }
+  return value;
+}
+
+/** Distinct participant ids in the roster. */
+export function rosterPids(roster: Roster | RosterEntry[] | undefined): string[] {
+  return Object.keys(normalizeRoster(roster));
+}
+
+/** The roster entries as a list (e.g. for counting or display). */
+export function rosterEntries(
+  roster: Roster | RosterEntry[] | undefined,
 ): RosterEntry[] {
-  const byPid = new Map<string, RosterEntry>();
-  for (const e of entries) byPid.set(e.pid, e);
-  byPid.set(entry.pid, entry);
-  return [...byPid.values()];
+  return Object.values(normalizeRoster(roster));
 }
 
 /**
- * True when `entries` already contains exactly `entry` (same name/color) for
- * its pid AND has no duplicate pids — i.e. an upsert would be a no-op. Used to
- * skip redundant writes (and the re-render they trigger).
+ * True when the roster already holds exactly `entry` for its pid — i.e. an
+ * upsert would be a no-op. Used to skip redundant writes (and the re-render
+ * they would trigger).
  */
-export function rosterIsCurrent(
-  entries: RosterEntry[],
+export function rosterEntryIsCurrent(
+  roster: Roster,
   entry: RosterEntry,
 ): boolean {
-  const existing = entries.find((e) => e.pid === entry.pid);
-  if (!existing) return false;
-  if (existing.name !== entry.name || existing.color !== entry.color)
-    return false;
-  // No duplicates anywhere (a deduped roster has one entry per pid).
-  const uniquePids = new Set(entries.map((e) => e.pid));
-  return uniquePids.size === entries.length;
+  const existing = roster[entry.pid];
+  return (
+    !!existing && existing.name === entry.name && existing.color === entry.color
+  );
 }

--- a/website/events/walking-together/session.html
+++ b/website/events/walking-together/session.html
@@ -25,14 +25,10 @@
     >
       <div style="max-width: 400px">
         <h1>walking together on the internet</h1>
-        <p>
-          with <a href="https://naiveweekly.com">kristoffer tjalve</a> &
-          <a href="https://spencer.place">spencer chang</a>, with
-          <a href="https://rhizome.org/">rhizome</a>
-        </p>
+        <p id="session-subtitle"></p>
       </div>
       <div id="react"></div>
     </main>
   </body>
-  <script type="module" src="./home.tsx"></script>
+  <script type="module" src="./walking-together.tsx"></script>
 </html>

--- a/website/events/walking-together/sessions.ts
+++ b/website/events/walking-together/sessions.ts
@@ -16,6 +16,15 @@ export interface WorkshopSession {
   archived: boolean;
   /** Credits line shown under the title on the session page. */
   subtitle: SubtitleSegment[];
+  /**
+   * Optional explicit playhtml room string, used verbatim instead of the
+   * derived `walking-together-<id>` room. Set this for sessions whose data
+   * lives in a room that predates this id scheme — e.g. the original Rhizome
+   * event, whose shared URLs live in the pre-v2 pathname-based room. The value
+   * is the un-prefixed room string; playhtml prepends the host (so
+   * `/events/walking-together/` resolves to the live `playhtml.fun-...` room).
+   */
+  room?: string;
 }
 
 export const SESSIONS: WorkshopSession[] = [
@@ -24,6 +33,10 @@ export const SESSIONS: WorkshopSession[] = [
     label: "walking together (Rhizome)",
     date: "2025-04-30",
     archived: true,
+    // The original Rhizome event ran before the session system, on the
+    // default pathname-based room. Point at it so the archived view shows the
+    // real shared URLs from that day.
+    room: "/events/walking-together/",
     subtitle: [
       "with ",
       { text: "kristoffer tjalve", href: "https://naiveweekly.com" },
@@ -46,12 +59,20 @@ export const SESSIONS: WorkshopSession[] = [
   },
 ];
 
-/** Playhtml room id for a session. */
+/** Derived playhtml room string for a session id. */
 export function sessionRoom(id: string): string {
   return `walking-together-${id}`;
 }
 
-/** The latest non-archived session — the fallback when no ?session is given. */
+/**
+ * The playhtml room string for a session — its explicit `room` override when
+ * set (e.g. the legacy Rhizome room), otherwise the derived id-based room.
+ */
+export function roomForSession(session: WorkshopSession): string {
+  return session.room ?? sessionRoom(session.id);
+}
+
+/** The latest non-archived session. */
 export function defaultSession(): WorkshopSession {
   const active = SESSIONS.filter((s) => !s.archived);
   if (active.length === 0) {
@@ -65,12 +86,20 @@ export function findSession(id: string): WorkshopSession | undefined {
 }
 
 /**
- * Resolve the session id from a location search string (e.g. "?session=foo").
- * Falls back to the default session when the param is absent or unknown.
+ * Raw `?session=` value from a location search string, or null when absent.
+ * Does not validate against SESSIONS — callers decide how to handle unknowns.
  */
-export function resolveSessionId(search: string): string {
-  const params = new URLSearchParams(search);
-  const id = params.get("session");
-  if (id && findSession(id)) return id;
-  return defaultSession().id;
+export function parseSessionId(search: string): string | null {
+  return new URLSearchParams(search).get("session");
+}
+
+/**
+ * Resolve a session from a location search string. Returns the matching
+ * session, or null when the param is absent or names an unknown session —
+ * the session page treats null as "redirect to the home list".
+ */
+export function resolveSession(search: string): WorkshopSession | null {
+  const id = parseSessionId(search);
+  if (!id) return null;
+  return findSession(id) ?? null;
 }

--- a/website/events/walking-together/walking-together.tsx
+++ b/website/events/walking-together/walking-together.tsx
@@ -7,10 +7,10 @@ import {
 } from "@playhtml/react";
 import { useStickyState } from "../../hooks/useStickyState";
 import {
-  resolveSessionId,
-  sessionRoom,
-  findSession,
+  resolveSession,
+  roomForSession,
   type SubtitleSegment,
+  type WorkshopSession,
 } from "./sessions";
 import { isAdmin } from "./admin";
 import { PortraitOverlay } from "./PortraitOverlay";
@@ -38,8 +38,12 @@ interface SharedURL {
   timestamp: number;
 }
 
-const SESSION_ID = resolveSessionId(window.location.search);
-const SESSION = findSession(SESSION_ID);
+// Resolve the session from ?session=<id>. An absent or unknown session sends
+// the visitor back to the home list rather than silently joining some room.
+const SESSION = resolveSession(window.location.search);
+if (!SESSION) {
+  window.location.replace("./index.html");
+}
 const IS_ARCHIVED = SESSION?.archived ?? false;
 
 // Element id for the shared roster store. Set as an explicit `id` on the
@@ -356,11 +360,11 @@ export const GroupActivityDisplay = withSharedState(
   },
 );
 
-function Main() {
+function Main({ session }: { session: WorkshopSession }) {
   return (
     <PlayProvider
       initOptions={{
-        room: sessionRoom(SESSION_ID),
+        room: roomForSession(session),
         cursors: { enabled: true, coordinateMode: "relative" },
       }}
     >
@@ -392,9 +396,16 @@ function SessionSubtitle({ segments }: { segments: SubtitleSegment[] }) {
   );
 }
 
-ReactDOM.render(<Main />, document.getElementById("react"));
+// Only mount when a valid session resolved; otherwise the redirect above is
+// already navigating away.
+if (SESSION) {
+  ReactDOM.render(<Main session={SESSION} />, document.getElementById("react"));
 
-const subtitleRoot = document.getElementById("session-subtitle");
-if (subtitleRoot && SESSION) {
-  ReactDOM.render(<SessionSubtitle segments={SESSION.subtitle} />, subtitleRoot);
+  const subtitleRoot = document.getElementById("session-subtitle");
+  if (subtitleRoot) {
+    ReactDOM.render(
+      <SessionSubtitle segments={SESSION.subtitle} />,
+      subtitleRoot,
+    );
+  }
 }

--- a/website/events/walking-together/walking-together.tsx
+++ b/website/events/walking-together/walking-together.tsx
@@ -14,7 +14,12 @@ import {
 } from "./sessions";
 import { isAdmin } from "./admin";
 import { PortraitOverlay } from "./PortraitOverlay";
-import { upsertRoster, rosterIsCurrent, type RosterEntry } from "./roster";
+import {
+  rosterPids,
+  rosterEntryIsCurrent,
+  type Roster,
+  type RosterEntry,
+} from "./roster";
 import "./walking-together.scss";
 
 // playhtml exposes `window.cursors` with `name`/`color` as settable
@@ -108,38 +113,37 @@ export function UserSetup() {
  * The rendered element carries an explicit id so the core library uses a
  * stable element id rather than hashing outerHTML (which differs per render). */
 const RosterAdmin = withSharedState(
-  { defaultData: { entries: [] as RosterEntry[] } },
+  { defaultData: { entries: {} as Roster } },
   ({ data, setData }) => {
     const { pid, name, color } = usePlayerIdentity();
     const [showPortrait, setShowPortrait] = useState(false);
 
-    // Always read the latest entries through a ref so the upsert effect does
-    // NOT depend on `data.entries`. Depending on the entries array re-runs the
-    // effect on every roster change from any client, which — combined with
-    // Yjs appending concurrent writes — snowballs into the same pid being
-    // written thousands of times. Keying the effect on the local identity
-    // alone means it only fires when *my* pid/name/color changes.
-    const entriesRef = React.useRef(data.entries);
-    entriesRef.current = data.entries;
+    // Read the latest roster through a ref so the upsert effect keys ONLY on
+    // the local identity (pid/name/color), not on `data.entries`. Depending on
+    // the shared roster would re-run this on every change from any client.
+    const rosterRef = React.useRef(data.entries);
+    rosterRef.current = data.entries;
 
     React.useEffect(() => {
       if (!pid) return;
-      const entries = entriesRef.current;
       const mine: RosterEntry = {
         pid,
         name: name ?? "Anonymous",
         color: color ?? "#000000",
       };
-      // Skip when our entry is already present, matching, and dupe-free —
-      // avoids a redundant write (and the re-render it triggers).
-      if (rosterIsCurrent(entries, mine)) return;
-      setData({ entries: upsertRoster(entries, mine) });
+      // Skip a redundant write when our entry already matches.
+      if (rosterEntryIsCurrent(rosterRef.current, mine)) return;
+      // Keyed mutator write: assigning entries[pid] overwrites in place, so
+      // this is idempotent and merge-safe — re-running it (or two clients
+      // racing) can never duplicate. This is the structural fix; the ref guard
+      // above is belt-and-suspenders to avoid needless writes.
+      setData((draft) => {
+        draft.entries[pid] = mine;
+      });
     }, [pid, name, color, setData]);
 
     const admin = isAdmin(name, color);
-    // Defensive de-dupe for display in case the stored roster still holds
-    // legacy duplicates (e.g. from before this fix, pre-reset).
-    const pids = [...new Set(data.entries.map((e) => e.pid))];
+    const pids = rosterPids(data.entries);
 
     return (
       <div className="admin-panel" id={ROSTER_ID}>


### PR DESCRIPTION
Single PR for the walking-together post-incident work. (Collapsed from the
earlier stacked #163 + #164 — #163 was closed as superseded; all its routing
commits are included here.)

## Summary

### Routing: index becomes the session home
- Bare `/events/walking-together/` now renders the **session list** (`index.tsx`). The per-session experience moved to `session.html` + `walking-together.tsx`, reached via `session.html?session=<id>`. Previously the bare URL silently joined the latest active session's room.
- Unknown/absent `?session` redirects to the home list instead of falling into a default room.
- **Per-session room override** (`room?` on `WorkshopSession`): the archived Rhizome session points at its original pre-v2 room (`/events/walking-together/`) so its read-only view shows the real shared URLs from that event (confirmed ~16KB of real data in Supabase). Other sessions keep the derived `walking-together-<id>` room.
- Session helpers reworked: `resolveSession` (nullable), `parseSessionId`, `roomForSession`, with tests.

### Hardening: keyed-map roster (the incident fix)
- Root cause of the June 2026 outage: a `useEffect` that both depended on `data.entries` and wrote it via the replacement form looped forever; with CRDT array appends under concurrency it grew one room to ~1.2M Yjs ops / 23MB and crashed the Durable Object (503), taking cursors down with it.
- Fix: the roster is now a keyed map (`Record<pid, entry>`) upserted in place with the mutator form (`setData(draft => { draft.entries[pid] = mine })`). A keyed write overwrites rather than appends — **idempotent by construction and merge-safe** (Yjs maps are last-write-wins per key). Re-running the effect or two clients racing can no longer duplicate. `roster.ts` also defensively normalizes any legacy array-shaped value.
- Verified SyncedStore supports new-key creation + idempotent keyed upsert (new test in `packages/playhtml/.../main.nested-data.test.ts`; test-only, no changeset).

### Docs & regression test
- `apps/docs` (data-essentials rule 7), the `building-playhtml-elements` plugin skill, and CLAUDE.md now document the self-triggering-write footgun, leading with the keyed-map mutator pattern as the primary defense. _(Initial footgun docs landed on main earlier; this leads with the stronger fix.)_
- `smoke-tests/partykit/multi-client-soak-smoke.mjs`: N clients each re-upsert their keyed entry; asserts convergence to N entries, bounded struct count, and no dropped clients. Verified it FAILS on the buggy array-append (=> 594 entries) and PASSES on the keyed map (=> 6 entries, ~1200 structs).

## Test Plan

- [x] `bunx vitest run --config website/vitest.config.mts website/events/walking-together/__tests__/`
- [x] Core library suite incl. new keyed-map test
- [x] Website type-check at baseline; `bun run build-site` produces `index.html` (list) + `session.html`
- [x] Browser-verified: bare URL → list; links → `session.html?session=`; valid session loads; unknown session redirects home
- [x] Soak test against local wrangler dev — PASS on keyed map, FAIL on array-append
- [ ] **Post-deploy (reviewer):** on `playhtml.fun`, confirm the archived Rhizome session shows the original April-2025 URLs (the room override is host-prefixed, so only resolves to the real room on the production host). Optionally run `bun smoke:partykit:soak` against staging.

Full root-cause analysis and the rationale for NOT adding a server-side write cap: `internal-docs/2026-06-06-walking-together-roster-bloat-postmortem.md`.