### PR TITLE
Render cursor trails with perfect-freehand

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
         "@playhtml/extension-types": "workspace:*",
         "@playhtml/react": "workspace:*",
         "html2canvas": "^1.4.1",
+        "perfect-freehand": "^1.2.3",
         "playhtml": "workspace:*",
         "profane-words": "^1.5.11",
         "react": "^19.0.0",
@@ -101,6 +102,7 @@
         "@playhtml/common": "workspace:*",
         "@playhtml/react": "workspace:*",
         "downshift": "^9.3.2",
+        "perfect-freehand": "^1.2.3",
         "playhtml": "workspace:*",
         "profane-words": "^1.5.11",
         "react": "^18.3.1",
@@ -1953,6 +1955,8 @@
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "perfect-debounce": ["perfect-debounce@2.0.0", "", {}, "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow=="],
+
+    "perfect-freehand": ["perfect-freehand@1.2.3", "", {}, "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -12,3 +12,4 @@ Format suggestion: "- short user-facing description (#PR)"
 - Stopped hidden inventory development features from observing and writing on every page.
 - Preserved pending event uploads when upgrading existing local browsing databases.
 - Stored click events sooner to avoid losing them during fast page exits.
+- Cursor trails now render as smooth, hand-drawn ink strokes with tapered ends (perfect-freehand)

--- a/extension/package.json
+++ b/extension/package.json
@@ -22,6 +22,7 @@
     "@playhtml/extension-types": "workspace:*",
     "@playhtml/react": "workspace:*",
     "html2canvas": "^1.4.1",
+    "perfect-freehand": "^1.2.3",
     "playhtml": "workspace:*",
     "profane-words": "^1.5.11",
     "react": "^19.0.0",

--- a/extension/website/package.json
+++ b/extension/website/package.json
@@ -14,6 +14,7 @@
     "@playhtml/common": "workspace:*",
     "@playhtml/react": "workspace:*",
     "downshift": "^9.3.2",
+    "perfect-freehand": "^1.2.3",
     "playhtml": "workspace:*",
     "profane-words": "^1.5.11",
     "react": "^18.3.1",

--- a/extension/website/shared/components/__tests__/trailPrimitives.test.ts
+++ b/extension/website/shared/components/__tests__/trailPrimitives.test.ts
@@ -29,18 +29,18 @@ function trailState(): TrailState {
 
 describe("computeTrailFrame", () => {
   it("returns null before the trail starts", () => {
-    expect(computeTrailFrame(trailState(), -10)).toBeNull();
+    expect(computeTrailFrame(trailState(), -10, 4)).toBeNull();
   });
 
   it("marks the trail finished at/after its duration", () => {
-    const frame = computeTrailFrame(trailState(), 1000);
+    const frame = computeTrailFrame(trailState(), 1000, 4);
     expect(frame).not.toBeNull();
     expect(frame!.isFinished).toBe(true);
     expect(frame!.trailProgress).toBe(1);
   });
 
   it("is mid-progress halfway through", () => {
-    const frame = computeTrailFrame(trailState(), 500);
+    const frame = computeTrailFrame(trailState(), 500, 4);
     expect(frame).not.toBeNull();
     expect(frame!.isFinished).toBe(false);
     expect(frame!.trailProgress).toBeGreaterThan(0);

--- a/extension/website/shared/components/trailPrimitives.tsx
+++ b/extension/website/shared/components/trailPrimitives.tsx
@@ -10,7 +10,7 @@ import {
 } from "../cursors";
 import { type TrailRenderer } from "../styles/trailRenderers";
 import {
-  buildStraightPathSegment,
+  buildFreehandPathSegment,
   type FinishedTrailOrderEntry,
 } from "../utils/trailAnimation";
 
@@ -25,9 +25,12 @@ export const COMPLETION_FADE_MS = 3000;
 export const TAIL_LENGTH = 1000;
 
 // Compute visible points and path data for a trail at a given elapsed time.
+// strokeSize is baked into the freehand outline geometry, so the path must be
+// rebuilt whenever it changes.
 export function computeTrailFrame(
   trailState: TrailState,
   elapsedTimeMs: number,
+  strokeSize: number,
   // When provided, the trail's progress (0..1) is used directly instead of
   // deriving it from `elapsedTimeMs - startOffsetMs`. The live animator passes
   // this so the frame never depends on `startOffsetMs` matching across the
@@ -75,10 +78,12 @@ export function computeTrailFrame(
   const pointCount = tailEnd - tailStart + 1 + (interpolatedHead ? 1 : 0);
   const pathData =
     pointCount >= 2
-      ? buildStraightPathSegment(
+      ? buildFreehandPathSegment(
           variedPoints,
           tailStart,
           tailEnd,
+          strokeSize,
+          isFinished,
           interpolatedHead,
         )
       : "";
@@ -136,9 +141,11 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
     const lastCursorTypeRef = useRef<string | undefined>(undefined);
     const lastTrailColorRef = useRef("");
     const finishedFrameRef = useRef<ReturnType<typeof computeTrailFrame>>(null);
+    const finishedFrameSizeRef = useRef<number | null>(null);
 
     useEffect(() => {
       finishedFrameRef.current = null;
+      finishedFrameSizeRef.current = null;
       lastPathDataRef.current = "";
       lastRendererIdRef.current = "";
       lastTrailOpacityRef.current = null;
@@ -171,15 +178,29 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
             return null;
           }
 
+          const strokeSize = renderer.getStrokeSize(
+            strokeWidth,
+            fixedMonoStrokeWidth,
+          );
+
           const isPastEnd =
             progressOverride !== undefined
               ? progressOverride >= 1
               : elapsedTimeMs - trailState.startOffsetMs >= trailState.durationMs;
-          let frame = isPastEnd ? finishedFrameRef.current : null;
+          let frame =
+            isPastEnd && finishedFrameSizeRef.current === strokeSize
+              ? finishedFrameRef.current
+              : null;
           if (!frame) {
-            frame = computeTrailFrame(trailState, elapsedTimeMs, progressOverride);
+            frame = computeTrailFrame(
+              trailState,
+              elapsedTimeMs,
+              strokeSize,
+              progressOverride,
+            );
             if (isPastEnd) {
               finishedFrameRef.current = frame;
+              finishedFrameSizeRef.current = strokeSize;
             }
           }
 
@@ -244,19 +265,11 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
       <g ref={groupRef} opacity="0">
         <path
           ref={haloRef}
-          fill="none"
           strokeLinecap="round"
           strokeLinejoin="round"
           style={{ display: "none" }}
         />
-        <path
-          ref={pathRef}
-          fill="none"
-          stroke={color}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          style={{ display: "none" }}
-        />
+        <path ref={pathRef} fill={color} style={{ display: "none" }} />
       </g>
     );
   },

--- a/extension/website/shared/styles/trailRenderers.ts
+++ b/extension/website/shared/styles/trailRenderers.ts
@@ -132,6 +132,9 @@ export interface TrailRenderer {
   readonly name: string;
   // SVG defs needed by this renderer (filters, gradients, etc.)
   readonly svgDefs?: string;
+  // Width of the freehand outline geometry built for this renderer's trails.
+  // The width is baked into the path data, so it must be known at build time.
+  getStrokeSize(strokeWidth: number, fixedMonoStrokeWidth: number): number;
   // Called per-frame to apply style to the trail path
   updatePath(params: TrailStyleParams): void;
   // Returns the color for the cursor icon
@@ -150,6 +153,7 @@ interface MonochromeStyle {
 
 interface AppliedAttributes {
   d?: string;
+  fill?: string;
   filter?: string;
   opacity?: string;
   stroke?: string;
@@ -213,11 +217,13 @@ function getMonochromeStyle(cursorType: string | undefined): MonochromeStyle {
 export const colorRenderer: TrailRenderer = {
   id: "color",
   name: "Color",
+  getStrokeSize(strokeWidth) {
+    return strokeWidth;
+  },
   updatePath({ pathEl, haloEl, pathData, trailOpacity, strokeWidth, trailColor }) {
     setPathAttribute(pathEl, "d", pathData);
-    setPathAttribute(pathEl, "stroke", trailColor);
+    setPathAttribute(pathEl, "fill", trailColor);
     setPathAttribute(pathEl, "opacity", String(trailOpacity));
-    setPathAttribute(pathEl, "strokeWidth", String(strokeWidth));
     removePathAttribute(pathEl, "filter");
     pathEl.style.display = "";
 
@@ -228,7 +234,10 @@ export const colorRenderer: TrailRenderer = {
           ? getPlateColor(trailColor, distance)
           : null;
       if (plateColor) {
+        // The trail width is baked into the outline geometry, so the plate
+        // reuses the same path and strokes its edge to extend past the trail.
         setPathAttribute(haloEl, "d", pathData);
+        setPathAttribute(haloEl, "fill", plateColor);
         setPathAttribute(haloEl, "stroke", plateColor);
         setPathAttribute(
           haloEl,
@@ -238,7 +247,7 @@ export const colorRenderer: TrailRenderer = {
         setPathAttribute(
           haloEl,
           "strokeWidth",
-          String(strokeWidth * PLATE_STROKE_MULTIPLIER),
+          String(strokeWidth * (PLATE_STROKE_MULTIPLIER - 1)),
         );
         haloEl.style.display = "";
       } else {
@@ -261,11 +270,13 @@ export const monochromeRenderer: TrailRenderer = {
     <feTurbulence type="fractalNoise" baseFrequency="0.04" numOctaves="4" result="noise" />
     <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G" />
   </filter>`,
-  updatePath({ pathEl, haloEl, pathData, trailOpacity, fixedMonoStrokeWidth }) {
+  getStrokeSize(_strokeWidth, fixedMonoStrokeWidth) {
+    return fixedMonoStrokeWidth;
+  },
+  updatePath({ pathEl, haloEl, pathData, trailOpacity }) {
     setPathAttribute(pathEl, "d", pathData);
-    setPathAttribute(pathEl, "stroke", "#000");
+    setPathAttribute(pathEl, "fill", "#000");
     setPathAttribute(pathEl, "opacity", String(0.8 * trailOpacity));
-    setPathAttribute(pathEl, "strokeWidth", String(fixedMonoStrokeWidth));
     setPathAttribute(pathEl, "filter", "url(#ink-texture)");
     pathEl.style.display = "";
     if (haloEl) haloEl.style.display = "none";

--- a/extension/website/shared/utils/__tests__/trailAnimation.test.ts
+++ b/extension/website/shared/utils/__tests__/trailAnimation.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  buildFreehandPathSegment,
   buildStraightPathSegment,
   getFinishedTrailRenderRange,
 } from "../trailAnimation";
@@ -21,6 +22,45 @@ describe("buildStraightPathSegment", () => {
     );
 
     expect(path).toBe("M 0 0 L 10 0 L 20 10 L 25 15");
+  });
+});
+
+describe("buildFreehandPathSegment", () => {
+  const points = [
+    { x: 0, y: 0 },
+    { x: 10, y: 0 },
+    { x: 20, y: 10 },
+    { x: 30, y: 25 },
+  ];
+
+  it("builds a closed filled outline around the point window", () => {
+    const path = buildFreehandPathSegment(points, 0, 3, 4, true);
+
+    expect(path.startsWith("M ")).toBe(true);
+    expect(path.endsWith(" Z")).toBe(true);
+    expect(path).toContain("Q");
+  });
+
+  it("includes the interpolated head in the outline", () => {
+    const withoutHead = buildFreehandPathSegment(points, 0, 2, 4, false);
+    const withHead = buildFreehandPathSegment(points, 0, 2, 4, false, {
+      x: 25,
+      y: 15,
+    });
+
+    expect(withHead).not.toBe(withoutHead);
+  });
+
+  it("bakes the stroke size into the geometry", () => {
+    const thin = buildFreehandPathSegment(points, 0, 3, 2, true);
+    const thick = buildFreehandPathSegment(points, 0, 3, 8, true);
+
+    expect(thick).not.toBe(thin);
+  });
+
+  it("returns an empty path for an empty window", () => {
+    expect(buildFreehandPathSegment(points, 2, 1, 4, true)).toBe("");
+    expect(buildFreehandPathSegment([], 0, 0, 4, true)).toBe("");
   });
 });
 

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Pure helpers for planning and drawing animated cursor trail frames.
 // ABOUTME: Keeps hot animation-loop calculations testable and allocation-light.
 
+import { getStroke } from "perfect-freehand";
+
 export interface FinishedTrailOrderEntry {
   originalIndex: number;
   finishedAtMs: number;
@@ -37,6 +39,62 @@ export function buildStraightPathSegment(
   }
 
   return path;
+}
+
+// Tuned for replayed cursor movement: velocity-based thinning gives the line
+// an inky, hand-drawn weight, while low streamline keeps the live head close
+// to the cursor icon instead of lagging behind it.
+const FREEHAND_OPTIONS = {
+  thinning: 0.5,
+  smoothing: 0.5,
+  streamline: 0.25,
+  simulatePressure: true,
+};
+
+// Converts a perfect-freehand outline polygon into a closed SVG path,
+// smoothing between outline points with quadratic midpoint curves.
+function getSvgPathFromStroke(outline: number[][]): string {
+  if (outline.length < 3) return "";
+
+  let path = `M ${outline[0][0].toFixed(2)} ${outline[0][1].toFixed(2)} Q`;
+  for (let i = 0; i < outline.length; i++) {
+    const [x0, y0] = outline[i];
+    const [x1, y1] = outline[(i + 1) % outline.length];
+    path += ` ${x0.toFixed(2)} ${y0.toFixed(2)} ${((x0 + x1) / 2).toFixed(2)} ${((y0 + y1) / 2).toFixed(2)}`;
+  }
+
+  return path + " Z";
+}
+
+// Builds a filled freehand-stroke outline for a window of trail points. The
+// stroke width is baked into the geometry, so the result must be rendered
+// with fill rather than stroke. While the trail is still drawing
+// (isComplete: false) the head is left untapered so it tracks the cursor.
+export function buildFreehandPathSegment(
+  points: Array<{ x: number; y: number }>,
+  startIndex: number,
+  endIndex: number,
+  size: number,
+  isComplete: boolean,
+  interpolatedHead?: { x: number; y: number },
+): string {
+  if (points.length === 0 || startIndex > endIndex) return "";
+
+  const inputPoints: Array<{ x: number; y: number }> = [];
+  for (let i = startIndex; i <= endIndex; i++) {
+    inputPoints.push(points[i]);
+  }
+  if (interpolatedHead) {
+    inputPoints.push(interpolatedHead);
+  }
+
+  const outline = getStroke(inputPoints, {
+    ...FREEHAND_OPTIONS,
+    size,
+    last: isComplete,
+  });
+
+  return getSvgPathFromStroke(outline);
 }
 
 export function getFinishedTrailRenderRange(

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -41,14 +41,17 @@ export function buildStraightPathSegment(
   return path;
 }
 
-// Tuned for replayed cursor movement: velocity-based thinning gives the line
-// an inky, hand-drawn weight, while low streamline keeps the live head close
-// to the cursor icon instead of lagging behind it.
+// Tuned for replayed cursor movement: the body stays a uniform width
+// (velocity-based thinning swings too wildly on real cursor data), with
+// explicit tapers at the ends for the hand-drawn feel. Low streamline keeps
+// the live head close to the cursor icon instead of lagging behind it.
 const FREEHAND_OPTIONS = {
-  thinning: 0.5,
+  thinning: 0,
   smoothing: 0.5,
   streamline: 0.25,
-  simulatePressure: true,
+  simulatePressure: false,
+  start: { taper: 20 },
+  end: { taper: 20 },
 };
 
 // Converts a perfect-freehand outline polygon into a closed SVG path,

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -43,16 +43,17 @@ export function buildStraightPathSegment(
 
 // Tuned for replayed cursor movement: the body stays a uniform width
 // (velocity-based thinning swings too wildly on real cursor data), with
-// explicit tapers at the ends for the hand-drawn feel. Low streamline keeps
-// the live head close to the cursor icon instead of lagging behind it.
+// explicit tapers at the ends for the hand-drawn feel. Near-zero streamline
+// keeps the live head glued to the cursor icon instead of lagging behind it.
 const FREEHAND_OPTIONS = {
   thinning: 0,
   smoothing: 0.5,
-  streamline: 0.25,
+  streamline: 0.05,
   simulatePressure: false,
-  start: { taper: 20 },
-  end: { taper: 20 },
 };
+
+// How many px of stroke length each end tapers over
+const END_TAPER = 20;
 
 // Converts a perfect-freehand outline polygon into a closed SVG path,
 // smoothing between outline points with quadratic midpoint curves.
@@ -72,7 +73,9 @@ function getSvgPathFromStroke(outline: number[][]): string {
 // Builds a filled freehand-stroke outline for a window of trail points. The
 // stroke width is baked into the geometry, so the result must be rendered
 // with fill rather than stroke. While the trail is still drawing
-// (isComplete: false) the head is left untapered so it tracks the cursor.
+// (isComplete: false) the head gets a blunt round cap instead of the end
+// taper — a taper would slide forward with the head and keep re-shaping
+// already-drawn ink every frame.
 export function buildFreehandPathSegment(
   points: Array<{ x: number; y: number }>,
   startIndex: number,
@@ -95,6 +98,8 @@ export function buildFreehandPathSegment(
     ...FREEHAND_OPTIONS,
     size,
     last: isComplete,
+    start: { taper: END_TAPER },
+    end: isComplete ? { taper: END_TAPER } : { taper: 0, cap: true },
   });
 
   return getSvgPathFromStroke(outline);


### PR DESCRIPTION
## Summary

Replaces the stroked-polyline cursor trails on wewere.online with filled [perfect-freehand](https://github.com/steveruizok/perfect-freehand) outlines, giving them a smooth, hand-drawn ink quality. Affects both the live `/portrait/` stream and the historical `/archive/` view (and the extension's HistoricalOverlay), since all of them render through the shared trail primitives.

## What changed

- **`buildFreehandPathSegment`** (`trailAnimation.ts`): feeds the visible point window through `getStroke()` and converts the outline polygon into a closed, fill-rendered SVG path.
- **Width is now baked into the geometry**, not a `stroke-width`. Renderers gained `getStrokeSize()` (color → the `strokeWidth` setting; monochrome → its per-trail fixed width) and switched from stroke- to fill-based styling. The pale-color plate reuses the same outline and strokes its edge to extend past the trail body.
- `computeTrailFrame` takes the stroke size; the finished-frame cache invalidates when it changes.

## Tuning (the iteration that mattered)

- **Uniform body, tapered ends.** Velocity-based thinning (`simulatePressure`) swung width wildly on real cursor data, making trails lurch thick→thin mid-stroke. Body width is now constant with explicit end tapers.
- **Stable drawing heads.** `streamline` dropped to 0.05 so new points aren't pulled back behind the cursor icon, and the end taper applies only to *finished* trails — while drawing, the head gets a blunt round cap so the taper region doesn't slide forward and re-shape already-drawn ink every frame.

The knobs live in `FREEHAND_OPTIONS` / `END_TAPER` in `trailAnimation.ts`.

## Testing

- All 243 extension tests pass (includes new `buildFreehandPathSegment` cases + updated `computeTrailFrame`/`trailPrimitives` signature tests).
- Website typecheck clean.
- Verified live on `/portrait/` against the real worker stream — uniform strokes, heads glued under the cursor, finished trails tapering as they settle, plates rendering under pale colors, monochrome ink filter intact.