### PR TITLE
website: give trailRenderers test a jsdom environment

### DIFF
--- a/extension/website/shared/styles/__tests__/trailRenderers.test.ts
+++ b/extension/website/shared/styles/__tests__/trailRenderers.test.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Tests trail renderer DOM mutation caching.
 // ABOUTME: Guards hot-path SVG attribute updates against redundant writes.
 
+// @vitest-environment jsdom
+
 import { describe, expect, it, vi } from "vitest";
 import { colorRenderer } from "../trailRenderers";
 


### PR DESCRIPTION
## Summary

The website vitest suite had one failing test:

\`\`\`
FAIL extension/website/shared/styles/__tests__/trailRenderers.test.ts > colorRenderer > does not reapply unchanged SVG path attributes
ReferenceError: document is not defined
\`\`\`

The test (added in #115, commit 36d5e32) calls \`document.createElementNS(...)\`, but the website's vitest run defaults to the \`node\` environment — \`vite.config.ts\` sets no \`test.environment\` and there's no separate vitest config — so \`document\` was undefined.

## Fix

Added a \`// @vitest-environment jsdom\` docblock scoped to this single DOM-dependent test. It's the only website test that touches the DOM, so a file-level docblock keeps the other tests on the fast \`node\` environment rather than imposing jsdom globally. This matches the \`extension\` package's existing jsdom usage; \`jsdom\` is already hoisted to the workspace root.

## Verification

\`bunx vitest run\` in \`extension/website\` — all tests pass, including the previously failing \`trailRenderers\` test:

\`\`\`
Test Files  6 passed (6)
     Tests  22 passed (22)
\`\`\`

No changeset: change is under \`extension/\`, not \`packages/\`. No PENDING.md bullet: test-infra only, no user-facing impact.