### PR TITLE
Fix experiment 8 typing flow

### DIFF
--- a/website/experiments/8/8.scss
+++ b/website/experiments/8/8.scss
@@ -1,3 +1,5 @@
+// ABOUTME: Styles the experiment 8 grid paper typing interface.
+// ABOUTME: Reserves scroll space so fixed controls do not cover typed cells.
 $cell-size: 32px;
 
 body {
@@ -13,7 +15,7 @@ body {
   width: 100vw;
   min-height: 100vh;
   position: relative;
-  padding-bottom: 60px; // Make room for bottom bar
+  padding-bottom: var(--bottom-scroll-clearance, 128px);
 }
 
 .grid-container {
@@ -36,6 +38,7 @@ body {
   align-items: center;
   justify-content: center;
   font-size: calc($cell-size - 2px);
+  line-height: 1;
   font-weight: 700;
   transition: all 0.1s ease;
   user-select: none;

--- a/website/experiments/8/8.tsx
+++ b/website/experiments/8/8.tsx
@@ -1,10 +1,24 @@
 // ABOUTME: Experiment 8 - Collaborative grid paper typing interface
 // ABOUTME: Every grid cell is filled with typed letters, colored by user
 import "./8.scss";
-import React, { useEffect, useState, useRef, useMemo } from "react";
+import React, { useEffect, useLayoutEffect, useState, useRef } from "react";
 import ReactDOM from "react-dom/client";
 import { PlayProvider, withSharedState, usePlayContext } from "@playhtml/react";
 import { OnlineNowIndicator } from "../../components/DataModes";
+import {
+  BOTTOM_BAR_HEIGHT_PX,
+  GRID_CELL_SIZE_PX,
+  getBottomScrollClearancePx,
+  getGridCellCount,
+  getGridRowHeightPx,
+  getGridWidthPx,
+  getRemoteTypingCursors,
+  getScrollEndY,
+  getTypingCursorPosition,
+  isScrollAtEnd,
+  shouldPublishTypingAwareness,
+  type TypingCursorAwareness,
+} from "./layout";
 
 interface CellData {
   letter: string;
@@ -17,15 +31,20 @@ const Main = withSharedState(
     defaultData: {
       letters: [] as CellData[],
     },
+    myDefaultAwareness: undefined as undefined | TypingCursorAwareness,
   },
-  ({ data, setData, awareness }) => {
+  ({ data, setData, awareness, myAwareness, setMyAwareness }) => {
     const { cursors } = usePlayContext();
     const myColor = cursors.color;
     const gridRef = useRef<HTMLDivElement>(null);
+    const bottomBarRef = useRef<HTMLDivElement>(null);
+    const shouldFollowScrollEndRef = useRef(true);
     const [gridDimensions, setGridDimensions] = useState({
       cols: 60,
       rows: 40,
     });
+    const [bottomBarHeightPx, setBottomBarHeightPx] =
+      useState(BOTTOM_BAR_HEIGHT_PX);
 
     // Calculate grid dimensions based on window size
     useEffect(() => {
@@ -48,14 +67,83 @@ const Main = withSharedState(
       return () => window.removeEventListener("resize", calculateDimensions);
     }, []);
 
+    useEffect(() => {
+      const bottomBar = bottomBarRef.current;
+      if (!bottomBar) return;
+
+      const updateBottomBarHeight = () => {
+        const nextHeight = Math.ceil(bottomBar.getBoundingClientRect().height);
+        setBottomBarHeightPx((currentHeight) =>
+          currentHeight === nextHeight ? currentHeight : nextHeight
+        );
+      };
+
+      updateBottomBarHeight();
+
+      const resizeObserver = new ResizeObserver(updateBottomBarHeight);
+      resizeObserver.observe(bottomBar);
+      window.addEventListener("resize", updateBottomBarHeight);
+
+      return () => {
+        resizeObserver.disconnect();
+        window.removeEventListener("resize", updateBottomBarHeight);
+      };
+    }, []);
+
+    useEffect(() => {
+      const updateScrollEndState = () => {
+        shouldFollowScrollEndRef.current = isScrollAtEnd({
+          scrollY: window.scrollY,
+          scrollHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
+        });
+      };
+
+      updateScrollEndState();
+      window.addEventListener("scroll", updateScrollEndState, { passive: true });
+      window.addEventListener("resize", updateScrollEndState);
+
+      return () => {
+        window.removeEventListener("scroll", updateScrollEndState);
+        window.removeEventListener("resize", updateScrollEndState);
+      };
+    }, []);
+
     // Minimum cells to fill the page
     const minCells = gridDimensions.cols * gridDimensions.rows;
 
-    // Total cells needed: 1 empty at top-left + all letters
-    const totalCells = Math.max(minCells, data.letters.length + 1);
+    const totalCells = getGridCellCount({
+      letterCount: data.letters.length,
+      minimumCellCount: minCells,
+      columnCount: gridDimensions.cols,
+    });
 
-    // Cursor is always at position 0 (top-left)
-    const cursorPosition = 0;
+    const cursorPosition = getTypingCursorPosition(data.letters.length);
+
+    useLayoutEffect(() => {
+      if (!shouldFollowScrollEndRef.current) return;
+
+      window.scrollTo(
+        0,
+        getScrollEndY({
+          scrollHeight: document.documentElement.scrollHeight,
+          viewportHeight: window.innerHeight,
+        })
+      );
+    }, [totalCells, bottomBarHeightPx]);
+
+    useEffect(() => {
+      const nextAwareness = { color: myColor, cursorPos: cursorPosition };
+
+      if (
+        shouldPublishTypingAwareness({
+          current: myAwareness,
+          next: nextAwareness,
+        })
+      ) {
+        setMyAwareness(nextAwareness);
+      }
+    }, [myColor, cursorPosition, myAwareness, setMyAwareness]);
 
     // Handle keyboard input
     useEffect(() => {
@@ -74,6 +162,12 @@ const Main = withSharedState(
           e.preventDefault();
           const char = e.key;
 
+          shouldFollowScrollEndRef.current = isScrollAtEnd({
+            scrollY: window.scrollY,
+            scrollHeight: document.documentElement.scrollHeight,
+            viewportHeight: window.innerHeight,
+          });
+
           setData((draft) => {
             draft.letters.push({
               letter: char,
@@ -88,10 +182,10 @@ const Main = withSharedState(
       return () => window.removeEventListener("keydown", handleKeyDown);
     }, [myColor, setData]);
 
-    // Get other users' cursor positions
-    const otherCursors = Object.entries(awareness || {})
-      .filter(([clientId]) => clientId !== "local")
-      .map(([, data]) => data as { color: string; cursorPos: number });
+    const otherCursors = getRemoteTypingCursors({
+      awareness: awareness || [],
+      myAwareness,
+    });
 
     // Get all active players from cursor awareness
     const activePlayers = cursors.allColors.map((color, index) => ({
@@ -127,23 +221,36 @@ const Main = withSharedState(
     }, [nameInput, editingName, cursors.name]);
 
     return (
-      <div id="experiment-8">
+      <div
+        id="experiment-8"
+        style={
+          {
+            "--bottom-scroll-clearance": `${getBottomScrollClearancePx({
+              bottomBarHeightPx,
+            })}px`,
+          } as React.CSSProperties
+        }
+      >
         <div
           ref={gridRef}
           className="grid-container"
           style={{
-            gridTemplateColumns: `repeat(${gridDimensions.cols}, 32px)`,
+            gridTemplateColumns: `repeat(${gridDimensions.cols}, ${GRID_CELL_SIZE_PX}px)`,
+            gridAutoRows: `${getGridRowHeightPx({
+              cellSizePx: GRID_CELL_SIZE_PX,
+            })}px`,
+            width: `${getGridWidthPx({
+              columnCount: gridDimensions.cols,
+              cellSizePx: GRID_CELL_SIZE_PX,
+            })}px`,
           }}
         >
           {Array.from({ length: totalCells }, (_, index) => {
-            // Index 0 is always empty, letters start at index 1
-            const letterIndex = index - 1;
-            const letter = letterIndex >= 0 ? data.letters[letterIndex] : null;
+            const letter = data.letters[index] || null;
             const isMyCursor = index === cursorPosition;
             const otherUserCursor = otherCursors.find(
               (c) => c.cursorPos === index
             );
-            const isEmpty = index === 0;
 
             return (
               <div
@@ -160,13 +267,13 @@ const Main = withSharedState(
                     : undefined,
                 }}
               >
-                {isEmpty ? "\u00A0" : letter?.letter || "\u00A0"}
+                {letter?.letter || "\u00A0"}
               </div>
             );
           })}
         </div>
 
-        <div className="bottom-bar">
+        <div ref={bottomBarRef} className="bottom-bar">
           <div className="active-players">
             {activePlayers.map((player, index) => (
               <div

--- a/website/experiments/8/__tests__/layout.test.ts
+++ b/website/experiments/8/__tests__/layout.test.ts
@@ -1,0 +1,117 @@
+// ABOUTME: Verifies grid typing positions for experiment 8.
+// ABOUTME: Covers scroll clearance reserved below the last typed row.
+import { describe, expect, it } from "vitest";
+import {
+  getBottomScrollClearancePx,
+  getGridCellCount,
+  getGridRowHeightPx,
+  getGridWidthPx,
+  getRemoteTypingCursors,
+  getScrollEndY,
+  getTrailingCellCount,
+  getTypingCursorPosition,
+  isScrollAtEnd,
+  shouldPublishTypingAwareness,
+} from "../layout";
+
+describe("experiment 8 layout", () => {
+  it("places the typing cursor after the last typed cell", () => {
+    expect(getTypingCursorPosition(0)).toBe(0);
+    expect(getTypingCursorPosition(5)).toBe(5);
+  });
+
+  it("keeps an empty cell available for the typing cursor", () => {
+    expect(getGridCellCount({ letterCount: 5, minimumCellCount: 4 })).toBe(6);
+  });
+
+  it("keeps one blank row after the row being typed into", () => {
+    expect(getTrailingCellCount({ cursorPosition: 0, columnCount: 10 })).toBe(
+      20
+    );
+    expect(getTrailingCellCount({ cursorPosition: 9, columnCount: 10 })).toBe(
+      20
+    );
+    expect(getTrailingCellCount({ cursorPosition: 10, columnCount: 10 })).toBe(
+      30
+    );
+    expect(
+      getGridCellCount({
+        letterCount: 10,
+        minimumCellCount: 100,
+        columnCount: 10,
+      })
+    ).toBe(30);
+  });
+
+  it("reserves the fixed bottom bar height below the grid", () => {
+    expect(
+      getBottomScrollClearancePx({
+        bottomBarHeightPx: 87,
+      })
+    ).toBe(87);
+  });
+
+  it("calculates the page scroll end", () => {
+    expect(getScrollEndY({ scrollHeight: 1376, viewportHeight: 993 })).toBe(
+      383
+    );
+    expect(getScrollEndY({ scrollHeight: 800, viewportHeight: 993 })).toBe(0);
+  });
+
+  it("detects when the page is pinned to the scroll end", () => {
+    expect(
+      isScrollAtEnd({
+        scrollY: 382.5,
+        scrollHeight: 1376,
+        viewportHeight: 993,
+      })
+    ).toBe(true);
+    expect(
+      isScrollAtEnd({
+        scrollY: 300,
+        scrollHeight: 1376,
+        viewportHeight: 993,
+      })
+    ).toBe(false);
+  });
+
+  it("matches grid width to complete cell columns", () => {
+    expect(getGridWidthPx({ columnCount: 19, cellSizePx: 32 })).toBe(608);
+  });
+
+  it("matches grid row height to the cell size", () => {
+    expect(getGridRowHeightPx({ cellSizePx: 32 })).toBe(32);
+  });
+
+  it("excludes the local cursor from remote typing cursors", () => {
+    const myCursor = { color: "purple", cursorPos: 5 };
+
+    expect(
+      getRemoteTypingCursors({
+        awareness: [
+          myCursor,
+          { color: "orange", cursorPos: 8 },
+          { color: "broken" },
+        ],
+        myAwareness: myCursor,
+      })
+    ).toEqual([{ color: "orange", cursorPos: 8 }]);
+  });
+
+  it("publishes typing awareness only when it changes", () => {
+    const current = { color: "purple", cursorPos: 5 };
+
+    expect(
+      shouldPublishTypingAwareness({
+        current,
+        next: { color: "purple", cursorPos: 5 },
+      })
+    ).toBe(false);
+    expect(
+      shouldPublishTypingAwareness({
+        current,
+        next: { color: "purple", cursorPos: 6 },
+      })
+    ).toBe(true);
+  });
+});

--- a/website/experiments/8/layout.ts
+++ b/website/experiments/8/layout.ts
@@ -1,0 +1,157 @@
+// ABOUTME: Calculates grid cell positions for experiment 8 typing.
+// ABOUTME: Keeps render math shared by the React view and tests.
+export const GRID_CELL_SIZE_PX = 32;
+export const BOTTOM_BAR_HEIGHT_PX = 64;
+export const SCROLL_END_TOLERANCE_PX = 1;
+
+export interface TypingCursorAwareness {
+  color: string;
+  cursorPos: number;
+}
+
+export function getTypingCursorPosition(letterCount: number): number {
+  assertNonNegativeInteger(letterCount, "letterCount");
+  return letterCount;
+}
+
+export function getGridCellCount({
+  letterCount,
+  minimumCellCount,
+  columnCount,
+}: {
+  letterCount: number;
+  minimumCellCount: number;
+  columnCount?: number;
+}): number {
+  assertNonNegativeInteger(letterCount, "letterCount");
+  assertNonNegativeInteger(minimumCellCount, "minimumCellCount");
+
+  if (columnCount !== undefined) {
+    return getTrailingCellCount({
+      cursorPosition: getTypingCursorPosition(letterCount),
+      columnCount,
+    });
+  }
+
+  return Math.max(minimumCellCount, letterCount + 1);
+}
+
+export function getTrailingCellCount({
+  cursorPosition,
+  columnCount,
+}: {
+  cursorPosition: number;
+  columnCount: number;
+}): number {
+  assertNonNegativeInteger(cursorPosition, "cursorPosition");
+  assertPositiveInteger(columnCount, "columnCount");
+
+  const cursorRow = Math.floor(cursorPosition / columnCount);
+  return (cursorRow + 2) * columnCount;
+}
+
+export function getBottomScrollClearancePx({
+  bottomBarHeightPx,
+}: {
+  bottomBarHeightPx: number;
+}): number {
+  assertNonNegativeInteger(bottomBarHeightPx, "bottomBarHeightPx");
+
+  return bottomBarHeightPx;
+}
+
+export function getGridWidthPx({
+  columnCount,
+  cellSizePx,
+}: {
+  columnCount: number;
+  cellSizePx: number;
+}): number {
+  assertPositiveInteger(columnCount, "columnCount");
+  assertPositiveInteger(cellSizePx, "cellSizePx");
+
+  return columnCount * cellSizePx;
+}
+
+export function getGridRowHeightPx({
+  cellSizePx,
+}: {
+  cellSizePx: number;
+}): number {
+  assertPositiveInteger(cellSizePx, "cellSizePx");
+
+  return cellSizePx;
+}
+
+export function getScrollEndY({
+  scrollHeight,
+  viewportHeight,
+}: {
+  scrollHeight: number;
+  viewportHeight: number;
+}): number {
+  assertNonNegativeInteger(scrollHeight, "scrollHeight");
+  assertNonNegativeInteger(viewportHeight, "viewportHeight");
+
+  return Math.max(0, scrollHeight - viewportHeight);
+}
+
+export function isScrollAtEnd({
+  scrollY,
+  scrollHeight,
+  viewportHeight,
+  tolerancePx = SCROLL_END_TOLERANCE_PX,
+}: {
+  scrollY: number;
+  scrollHeight: number;
+  viewportHeight: number;
+  tolerancePx?: number;
+}): boolean {
+  assertNonNegativeInteger(scrollHeight, "scrollHeight");
+  assertNonNegativeInteger(viewportHeight, "viewportHeight");
+  assertNonNegativeInteger(tolerancePx, "tolerancePx");
+
+  return getScrollEndY({ scrollHeight, viewportHeight }) - scrollY <= tolerancePx;
+}
+
+export function getRemoteTypingCursors({
+  awareness,
+  myAwareness,
+}: {
+  awareness: unknown[];
+  myAwareness?: TypingCursorAwareness;
+}): TypingCursorAwareness[] {
+  return awareness.filter(
+    (cursor): cursor is TypingCursorAwareness =>
+      cursor !== myAwareness && isTypingCursorAwareness(cursor),
+  );
+}
+
+export function shouldPublishTypingAwareness({
+  current,
+  next,
+}: {
+  current?: TypingCursorAwareness;
+  next: TypingCursorAwareness;
+}): boolean {
+  return current?.color !== next.color || current.cursorPos !== next.cursorPos;
+}
+
+function assertNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new RangeError(`${name} must be a non-negative integer`);
+  }
+}
+
+function assertPositiveInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive integer`);
+  }
+}
+
+function isTypingCursorAwareness(value: unknown): value is TypingCursorAwareness {
+  if (!value || typeof value !== "object") return false;
+
+  const cursor = value as TypingCursorAwareness;
+  return typeof cursor.color === "string" && Number.isInteger(cursor.cursorPos);
+}


### PR DESCRIPTION
## Summary

- Fix experiment 8 so the typing cursor follows the end of the shared text instead of staying at the top.
- Keep the grid aligned by sharing sizing math for columns, row height, trailing blank row, and bottom clearance.
- Make bottom scrolling flush with the fixed bar and keep the viewport pinned when typing at the end creates more rows.

## Test Plan

- `bunx vitest run --config website/vitest.config.mts website/experiments/8/__tests__/layout.test.ts`
- `/Users/spencerchang/.bun/bin/bun run build-site`
- Live preview checks at `/experiments/8/`: row height, wide viewport sizing, bottom flush, and auto-scroll-at-end behavior.

## Notes

- `build-site` passes with existing Sass import deprecation warnings, docs asset warning for `/docs/fire-hydrant.png`, Rollup circular re-export warnings in docs demos, chunk-size warning, and missing Astro sitemap `site` config warning.
