### PR TITLE
Show extension storage stats from aggregate

### DIFF
--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -1,0 +1,77 @@
+// ABOUTME: Verifies the data collection settings screen surfaces local storage size.
+// ABOUTME: Covers popup copy around import/export controls for local event data.
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+
+vi.mock("../components/Collections.scss", () => ({}));
+
+async function renderCollections() {
+  const { Collections } = await import("../components/Collections");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<Collections onBack={vi.fn()} />);
+  });
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  return { container, root };
+}
+
+function cleanupRoot(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+describe("Collections", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(async (message) => {
+      if (message?.type === "GET_STORAGE_STATS") {
+        return {
+          success: true,
+          stats: {
+            totalEvents: 0,
+            estimatedSizeBytes: 1536,
+            oldestEvent: 0,
+            countsByType: {},
+          },
+        };
+      }
+      return { success: true };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("shows local database size above import and export controls", async () => {
+    const { container, root } = await renderCollections();
+
+    try {
+      const text = container.textContent ?? "";
+      const sizeIndex = text.indexOf("Local database");
+      const exportIndex = text.indexOf("Export data");
+
+      expect(sizeIndex).toBeGreaterThanOrEqual(0);
+      expect(text).toContain("1.5 KB");
+      expect(exportIndex).toBeGreaterThan(sizeIndex);
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+});

--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Verifies the data collection settings screen surfaces local storage size.
-// ABOUTME: Covers popup copy around import/export controls for local event data.
+// ABOUTME: Covers popup stats copy for local event data.
 
 import React from "react";
 import { act } from "react";
@@ -43,10 +43,10 @@ describe("Collections", () => {
         return {
           success: true,
           stats: {
-            totalEvents: 0,
+            totalEvents: 3,
             estimatedSizeBytes: 1536,
-            oldestEvent: 0,
-            countsByType: {},
+            oldestEvent: Date.now(),
+            countsByType: { cursor: 2, keyboard: 1 },
           },
         };
       }
@@ -59,17 +59,19 @@ describe("Collections", () => {
     document.body.innerHTML = "";
   });
 
-  it("shows local database size above import and export controls", async () => {
+  it("shows local database size in the top stats card", async () => {
     const { container, root } = await renderCollections();
 
     try {
       const text = container.textContent ?? "";
-      const sizeIndex = text.indexOf("Local database");
+      const eventsIndex = text.indexOf("3events");
+      const sizeIndex = text.indexOf("1.5 KBstored");
       const exportIndex = text.indexOf("Export data");
 
+      expect(eventsIndex).toBeGreaterThanOrEqual(0);
       expect(sizeIndex).toBeGreaterThanOrEqual(0);
-      expect(text).toContain("1.5 KB");
       expect(exportIndex).toBeGreaterThan(sizeIndex);
+      expect(text).not.toContain("Local database");
     } finally {
       cleanupRoot(root, container);
     }

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Verifies local event storage stats read from persisted aggregates.
+// ABOUTME: Covers storage summary behavior without scanning every stored event.
+
+import { describe, expect, it } from "vitest";
+import { LocalEventStore } from "../storage/LocalEventStore";
+
+function createStoreWithGlobalStats(globalStats: unknown) {
+  const store = new LocalEventStore() as any;
+  store.isInitialized = true;
+  store.db = {
+    transaction(storeNames: string[]) {
+      expect(storeNames).toEqual(["domain_stats"]);
+      return {
+        objectStore(name: string) {
+          expect(name).toBe("domain_stats");
+          return {
+            get(key: string) {
+              expect(key).toBe("__global__");
+              const request: any = {};
+              queueMicrotask(() => {
+                request.result = globalStats;
+                request.onsuccess?.();
+              });
+              return request;
+            },
+          };
+        },
+      };
+    },
+  };
+  return store as LocalEventStore;
+}
+
+describe("LocalEventStore storage stats", () => {
+  it("reads storage stats from the global aggregate", async () => {
+    const store = createStoreWithGlobalStats({
+      key: "__global__",
+      domain: "",
+      totalTimeMs: 0,
+      hourBuckets: new Array(24).fill(0),
+      sessionCount: 0,
+      pendingFocusTs: null,
+      pendingFocusUrl: "",
+      eventsByType: { cursor: 2, keyboard: 1 },
+      firstVisit: 100,
+      lastVisit: 300,
+      uniqueUrls: [],
+      processedNavIds: [],
+      storageSizeBytes: 4096,
+    });
+
+    await expect(store.getStorageStats()).resolves.toEqual({
+      totalEvents: 3,
+      estimatedSizeBytes: 4096,
+      oldestEvent: 100,
+      newestEvent: 300,
+      countsByType: { cursor: 2, keyboard: 1 },
+    });
+  });
+});

--- a/extension/src/__tests__/ProfilePage.test.tsx
+++ b/extension/src/__tests__/ProfilePage.test.tsx
@@ -105,4 +105,18 @@ describe("ProfilePage", () => {
       cleanupRoot(root, container);
     }
   });
+
+  it("does not fetch or show local storage stats", async () => {
+    const { container, root } = await renderProfilePage();
+
+    try {
+      expect(browser.runtime.sendMessage).not.toHaveBeenCalledWith({
+        type: "GET_STORAGE_STATS",
+      });
+      expect(container.textContent).not.toContain("events stored");
+      expect(container.textContent).not.toContain("local data");
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
 });

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -158,6 +158,30 @@
     margin-top: 12px;
   }
 
+  &__database-size {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 8px;
+    padding: 7px 10px;
+    border: 1px solid $border;
+    border-radius: 6px;
+    color: $text;
+    font-size: 11px;
+    line-height: 1.3;
+  }
+
+  &__database-size-label {
+    color: $text-muted;
+  }
+
+  &__database-size-value {
+    flex-shrink: 0;
+    font-family: $font-mono;
+    font-weight: 700;
+  }
+
   &__transfer-buttons {
     display: flex;
     gap: 8px;

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -158,30 +158,6 @@
     margin-top: 12px;
   }
 
-  &__database-size {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 8px;
-    padding: 7px 10px;
-    border: 1px solid $border;
-    border-radius: 6px;
-    color: $text;
-    font-size: 11px;
-    line-height: 1.3;
-  }
-
-  &__database-size-label {
-    color: $text-muted;
-  }
-
-  &__database-size-value {
-    flex-shrink: 0;
-    font-family: $font-mono;
-    font-weight: 700;
-  }
-
   &__transfer-buttons {
     display: flex;
     gap: 8px;

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -804,16 +804,6 @@ export function Collections({ onBack }: CollectionsProps) {
         </div>
 
         <div className="collections__transfer">
-          {storageStats && (
-            <div className="collections__database-size">
-              <span className="collections__database-size-label">
-                Local database
-              </span>
-              <span className="collections__database-size-value">
-                {formatSize(storageStats.estimatedSizeBytes)}
-              </span>
-            </div>
-          )}
           <div className="collections__transfer-buttons">
             <button
               className="collections__transfer-btn"

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -282,7 +282,12 @@ export function Collections({ onBack }: CollectionsProps) {
         type: "CLEAR_ALL_EVENTS",
       });
       if (response?.success) {
-        setStorageStats(null);
+        setStorageStats({
+          totalEvents: 0,
+          estimatedSizeBytes: 0,
+          oldestEvent: 0,
+          countsByType: {},
+        });
       } else {
         alert("Failed to clear data. Please try again.");
       }
@@ -799,6 +804,16 @@ export function Collections({ onBack }: CollectionsProps) {
         </div>
 
         <div className="collections__transfer">
+          {storageStats && (
+            <div className="collections__database-size">
+              <span className="collections__database-size-label">
+                Local database
+              </span>
+              <span className="collections__database-size-value">
+                {formatSize(storageStats.estimatedSizeBytes)}
+              </span>
+            </div>
+          )}
           <div className="collections__transfer-buttons">
             <button
               className="collections__transfer-btn"

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -1,6 +1,6 @@
 // ABOUTME: Profile settings page showing identity info and cursor color picker
 // ABOUTME: Accessed by clicking the cursor icon in the popup header
-import React, { useEffect, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import browser from "webextension-polyfill";
 import type { PlayerIdentity } from "../types";
 import { CursorSvg } from "./icons";
@@ -19,39 +19,15 @@ function randomPrimaryColor(): string {
   return hslToHex(hue, 70, 60);
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
 export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props) {
   const savedColor = playerIdentity.playerStyle?.colorPalette?.[0] ?? "#4a9a8a";
   const [color, setColor] = useState(savedColor);
   const [copied, setCopied] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [storageStats, setStorageStats] = useState<{
-    totalEvents: number;
-    estimatedSizeBytes: number;
-  } | null>(null);
   const colorInputRef = useRef<HTMLInputElement>(null);
   const opensNativePickerInPopup = !import.meta.env.FIREFOX;
 
   const hasColorChanged = color !== savedColor;
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const response = await browser.runtime.sendMessage({ type: "GET_STORAGE_STATS" });
-        if (response?.success && response.stats) {
-          setStorageStats({
-            totalEvents: response.stats.totalEvents ?? 0,
-            estimatedSizeBytes: response.stats.estimatedSizeBytes ?? 0,
-          });
-        }
-      } catch {}
-    })();
-  }, []);
 
   const commitColor = (nextColor: string) => {
     setColor(nextColor);
@@ -189,22 +165,6 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
                   {siteCount === 1 ? "site discovered" : "sites discovered"}
                 </span>
               </div>
-            )}
-            {storageStats && (
-              <>
-                <div className="profile-section__stat">
-                  <span className="profile-section__stat-value">
-                    {storageStats.totalEvents.toLocaleString()}
-                  </span>
-                  <span className="profile-section__stat-label">events stored</span>
-                </div>
-                <div className="profile-section__stat">
-                  <span className="profile-section__stat-value">
-                    ~{formatBytes(storageStats.estimatedSizeBytes)}
-                  </span>
-                  <span className="profile-section__stat-label">local data</span>
-                </div>
-              </>
             )}
           </div>
         </section>

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/urlNormalization";
 
 const DB_NAME = "collection_events_db";
-const DB_VERSION = 8;
+const DB_VERSION = 9;
 const STORE_NAME = "events";
 const STATS_STORE_NAME = "domain_stats";
 
@@ -64,6 +64,8 @@ export interface DomainStatsAggregate {
   pendingFocusUrl: string;
   /** Running event counts by type */
   eventsByType: Record<string, number>;
+  /** Estimated serialized byte size for events represented by this aggregate. */
+  storageSizeBytes: number;
   /** Earliest event timestamp */
   firstVisit: number;
   /** Latest event timestamp */
@@ -228,13 +230,14 @@ export class LocalEventStore {
         // v6: create domain_stats store (keyPath: "domain")
         // v7: recreate with keyPath: "key" to support both domain and page-level aggregates
         // v8: force rebuild to populate page-level + global aggregates added after v7
-        if (oldVersion < 8) {
+        // v9: force rebuild to populate storageSizeBytes in aggregates
+        if (oldVersion < 9) {
           if (db.objectStoreNames.contains(STATS_STORE_NAME)) {
             db.deleteObjectStore(STATS_STORE_NAME);
           }
           db.createObjectStore(STATS_STORE_NAME, { keyPath: "key" });
           if (VERBOSE) {
-            console.log("[LocalEventStore] Created domain_stats store (v8, keyPath: key)");
+            console.log("[LocalEventStore] Created domain_stats store (keyPath: key)");
           }
         }
       };
@@ -672,40 +675,24 @@ export class LocalEventStore {
         return;
       }
 
-      const transaction = this.db.transaction([STORE_NAME], "readonly");
-      const store = transaction.objectStore(STORE_NAME);
+      const transaction = this.db.transaction([STATS_STORE_NAME], "readonly");
+      const statsStore = transaction.objectStore(STATS_STORE_NAME);
+      const request = statsStore.get(GLOBAL_STATS_KEY);
 
-      // Single cursor pass: collect total count, timestamp bounds, per-type counts, and actual serialized size
-      // TODO: decide if we need per-type event counts and if so, we should store counts natively in database so we don't have to count them here
-      const countsByType: Record<string, number> = {};
-      let totalEvents = 0;
-      let oldestEvent = 0;
-      let newestEvent = 0;
-      let actualSizeBytes = 0;
-
-      const request = store.openCursor();
-
-      request.onsuccess = (event) => {
-        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
-
-        if (cursor) {
-          const evt = cursor.value as CollectionEvent;
-          totalEvents++;
-          countsByType[evt.type] = (countsByType[evt.type] ?? 0) + 1;
-          if (oldestEvent === 0 || evt.ts < oldestEvent) oldestEvent = evt.ts;
-          if (evt.ts > newestEvent) newestEvent = evt.ts;
-          // Serialized size: string length ≈ bytes for mostly-ASCII event JSON (avoids TextEncoder per-event for perf)
-          actualSizeBytes += JSON.stringify(evt).length;
-          cursor.continue();
-        } else {
-          resolve({
-            totalEvents,
-            estimatedSizeBytes: actualSizeBytes,
-            oldestEvent,
-            newestEvent,
-            countsByType,
-          });
-        }
+      request.onsuccess = () => {
+        const aggregate = request.result as DomainStatsAggregate | undefined;
+        const countsByType = aggregate?.eventsByType ?? {};
+        const totalEvents = Object.values(countsByType).reduce(
+          (sum, count) => sum + count,
+          0,
+        );
+        resolve({
+          totalEvents,
+          estimatedSizeBytes: aggregate?.storageSizeBytes ?? 0,
+          oldestEvent: aggregate?.firstVisit ?? 0,
+          newestEvent: aggregate?.lastVisit ?? 0,
+          countsByType,
+        });
       };
 
       request.onerror = () => reject(request.error);
@@ -910,9 +897,9 @@ export class LocalEventStore {
 
     // Update domain aggregates in a separate transaction so a stats
     // failure never blocks event storage
-    if (eventsByDomain.size > 0) {
+    if (events.length > 0) {
       try {
-        await this.updateDomainStats(eventsByDomain);
+        await this.updateDomainStats(events, eventsByDomain);
       } catch (e) {
         console.error("[LocalEventStore] Failed to update domain stats:", e);
       }
@@ -929,6 +916,7 @@ export class LocalEventStore {
       pendingFocusTs: null,
       pendingFocusUrl: "",
       eventsByType: {},
+      storageSizeBytes: 0,
       firstVisit: 0,
       lastVisit: 0,
       uniqueUrls: [],
@@ -946,9 +934,11 @@ export class LocalEventStore {
   ): void {
     const urlSet = new Set(agg.uniqueUrls);
     const processedSet = new Set(agg.processedNavIds);
+    agg.storageSizeBytes ??= 0;
 
     for (const evt of events) {
       agg.eventsByType[evt.type] = (agg.eventsByType[evt.type] ?? 0) + 1;
+      agg.storageSizeBytes += JSON.stringify(evt).length;
       if (agg.firstVisit === 0 || evt.ts < agg.firstVisit) {
         agg.firstVisit = evt.ts;
       }
@@ -992,17 +982,16 @@ export class LocalEventStore {
    * Incrementally update both domain-level and page-level aggregates.
    */
   private async updateDomainStats(
+    events: CollectionEvent[],
     eventsByDomain: Map<string, CollectionEvent[]>,
   ): Promise<void> {
     // Collect all aggregate keys we need to read/write (global + domain + page)
     const keyToEvents = new Map<string, { domain: string; events: CollectionEvent[] }>();
 
     // Global aggregate: receives ALL events from every domain
-    keyToEvents.set(GLOBAL_STATS_KEY, { domain: "", events: [] });
+    keyToEvents.set(GLOBAL_STATS_KEY, { domain: "", events });
 
     for (const [dom, domainEvents] of eventsByDomain) {
-      keyToEvents.get(GLOBAL_STATS_KEY)!.events.push(...domainEvents);
-
       // Domain-level aggregate
       const dKey = domainStatsKey(dom);
       if (!keyToEvents.has(dKey)) {


### PR DESCRIPTION
## Summary
- Show local storage size only in the existing Data Collection Settings top stats card.
- Remove the duplicate import/export storage-size row and remove storage stats from the profile/cursor color screen.
- Read `GET_STORAGE_STATS` from the precomputed global `domain_stats` aggregate instead of scanning and stringifying every local event on demand.

## Why
The profile screen could take a while to show storage stats because `getStorageStats()` cursor-scanned the entire `events` store and estimated size with `JSON.stringify` per event. The stats now come from an incrementally maintained aggregate, with an IndexedDB version bump to rebuild existing aggregate rows once.

## Validation
- `bun run test --run` in `extension/`: 30 files, 200 tests passed.
- `bunx tsc` still fails on existing unrelated type errors outside this change; no diagnostics referenced `LocalEventStore`, `Collections`, or `ProfilePage`.