### PR TITLE
Reduce extension CPU work and add trace harness

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
     },
     "extension": {
       "name": "@playhtml/extension",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@playhtml/common": "workspace:*",
         "@playhtml/extension-types": "workspace:*",
@@ -86,6 +86,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "@wxt-dev/module-react": "^1.1.3",
         "agentation": "^2.2.1",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^27.4.0",
         "typescript": "^5.0.2",
         "vite": "^7.1.2",
@@ -1320,6 +1321,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -9,3 +9,4 @@ file back to just the header. Merge that PR to ship.
 Format suggestion: "- short user-facing description (#PR)"
 -->
 - Reduced background CPU and storage work while collecting browsing activity.
+- Stopped hidden inventory development features from observing and writing on every page.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -11,3 +11,4 @@ Format suggestion: "- short user-facing description (#PR)"
 - Reduced background CPU and storage work while collecting browsing activity.
 - Stopped hidden inventory development features from observing and writing on every page.
 - Preserved pending event uploads when upgrading existing local browsing databases.
+- Stored click events sooner to avoid losing them during fast page exits.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -8,3 +8,4 @@ file back to just the header. Merge that PR to ship.
 
 Format suggestion: "- short user-facing description (#PR)"
 -->
+- Reduced background CPU and storage work while collecting browsing activity.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -10,3 +10,4 @@ Format suggestion: "- short user-facing description (#PR)"
 -->
 - Reduced background CPU and storage work while collecting browsing activity.
 - Stopped hidden inventory development features from observing and writing on every page.
+- Preserved pending event uploads when upgrading existing local browsing databases.

--- a/extension/package.json
+++ b/extension/package.json
@@ -37,6 +37,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "@wxt-dev/module-react": "^1.1.3",
     "agentation": "^2.2.1",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^27.4.0",
     "typescript": "^5.0.2",
     "vite": "^7.1.2",

--- a/extension/src/__tests__/CursorCollector.test.ts
+++ b/extension/src/__tests__/CursorCollector.test.ts
@@ -73,6 +73,18 @@ describe("CursorCollector", () => {
   });
 
   describe("movement tracking", () => {
+    it("does not run the real-time loop without a real-time callback", () => {
+      collector.disable();
+      collector = new CursorCollector();
+      collector.setEmitCallback(emitCallback);
+      const requestAnimationFrameSpy = vi.spyOn(window, "requestAnimationFrame");
+
+      collector.enable();
+
+      expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+      requestAnimationFrameSpy.mockRestore();
+    });
+
     it("emits move events when cursor moves beyond threshold", async () => {
       collector.enable();
 
@@ -140,6 +152,23 @@ describe("CursorCollector", () => {
 
       // Real-time callback should be called
       expect(realTimeCallback).toHaveBeenCalled();
+    });
+
+    it("reuses cursor style while the pointer stays on the same target", () => {
+      const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
+      const element = createTestElement("button", {
+        id: "steady-target",
+        cursor: "pointer",
+      });
+
+      collector.enable();
+
+      simulateMouseMove(100, 100, element);
+      simulateMouseMove(120, 120, element);
+      simulateMouseMove(140, 140, element);
+
+      expect(getComputedStyleSpy).toHaveBeenCalledTimes(1);
+      getComputedStyleSpy.mockRestore();
     });
   });
 

--- a/extension/src/__tests__/CursorCollector.test.ts
+++ b/extension/src/__tests__/CursorCollector.test.ts
@@ -85,6 +85,22 @@ describe("CursorCollector", () => {
       requestAnimationFrameSpy.mockRestore();
     });
 
+    it("does not schedule real-time mousemove work without a real-time callback", () => {
+      collector.disable();
+      collector = new CursorCollector();
+      collector.setEmitCallback(emitCallback);
+      const scheduleRealTimeSpy = vi.spyOn(
+        collector as unknown as { scheduleRealTimeUpdate: () => void },
+        "scheduleRealTimeUpdate",
+      );
+
+      collector.enable();
+      simulateMouseMove(100, 100);
+
+      expect(scheduleRealTimeSpy).not.toHaveBeenCalled();
+      scheduleRealTimeSpy.mockRestore();
+    });
+
     it("emits move events when cursor moves beyond threshold", async () => {
       collector.enable();
 

--- a/extension/src/__tests__/CursorCollector.test.ts
+++ b/extension/src/__tests__/CursorCollector.test.ts
@@ -173,14 +173,11 @@ describe("CursorCollector", () => {
   });
 
   describe("click detection", () => {
-    it("emits click event for quick mousedown/mouseup (debounced)", async () => {
+    it("emits click event for quick mousedown/mouseup", async () => {
       collector.enable();
 
       const element = createTestElement("button", { id: "click-target" });
       await simulateClick(100, 100, 100, 0, element); // 100ms hold
-
-      // Click is debounced, so wait for debounce period (2s)
-      await advanceTime(2000);
 
       // Should emit click (not hold, since < 250ms)
       expect(emitCallback).toHaveBeenCalled();
@@ -206,7 +203,7 @@ describe("CursorCollector", () => {
       expect(call.quantity).toBeUndefined(); // Hold events don't have quantity
     });
     
-    it("debounces rapid clicks within 2 second window and tracks quantity", async () => {
+    it("emits rapid clicks as separate events", async () => {
       collector.enable();
 
       const element = createTestElement("button", { id: "rapid-click" });
@@ -221,20 +218,17 @@ describe("CursorCollector", () => {
       
       // Third click (within 2s window)
       await simulateClick(200, 200, 50, 0, element);
-      await advanceTime(2000); // Wait for debounce
 
-      // Should only emit once with quantity 3
       const clickCalls = emitCallback.mock.calls.filter(
         (call) => (call[0] as CursorEventData).event === "click"
       );
-      expect(clickCalls.length).toBe(1);
-      
-      const call = clickCalls[0][0] as CursorEventData;
-      expect(call.event).toBe("click");
-      expect(call.quantity).toBe(3);
-      // Should use the last click's position
-      expect(call.x).toBeCloseTo(200 / 1024, 4);
-      expect(call.y).toBeCloseTo(200 / 768, 4);
+      expect(clickCalls.length).toBe(3);
+
+      expect((clickCalls[0][0] as CursorEventData).quantity).toBe(1);
+      expect((clickCalls[1][0] as CursorEventData).quantity).toBe(1);
+      expect((clickCalls[2][0] as CursorEventData).quantity).toBe(1);
+      expect((clickCalls[2][0] as CursorEventData).x).toBeCloseTo(200 / 1024, 4);
+      expect((clickCalls[2][0] as CursorEventData).y).toBeCloseTo(200 / 768, 4);
     });
     
     it("emits separate click events if clicks are spaced out", async () => {
@@ -267,9 +261,6 @@ describe("CursorCollector", () => {
       simulateMouseDown(100, 100, 2);
       await advanceTime(100);
       simulateMouseUp(100, 100, 2);
-      
-      // Wait for debounce
-      await advanceTime(2000);
 
       expect(emitCallback).toHaveBeenCalled();
       const call = emitCallback.mock.calls[0][0] as CursorEventData;
@@ -281,9 +272,6 @@ describe("CursorCollector", () => {
 
       // Click at (512, 384) in 1024x768 viewport = (0.5, 0.5)
       await simulateClick(512, 384, 100);
-      
-      // Wait for debounce
-      await advanceTime(2000);
 
       expect(emitCallback).toHaveBeenCalled();
       const call = emitCallback.mock.calls[0][0] as CursorEventData;

--- a/extension/src/__tests__/EventBuffer.test.ts
+++ b/extension/src/__tests__/EventBuffer.test.ts
@@ -32,6 +32,13 @@ function testEvent(id: string): CollectionEvent {
   };
 }
 
+function clickEvent(id: string): CollectionEvent {
+  return {
+    ...testEvent(id),
+    data: { event: "click", x: 0.5, y: 0.5, quantity: 1 },
+  };
+}
+
 describe("EventBuffer", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -75,6 +82,54 @@ describe("EventBuffer", () => {
       type: "STORE_EVENTS",
       events: [expect.objectContaining({ id: "queued", uploaded: false })],
     });
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(2, {
+      type: "FLUSH_PENDING_UPLOADS",
+    });
+  });
+
+  it("stores cursor click events without waiting for the storage timer", async () => {
+    const buffer = new EventBuffer();
+
+    await buffer.addEvent(clickEvent("click"));
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "STORE_EVENTS",
+      events: [expect.objectContaining({ id: "click", uploaded: false })],
+    });
+  });
+
+  it("waits for an active storage write before asking the background to upload", async () => {
+    const buffer = new EventBuffer();
+    let resolveStoreMessage: (() => void) | undefined;
+
+    vi.mocked(browser.runtime.sendMessage).mockImplementation((message) => {
+      if ((message as { type?: string }).type === "STORE_EVENTS") {
+        return new Promise((resolve) => {
+          resolveStoreMessage = () => resolve({});
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    for (let i = 0; i < 25; i++) {
+      await buffer.addEvent(testEvent(`event-${i}`));
+    }
+
+    const flushPromise = buffer.flushBatch();
+    await Promise.resolve();
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(1, {
+      type: "STORE_EVENTS",
+      events: expect.arrayContaining([
+        expect.objectContaining({ id: "event-0", uploaded: false }),
+        expect.objectContaining({ id: "event-24", uploaded: false }),
+      ]),
+    });
+
+    resolveStoreMessage?.();
+    await flushPromise;
+
     expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(2, {
       type: "FLUSH_PENDING_UPLOADS",
     });

--- a/extension/src/__tests__/EventBuffer.test.ts
+++ b/extension/src/__tests__/EventBuffer.test.ts
@@ -1,0 +1,106 @@
+// ABOUTME: Tests local event buffering before events cross into the background worker.
+// ABOUTME: Verifies batching, upload flushing, and cached event metadata lookups.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import { EventBuffer } from "../storage/EventBuffer";
+import { getParticipantId, getSessionId } from "../storage/participant";
+import type { CollectionEvent } from "../collectors/types";
+
+const participantMocks = vi.hoisted(() => ({
+  getParticipantId: vi.fn().mockResolvedValue("test-participant-id"),
+  getSessionId: vi.fn().mockResolvedValue("test-session-id"),
+  getTimezone: vi.fn().mockReturnValue("America/New_York"),
+}));
+
+vi.mock("../storage/participant", () => participantMocks);
+
+function testEvent(id: string): CollectionEvent {
+  return {
+    id,
+    type: "cursor",
+    ts: Date.now(),
+    data: { event: "move", x: 0.5, y: 0.5 },
+    meta: {
+      pid: "pid",
+      sid: "sid",
+      url: "https://example.com/",
+      vw: 1024,
+      vh: 768,
+      tz: "America/New_York",
+    },
+  };
+}
+
+describe("EventBuffer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({});
+    vi.mocked(getParticipantId).mockResolvedValue("test-participant-id");
+    vi.mocked(getSessionId).mockResolvedValue("test-session-id");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("batches stored events before sending them to the background", async () => {
+    const buffer = new EventBuffer();
+
+    await buffer.addEvent(testEvent("one"));
+    await buffer.addEvent(testEvent("two"));
+
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "STORE_EVENTS",
+      events: [
+        expect.objectContaining({ id: "one", uploaded: false }),
+        expect.objectContaining({ id: "two", uploaded: false }),
+      ],
+    });
+  });
+
+  it("flushes queued events before asking the background to upload", async () => {
+    const buffer = new EventBuffer();
+
+    await buffer.addEvent(testEvent("queued"));
+    await buffer.flushBatch();
+
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(1, {
+      type: "STORE_EVENTS",
+      events: [expect.objectContaining({ id: "queued", uploaded: false })],
+    });
+    expect(browser.runtime.sendMessage).toHaveBeenNthCalledWith(2, {
+      type: "FLUSH_PENDING_UPLOADS",
+    });
+  });
+
+  it("reuses participant and session lookups for event metadata", async () => {
+    const buffer = new EventBuffer();
+
+    await buffer.createEvent("cursor", { event: "move", x: 0.1, y: 0.2 });
+    await buffer.createEvent("viewport", { event: "scroll", scrollY: 0.3 });
+
+    expect(getParticipantId).toHaveBeenCalledTimes(1);
+    expect(getSessionId).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache temporary participant IDs", async () => {
+    vi.mocked(getParticipantId)
+      .mockResolvedValueOnce("pk_temp_race")
+      .mockResolvedValueOnce("pk_real");
+    const buffer = new EventBuffer();
+
+    const first = await buffer.createEvent("cursor", { event: "move" });
+    const second = await buffer.createEvent("cursor", { event: "move" });
+
+    expect(first.meta.pid).toBe("pk_temp_race");
+    expect(second.meta.pid).toBe("pk_real");
+    expect(getParticipantId).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -59,6 +59,10 @@ async function deleteEventDatabase(): Promise<void> {
   });
 }
 
+async function waitForBackgroundDatabaseWork(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 async function openVersion8Database(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = fakeIndexedDB.open(DB_NAME, 8);
@@ -175,6 +179,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  await waitForBackgroundDatabaseWork();
   closeStores();
   await deleteEventDatabase();
   restoreIndexedDBGlobals();

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -1,18 +1,107 @@
-// ABOUTME: Verifies local event storage stats read from persisted aggregates.
-// ABOUTME: Covers storage summary behavior without scanning every stored event.
+// ABOUTME: Tests local event database storage, query, and aggregate behavior.
+// ABOUTME: Guards hot paths, storage stats, and upload metadata handling in IndexedDB.
 
-import { describe, expect, it } from "vitest";
-import { LocalEventStore } from "../storage/LocalEventStore";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  IDBKeyRange as fakeIDBKeyRange,
+  indexedDB as fakeIndexedDB,
+} from "fake-indexeddb";
+import { LocalEventStore, type DomainStatsAggregate } from "../storage/LocalEventStore";
+import type { CollectionEvent } from "../collectors/types";
 
-function createStoreWithGlobalStats(globalStats: unknown) {
-  const store = new LocalEventStore() as any;
-  store.isInitialized = true;
-  store.db = {
+const DB_NAME = "collection_events_db";
+const STORE_NAME = "events";
+const STATS_STORE_NAME = "domain_stats";
+
+const originalIndexedDB = globalThis.indexedDB;
+const originalIDBKeyRange = globalThis.IDBKeyRange;
+let stores: LocalEventStore[] = [];
+
+type StoredTestEvent = CollectionEvent & {
+  uploaded?: boolean;
+  uploadState?: string;
+};
+
+function setIndexedDBGlobals(): void {
+  (globalThis as typeof globalThis & { indexedDB: IDBFactory }).indexedDB =
+    fakeIndexedDB;
+  Object.defineProperty(globalThis, "IDBKeyRange", {
+    value: fakeIDBKeyRange,
+    configurable: true,
+  });
+  window.indexedDB = fakeIndexedDB;
+  Object.defineProperty(window, "IDBKeyRange", {
+    value: fakeIDBKeyRange,
+    configurable: true,
+  });
+}
+
+function restoreIndexedDBGlobals(): void {
+  (globalThis as typeof globalThis & { indexedDB: IDBFactory }).indexedDB =
+    originalIndexedDB;
+  Object.defineProperty(globalThis, "IDBKeyRange", {
+    value: originalIDBKeyRange,
+    configurable: true,
+  });
+  window.indexedDB = originalIndexedDB;
+  Object.defineProperty(window, "IDBKeyRange", {
+    value: originalIDBKeyRange,
+    configurable: true,
+  });
+}
+
+async function deleteEventDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = fakeIndexedDB.deleteDatabase(DB_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("IndexedDB delete blocked"));
+  });
+}
+
+async function openVersion8Database(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = fakeIndexedDB.open(DB_NAME, 8);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const eventStore = db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      eventStore.createIndex("ts", "ts", { unique: false });
+      eventStore.createIndex("type", "type", { unique: false });
+      eventStore.createIndex("uploaded", "uploaded", { unique: false });
+      eventStore.createIndex("domain", "domain", { unique: false });
+      eventStore.createIndex("normalizedUrl", "normalizedUrl", { unique: false });
+      const statsStore = db.createObjectStore(STATS_STORE_NAME, { keyPath: "key" });
+      statsStore.put(aggregate());
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function putSeedEvent(db: IDBDatabase, seedEvent: CollectionEvent): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readwrite");
+    transaction.objectStore(STORE_NAME).put(seedEvent);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+function createStore(): LocalEventStore {
+  const store = new LocalEventStore();
+  stores.push(store);
+  return store;
+}
+
+function createStoreWithGlobalStats(globalStats: unknown): LocalEventStore {
+  const store = Object.create(LocalEventStore.prototype) as LocalEventStore;
+  (store as any).isInitialized = true;
+  (store as any).db = {
     transaction(storeNames: string[]) {
-      expect(storeNames).toEqual(["domain_stats"]);
+      expect(storeNames).toEqual([STATS_STORE_NAME]);
       return {
         objectStore(name: string) {
-          expect(name).toBe("domain_stats");
+          expect(name).toBe(STATS_STORE_NAME);
           return {
             get(key: string) {
               expect(key).toBe("__global__");
@@ -28,8 +117,100 @@ function createStoreWithGlobalStats(globalStats: unknown) {
       };
     },
   };
-  return store as LocalEventStore;
+  return store;
 }
+
+function closeStores(): void {
+  for (const store of stores) {
+    (store as unknown as { db: IDBDatabase | null }).db?.close();
+  }
+  stores = [];
+}
+
+function aggregate(): DomainStatsAggregate {
+  return {
+    key: "example.com",
+    domain: "example.com",
+    totalTimeMs: 0,
+    hourBuckets: new Array(24).fill(0),
+    sessionCount: 0,
+    pendingFocusTs: null,
+    pendingFocusUrl: "",
+    eventsByType: {},
+    storageSizeBytes: 0,
+    firstVisit: 0,
+    lastVisit: 0,
+    uniqueUrls: ["https://example.com/"],
+    processedNavIds: ["nav-1"],
+  };
+}
+
+function event(id: string, type: CollectionEvent["type"]): CollectionEvent {
+  return {
+    id,
+    type,
+    ts: 1_000,
+    data: type === "navigation" ? { event: "focus" } : { event: "move" },
+    meta: {
+      pid: "pid",
+      sid: "sid",
+      url: "https://example.com/page",
+      vw: 1024,
+      vh: 768,
+      tz: "America/New_York",
+    },
+    domain: "example.com",
+    normalizedUrl: "https://example.com/page",
+  };
+}
+
+function contentScriptEvent(id: string, type: CollectionEvent["type"]): CollectionEvent {
+  const { domain, normalizedUrl, ...sourceEvent } = event(id, type);
+  return sourceEvent;
+}
+
+beforeEach(async () => {
+  setIndexedDBGlobals();
+  await deleteEventDatabase();
+});
+
+afterEach(async () => {
+  closeStores();
+  await deleteEventDatabase();
+  restoreIndexedDBGlobals();
+});
+
+describe("LocalEventStore aggregates", () => {
+  it("preserves URL and navigation ID arrays for non-navigation events", () => {
+    const agg = aggregate();
+    const uniqueUrls = agg.uniqueUrls;
+    const processedNavIds = agg.processedNavIds;
+
+    (LocalEventStore as any).applyEventsToAggregate(agg, [
+      event("cursor-1", "cursor"),
+    ]);
+
+    expect(agg.uniqueUrls).toBe(uniqueUrls);
+    expect(agg.processedNavIds).toBe(processedNavIds);
+    expect(agg.eventsByType.cursor).toBe(1);
+    expect(agg.storageSizeBytes).toBeGreaterThan(0);
+    expect(agg.firstVisit).toBe(1_000);
+    expect(agg.lastVisit).toBe(1_000);
+  });
+
+  it("tracks URLs and navigation IDs for navigation events", () => {
+    const agg = aggregate();
+
+    (LocalEventStore as any).applyEventsToAggregate(agg, [
+      event("nav-2", "navigation"),
+    ]);
+
+    expect(agg.uniqueUrls).toContain("https://example.com/page");
+    expect(agg.processedNavIds).toContain("nav-2");
+    expect(agg.pendingFocusTs).toBe(1_000);
+    expect(agg.pendingFocusUrl).toBe("https://example.com/page");
+  });
+});
 
 describe("LocalEventStore storage stats", () => {
   it("reads storage stats from the global aggregate", async () => {
@@ -42,11 +223,11 @@ describe("LocalEventStore storage stats", () => {
       pendingFocusTs: null,
       pendingFocusUrl: "",
       eventsByType: { cursor: 2, keyboard: 1 },
+      storageSizeBytes: 4096,
       firstVisit: 100,
       lastVisit: 300,
       uniqueUrls: [],
       processedNavIds: [],
-      storageSizeBytes: 4096,
     });
 
     await expect(store.getStorageStats()).resolves.toEqual({
@@ -56,5 +237,65 @@ describe("LocalEventStore storage stats", () => {
       newestEvent: 300,
       countsByType: { cursor: 2, keyboard: 1 },
     });
+  });
+});
+
+describe("LocalEventStore pending uploads", () => {
+  it("derives query indexes when storing content script events", async () => {
+    const store = createStore();
+    await store.addEvents([contentScriptEvent("cursor-indexed", "cursor")]);
+
+    const domainEvents = await store.queryByDomain("example.com");
+    const urlEvents = await store.queryByUrl("https://example.com/page?ignored=true#hash");
+
+    expect(domainEvents.map((storedEvent) => storedEvent.id)).toEqual(["cursor-indexed"]);
+    expect(urlEvents.map((storedEvent) => storedEvent.id)).toEqual(["cursor-indexed"]);
+  });
+
+  it("stores new events as pending when uploaded is missing", async () => {
+    const store = createStore();
+    const sourceEvent = event("cursor-pending", "cursor");
+    await store.addEvents([sourceEvent]);
+
+    const events = await store.getPendingEvents(100);
+
+    expect(events.map((pendingEvent) => pendingEvent.id)).toEqual(["cursor-pending"]);
+    expect((sourceEvent as StoredTestEvent).uploaded).toBeUndefined();
+    expect((sourceEvent as StoredTestEvent).uploadState).toBeUndefined();
+    expect((events[0] as StoredTestEvent).uploaded).toBeUndefined();
+    expect((events[0] as StoredTestEvent).uploadState).toBeUndefined();
+  });
+
+  it("backfills existing events with missing uploaded flags as pending", async () => {
+    const db = await openVersion8Database();
+    const pendingEvent = event("migrated-pending", "cursor");
+    const uploadedEvent = {
+      ...event("already-uploaded", "cursor"),
+      uploaded: true,
+    } as CollectionEvent & { uploaded: boolean };
+
+    await putSeedEvent(db, pendingEvent);
+    await putSeedEvent(db, uploadedEvent);
+    db.close();
+
+    const store = createStore();
+    const events = await store.getPendingEvents(100);
+
+    expect(events.map((storedEvent) => storedEvent.id)).toEqual(["migrated-pending"]);
+    expect((events[0] as StoredTestEvent).uploaded).toBeUndefined();
+    expect((events[0] as StoredTestEvent).uploadState).toBeUndefined();
+  });
+
+  it("removes uploaded events from pending reads", async () => {
+    const store = createStore();
+    await store.addEvents([event("cursor-pending", "cursor")]);
+
+    await store.markEventsAsUploaded(["cursor-pending"]);
+
+    const pendingEvents = await store.getPendingEvents(100);
+    const storedEvents = await store.getAllEvents();
+    expect(pendingEvents).toEqual([]);
+    expect((storedEvents[0] as StoredTestEvent).uploaded).toBeUndefined();
+    expect((storedEvents[0] as StoredTestEvent).uploadState).toBeUndefined();
   });
 });

--- a/extension/src/__tests__/collectors.integration.test.ts
+++ b/extension/src/__tests__/collectors.integration.test.ts
@@ -7,7 +7,13 @@ import { CursorCollector } from "../collectors/CursorCollector";
 import { NavigationCollector } from "../collectors/NavigationCollector";
 import { ViewportCollector } from "../collectors/ViewportCollector";
 import { EventBuffer } from "../storage/EventBuffer";
-import { simulateMouseMove, simulateScroll, advanceTime } from "./test-utils";
+import {
+  advanceTime,
+  createTestElement,
+  simulateClick,
+  simulateMouseMove,
+  simulateScroll,
+} from "./test-utils";
 import browser from "webextension-polyfill";
 
 // Mock the storage module
@@ -270,14 +276,41 @@ describe("Collector Integration", () => {
       flushSpy.mockRestore();
     });
 
-    it("flushes queued events when collectors stop", () => {
+    it("flushes queued events when collectors stop", async () => {
       const eventBuffer = manager.getEventBuffer();
       const flushSpy = vi.spyOn(eventBuffer, "manualFlush");
 
-      manager.stopAll();
+      await manager.stopAll();
 
       expect(flushSpy).toHaveBeenCalled();
       flushSpy.mockRestore();
+    });
+
+    it("stores pending debounced cursor clicks when collectors stop", async () => {
+      const cursorCollector = new CursorCollector();
+      manager.registerCollector(cursorCollector);
+      vi.mocked(browser.runtime.sendMessage).mockResolvedValue({ success: true });
+
+      await manager.enableCollector("cursor");
+
+      const target = createTestElement("button", { id: "stop-click-target" });
+      await simulateClick(100, 100, 50, 0, target);
+      await manager.stopAll();
+
+      expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+        type: "STORE_EVENTS",
+        events: [
+          expect.objectContaining({
+            type: "cursor",
+            data: expect.objectContaining({
+              event: "click",
+              quantity: 1,
+              t: "#stop-click-target",
+            }),
+            uploaded: false,
+          }),
+        ],
+      });
     });
   });
 

--- a/extension/src/__tests__/collectors.integration.test.ts
+++ b/extension/src/__tests__/collectors.integration.test.ts
@@ -269,6 +269,16 @@ describe("Collector Integration", () => {
       expect(flushSpy).toHaveBeenCalled();
       flushSpy.mockRestore();
     });
+
+    it("flushes queued events when collectors stop", () => {
+      const eventBuffer = manager.getEventBuffer();
+      const flushSpy = vi.spyOn(eventBuffer, "manualFlush");
+
+      manager.stopAll();
+
+      expect(flushSpy).toHaveBeenCalled();
+      flushSpy.mockRestore();
+    });
   });
 
   describe("error handling", () => {

--- a/extension/src/__tests__/collectors.integration.test.ts
+++ b/extension/src/__tests__/collectors.integration.test.ts
@@ -286,7 +286,7 @@ describe("Collector Integration", () => {
       flushSpy.mockRestore();
     });
 
-    it("stores pending debounced cursor clicks when collectors stop", async () => {
+    it("stores cursor clicks when collectors stop", async () => {
       const cursorCollector = new CursorCollector();
       manager.registerCollector(cursorCollector);
       vi.mocked(browser.runtime.sendMessage).mockResolvedValue({ success: true });

--- a/extension/src/__tests__/content-dev-features.test.ts
+++ b/extension/src/__tests__/content-dev-features.test.ts
@@ -1,0 +1,137 @@
+// ABOUTME: Regression tests for content-script internal development feature gates.
+// ABOUTME: Verifies hidden inventory features do not run on every page.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageGet = vi.hoisted(() => vi.fn());
+const storageSet = vi.hoisted(() => vi.fn());
+const runtimeSendMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        get: storageGet,
+        set: storageSet,
+      },
+      onChanged: {
+        addListener: vi.fn(),
+      },
+    },
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      sendMessage: runtimeSendMessage,
+      onMessage: {
+        addListener: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock("../flags", () => ({
+  FLAGS: { COPRESENCE: true },
+}));
+
+vi.mock("../collectors/CollectorManager", () => ({
+  CollectorManager: class {
+    registerCollector = vi.fn();
+    init = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn();
+    pauseAll = vi.fn();
+    resumeAll = vi.fn();
+    getCollectorStatuses = vi.fn(() => []);
+  },
+}));
+
+vi.mock("../collectors/CursorCollector", () => ({
+  CursorCollector: class {},
+}));
+
+vi.mock("../collectors/NavigationCollector", () => ({
+  NavigationCollector: class {},
+}));
+
+vi.mock("../collectors/ViewportCollector", () => ({
+  ViewportCollector: class {},
+}));
+
+vi.mock("../collectors/KeyboardCollector", () => ({
+  KeyboardCollector: class {},
+}));
+
+describe("content internal development features", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    document.body.innerHTML = '<div can-collect="true">collectable</div>';
+    document.documentElement.dataset.playhtml = "true";
+
+    storageGet.mockReset();
+    storageGet.mockImplementation((keys: string | string[]) => {
+      if (!Array.isArray(keys)) return Promise.resolve({});
+      if (keys.includes("internalDevFeaturesEnabled")) {
+        return Promise.resolve({ internalDevFeaturesEnabled: false });
+      }
+      if (keys.includes("gameInventory")) {
+        return Promise.resolve({
+          gameInventory: { items: [], totalItems: 0, lastUpdated: 0 },
+        });
+      }
+
+      return Promise.resolve(
+        Object.fromEntries(
+          keys
+            .filter((key) => key.startsWith("migration_v1_done_"))
+            .map((key) => [key, true]),
+        ),
+      );
+    });
+
+    storageSet.mockReset();
+    storageSet.mockResolvedValue(undefined);
+
+    runtimeSendMessage.mockReset();
+    runtimeSendMessage.mockImplementation((message: { type?: string }) => {
+      if (message.type === "GET_PLAYER_IDENTITY") {
+        return Promise.resolve({
+          publicKey: "pk_test",
+          playerStyle: { colorPalette: ["#4a9a8a"] },
+          discoveredSites: [],
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it("does not initialize inventory discovery or collection observers when internal dev features are off", async () => {
+    const observe = vi.fn();
+    const mutationObserver = vi.fn(function () {
+      return { observe, disconnect: vi.fn(), takeRecords: vi.fn(() => []) };
+    });
+    vi.stubGlobal("MutationObserver", mutationObserver);
+
+    const contentScript = (await import("../entrypoints/content")).default as {
+      main: () => void;
+    };
+
+    contentScript.main();
+
+    await vi.waitFor(() => {
+      expect(runtimeSendMessage).toHaveBeenCalledWith({
+        type: "UPDATE_SITE_DISCOVERY",
+        domain: window.location.hostname,
+      });
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(storageGet).toHaveBeenCalledWith(["internalDevFeaturesEnabled"]);
+    expect(storageGet).not.toHaveBeenCalledWith(["gameInventory"]);
+    expect(mutationObserver).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/__tests__/content-milestone-toast.test.ts
+++ b/extension/src/__tests__/content-milestone-toast.test.ts
@@ -91,6 +91,12 @@ const milestone = {
   period: "alltime",
 } as const;
 
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean | void;
+
 describe("content milestone toasts", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -109,10 +115,12 @@ describe("content milestone toasts", () => {
     contentScript.main();
 
     const addListener = vi.mocked(browser.runtime.onMessage.addListener);
-    const listener = addListener.mock.calls[0][0];
+    const listener = addListener.mock.calls[0][0] as RuntimeMessageListener;
 
     const firstResponse = await new Promise((resolve) => {
-      listener({ type: "SHOW_MILESTONE", milestone }, {}, resolve);
+      listener({ type: "SHOW_MILESTONE", milestone }, {}, (response) => {
+        resolve(response);
+      });
     });
 
     expect(firstResponse).toEqual({ success: true });
@@ -125,7 +133,9 @@ describe("content milestone toasts", () => {
           milestone: { ...milestone, copy: "You crossed another milestone." },
         },
         {},
-        resolve,
+        (response) => {
+          resolve(response);
+        },
       );
     });
 

--- a/extension/src/__tests__/content-milestone-toast.test.ts
+++ b/extension/src/__tests__/content-milestone-toast.test.ts
@@ -110,21 +110,26 @@ describe("content milestone toasts", () => {
 
     const addListener = vi.mocked(browser.runtime.onMessage.addListener);
     const listener = addListener.mock.calls[0][0];
-    const sendResponse = vi.fn();
 
-    listener({ type: "SHOW_MILESTONE", milestone }, {}, sendResponse);
+    const firstResponse = await new Promise((resolve) => {
+      listener({ type: "SHOW_MILESTONE", milestone }, {}, resolve);
+    });
 
+    expect(firstResponse).toEqual({ success: true });
     expect(document.body.childElementCount).toBe(1);
 
-    listener(
-      {
-        type: "SHOW_MILESTONE",
-        milestone: { ...milestone, copy: "You crossed another milestone." },
-      },
-      {},
-      sendResponse,
-    );
+    const secondResponse = await new Promise((resolve) => {
+      listener(
+        {
+          type: "SHOW_MILESTONE",
+          milestone: { ...milestone, copy: "You crossed another milestone." },
+        },
+        {},
+        resolve,
+      );
+    });
 
+    expect(secondResponse).toEqual({ success: true });
     expect(document.body.childElementCount).toBe(1);
   });
 });

--- a/extension/src/collectors/BaseCollector.ts
+++ b/extension/src/collectors/BaseCollector.ts
@@ -103,6 +103,10 @@ export abstract class BaseCollector<T = unknown> {
   setRealTimeCallback(callback: (data: T) => void): void {
     this.onRealTimeCallback = callback;
   }
+
+  protected hasRealTimeCallback(): boolean {
+    return this.onRealTimeCallback !== undefined;
+  }
   
   /**
    * Emit an event to both buffers (archival) and real-time streams

--- a/extension/src/collectors/BaseCollector.ts
+++ b/extension/src/collectors/BaseCollector.ts
@@ -24,8 +24,9 @@ export abstract class BaseCollector<T = unknown> {
   protected sampleRate: number = 100; // ms between samples (default)
   
   // Callbacks for emitting events
-  private onEmitCallback?: (event: T) => void;
+  private onEmitCallback?: (event: T) => void | Promise<void>;
   private onRealTimeCallback?: (data: T) => void;
+  private pendingEventEmits = new Set<Promise<void>>();
   
   /**
    * Start collecting data
@@ -46,6 +47,11 @@ export abstract class BaseCollector<T = unknown> {
   protected sample(): T | null {
     return null;
   }
+
+  /**
+   * Emit any pending debounced data before this collector stops accepting emissions.
+   */
+  protected drainPendingEvents(): void {}
   
   /**
    * Enable this collector
@@ -62,6 +68,7 @@ export abstract class BaseCollector<T = unknown> {
    */
   disable(): void {
     if (this.enabled) {
+      this.drainPendingEvents();
       this.enabled = false;
       this.stop();
     }
@@ -93,7 +100,7 @@ export abstract class BaseCollector<T = unknown> {
   /**
    * Set the callback for buffered events (archival)
    */
-  setEmitCallback(callback: (event: T) => void): void {
+  setEmitCallback(callback: (event: T) => void | Promise<void>): void {
     this.onEmitCallback = callback;
   }
   
@@ -116,7 +123,17 @@ export abstract class BaseCollector<T = unknown> {
 
     // Emit to buffer for archival
     if (this.onEmitCallback) {
-      this.onEmitCallback(data);
+      const result = this.onEmitCallback(data);
+      if (result) {
+        const pending = Promise.resolve(result)
+          .catch((error) => {
+            console.error(`[BaseCollector] Emit callback failed for ${this.type}:`, error);
+          })
+          .finally(() => {
+            this.pendingEventEmits.delete(pending);
+          });
+        this.pendingEventEmits.add(pending);
+      }
     } else {
       console.warn(`[BaseCollector] No emit callback set for ${this.type}`);
     }
@@ -134,6 +151,10 @@ export abstract class BaseCollector<T = unknown> {
     if (this.onRealTimeCallback) {
       this.onRealTimeCallback(data);
     }
+  }
+
+  async waitForPendingEvents(): Promise<void> {
+    await Promise.all(Array.from(this.pendingEventEmits));
   }
   
   /**

--- a/extension/src/collectors/CollectorManager.ts
+++ b/extension/src/collectors/CollectorManager.ts
@@ -227,13 +227,16 @@ export class CollectorManager {
    * Stop all enabled collectors, flushing any pending buffered events.
    * Called on beforeunload to avoid losing in-flight debounce/throttle data.
    */
-  stopAll(): void {
+  async stopAll(): Promise<void> {
+    const stoppingCollectors: BaseCollector<any>[] = [];
     for (const collector of this.collectors.values()) {
       if (collector.isEnabled()) {
         collector.disable();
+        stoppingCollectors.push(collector);
       }
     }
-    void this.eventBuffer.manualFlush();
+    await Promise.all(stoppingCollectors.map((collector) => collector.waitForPendingEvents()));
+    await this.eventBuffer.manualFlush();
   }
 
   /**

--- a/extension/src/collectors/CollectorManager.ts
+++ b/extension/src/collectors/CollectorManager.ts
@@ -224,8 +224,8 @@ export class CollectorManager {
   }
 
   /**
-   * Stop all enabled collectors, flushing any pending buffered events.
-   * Called on beforeunload to avoid losing in-flight debounce/throttle data.
+   * Stop all enabled collectors, then flush buffered events.
+   * Browser unload callers should treat this as best effort.
    */
   async stopAll(): Promise<void> {
     const stoppingCollectors: BaseCollector<any>[] = [];

--- a/extension/src/collectors/CollectorManager.ts
+++ b/extension/src/collectors/CollectorManager.ts
@@ -233,6 +233,7 @@ export class CollectorManager {
         collector.disable();
       }
     }
+    void this.eventBuffer.manualFlush();
   }
 
   /**

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -52,12 +52,6 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
   private mouseDownScrollY: number = 0;
   private holdThreshold = 250; // ms to distinguish click vs hold
   
-  // Click debouncing (similar to zoom/resize/navigation)
-  private clickDebounce = 2000; // ms - wait for rapid clicks to settle
-  private clickTimer: number | null = null;
-  private clickQuantity = 0; // Count clicks during debounce window
-  private pendingClickData: CursorEventData | null = null; // Store last click data
-  
   start(): void {
     // Note: enable() already checks if enabled, so we don't need to check here
     if (VERBOSE) {
@@ -160,7 +154,6 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
           duration: duration,
         });
       } else {
-        // Click events are debounced to handle rapid clicking
         this.handleClick({
           ...normalized,
           scrollX: this.mouseDownScrollX,
@@ -187,18 +180,6 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     }
   }
   
-  protected drainPendingEvents(): void {
-    if (this.pendingClickData) {
-      const dataWithQuantity: CursorEventData = {
-        ...this.pendingClickData,
-        quantity: this.clickQuantity,
-      };
-      this.emitDiscreteEvent(dataWithQuantity);
-      this.pendingClickData = null;
-      this.clickQuantity = 0;
-    }
-  }
-
   stop(): void {
     if (this.mouseMoveHandler) {
       document.removeEventListener('mousemove', this.mouseMoveHandler);
@@ -223,12 +204,6 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     if (this.sampleTimer !== null) {
       clearTimeout(this.sampleTimer);
       this.sampleTimer = null;
-    }
-
-    // Clear click debounce timer
-    if (this.clickTimer !== null) {
-      clearTimeout(this.clickTimer);
-      this.clickTimer = null;
     }
 
     // Clear cursor change debounce timer
@@ -329,43 +304,11 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     this.emitRealTime(data);
   }
   
-  /**
-   * Handle click events with debouncing
-   * Similar to zoom/resize/navigation - debounces rapid clicks within 2s window
-   */
   private handleClick(clickData: CursorEventData): void {
-    // Increment quantity counter for this debounce window
-    this.clickQuantity++;
-    
-    // Store the latest click data (position, target, button)
-    this.pendingClickData = clickData;
-    
-    // Clear existing timer
-    if (this.clickTimer !== null) {
-      clearTimeout(this.clickTimer);
-    }
-    
-    // Set new timer
-    this.clickTimer = window.setTimeout(() => {
-      if (this.pendingClickData) {
-        // Emit click event with quantity
-        const dataWithQuantity: CursorEventData = {
-          ...this.pendingClickData,
-          quantity: this.clickQuantity,
-        };
-        
-        if (VERBOSE) {
-          console.log(`[CursorCollector] Emitting click event (${this.clickQuantity} clicks):`, dataWithQuantity);
-        }
-        
-        this.emitDiscreteEvent(dataWithQuantity);
-        
-        // Reset state
-        this.pendingClickData = null;
-        this.clickQuantity = 0;
-      }
-      this.clickTimer = null;
-    }, this.clickDebounce);
+    this.emitDiscreteEvent({
+      ...clickData,
+      quantity: 1,
+    });
   }
   
   /**

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -33,6 +33,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
   private cursorChangeTimer: number | null = null;
   private cursorChangeDebounce = 500; // ms - debounce rapid cursor style changes
   private pendingCursorStyle: string | undefined;
+  private lastCursorStyleTarget: HTMLElement | null = null;
 
   // Last sampled position (for movement threshold)
   private lastSampledX = 0;
@@ -78,24 +79,28 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
         // Create a simple selector (tag + id/class if available)
         this.currentTarget = getElementSelector(target);
 
-        // Detect cursor style changes (debounced)
-        const computedStyle = window.getComputedStyle(target);
-        const cursorStyle = computedStyle.cursor || 'auto';
-        this.currentCursorStyle = cursorStyle;
+        if (target !== this.lastCursorStyleTarget) {
+          this.lastCursorStyleTarget = target;
 
-        if (this.lastCursorStyle === undefined) {
-          this.lastCursorStyle = cursorStyle;
-        } else if (this.lastCursorStyle !== cursorStyle) {
-          this.pendingCursorStyle = cursorStyle;
-          if (this.cursorChangeTimer === null) {
-            this.cursorChangeTimer = window.setTimeout(() => {
-              this.cursorChangeTimer = null;
-              // Only emit if cursor actually settled on a different style
-              if (this.pendingCursorStyle !== undefined && this.pendingCursorStyle !== this.lastCursorStyle) {
-                this.lastCursorStyle = this.pendingCursorStyle;
-                this.emitCursorChangeEvent();
-              }
-            }, this.cursorChangeDebounce);
+          // Detect cursor style changes (debounced)
+          const computedStyle = window.getComputedStyle(target);
+          const cursorStyle = computedStyle.cursor || 'auto';
+          this.currentCursorStyle = cursorStyle;
+
+          if (this.lastCursorStyle === undefined) {
+            this.lastCursorStyle = cursorStyle;
+          } else if (this.lastCursorStyle !== cursorStyle) {
+            this.pendingCursorStyle = cursorStyle;
+            if (this.cursorChangeTimer === null) {
+              this.cursorChangeTimer = window.setTimeout(() => {
+                this.cursorChangeTimer = null;
+                // Only emit if cursor actually settled on a different style
+                if (this.pendingCursorStyle !== undefined && this.pendingCursorStyle !== this.lastCursorStyle) {
+                  this.lastCursorStyle = this.pendingCursorStyle;
+                  this.emitCursorChangeEvent();
+                }
+              }, this.cursorChangeDebounce);
+            }
           }
         }
       }
@@ -174,8 +179,9 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     document.addEventListener('mousedown', this.mouseDownHandler, { passive: true });
     document.addEventListener('mouseup', this.mouseUpHandler, { passive: true });
     
-    // Start animation frame loop for real-time updates
-    this.startRealTimeLoop();
+    if (this.hasRealTimeCallback()) {
+      this.startRealTimeLoop();
+    }
     if (VERBOSE) {
       console.log('[CursorCollector] Started successfully');
     }
@@ -300,6 +306,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     };
     
     // Emit to real-time stream (PartyKit)
+    if (!this.hasRealTimeCallback()) return;
     this.emitRealTime(data);
   }
   

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -99,8 +99,9 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
         }
       }
       
-      // Schedule real-time update
-      this.scheduleRealTimeUpdate();
+      if (this.hasRealTimeCallback()) {
+        this.scheduleRealTimeUpdate();
+      }
 
       // Schedule archival sample if movement is significant enough
       const dx = Math.abs(this.currentX - this.lastSampledX);

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -187,6 +187,18 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     }
   }
   
+  protected drainPendingEvents(): void {
+    if (this.pendingClickData) {
+      const dataWithQuantity: CursorEventData = {
+        ...this.pendingClickData,
+        quantity: this.clickQuantity,
+      };
+      this.emitDiscreteEvent(dataWithQuantity);
+      this.pendingClickData = null;
+      this.clickQuantity = 0;
+    }
+  }
+
   stop(): void {
     if (this.mouseMoveHandler) {
       document.removeEventListener('mousemove', this.mouseMoveHandler);
@@ -223,17 +235,6 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     if (this.cursorChangeTimer !== null) {
       clearTimeout(this.cursorChangeTimer);
       this.cursorChangeTimer = null;
-    }
-    
-    // Emit any pending click before stopping
-    if (this.pendingClickData) {
-      const dataWithQuantity: CursorEventData = {
-        ...this.pendingClickData,
-        quantity: this.clickQuantity,
-      };
-      this.emitDiscreteEvent(dataWithQuantity);
-      this.pendingClickData = null;
-      this.clickQuantity = 0;
     }
   }
   

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -64,15 +64,28 @@ export default defineContentScript({
           this.setupElementPicker();
           this.setupPresenceDetection();
 
-          // Check if this is a new site discovery
-          await this.checkSiteDiscovery();
+          if (await this.areInternalDevFeaturesEnabled()) {
+            // Check if this is a new site discovery
+            await this.checkSiteDiscovery();
 
-          // Set up collection detection for can-collect elements
-          this.setupCollectionDetection();
+            // Set up collection detection for can-collect elements
+            this.setupCollectionDetection();
+          }
 
           this.isInitialized = true;
         } catch (error) {
           console.error("Failed to initialize PlayHTML Extension:", error);
+        }
+      }
+
+      private async areInternalDevFeaturesEnabled(): Promise<boolean> {
+        try {
+          const result = await browser.storage.local.get([
+            "internalDevFeaturesEnabled",
+          ]);
+          return result.internalDevFeaturesEnabled === true;
+        } catch {
+          return false;
         }
       }
 

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -1161,9 +1161,9 @@ export default defineContentScript({
         // Initialize manager (loads saved enabled state)
         await collectorManager.init();
 
-        // Flush pending debounced events before the page unloads
+        // Best-effort final flush; browsers may not wait for async unload work.
         window.addEventListener("beforeunload", () => {
-          collectorManager?.stopAll();
+          void collectorManager?.stopAll().catch(console.error);
         }, { once: true });
         if (VERBOSE) {
           console.log(

--- a/extension/src/storage/EventBuffer.ts
+++ b/extension/src/storage/EventBuffer.ts
@@ -15,6 +15,15 @@ interface EventMetadataBase {
   tz: string;
 }
 
+function shouldStoreWithoutDelay(event: CollectionEvent): boolean {
+  return (
+    event.type === 'cursor' &&
+    typeof event.data === 'object' &&
+    event.data !== null &&
+    (event.data as { event?: unknown }).event === 'click'
+  );
+}
+
 /**
  * EventBuffer manages event creation and batching
  *
@@ -26,6 +35,7 @@ export class EventBuffer {
   private batchTimer: number | null = null;
   private storeTimer: number | null = null;
   private pendingEvents: CollectionEvent[] = [];
+  private storeFlushPromise: Promise<boolean> | null = null;
   private metadataBasePromise: Promise<EventMetadataBase> | null = null;
 
   /**
@@ -35,7 +45,10 @@ export class EventBuffer {
     const eventWithFlag = { ...event, uploaded: false };
 
     this.pendingEvents.push(eventWithFlag);
-    if (this.pendingEvents.length >= STORE_BATCH_MAX_EVENTS) {
+    if (
+      shouldStoreWithoutDelay(eventWithFlag) ||
+      this.pendingEvents.length >= STORE_BATCH_MAX_EVENTS
+    ) {
       void this.flushStoredEvents();
     } else {
       this.scheduleStoreFlush();
@@ -59,19 +72,35 @@ export class EventBuffer {
       this.storeTimer = null;
     }
 
+    if (this.storeFlushPromise) {
+      const stored = await this.storeFlushPromise;
+      if (!stored) return false;
+    }
+
     if (this.pendingEvents.length === 0) return true;
 
     const events = this.pendingEvents.splice(0, this.pendingEvents.length);
-    try {
-      await browser.runtime.sendMessage({
+    const flushPromise = browser.runtime
+      .sendMessage({
         type: 'STORE_EVENTS',
         events,
-      });
-      return true;
-    } catch (error) {
-      this.pendingEvents.unshift(...events);
-      console.error(error);
-      return false;
+      })
+      .then(
+        () => true,
+        (error) => {
+          this.pendingEvents.unshift(...events);
+          console.error(error);
+          return false;
+        },
+      );
+
+    this.storeFlushPromise = flushPromise;
+    try {
+      return await flushPromise;
+    } finally {
+      if (this.storeFlushPromise === flushPromise) {
+        this.storeFlushPromise = null;
+      }
     }
   }
 

--- a/extension/src/storage/EventBuffer.ts
+++ b/extension/src/storage/EventBuffer.ts
@@ -6,6 +6,14 @@ import { VERBOSE } from '../config';
 import browser from 'webextension-polyfill';
 
 const BATCH_INTERVAL_MS = 3000; // 3 seconds
+const STORE_BATCH_INTERVAL_MS = 250;
+const STORE_BATCH_MAX_EVENTS = 25;
+
+interface EventMetadataBase {
+  pid: string;
+  sid: string;
+  tz: string;
+}
 
 /**
  * EventBuffer manages event creation and batching
@@ -16,6 +24,9 @@ const BATCH_INTERVAL_MS = 3000; // 3 seconds
  */
 export class EventBuffer {
   private batchTimer: number | null = null;
+  private storeTimer: number | null = null;
+  private pendingEvents: CollectionEvent[] = [];
+  private metadataBasePromise: Promise<EventMetadataBase> | null = null;
 
   /**
    * Add an event — stores it in the background service worker and schedules a flush
@@ -23,12 +34,45 @@ export class EventBuffer {
   async addEvent(event: CollectionEvent): Promise<void> {
     const eventWithFlag = { ...event, uploaded: false };
 
-    browser.runtime.sendMessage({
-      type: 'STORE_EVENTS',
-      events: [eventWithFlag],
-    }).catch(console.error);
+    this.pendingEvents.push(eventWithFlag);
+    if (this.pendingEvents.length >= STORE_BATCH_MAX_EVENTS) {
+      void this.flushStoredEvents();
+    } else {
+      this.scheduleStoreFlush();
+    }
 
     this.scheduleBatch();
+  }
+
+  private scheduleStoreFlush(): void {
+    if (this.storeTimer !== null) return;
+
+    this.storeTimer = window.setTimeout(() => {
+      this.storeTimer = null;
+      void this.flushStoredEvents();
+    }, STORE_BATCH_INTERVAL_MS);
+  }
+
+  private async flushStoredEvents(): Promise<boolean> {
+    if (this.storeTimer !== null) {
+      clearTimeout(this.storeTimer);
+      this.storeTimer = null;
+    }
+
+    if (this.pendingEvents.length === 0) return true;
+
+    const events = this.pendingEvents.splice(0, this.pendingEvents.length);
+    try {
+      await browser.runtime.sendMessage({
+        type: 'STORE_EVENTS',
+        events,
+      });
+      return true;
+    } catch (error) {
+      this.pendingEvents.unshift(...events);
+      console.error(error);
+      return false;
+    }
   }
 
   /**
@@ -51,7 +95,27 @@ export class EventBuffer {
    * Trigger upload of pending events via background service worker
    */
   async flushBatch(): Promise<void> {
+    const stored = await this.flushStoredEvents();
+    if (!stored) return;
     browser.runtime.sendMessage({ type: 'FLUSH_PENDING_UPLOADS' }).catch(console.error);
+  }
+
+  private async getMetadataBase(): Promise<EventMetadataBase> {
+    if (!this.metadataBasePromise) {
+      this.metadataBasePromise = Promise.all([
+        getParticipantId(),
+        getSessionId(),
+      ]).then(([pid, sid]) => ({
+        pid,
+        sid,
+        tz: getTimezone(),
+      }));
+    }
+    const metadata = await this.metadataBasePromise;
+    if (metadata.pid.startsWith('pk_temp_')) {
+      this.metadataBasePromise = null;
+    }
+    return metadata;
   }
 
   /**
@@ -61,10 +125,7 @@ export class EventBuffer {
     type: CollectionEventType,
     data: unknown
   ): Promise<CollectionEvent> {
-    const [pid, sid] = await Promise.all([
-      getParticipantId(),
-      getSessionId(),
-    ]);
+    const { pid, sid, tz } = await this.getMetadataBase();
 
     const { generateULID } = await import('../collectors/types');
 
@@ -79,7 +140,7 @@ export class EventBuffer {
         url: window.location.href,
         vw: window.innerWidth,
         vh: window.innerHeight,
-        tz: getTimezone(),
+        tz,
       },
     };
   }

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -103,10 +103,15 @@ function getUploadState(event: StoredCollectionEvent): UploadState {
 }
 
 function prepareStoredEvent(event: CollectionEvent): StoredCollectionEvent {
-  const storedEvent = event as StoredCollectionEvent;
+  const storedEvent: StoredCollectionEvent = { ...event };
   storedEvent.uploadState = getUploadState(storedEvent);
   storedEvent.uploaded = storedEvent.uploadState === UPLOAD_STATE_UPLOADED;
   return storedEvent;
+}
+
+function toCollectionEvent(event: StoredCollectionEvent): CollectionEvent {
+  const { uploaded, uploadState, ...collectionEvent } = event;
+  return collectionEvent;
 }
 
 export interface ScreenTimeResult {
@@ -436,7 +441,7 @@ export class LocalEventStore {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
+          const evt = cursor.value as StoredCollectionEvent;
 
           let include = true;
           if (options.type && evt.type !== options.type) include = false;
@@ -444,7 +449,7 @@ export class LocalEventStore {
           if (options.endTs && evt.ts > options.endTs) include = false;
 
           if (include) {
-            events.push(evt);
+            events.push(toCollectionEvent(evt));
           }
 
           if (options.limit && events.length >= options.limit) {
@@ -499,7 +504,7 @@ export class LocalEventStore {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
+          const evt = cursor.value as StoredCollectionEvent;
 
           let include = true;
           if (options.type && evt.type !== options.type) include = false;
@@ -507,7 +512,7 @@ export class LocalEventStore {
           if (options.endTs && evt.ts > options.endTs) include = false;
 
           if (include) {
-            events.push(evt);
+            events.push(toCollectionEvent(evt));
           }
 
           if (options.limit && events.length >= options.limit) {
@@ -554,7 +559,7 @@ export class LocalEventStore {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
+          const evt = cursor.value as StoredCollectionEvent;
           totalEvents++;
           eventsByType[evt.type] = (eventsByType[evt.type] || 0) + 1;
           firstVisit = Math.min(firstVisit, evt.ts);
@@ -802,7 +807,7 @@ export class LocalEventStore {
           if (options.type && evt.type !== options.type) include = false;
 
           if (include) {
-            events.push(evt);
+            events.push(toCollectionEvent(evt));
             if (options.limit && events.length >= options.limit) {
               events.sort((a, b) => a.ts - b.ts);
               resolve(events);
@@ -1135,7 +1140,7 @@ export class LocalEventStore {
 
         if (cursor && events.length < limit) {
           const evt = cursor.value as StoredCollectionEvent;
-          events.push(evt as CollectionEvent);
+          events.push(toCollectionEvent(evt));
           cursor.continue();
         } else {
           resolve(events);

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -926,6 +926,7 @@ export class LocalEventStore {
 
     // Group events by domain for stats updates
     const eventsByDomain = new Map<string, CollectionEvent[]>();
+    const storedEvents: StoredCollectionEvent[] = [];
     for (const event of events) {
       const storedEvent = prepareStoredEvent(event);
       if (storedEvent.meta?.url) {
@@ -942,6 +943,7 @@ export class LocalEventStore {
         }
         eventsByDomain.get(storedEvent.domain)!.push(storedEvent);
       }
+      storedEvents.push(storedEvent);
     }
 
     // Write events to the main store
@@ -957,8 +959,8 @@ export class LocalEventStore {
       transaction.oncomplete = () => resolve();
       transaction.onerror = () => reject(transaction.error);
 
-      for (const event of events) {
-        evtStore.put(prepareStoredEvent(event));
+      for (const event of storedEvents) {
+        evtStore.put(event);
       }
     });
 

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -932,8 +932,9 @@ export class LocalEventStore {
     agg: DomainStatsAggregate,
     events: CollectionEvent[],
   ): void {
-    const urlSet = new Set(agg.uniqueUrls);
-    const processedSet = new Set(agg.processedNavIds);
+    const hasNavigationEvents = events.some((evt) => evt.type === "navigation");
+    const urlSet = hasNavigationEvents ? new Set(agg.uniqueUrls) : null;
+    const processedSet = hasNavigationEvents ? new Set(agg.processedNavIds) : null;
     agg.storageSizeBytes ??= 0;
 
     for (const evt of events) {
@@ -945,11 +946,12 @@ export class LocalEventStore {
       if (evt.ts > agg.lastVisit) {
         agg.lastVisit = evt.ts;
       }
-      if (evt.meta?.url) {
+      if (urlSet && evt.meta?.url) {
         urlSet.add(evt.meta.url);
       }
 
       if (evt.type === "navigation") {
+        if (!processedSet) continue;
         if (processedSet.has(evt.id)) continue;
         processedSet.add(evt.id);
 
@@ -974,8 +976,12 @@ export class LocalEventStore {
       }
     }
 
-    agg.uniqueUrls = [...urlSet];
-    agg.processedNavIds = [...processedSet];
+    if (urlSet) {
+      agg.uniqueUrls = [...urlSet];
+    }
+    if (processedSet) {
+      agg.processedNavIds = [...processedSet];
+    }
   }
 
   /**
@@ -1057,7 +1063,8 @@ export class LocalEventStore {
 
       const transaction = this.db.transaction([STORE_NAME], "readonly");
       const store = transaction.objectStore(STORE_NAME);
-      const request = store.openCursor();
+      const uploadedIndex = store.index("uploaded");
+      const request = uploadedIndex.openCursor(IDBKeyRange.only(false));
 
       const events: CollectionEvent[] = [];
 
@@ -1066,9 +1073,7 @@ export class LocalEventStore {
 
         if (cursor && events.length < limit) {
           const evt = cursor.value;
-          if (evt.uploaded !== true) {
-            events.push(evt as CollectionEvent);
-          }
+          events.push(evt as CollectionEvent);
           cursor.continue();
         } else {
           resolve(events);

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -12,6 +12,15 @@ const DB_NAME = "collection_events_db";
 const DB_VERSION = 9;
 const STORE_NAME = "events";
 const STATS_STORE_NAME = "domain_stats";
+const UPLOAD_STATE_PENDING = "pending";
+const UPLOAD_STATE_UPLOADED = "uploaded";
+
+type UploadState = typeof UPLOAD_STATE_PENDING | typeof UPLOAD_STATE_UPLOADED;
+
+interface StoredCollectionEvent extends CollectionEvent {
+  uploaded?: boolean;
+  uploadState?: UploadState;
+}
 
 // Aggregate key for cross-domain totals (all browsing activity combined)
 const GLOBAL_STATS_KEY = "__global__";
@@ -87,6 +96,19 @@ function pageStatsKey(domain: string, normalizedUrl: string): string {
   return `${domain}::${normalizedUrl}`;
 }
 
+function getUploadState(event: StoredCollectionEvent): UploadState {
+  return event.uploaded === true || event.uploadState === UPLOAD_STATE_UPLOADED
+    ? UPLOAD_STATE_UPLOADED
+    : UPLOAD_STATE_PENDING;
+}
+
+function prepareStoredEvent(event: CollectionEvent): StoredCollectionEvent {
+  const storedEvent = event as StoredCollectionEvent;
+  storedEvent.uploadState = getUploadState(storedEvent);
+  storedEvent.uploaded = storedEvent.uploadState === UPLOAD_STATE_UPLOADED;
+  return storedEvent;
+}
+
 export interface ScreenTimeResult {
   totalMs: number;
   sessions: ScreenTimeSession[];
@@ -109,6 +131,7 @@ function extractDomain(url: string | null): string {
 export class LocalEventStore {
   private db: IDBDatabase | null = null;
   private isInitialized = false;
+  private initPromise: Promise<void> | null = null;
 
   constructor() {
     this.init().catch(console.error);
@@ -119,11 +142,15 @@ export class LocalEventStore {
    */
   private async init(): Promise<void> {
     if (this.isInitialized) return;
+    if (this.initPromise) return this.initPromise;
 
-    return new Promise((resolve, reject) => {
+    this.initPromise = new Promise((resolve, reject) => {
       const request = indexedDB.open(DB_NAME, DB_VERSION);
 
-      request.onerror = () => reject(request.error);
+      request.onerror = () => {
+        this.initPromise = null;
+        reject(request.error);
+      };
       request.onblocked = () => {
         console.warn("[LocalEventStore] DB upgrade blocked by another connection");
       };
@@ -134,6 +161,7 @@ export class LocalEventStore {
         if (VERBOSE) {
           console.log("[LocalEventStore] Initialized successfully");
         }
+        this.initPromise = null;
         resolve();
         // Backfill session stats in the background (non-blocking)
         this.backfillSessionStats().catch((e) =>
@@ -240,8 +268,39 @@ export class LocalEventStore {
             console.log("[LocalEventStore] Created domain_stats store (keyPath: key)");
           }
         }
+
+        if (oldVersion < 9) {
+          if (store.indexNames.contains("uploaded")) {
+            store.deleteIndex("uploaded");
+          }
+          if (!store.indexNames.contains("uploadState")) {
+            store.createIndex("uploadState", "uploadState", { unique: false });
+          }
+
+          const tx = (event.target as IDBOpenDBRequest).transaction!;
+          const objStore = tx.objectStore(STORE_NAME);
+          const backfillReq = objStore.openCursor();
+          backfillReq.onsuccess = () => {
+            const cursor = backfillReq.result;
+            if (cursor) {
+              const evt = cursor.value as StoredCollectionEvent;
+              const nextState = getUploadState(evt);
+              if (
+                evt.uploadState !== nextState ||
+                evt.uploaded !== (nextState === UPLOAD_STATE_UPLOADED)
+              ) {
+                evt.uploadState = nextState;
+                evt.uploaded = nextState === UPLOAD_STATE_UPLOADED;
+                cursor.update(evt);
+              }
+              cursor.continue();
+            }
+          };
+        }
       };
     });
+
+    return this.initPromise;
   }
 
   /**
@@ -863,17 +922,20 @@ export class LocalEventStore {
     // Group events by domain for stats updates
     const eventsByDomain = new Map<string, CollectionEvent[]>();
     for (const event of events) {
-      if (event.meta?.url) {
-        if (!event.domain) {
-          event.domain = extractDomain(event.meta.url);
+      const storedEvent = prepareStoredEvent(event);
+      if (storedEvent.meta?.url) {
+        if (!storedEvent.domain) {
+          storedEvent.domain = extractDomain(storedEvent.meta.url);
         }
-        if (!event.normalizedUrl) {
-          event.normalizedUrl = normalizeUrl(event.meta.url);
+        if (!storedEvent.normalizedUrl) {
+          storedEvent.normalizedUrl = normalizeUrl(storedEvent.meta.url);
         }
       }
-      if (event.domain) {
-        if (!eventsByDomain.has(event.domain)) eventsByDomain.set(event.domain, []);
-        eventsByDomain.get(event.domain)!.push(event);
+      if (storedEvent.domain) {
+        if (!eventsByDomain.has(storedEvent.domain)) {
+          eventsByDomain.set(storedEvent.domain, []);
+        }
+        eventsByDomain.get(storedEvent.domain)!.push(storedEvent);
       }
     }
 
@@ -891,7 +953,7 @@ export class LocalEventStore {
       transaction.onerror = () => reject(transaction.error);
 
       for (const event of events) {
-        evtStore.put(event);
+        evtStore.put(prepareStoredEvent(event));
       }
     });
 
@@ -1063,8 +1125,8 @@ export class LocalEventStore {
 
       const transaction = this.db.transaction([STORE_NAME], "readonly");
       const store = transaction.objectStore(STORE_NAME);
-      const uploadedIndex = store.index("uploaded");
-      const request = uploadedIndex.openCursor(IDBKeyRange.only(false));
+      const uploadStateIndex = store.index("uploadState");
+      const request = uploadStateIndex.openCursor(IDBKeyRange.only(UPLOAD_STATE_PENDING));
 
       const events: CollectionEvent[] = [];
 
@@ -1072,7 +1134,7 @@ export class LocalEventStore {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor && events.length < limit) {
-          const evt = cursor.value;
+          const evt = cursor.value as StoredCollectionEvent;
           events.push(evt as CollectionEvent);
           cursor.continue();
         } else {
@@ -1110,6 +1172,7 @@ export class LocalEventStore {
           const evt = getRequest.result;
           if (evt) {
             evt.uploaded = true;
+            evt.uploadState = UPLOAD_STATE_UPLOADED;
             store.put(evt);
           }
           completed++;

--- a/scripts/trace-extension-performance.mjs
+++ b/scripts/trace-extension-performance.mjs
@@ -1,0 +1,437 @@
+// ABOUTME: Runs a deterministic Chrome trace against an unpacked extension build.
+// ABOUTME: Prints renderer performance metrics and writes trace JSON for comparison.
+
+import { createServer } from "node:http";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const playwrightChromePath = resolve(
+  homedir(),
+  "Library/Caches/ms-playwright/chromium-1217/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+);
+const chromePathCandidates = [
+  playwrightChromePath,
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+];
+const defaultChromePath =
+  chromePathCandidates.find((candidate) => existsSync(candidate)) ?? chromePathCandidates[0];
+const RUN_TIMEOUT_MS = 60_000;
+
+function parseArgs(argv) {
+  const args = {
+    chromePath: defaultChromePath,
+    runs: 1,
+    outDir: "/private/tmp/playhtml-extension-traces",
+    labels: [],
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--chrome-path") {
+      args.chromePath = argv[++i];
+    } else if (arg === "--runs") {
+      args.runs = Number(argv[++i]);
+    } else if (arg === "--out-dir") {
+      args.outDir = argv[++i];
+    } else if (arg === "--extension") {
+      const raw = argv[++i];
+      const splitAt = raw.indexOf(":");
+      if (splitAt === -1) {
+        throw new Error("--extension expects label:/absolute/path");
+      }
+      args.labels.push({
+        label: raw.slice(0, splitAt),
+        extensionPath: resolve(raw.slice(splitAt + 1)),
+      });
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.labels.length === 0) {
+    throw new Error("Pass at least one --extension label:/absolute/path");
+  }
+  if (!Number.isInteger(args.runs) || args.runs < 1) {
+    throw new Error("--runs must be a positive integer");
+  }
+
+  return args;
+}
+
+function pageHtml() {
+  const blocks = Array.from({ length: 60 }, (_, index) => {
+    return `<p>Trace row ${
+      index + 1
+    }: this paragraph gives the page enough height for scroll collection and enough text for layout work.</p>`;
+  }).join("\n");
+
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>we were online performance trace</title>
+    <style>
+      body {
+        margin: 0;
+        font: 16px system-ui, sans-serif;
+        min-height: 6000px;
+        background: #f7f5f0;
+      }
+      header {
+        position: sticky;
+        top: 0;
+        padding: 24px;
+        background: white;
+        border-bottom: 1px solid #ddd;
+      }
+      #hover-target {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 360px;
+        height: 180px;
+        margin: 16px 0;
+        border: 1px solid #648f88;
+        background: #e3f0ec;
+        cursor: pointer;
+      }
+      input {
+        display: block;
+        width: 360px;
+        padding: 12px;
+        margin-top: 12px;
+        font: inherit;
+      }
+      main {
+        padding: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Extension performance trace</h1>
+      <button id="hover-target">Stable pointer target</button>
+      <input id="typing-target" value="" placeholder="Typing target">
+    </header>
+    <main>${blocks}</main>
+  </body>
+</html>`;
+}
+
+async function withServer(callback) {
+  const server = createServer((req, res) => {
+    if (req.url === "/favicon.ico") {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+    res.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    });
+    res.end(pageHtml());
+  });
+
+  await new Promise((resolveServer) => {
+    server.listen(0, "127.0.0.1", resolveServer);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Could not resolve local trace server port");
+  }
+
+  try {
+    return await callback(`http://127.0.0.1:${address.port}/`);
+  } finally {
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+}
+
+async function readTraceStream(client, stream) {
+  let result = "";
+  while (true) {
+    const chunk = await client.send("IO.read", { handle: stream });
+    result += chunk.data ?? "";
+    if (chunk.eof) break;
+  }
+  await client.send("IO.close", { handle: stream });
+  return result;
+}
+
+async function collectTrace(client) {
+  const done = new Promise((resolveDone) => {
+    client.once("Tracing.tracingComplete", resolveDone);
+  });
+  await client.send("Tracing.end");
+  const event = await done;
+  return readTraceStream(client, event.stream);
+}
+
+function metricsMap(metricsResponse) {
+  return Object.fromEntries(
+    metricsResponse.metrics.map((metric) => [metric.name, metric.value]),
+  );
+}
+
+function diffMetrics(before, after) {
+  const names = [
+    "TaskDuration",
+    "ScriptDuration",
+    "LayoutDuration",
+    "RecalcStyleDuration",
+    "JSHeapUsedSize",
+  ];
+  return Object.fromEntries(
+    names.map((name) => [name, (after[name] ?? 0) - (before[name] ?? 0)]),
+  );
+}
+
+function traceSummary(traceText) {
+  const parsed = JSON.parse(traceText);
+  const mainThreadIds = new Set();
+
+  for (const event of parsed.traceEvents ?? []) {
+    if (
+      event.ph === "M" &&
+      event.name === "thread_name" &&
+      event.args?.name === "CrRendererMain"
+    ) {
+      mainThreadIds.add(`${event.pid}:${event.tid}`);
+    }
+  }
+
+  const totals = new Map();
+  for (const event of parsed.traceEvents ?? []) {
+    if (event.ph !== "X" || typeof event.dur !== "number") continue;
+    if (!mainThreadIds.has(`${event.pid}:${event.tid}`)) continue;
+    totals.set(event.name, (totals.get(event.name) ?? 0) + event.dur / 1000);
+  }
+
+  const top = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12)
+    .map(([name, durationMs]) => ({ name, durationMs }));
+
+  return {
+    rendererMainThreadCount: mainThreadIds.size,
+    topRendererEvents: top,
+  };
+}
+
+async function setExtensionStorage(context, page, url) {
+  let worker = context.serviceWorkers().find((candidate) =>
+    candidate.url().startsWith("chrome-extension://"),
+  );
+  if (!worker) {
+    const workerReady = context.waitForEvent("serviceworker", {
+      timeout: 10_000,
+    });
+    await page.goto(`${url}?warmup=1`, { waitUntil: "domcontentloaded" });
+    worker = await workerReady;
+  }
+
+  await worker.evaluate(() => {
+    return new Promise((resolveStorage) => {
+      chrome.storage.local.set(
+        {
+          onboarding_complete: true,
+          playerIdentity: {
+            publicKey: "pk_" + "1".repeat(130),
+            privateKey: {},
+            playerStyle: {
+              colorPalette: ["#4a9a8a"],
+              animationStyle: "gentle",
+              interactionPatterns: [],
+            },
+            createdAt: Date.now(),
+            discoveredSites: [],
+          },
+          collection_mode_cursor: "local",
+          collection_mode_navigation: "local",
+          collection_mode_viewport: "local",
+          collection_mode_keyboard: "local",
+          collection_keyboard_privacy_level: 0,
+          collection_keyboard_filter_substrings: [],
+        },
+        resolveStorage,
+      );
+    });
+  });
+}
+
+async function runScenario(page, url) {
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(750);
+
+  const target = page.locator("#hover-target");
+  const box = await target.boundingBox();
+  if (!box) throw new Error("Trace target did not render");
+  const centerX = box.x + box.width / 2;
+  const centerY = box.y + box.height / 2;
+
+  await page.mouse.move(centerX, centerY);
+  await page.waitForTimeout(500);
+
+  await page.locator("#typing-target").click();
+  await page.keyboard.type("grounded performance trace input", { delay: 15 });
+
+  for (let i = 0; i < 240; i++) {
+    await page.mouse.move(
+      centerX - 120 + (i % 24) * 10,
+      centerY - 60 + (i % 12) * 10,
+    );
+    if (i % 12 === 0) await page.waitForTimeout(12);
+  }
+
+  for (let i = 0; i < 28; i++) {
+    await page.mouse.wheel(0, 160);
+    await page.waitForTimeout(35);
+  }
+
+  await page.waitForTimeout(3_000);
+}
+
+async function runOne({ chromePath, extensionPath, label, outDir, runIndex, url }) {
+  const safeLabel = label.replace(/[^a-z0-9_-]/gi, "_");
+  const userDataDir = resolve(outDir, `${safeLabel}-profile-${runIndex}-${process.pid}`);
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    executablePath: chromePath,
+    headless: false,
+    ignoreDefaultArgs: ["--disable-extensions"],
+    viewport: { width: 1280, height: 900 },
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      "--disable-background-networking",
+      "--disable-default-apps",
+      "--disable-sync",
+      "--no-default-browser-check",
+      "--no-first-run",
+    ],
+  });
+
+  let timeoutId;
+  let timedOut = false;
+  const timeout = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      timedOut = true;
+      context.close().catch(() => {});
+      reject(
+        new Error(`${label} run ${runIndex} timed out after ${RUN_TIMEOUT_MS}ms`),
+      );
+    }, RUN_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([runTraceScenario(), timeout]);
+  } finally {
+    clearTimeout(timeoutId);
+    if (!timedOut) {
+      await context.close().catch(() => {});
+    }
+  }
+
+  async function runTraceScenario() {
+    const page = await context.newPage();
+    await setExtensionStorage(context, page, url);
+    const client = await context.newCDPSession(page);
+    await client.send("Performance.enable");
+
+    const before = metricsMap(await client.send("Performance.getMetrics"));
+    await client.send("Tracing.start", {
+      transferMode: "ReturnAsStream",
+      categories: [
+        "devtools.timeline",
+        "disabled-by-default-devtools.timeline",
+        "v8.execute",
+        "blink.user_timing",
+      ].join(","),
+    });
+
+    await runScenario(page, url);
+
+    const after = metricsMap(await client.send("Performance.getMetrics"));
+    const traceText = await collectTrace(client);
+    const tracePath = resolve(outDir, `${safeLabel}-run-${runIndex}.trace.json`);
+    await writeFile(tracePath, traceText);
+
+    return {
+      label,
+      runIndex,
+      tracePath,
+      metrics: diffMetrics(before, after),
+      trace: traceSummary(traceText),
+    };
+  }
+}
+
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function summarize(results) {
+  const byLabel = new Map();
+  for (const result of results) {
+    if (!byLabel.has(result.label)) byLabel.set(result.label, []);
+    byLabel.get(result.label).push(result);
+  }
+
+  return [...byLabel.entries()].map(([label, items]) => ({
+    label,
+    runs: items.length,
+    meanMetrics: Object.fromEntries(
+      Object.keys(items[0].metrics).map((metric) => [
+        metric,
+        mean(items.map((item) => item.metrics[metric])),
+      ]),
+    ),
+    traces: items.map((item) => item.tracePath),
+    topRendererEvents: items[0].trace.topRendererEvents,
+  }));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  await mkdir(args.outDir, { recursive: true });
+
+  const results = await withServer(async (url) => {
+    const all = [];
+    for (const extension of args.labels) {
+      for (let runIndex = 1; runIndex <= args.runs; runIndex++) {
+        console.log(`Tracing ${extension.label} run ${runIndex}/${args.runs}`);
+        all.push(await runOne({
+          chromePath: args.chromePath,
+          extensionPath: extension.extensionPath,
+          label: extension.label,
+          outDir: args.outDir,
+          runIndex,
+          url,
+        }));
+      }
+    }
+    return all;
+  });
+
+  const summary = {
+    createdAt: new Date().toISOString(),
+    repoRoot,
+    runs: results,
+    summary: summarize(results),
+  };
+
+  const summaryPath = resolve(args.outDir, "summary.json");
+  await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  console.log(JSON.stringify(summary.summary, null, 2));
+  console.log(`Trace summary: ${summaryPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- reduces always-on content-script CPU work by stopping idle cursor animation frames and mousemove real-time throttle work unless real-time cursor callbacks are active
- batches event-buffer storage writes and caches event metadata used during queueing
- moves pending-upload reads to a valid string IndexedDB key and migrates existing local rows safely
- keeps upload bookkeeping local to IndexedDB so pending/uploaded state does not leak into outgoing collection payloads
- derives domain and normalized URL indexes on the exact event rows written to IndexedDB, so content-script events remain queryable by domain and URL
- stores click events without a debounce delay and waits for active storage writes before triggering background upload flushes
- improves aggregate event reads to avoid unnecessary navigation-array copies while preserving the aggregate-backed storage-size accounting from latest `main`
- gates dev-only content-script discovery observers behind the internal dev feature flag
- adds a Chrome trace harness for production extension builds so performance work can be measured instead of guessed

## Rationale

Users reported high CPU usage in the browser extension, especially on Firefox. The hottest shared paths were work performed while collecting events and content-script observers running on ordinary pages. This PR reduces background work that was happening even when the extension did not need to render live cursor state, lowers IndexedDB pressure during event collection, and prevents development-only observers from running in production-like extension sessions unless explicitly enabled.

The pending-upload optimization now uses `uploadState: "pending" | "uploaded"` rather than querying the existing boolean `uploaded` index. IndexedDB does not support boolean keys for key-range queries, so the local DB upgrade backfills `uploadState` from existing rows and keeps the boolean flag only for local storage/index compatibility.

The migration and review fixes keep storage metadata out of returned `CollectionEvent` objects while preserving the indexed fields needed for local queries. New writes clone the source event before adding local metadata, persisted reads strip `uploaded`/`uploadState`, and content-script events without precomputed indexes are still stored with `domain` and `normalizedUrl` on the row that IndexedDB indexes.

## Performance Evidence

Production Chrome trace comparison against the parent commit on the same machine:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| TaskDuration | 2.673s | 0.296s | -88.9% |
| ScriptDuration | 0.518s | 0.044s | -91.5% |
| LayoutDuration | 0.021s | 0.006s | -73.8% |
| RecalcStyleDuration | 0.014s | 0.004s | -70.8% |
| JSHeapUsedSize | 3.67 MB | 3.48 MB | -5.4% |

The trace harness uses production extension builds rather than WXT dev/HMR sessions, because dev mode adds unrelated background work and would make the profile noisy.

## Validation

- rebased onto latest `main` (`518c8d0`)
- `bun run test -- run` from `extension/`: 35 files, 239 tests passed
- `bun run build` from `extension/`: passed
- `bun run build:firefox` from `extension/`: passed
- `node --check scripts/trace-extension-performance.mjs`: passed
- `git diff --check`: passed
- GitHub Actions `PR Validation` run #287: passed
- GitHub Actions `pkg.pr.new` run #385: passed
- `bunx tsc --noEmit` from `extension/`: still fails on pre-existing website/shared trail settings, worker Cloudflare global types, and WXT manifest typing errors; no PR-local typecheck errors are introduced here

## Notes

The next step is the stacked report-only workflow for trace comparisons on future PRs.