### PR TITLE
Fix Wikipedia portal target selection

### DIFF
--- a/extension/src/__tests__/PresenceCountPill.test.ts
+++ b/extension/src/__tests__/PresenceCountPill.test.ts
@@ -65,6 +65,7 @@ describe("PresenceCountPill", () => {
             page: {
               url: "https://en.wikipedia.org/wiki/Stale",
               title: "Stale",
+              visible: true,
               lastSeenAt: Date.now() - 60_000,
             },
           },
@@ -123,6 +124,47 @@ describe("PresenceCountPill", () => {
     pill.destroy();
   });
 
+  it("does not show the jump portal for Wikipedia media views", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
+    setLocation("https://en.wikipedia.org/wiki/Current");
+
+    const pagePresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+      ]),
+    );
+    const lobbyPresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+        [
+          "peer",
+          {
+            isMe: false,
+            playerIdentity: identity("peer"),
+            page: {
+              url: "https://en.wikipedia.org/wiki/Octopus#/media/File:Octopus.jpg",
+              title: "Octopus",
+              visible: true,
+              lastSeenAt: Date.now(),
+            },
+          },
+        ],
+      ]),
+    );
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(
+      document.querySelector('button[title="jump to someone"]'),
+    ).toBeNull();
+
+    pill.destroy();
+  });
+
   it("jumps to a fresh lobby page instead of a stale one", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
@@ -147,6 +189,7 @@ describe("PresenceCountPill", () => {
             page: {
               url: "https://en.wikipedia.org/wiki/Stale",
               title: "Stale",
+              visible: true,
               lastSeenAt: Date.now() - 60_000,
             },
           },

--- a/extension/src/__tests__/PresenceCountPill.test.ts
+++ b/extension/src/__tests__/PresenceCountPill.test.ts
@@ -82,6 +82,47 @@ describe("PresenceCountPill", () => {
     pill.destroy();
   });
 
+  it("does not show the jump portal for fresh hidden lobby pages", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
+    setLocation("https://en.wikipedia.org/wiki/Current");
+
+    const pagePresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+      ]),
+    );
+    const lobbyPresence = presenceApi(
+      "me",
+      new Map([
+        ["me", { isMe: true, playerIdentity: identity("me") }],
+        [
+          "peer",
+          {
+            isMe: false,
+            playerIdentity: identity("peer"),
+            page: {
+              url: "https://en.wikipedia.org/wiki/Hidden",
+              title: "Hidden",
+              visible: false,
+              lastSeenAt: Date.now(),
+            },
+          },
+        ],
+      ]),
+    );
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(
+      document.querySelector('button[title="jump to someone"]'),
+    ).toBeNull();
+
+    pill.destroy();
+  });
+
   it("jumps to a fresh lobby page instead of a stale one", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
@@ -118,6 +159,7 @@ describe("PresenceCountPill", () => {
             page: {
               url: "https://en.wikipedia.org/wiki/Fresh",
               title: "Fresh",
+              visible: true,
               lastSeenAt: Date.now(),
             },
           },

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -14,6 +14,7 @@ export interface WikiPresenceFields {
     color: string;
     pid?: string;
     lastSeenAt?: number;
+    visible?: boolean;
   } | null;
 }
 
@@ -280,22 +281,32 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   if (typeof deps.createPresenceRoom === "function") {
     const lobby = deps.createPresenceRoom("lobby");
     const publishLobbyPage = () => {
+      if (document.visibilityState !== "visible") {
+        lobby.presence.setMyPresence("page", null);
+        return;
+      }
       lobby.presence.setMyPresence("page", {
         url: location.href,
         title: document.title.replace(/ - Wikipedia$/, ""),
         color: deps.playerColor,
         pid: lobby.presence.getMyIdentity().publicKey,
+        visible: true,
         lastSeenAt: Date.now(),
       });
+    };
+    const clearLobbyPage = () => {
+      lobby.presence.setMyPresence("page", null);
     };
     publishLobbyPage();
     const lobbyHeartbeat = window.setInterval(publishLobbyPage, 10_000);
     window.addEventListener("focus", publishLobbyPage);
+    window.addEventListener("pagehide", clearLobbyPage);
     document.addEventListener("visibilitychange", publishLobbyPage);
     lobbyPresence = lobby.presence;
     cleanups.push(() => {
       window.clearInterval(lobbyHeartbeat);
       window.removeEventListener("focus", publishLobbyPage);
+      window.removeEventListener("pagehide", clearLobbyPage);
       document.removeEventListener("visibilitychange", publishLobbyPage);
       lobby.destroy();
     });

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -249,6 +249,16 @@ export function isWikiArticleUrl(url: string): boolean {
   }
 }
 
+export function isWikipediaPortalArticleUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url, location.origin);
+    if (parsed.hash.startsWith("#/media/")) return false;
+  } catch {
+    return false;
+  }
+  return isWikiArticleUrl(url);
+}
+
 export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   const cleanups: (() => void)[] = [];
 
@@ -281,7 +291,10 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   if (typeof deps.createPresenceRoom === "function") {
     const lobby = deps.createPresenceRoom("lobby");
     const publishLobbyPage = () => {
-      if (document.visibilityState !== "visible") {
+      if (
+        document.visibilityState !== "visible" ||
+        !isWikipediaPortalArticleUrl(location.href)
+      ) {
         lobby.presence.setMyPresence("page", null);
         return;
       }

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -107,7 +107,9 @@ export class PresenceCountPill {
   private isFreshLobbyPage(
     page: WikiPresenceView["page"],
   ): page is NonNullable<WikiPresenceView["page"]> {
-    if (!page?.url || typeof page.lastSeenAt !== "number") return false;
+    if (!page?.url) return false;
+    if (page.visible !== true) return false;
+    if (typeof page.lastSeenAt !== "number") return false;
     return Date.now() - page.lastSeenAt <= LOBBY_PAGE_TTL_MS;
   }
 

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -2,7 +2,10 @@
 // ABOUTME: Includes a jump-to-someone button powered by a domain-wide lobby.
 
 import type { PresenceAPI } from "@playhtml/common";
-import type { WikiPresenceView } from "../custom-sites/wikipedia";
+import {
+  isWikipediaPortalArticleUrl,
+  type WikiPresenceView,
+} from "../custom-sites/wikipedia";
 
 // Concentric ellipses suggesting a portal
 const PORTAL_SVG = `<svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -109,6 +112,7 @@ export class PresenceCountPill {
   ): page is NonNullable<WikiPresenceView["page"]> {
     if (!page?.url) return false;
     if (page.visible !== true) return false;
+    if (!isWikipediaPortalArticleUrl(page.url)) return false;
     if (typeof page.lastSeenAt !== "number") return false;
     return Date.now() - page.lastSeenAt <= LOBBY_PAGE_TTL_MS;
   }


### PR DESCRIPTION
## Summary

- Clear Wikipedia lobby page presence when a tab is hidden so background tabs are not treated as live portal destinations.
- Require portal targets to be visible, fresh Wikipedia article pages.
- Exclude Wikipedia media hash views like `#/media/...` from both lobby publishing and portal target selection.
- Add regression coverage for stale pages, hidden pages, media views, and valid fresh article targets.

## Root Cause

The domain lobby used a heartbeat that kept background tabs fresh, so the portal could treat an inactive tab as a live person. Wikipedia media views also keep the article pathname with a `#/media/...` hash, so pathname-only article checks allowed detailed image views through.

## Verification

- `bun run test -- run PresenceCountPill.test.ts`
- `bun run test -- run` from `extension/`
- `bun run build-extension`

Note: repo-wide `bun run lint` still has unrelated existing type errors in website/portrait/shared/worker files; those were not introduced by this branch.