### PR TITLE
Speed high-data extension loads

### DIFF
--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -63,7 +63,9 @@ async function waitForBackgroundDatabaseWork(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-async function openVersion8Database(): Promise<IDBDatabase> {
+async function openVersion8Database(
+  seedAggregate: Partial<DomainStatsAggregate> = aggregate(),
+): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = fakeIndexedDB.open(DB_NAME, 8);
     request.onupgradeneeded = () => {
@@ -75,7 +77,7 @@ async function openVersion8Database(): Promise<IDBDatabase> {
       eventStore.createIndex("domain", "domain", { unique: false });
       eventStore.createIndex("normalizedUrl", "normalizedUrl", { unique: false });
       const statsStore = db.createObjectStore(STATS_STORE_NAME, { keyPath: "key" });
-      statsStore.put(aggregate());
+      statsStore.put(seedAggregate);
     };
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(request.error);
@@ -217,6 +219,44 @@ describe("LocalEventStore aggregates", () => {
   });
 });
 
+describe("LocalEventStore aggregate migrations", () => {
+  it("preserves version 8 stats aggregates when opening version 9", async () => {
+    const db = await openVersion8Database({
+      ...aggregate(),
+      totalTimeMs: 12_345,
+      sessionCount: 7,
+      storageSizeBytes: undefined,
+    });
+    db.close();
+
+    const store = createStore();
+    const stats = await store.getSessionStats("example.com");
+
+    expect(stats?.totalTimeMs).toBe(12_345);
+    expect(stats?.sessionCount).toBe(7);
+  });
+
+  it("lists domains from stats aggregates", async () => {
+    const store = createStore();
+    await store.addEvents([
+      event("navigation-1", "navigation"),
+      event("cursor-1", "cursor"),
+    ]);
+
+    const domains = await store.getAllDomains();
+
+    expect(domains).toEqual([
+      expect.objectContaining({
+        domain: "example.com",
+        eventCount: 2,
+        totalTimeMs: 0,
+        uniquePageCount: 1,
+        eventCounts: { navigation: 1, cursor: 1 },
+      }),
+    ]);
+  });
+});
+
 describe("LocalEventStore storage stats", () => {
   it("reads storage stats from the global aggregate", async () => {
     const store = createStoreWithGlobalStats({
@@ -246,6 +286,25 @@ describe("LocalEventStore storage stats", () => {
 });
 
 describe("LocalEventStore pending uploads", () => {
+  it("filters all-event reads by multiple event types", async () => {
+    const store = createStore();
+    await store.addEvents([
+      { ...event("cursor-event", "cursor"), ts: 1_000 },
+      { ...event("keyboard-event", "keyboard"), ts: 2_000 },
+      { ...event("navigation-event", "navigation"), ts: 3_000 },
+    ]);
+
+    const events = await store.getAllEvents({
+      types: ["cursor", "navigation"],
+      limit: 10,
+    });
+
+    expect(events.map((storedEvent) => storedEvent.id)).toEqual([
+      "cursor-event",
+      "navigation-event",
+    ]);
+  });
+
   it("derives query indexes when storing content script events", async () => {
     const store = createStore();
     await store.addEvents([contentScriptEvent("cursor-indexed", "cursor")]);

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -286,6 +286,57 @@ describe("LocalEventStore storage stats", () => {
 });
 
 describe("LocalEventStore pending uploads", () => {
+  it("prunes old uploaded events while retaining old pending and recent events", async () => {
+    const store = createStore();
+    await store.addEvents([
+      { ...event("old-uploaded", "cursor"), ts: 1_000 },
+      { ...event("old-pending", "cursor"), ts: 2_000 },
+      { ...event("recent-uploaded", "cursor"), ts: 5_000 },
+    ]);
+    await store.markEventsAsUploaded(["old-uploaded", "recent-uploaded"]);
+
+    const deleted = await store.pruneUploadedEventsOlderThan(3_000);
+    const remainingEvents = await store.getAllEvents();
+    const pendingEvents = await store.getPendingEvents(10);
+
+    expect(deleted).toBe(1);
+    expect(remainingEvents.map((storedEvent) => storedEvent.id)).toEqual([
+      "old-pending",
+      "recent-uploaded",
+    ]);
+    expect(pendingEvents.map((storedEvent) => storedEvent.id)).toEqual([
+      "old-pending",
+    ]);
+  });
+
+  it("keeps aggregate session stats when old uploaded raw events are pruned", async () => {
+    const store = createStore();
+    await store.addEvents([
+      {
+        ...event("focus-event", "navigation"),
+        ts: 1_000,
+        data: { event: "focus" },
+      },
+      {
+        ...event("blur-event", "navigation"),
+        ts: 7_000,
+        data: { event: "blur" },
+      },
+    ]);
+    await store.markEventsAsUploaded(["focus-event", "blur-event"]);
+
+    const before = await store.getSessionStats("example.com");
+    const deleted = await store.pruneUploadedEventsOlderThan(10_000);
+    const after = await store.getSessionStats("example.com");
+    const remainingEvents = await store.getAllEvents();
+
+    expect(before?.totalTimeMs).toBe(6_000);
+    expect(deleted).toBe(2);
+    expect(remainingEvents).toEqual([]);
+    expect(after?.totalTimeMs).toBe(6_000);
+    expect(after?.sessionCount).toBe(1);
+  });
+
   it("filters all-event reads by multiple event types", async () => {
     const store = createStore();
     await store.addEvents([

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -12,6 +12,7 @@ import type { CollectionEvent } from "../collectors/types";
 const DB_NAME = "collection_events_db";
 const STORE_NAME = "events";
 const STATS_STORE_NAME = "domain_stats";
+const STATS_BACKFILL_STATE_KEY = "__stats_backfill_state__";
 
 const originalIndexedDB = globalThis.indexedDB;
 const originalIDBKeyRange = globalThis.IDBKeyRange;
@@ -84,6 +85,28 @@ async function openVersion8Database(
   });
 }
 
+async function openVersion7Database(seedEvents: CollectionEvent[]): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = fakeIndexedDB.open(DB_NAME, 7);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const eventStore = db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      eventStore.createIndex("ts", "ts", { unique: false });
+      eventStore.createIndex("type", "type", { unique: false });
+      eventStore.createIndex("uploaded", "uploaded", { unique: false });
+      eventStore.createIndex("domain", "domain", { unique: false });
+      eventStore.createIndex("normalizedUrl", "normalizedUrl", { unique: false });
+      db.createObjectStore(STATS_STORE_NAME, { keyPath: "key" });
+
+      for (const seedEvent of seedEvents) {
+        eventStore.put(seedEvent);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
 async function putSeedEvent(db: IDBDatabase, seedEvent: CollectionEvent): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const transaction = db.transaction([STORE_NAME], "readwrite");
@@ -93,36 +116,21 @@ async function putSeedEvent(db: IDBDatabase, seedEvent: CollectionEvent): Promis
   });
 }
 
+async function putStatsRows(db: IDBDatabase, rows: unknown[]): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction([STATS_STORE_NAME], "readwrite");
+    const statsStore = transaction.objectStore(STATS_STORE_NAME);
+    for (const row of rows) {
+      statsStore.put(row);
+    }
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
 function createStore(): LocalEventStore {
   const store = new LocalEventStore();
   stores.push(store);
-  return store;
-}
-
-function createStoreWithGlobalStats(globalStats: unknown): LocalEventStore {
-  const store = Object.create(LocalEventStore.prototype) as LocalEventStore;
-  (store as any).isInitialized = true;
-  (store as any).db = {
-    transaction(storeNames: string[]) {
-      expect(storeNames).toEqual([STATS_STORE_NAME]);
-      return {
-        objectStore(name: string) {
-          expect(name).toBe(STATS_STORE_NAME);
-          return {
-            get(key: string) {
-              expect(key).toBe("__global__");
-              const request: any = {};
-              queueMicrotask(() => {
-                request.result = globalStats;
-                request.onsuccess?.();
-              });
-              return request;
-            },
-          };
-        },
-      };
-    },
-  };
   return store;
 }
 
@@ -236,6 +244,24 @@ describe("LocalEventStore aggregate migrations", () => {
     expect(stats?.sessionCount).toBe(7);
   });
 
+  it("reports local raw storage stats when preserved version 8 aggregates do not have size data", async () => {
+    const db = await openVersion8Database({
+      ...aggregate(),
+      storageSizeBytes: undefined,
+    });
+    await putSeedEvent(db, { ...event("cursor-1", "cursor"), ts: 2_000 });
+    db.close();
+
+    const store = createStore();
+    const stats = await store.getStorageStats();
+
+    expect(stats.totalEvents).toBe(1);
+    expect(stats.estimatedSizeBytes).toBeGreaterThan(0);
+    expect(stats.oldestEvent).toBe(2_000);
+    expect(stats.newestEvent).toBe(2_000);
+    expect(stats.countsByType).toEqual({ cursor: 1 });
+  });
+
   it("lists domains from stats aggregates", async () => {
     const store = createStore();
     await store.addEvents([
@@ -255,33 +281,100 @@ describe("LocalEventStore aggregate migrations", () => {
       }),
     ]);
   });
+
+  it("waits for aggregate backfill before listing domains after older upgrades", async () => {
+    const db = await openVersion7Database([
+      event("navigation-1", "navigation"),
+      event("cursor-1", "cursor"),
+    ]);
+    db.close();
+
+    const store = createStore();
+    const domains = await store.getAllDomains();
+
+    expect(domains).toEqual([
+      expect.objectContaining({
+        domain: "example.com",
+        eventCount: 2,
+        uniquePageCount: 1,
+        eventCounts: { navigation: 1, cursor: 1 },
+      }),
+    ]);
+  });
+
+  it("counts events queued during aggregate backfill exactly once", async () => {
+    const queuedEvent = { ...event("queued-cursor", "cursor"), ts: 2_000 };
+    const db = await openVersion7Database([
+      { ...event("old-cursor", "cursor"), ts: 1_000 },
+      queuedEvent,
+    ]);
+    db.close();
+
+    const store = createStore();
+    (store as any).queueEventsForStatsAfterBackfill([queuedEvent]);
+    await store.ensureHistoricalStats();
+    const stats = await store.getSessionStats("example.com");
+
+    expect(stats?.eventsByType.cursor).toBe(2);
+    expect(stats?.firstVisit).toBe(1_000);
+    expect(stats?.lastVisit).toBe(2_000);
+  });
+
+  it("rebuilds aggregates when a previous backfill did not complete", async () => {
+    const db = await openVersion7Database([
+      { ...event("old-cursor", "cursor"), ts: 1_000 },
+      { ...event("queued-cursor", "cursor"), ts: 2_000 },
+    ]);
+    db.close();
+
+    const store = createStore();
+    await store.ensureHistoricalStats();
+    await putStatsRows((store as any).db, [
+      {
+        ...aggregate(),
+        eventsByType: { cursor: 1 },
+        firstVisit: 1_000,
+        lastVisit: 1_000,
+      },
+      {
+        key: STATS_BACKFILL_STATE_KEY,
+        state: "running",
+      },
+    ]);
+    (store as any).statsBackfillComplete = false;
+
+    const domains = await store.getAllDomains();
+
+    expect(domains).toEqual([
+      expect.objectContaining({
+        domain: "example.com",
+        eventCount: 2,
+        eventCounts: { cursor: 2 },
+        firstVisit: 1_000,
+        lastVisit: 2_000,
+      }),
+    ]);
+  });
 });
 
 describe("LocalEventStore storage stats", () => {
-  it("reads storage stats from the global aggregate", async () => {
-    const store = createStoreWithGlobalStats({
-      key: "__global__",
-      domain: "",
-      totalTimeMs: 0,
-      hourBuckets: new Array(24).fill(0),
-      sessionCount: 0,
-      pendingFocusTs: null,
-      pendingFocusUrl: "",
-      eventsByType: { cursor: 2, keyboard: 1 },
-      storageSizeBytes: 4096,
-      firstVisit: 100,
-      lastVisit: 300,
-      uniqueUrls: [],
-      processedNavIds: [],
-    });
+  it("reads storage stats from retained local event rows", async () => {
+    const store = createStore();
+    await store.addEvents([
+      { ...event("cursor-1", "cursor"), ts: 100 },
+      { ...event("cursor-2", "cursor"), ts: 200 },
+      { ...event("keyboard-1", "keyboard"), ts: 300 },
+    ]);
 
-    await expect(store.getStorageStats()).resolves.toEqual({
+    const stats = await store.getStorageStats();
+
+    expect(stats).toMatchObject({
       totalEvents: 3,
-      estimatedSizeBytes: 4096,
       oldestEvent: 100,
       newestEvent: 300,
       countsByType: { cursor: 2, keyboard: 1 },
     });
+    expect(stats.estimatedSizeBytes).toBeGreaterThan(0);
   });
 });
 
@@ -335,6 +428,25 @@ describe("LocalEventStore pending uploads", () => {
     expect(remainingEvents).toEqual([]);
     expect(after?.totalTimeMs).toBe(6_000);
     expect(after?.sessionCount).toBe(1);
+  });
+
+  it("reports storage bounds from retained raw events after pruning", async () => {
+    const store = createStore();
+    await store.addEvents([
+      { ...event("old-uploaded", "cursor"), ts: 1_000 },
+      { ...event("old-pending", "cursor"), ts: 2_000 },
+      { ...event("recent-uploaded", "keyboard"), ts: 5_000 },
+    ]);
+    await store.markEventsAsUploaded(["old-uploaded", "recent-uploaded"]);
+
+    await store.pruneUploadedEventsOlderThan(3_000);
+
+    await expect(store.getStorageStats()).resolves.toMatchObject({
+      totalEvents: 2,
+      oldestEvent: 2_000,
+      newestEvent: 5_000,
+      countsByType: { cursor: 1, keyboard: 1 },
+    });
   });
 
   it("filters all-event reads by multiple event types", async () => {

--- a/extension/src/__tests__/ViewportCollector.test.ts
+++ b/extension/src/__tests__/ViewportCollector.test.ts
@@ -72,6 +72,42 @@ describe("ViewportCollector", () => {
 
       removeSpy.mockRestore();
     });
+
+    it("flushes pending scroll before disabling", async () => {
+      collector.enable();
+
+      simulateScroll(0, 100);
+      await advanceTime(250);
+      collector.disable();
+
+      const scrollCalls = emitCallback.mock.calls.filter(
+        (call) => (call[0] as ViewportEventData).event === "scroll"
+      );
+      expect(scrollCalls.length).toBe(1);
+    });
+
+    it("flushes pending zoom before disabling", async () => {
+      collector.enable();
+
+      Object.defineProperty(window, "visualViewport", {
+        value: {
+          scale: 1.5,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+      simulateResize(1024, 768);
+      await advanceTime(500);
+      collector.disable();
+
+      const zoomCalls = emitCallback.mock.calls.filter(
+        (call) => (call[0] as ViewportEventData).event === "zoom"
+      );
+      expect(zoomCalls.length).toBe(1);
+      expect((zoomCalls[0][0] as ViewportEventData).zoom).toBe(1.5);
+    });
   });
 
   describe("scroll events", () => {
@@ -83,7 +119,7 @@ describe("ViewportCollector", () => {
       // scrollY = 616 → normalized = 616 / 1232 ≈ 0.5
       simulateScroll(0, 616);
 
-      await advanceTime(100); // Past throttle (100ms)
+      await advanceTime(500); // Past throttle (500ms)
 
       expect(emitCallback).toHaveBeenCalledTimes(1);
       const call = emitCallback.mock.calls[0][0] as ViewportEventData;
@@ -92,16 +128,16 @@ describe("ViewportCollector", () => {
       expect(call.scrollY).toBeCloseTo(0.5, 2);
     });
 
-    it("throttles scroll events to 100ms", async () => {
+    it("throttles scroll events to 500ms", async () => {
       collector.enable();
 
       simulateScroll(0, 100);
-      await advanceTime(50); // Less than throttle
+      await advanceTime(499); // Less than throttle
 
       expect(emitCallback).not.toHaveBeenCalled();
 
       simulateScroll(0, 200);
-      await advanceTime(60); // Now past 100ms total
+      await advanceTime(1); // Now past 500ms total
 
       expect(emitCallback).toHaveBeenCalledTimes(1);
     });
@@ -111,7 +147,7 @@ describe("ViewportCollector", () => {
 
       // Scroll to top
       simulateScroll(0, 0);
-      await advanceTime(100);
+      await advanceTime(500);
 
       let call = emitCallback.mock.calls[0][0] as ViewportEventData;
       expect(call.scrollY).toBe(0);
@@ -119,7 +155,7 @@ describe("ViewportCollector", () => {
       // Scroll to bottom (max scroll)
       const maxScrollY = 2000 - 768; // 1232
       simulateScroll(0, maxScrollY);
-      await advanceTime(100);
+      await advanceTime(500);
 
       call = emitCallback.mock.calls[1][0] as ViewportEventData;
       expect(call.scrollY).toBeCloseTo(1, 2);
@@ -132,7 +168,7 @@ describe("ViewportCollector", () => {
       Object.defineProperty(document.documentElement, 'scrollWidth', { value: 2000, writable: true, configurable: true });
       simulateScroll(500, 0);
 
-      await advanceTime(100);
+      await advanceTime(500);
 
       expect(emitCallback).toHaveBeenCalled();
       const call = emitCallback.mock.calls[0][0] as ViewportEventData;
@@ -144,7 +180,7 @@ describe("ViewportCollector", () => {
 
       // Scroll beyond max (should clamp to 1)
       simulateScroll(0, 10000);
-      await advanceTime(100);
+      await advanceTime(500);
 
       const call = emitCallback.mock.calls[0][0] as ViewportEventData;
       expect(call.scrollY).toBeLessThanOrEqual(1);
@@ -156,7 +192,7 @@ describe("ViewportCollector", () => {
       collector.enable();
 
       simulateResize(1280, 1024);
-      await advanceTime(200); // Past debounce (200ms)
+      await advanceTime(1000); // Past debounce (1000ms)
 
       expect(emitCallback).toHaveBeenCalledTimes(1);
       const call = emitCallback.mock.calls[0][0] as ViewportEventData;
@@ -165,16 +201,16 @@ describe("ViewportCollector", () => {
       expect(call.height).toBe(1024);
     });
 
-    it("debounces resize events to 200ms", async () => {
+    it("debounces resize events to 1000ms", async () => {
       collector.enable();
 
       simulateResize(1100, 800);
-      await advanceTime(100); // Less than debounce
+      await advanceTime(999); // Less than debounce
 
       expect(emitCallback).not.toHaveBeenCalled();
 
       simulateResize(1200, 900);
-      await advanceTime(200); // Complete the debounce from second resize
+      await advanceTime(1000); // Complete the debounce from second resize
 
       // Should only emit once (debounced)
       expect(emitCallback).toHaveBeenCalledTimes(1);
@@ -184,16 +220,25 @@ describe("ViewportCollector", () => {
       collector.enable();
 
       simulateResize(1100, 800);
-      await advanceTime(150); // Partway through debounce
+      await advanceTime(750); // Partway through debounce
 
       simulateResize(1200, 900); // New resize cancels previous
-      await advanceTime(200); // Complete new debounce
+      await advanceTime(1000); // Complete new debounce
 
       // Should only emit once with latest dimensions
       expect(emitCallback).toHaveBeenCalledTimes(1);
       const call = emitCallback.mock.calls[0][0] as ViewportEventData;
       expect(call.width).toBe(1200);
       expect(call.height).toBe(900);
+    });
+
+    it("ignores tiny resize changes", async () => {
+      collector.enable();
+
+      simulateResize(1040, 790);
+      await advanceTime(1000);
+
+      expect(emitCallback).not.toHaveBeenCalled();
     });
   });
 
@@ -215,7 +260,7 @@ describe("ViewportCollector", () => {
 
       // Trigger resize (which checks zoom)
       simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
+      await advanceTime(1000); // Wait for resize debounce (1000ms)
 
       expect(emitCallback).toHaveBeenCalled();
       const zoomCall = emitCallback.mock.calls.find(
@@ -237,7 +282,7 @@ describe("ViewportCollector", () => {
 
       // Zoom stays at 1
       simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
+      await advanceTime(1000); // Wait for resize debounce (1000ms)
 
       // Should only emit resize, not zoom
       const zoomCalls = emitCallback.mock.calls.filter(
@@ -246,7 +291,7 @@ describe("ViewportCollector", () => {
       expect(zoomCalls.length).toBe(0);
     });
 
-    it("debounces rapid zoom changes within 2 seconds and tracks quantity", async () => {
+    it("emits the settled zoom value after resize debounce", async () => {
       collector.enable();
 
       // First zoom: 1 -> 1.25
@@ -260,17 +305,15 @@ describe("ViewportCollector", () => {
         configurable: true,
       });
       simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
+      await advanceTime(500); // Still inside the resize debounce window
 
-      // Should emit first zoom
-      let zoomCalls = emitCallback.mock.calls.filter(
-        (call) => (call[0] as ViewportEventData).event === "zoom"
-      );
-      expect(zoomCalls.length).toBe(1);
-      expect((zoomCalls[0][0] as ViewportEventData).quantity).toBe(1);
+      expect(
+        emitCallback.mock.calls.filter(
+          (call) => (call[0] as ViewportEventData).event === "zoom"
+        )
+      ).toHaveLength(0);
 
-      // Second zoom: 1.25 -> 1.5 (within 500ms of first - should be debounced)
-      await advanceTime(300); // 300ms since first zoom
+      // Second zoom: 1.25 -> 1.5 before the debounce settles
       Object.defineProperty(window, "visualViewport", {
         value: {
           scale: 1.5,
@@ -281,33 +324,24 @@ describe("ViewportCollector", () => {
         configurable: true,
       });
       simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
+      await advanceTime(1000); // Wait for the final resize debounce
 
-      // Third zoom: 1.5 -> 1.75 (within 2s window of first - should still be debounced)
-      await advanceTime(300); // 800ms since first zoom
-      Object.defineProperty(window, "visualViewport", {
-        value: {
-          scale: 1.75,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-        },
-        writable: true,
-        configurable: true,
-      });
-      simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
-
-      // Still only 1 zoom event (within 2s debounce window)
-      zoomCalls = emitCallback.mock.calls.filter(
+      let zoomCalls = emitCallback.mock.calls.filter(
         (call) => (call[0] as ViewportEventData).event === "zoom"
       );
       expect(zoomCalls.length).toBe(1);
+      const settledZoom = zoomCalls[0][0] as ViewportEventData;
+      expect(settledZoom.zoom).toBe(1.5);
+      expect(settledZoom.previous_zoom).toBe(1);
+      expect(settledZoom.quantity).toBe(2);
+    });
 
-      // Fourth zoom: 1.75 -> 2.0 (after >2s since first zoom - should emit new event)
-      await advanceTime(1500); // Now >2s since first zoom (200+300+200+300+200+1500 = 2700ms)
+    it("ignores zoom changes below five percent", async () => {
+      collector.enable();
+
       Object.defineProperty(window, "visualViewport", {
         value: {
-          scale: 2.0,
+          scale: 1.04,
           addEventListener: vi.fn(),
           removeEventListener: vi.fn(),
         },
@@ -315,19 +349,12 @@ describe("ViewportCollector", () => {
         configurable: true,
       });
       simulateResize(1024, 768);
-      await advanceTime(200); // Wait for resize debounce (200ms)
+      await advanceTime(1000);
 
-      // Should now have 2 zoom events
-      zoomCalls = emitCallback.mock.calls.filter(
+      const zoomCalls = emitCallback.mock.calls.filter(
         (call) => (call[0] as ViewportEventData).event === "zoom"
       );
-      expect(zoomCalls.length).toBe(2);
-
-      // Check the second zoom event has previous_zoom and quantity
-      const secondZoom = zoomCalls[1][0] as ViewportEventData;
-      expect(secondZoom.zoom).toBe(2.0);
-      expect(secondZoom.previous_zoom).toBe(1.75);
-      expect(secondZoom.quantity).toBe(1); // New debounce window
+      expect(zoomCalls.length).toBe(0);
     });
   });
 
@@ -351,11 +378,11 @@ describe("ViewportCollector", () => {
 
       // Scroll
       simulateScroll(0, 100);
-      await advanceTime(100);
+      await advanceTime(500);
 
       // Resize
       simulateResize(1280, 1024);
-      await advanceTime(200);
+      await advanceTime(1000);
 
       // Zoom change
       Object.defineProperty(window, "visualViewport", {
@@ -368,7 +395,7 @@ describe("ViewportCollector", () => {
         configurable: true,
       });
       simulateResize(1280, 1024);
-      await advanceTime(200);
+      await advanceTime(1000);
 
       expect(emitCallback).toHaveBeenCalled();
       const events = emitCallback.mock.calls.map(

--- a/extension/src/__tests__/background-retention.test.ts
+++ b/extension/src/__tests__/background-retention.test.ts
@@ -71,7 +71,8 @@ describe("background local retention", () => {
   it("does not schedule uploaded raw-event pruning on startup", async () => {
     const background = await import("../entrypoints/background");
 
-    background.default();
+    const startBackground = background.default as unknown as () => void;
+    startBackground();
 
     expect(browserMock.alarms.create).toHaveBeenCalledWith("checkMilestones", {
       periodInMinutes: 5,

--- a/extension/src/__tests__/background-retention.test.ts
+++ b/extension/src/__tests__/background-retention.test.ts
@@ -1,0 +1,90 @@
+// ABOUTME: Tests background service worker startup wiring for local data retention.
+// ABOUTME: Verifies raw-event pruning stays inactive during service worker startup.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const browserMock = vi.hoisted(() => ({
+  storage: {
+    local: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+    },
+    session: {
+      setAccessLevel: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+  runtime: {
+    getURL: vi.fn((path: string) => `moz-extension://test/${path}`),
+    onInstalled: {
+      addListener: vi.fn(),
+    },
+    onMessage: {
+      addListener: vi.fn(),
+    },
+  },
+  tabs: {
+    create: vi.fn().mockResolvedValue({}),
+  },
+  alarms: {
+    create: vi.fn(),
+    onAlarm: {
+      addListener: vi.fn(),
+    },
+  },
+}));
+
+const storeMock = vi.hoisted(() => ({
+  getPendingEvents: vi.fn().mockResolvedValue([]),
+  markEventsAsUploaded: vi.fn().mockResolvedValue(undefined),
+  ensureHistoricalStats: vi.fn().mockResolvedValue(undefined),
+  pruneUploadedEventsOlderThan: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("webextension-polyfill", () => ({
+  default: browserMock,
+}));
+
+vi.mock("../storage/LocalEventStore", () => ({
+  LocalEventStore: vi.fn(() => storeMock),
+}));
+
+vi.mock("../storage/sync", () => ({
+  uploadEvents: vi.fn().mockResolvedValue(undefined),
+  syncParticipantColor: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../storage/restore", () => ({
+  fetchEventsByPid: vi.fn().mockResolvedValue([]),
+}));
+
+describe("background local retention", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubGlobal("defineBackground", (setup: () => void) => setup);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not schedule uploaded raw-event pruning on startup", async () => {
+    const background = await import("../entrypoints/background");
+
+    background.default();
+
+    expect(browserMock.alarms.create).toHaveBeenCalledWith("checkMilestones", {
+      periodInMinutes: 5,
+    });
+    expect(browserMock.alarms.create).not.toHaveBeenCalledWith(
+      "pruneLocalEvents",
+      expect.anything(),
+    );
+
+    const alarmListener =
+      browserMock.alarms.onAlarm.addListener.mock.calls[0]?.[0];
+    await alarmListener?.({ name: "pruneLocalEvents" });
+
+    expect(storeMock.pruneUploadedEventsOlderThan).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/collectors/ViewportCollector.ts
+++ b/extension/src/collectors/ViewportCollector.ts
@@ -19,10 +19,10 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
 
   private scrollHandler?: () => void;
   private resizeHandler?: () => void;
-  private lastResizeTime = 0;
-  private scrollThrottle = 100; // ms
+  private scrollThrottle = 500; // ms
   private scrollTimer: number | null = null;
-  private resizeDebounce = 200; // ms - wait for resize to settle
+  private resizeDebounce = 1000; // ms - wait for resize to settle
+  private resizeMinChangePx = 50;
   private resizeTimer: number | null = null;
   private resizeQuantity = 0; // Count resize events during debounce window
 
@@ -36,9 +36,7 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
 
   // Zoom tracking
   private lastZoomLevel: number | null = null;
-  private lastZoomEmitTime = -Infinity;
-  private zoomDebounce = 2000; // ms - wait for zoom to settle before emitting
-  private zoomQuantity = 0; // Count zoom changes during debounce window
+  private zoomMinChange = 0.05;
   private visualViewport: VisualViewport | null = null;
 
   start(): void {
@@ -115,6 +113,14 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
       this.resizeHandler = undefined;
     }
 
+    this.flushPendingEvents();
+  }
+
+  protected drainPendingEvents(): void {
+    this.flushPendingEvents();
+  }
+
+  private flushPendingEvents(): void {
     // Flush any pending scroll event that was waiting in the throttle timer
     if (this.scrollTimer !== null) {
       clearTimeout(this.scrollTimer);
@@ -127,6 +133,8 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
       clearTimeout(this.resizeTimer);
       this.resizeTimer = null;
       this.emitResizeEvent();
+      this.checkZoomChange();
+      this.resizeQuantity = 0;
     }
   }
 
@@ -192,7 +200,7 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
 
   /**
    * Emit resize event
-   * Only emits if there's actual size change (delta > 0)
+   * Only emits if there's a meaningful size change
    */
   private emitResizeEvent(): void {
     if (!this.enabled) return;
@@ -204,16 +212,17 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
     const deltaWidth = Math.abs(currentWidth - this.lastResizeWidth);
     const deltaHeight = Math.abs(currentHeight - this.lastResizeHeight);
 
-    // Only emit if there's actual size change (at least 1 pixel)
-    // This filters out resize events that fire but don't actually change size
-    if (deltaWidth === 0 && deltaHeight === 0) {
+    // Only emit if there's a meaningful resize.
+    // This filters out resize events that fire for tiny browser chrome changes.
+    if (
+      deltaWidth < this.resizeMinChangePx &&
+      deltaHeight < this.resizeMinChangePx
+    ) {
       if (VERBOSE) {
         console.log(
-          "[ViewportCollector] Resize event fired but no size change detected, skipping",
+          "[ViewportCollector] Resize event fired but no meaningful size change detected, skipping",
         );
       }
-      // Reset quantity counter since no actual resize occurred
-      this.resizeQuantity = 0;
       return;
     }
 
@@ -243,70 +252,47 @@ export class ViewportCollector extends BaseCollector<ViewportEventData> {
   }
 
   /**
-   * Check for zoom level changes and emit if changed
-   * Debounced to prevent spam during continuous zooming
-   * Only emits if there's actual zoom change (delta > 0)
+   * Check for settled zoom level changes and emit if changed.
+   * Called after resize debounce so continuous zoom gestures emit their final state.
    */
   private checkZoomChange(): void {
     const currentZoom = this.getZoomLevel();
-    const now = Date.now();
 
-    // Check if zoom actually changed (with small threshold to avoid floating point issues)
     const zoomDelta =
       this.lastZoomLevel !== null
         ? Math.abs(currentZoom - this.lastZoomLevel)
         : 0;
-    const hasZoomChange = zoomDelta > 0.001; // 0.1% threshold for zoom changes
+    const hasZoomChange = zoomDelta >= this.zoomMinChange;
 
     if (hasZoomChange) {
-      // Debounce: only emit if enough time has passed since last zoom event
-      const timeSinceLastEmit = now - this.lastZoomEmitTime;
+      const data: ViewportEventData = {
+        event: "zoom",
+        zoom: currentZoom,
+        previous_zoom: this.lastZoomLevel ?? undefined,
+        quantity: Math.max(1, this.resizeQuantity),
+      };
 
-      if (timeSinceLastEmit >= this.zoomDebounce) {
-        // New debounce window — reset counter and count just this zoom
-        this.zoomQuantity = 1;
-
-        const data: ViewportEventData = {
-          event: "zoom",
-          zoom: currentZoom,
-          previous_zoom: this.lastZoomLevel ?? undefined,
-          quantity: this.zoomQuantity,
-        };
-
-        if (VERBOSE) {
-          console.log(
-            `[ViewportCollector] Emitting zoom event (${this.zoomQuantity} zooms):`,
-            {
-              ...data,
-              zoomDelta,
-            },
-          );
-        }
-
-        this.emit(data);
-        this.lastZoomEmitTime = now;
-        this.zoomQuantity = 0; // Reset counter
-      } else {
-        if (VERBOSE) {
-          console.log(
-            `[ViewportCollector] Zoom change detected but debounced (${timeSinceLastEmit}ms < ${this.zoomDebounce}ms, total: ${this.zoomQuantity})`,
-          );
-        }
-      }
-    } else {
-      // No zoom change detected, reset quantity counter
-      if (this.zoomQuantity > 0 && VERBOSE) {
+      if (VERBOSE) {
         console.log(
-          `[ViewportCollector] Zoom check fired but no change detected (delta: ${zoomDelta.toFixed(
-            6,
-          )}), resetting quantity counter`,
+          `[ViewportCollector] Emitting settled zoom event (${data.quantity} resize events):`,
+          {
+            ...data,
+            zoomDelta,
+          },
         );
       }
-      this.zoomQuantity = 0;
-    }
 
-    // Always update last zoom level to track changes
-    this.lastZoomLevel = currentZoom;
+      this.emit(data);
+      this.lastZoomLevel = currentZoom;
+    } else {
+      if (VERBOSE) {
+        console.log(
+          `[ViewportCollector] Zoom check fired but no meaningful change detected (delta: ${zoomDelta.toFixed(
+            6,
+          )})`,
+        );
+      }
+    }
   }
 
   /**

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -1,11 +1,10 @@
 // ABOUTME: Main popup home view showing internet portrait status and data collection summary
 // ABOUTME: Entry point for the "we were online" experience
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 import { PlayerIdentityCard } from "./PlayerIdentityCard";
 import type { PlayerIdentity } from "../types";
 import type { CollectorStatus } from "../collectors/types";
-import type { CollectionEvent } from "../collectors/types";
 import { TinyMovementPreview } from "./TinyMovementPreview";
 import { PortraitCard } from "./PortraitCard";
 import { CollectorIcon } from "./icons";
@@ -41,13 +40,6 @@ export function InternetPortraitHome({
   const [collectors, setCollectors] = useState<CollectorStatus[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [presenceCount, setPresenceCount] = useState<number | null>(null);
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const animRef = useRef<number | null>(null);
-  const tRef = useRef<number>(0);
-  const cursorEventsRef = useRef<CollectionEvent[] | null>(null);
-  const [recentCursorEvents, setRecentCursorEvents] = useState<
-    CollectionEvent[] | null
-  >(null);
   const [portraitStats, setPortraitStats] = useState<PortraitStats | null>(
     null,
   );
@@ -70,70 +62,11 @@ export function InternetPortraitHome({
         } else {
           setCollectors(null);
         }
-        // Try to pull recent cursor events for preview (best-effort)
-        try {
-          if (tab.url) {
-            const url = new URL(tab.url);
-            const domain = url.hostname.replace(/^www\./, '');
-            const recent = await browser.runtime.sendMessage({
-              type: "GET_RECENT_EVENTS",
-              domain,
-            });
-            if (recent?.success && Array.isArray(recent.events)) {
-              cursorEventsRef.current = recent.events as CollectionEvent[];
-              setRecentCursorEvents(recent.events as CollectionEvent[]);
-            }
-          }
-        } catch {}
       } catch (e) {
         setError("Collectors unavailable on this page");
       }
     };
     loadStatuses().catch(() => {});
-    // Start canvas animation using recent cursor events if available
-    const draw = () => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return;
-      const w = (canvas.width = canvas.clientWidth);
-      const h = (canvas.height = canvas.clientHeight);
-      ctx.fillStyle = "rgba(90,78,65,0.08)";
-      ctx.fillRect(0, 0, w, h);
-
-      const events = cursorEventsRef.current || [];
-      tRef.current += 0.02;
-      const maxPoints = Math.min(50, events.length);
-      const start = Math.max(0, events.length - maxPoints);
-      const points = events.slice(start).map((e) => {
-        const d: any = e.data || {};
-        return { x: (d.x || 0) * w, y: (d.y || 0) * h };
-      });
-
-      ctx.strokeStyle = "rgba(74,154,138,0.7)";
-      ctx.lineWidth = 2;
-      ctx.beginPath();
-      for (let i = 0; i < points.length - 1; i++) {
-        const p = points[i],
-          q = points[i + 1];
-        if (i === 0) ctx.moveTo(p.x, p.y);
-        ctx.lineTo(q.x, q.y);
-      }
-      ctx.stroke();
-
-      const head = points[points.length - 1];
-      if (head) {
-        ctx.beginPath();
-        ctx.arc(head.x, head.y, 4, 0, Math.PI * 2);
-        ctx.fillStyle = "#4a9a8a";
-        ctx.fill();
-      }
-      animRef.current = requestAnimationFrame(draw);
-    };
-    animRef.current = requestAnimationFrame(draw);
-    return () => {
-      if (animRef.current) cancelAnimationFrame(animRef.current);
-    };
   }, []);
 
   // Load portrait stats for current tab's domain via background store.

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -295,6 +295,7 @@ export default defineBackground(() => {
       const domain = message.domain as string
       const rawUrl = message.url as string | undefined
       const normalizedUrl = rawUrl ? normalizeUrl(rawUrl) : undefined
+      const includePageSessions = message.includePageSessions === true
       ;(async () => {
         try {
           // Screen time and hour buckets are pre-computed in domain_stats (O(1)).
@@ -304,7 +305,9 @@ export default defineBackground(() => {
           const [agg, cursorEvents, pageAggs] = await Promise.all([
             store.getSessionStats(domain, normalizedUrl).catch(() => null),
             store.queryByDomain(domain, { type: 'cursor', limit: 2000 }),
-            store.getPageStats(domain).catch(() => [] as never[]),
+            includePageSessions
+              ? store.getPageStats(domain).catch(() => [] as never[])
+              : Promise.resolve([] as never[]),
           ])
 
           // Only return null stats when there is truly no data at all.
@@ -335,18 +338,21 @@ export default defineBackground(() => {
           // Build per-page breakdown from page-level aggregates for the stats
           // page's expanded domain view. Each page aggregate yields one entry
           // per session so computeTopPages() can sum and count correctly.
-          const sessions: Array<{ url: string; focusTs: number; blurTs: number; durationMs: number }> = []
-          for (const p of pageAggs) {
-            const url = p.key.slice(domain.length + 2) // strip "domain::" prefix → normalizedUrl
-            // Emit one synthetic session per recorded session so visit counts are accurate
-            const perSessionMs = p.sessionCount > 0 ? p.totalTimeMs / p.sessionCount : p.totalTimeMs
-            for (let i = 0; i < Math.max(1, p.sessionCount); i++) {
-              sessions.push({
-                url,
-                focusTs: p.firstVisit,
-                blurTs: p.lastVisit,
-                durationMs: perSessionMs,
-              })
+          let sessions: Array<{ url: string; focusTs: number; blurTs: number; durationMs: number }> | undefined
+          if (includePageSessions) {
+            sessions = []
+            for (const p of pageAggs) {
+              const url = p.key.slice(domain.length + 2) // strip "domain::" prefix → normalizedUrl
+              // Emit one synthetic session per recorded session so visit counts are accurate
+              const perSessionMs = p.sessionCount > 0 ? p.totalTimeMs / p.sessionCount : p.totalTimeMs
+              for (let i = 0; i < Math.max(1, p.sessionCount); i++) {
+                sessions.push({
+                  url,
+                  focusTs: p.firstVisit,
+                  blurTs: p.lastVisit,
+                  durationMs: perSessionMs,
+                })
+              }
             }
           }
 
@@ -367,7 +373,7 @@ export default defineBackground(() => {
               cursorDistancePx,
               eventCounts: agg?.eventsByType ?? {},
               dateRange,
-              sessions,
+              ...(sessions ? { sessions } : {}),
               // Only include uniquePageCount for domain-level stats (not page-level)
               uniquePageCount: normalizedUrl ? undefined : (agg?.uniqueUrls?.length ?? 0),
             },

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -20,6 +20,7 @@ import {
 import { checkAllMilestones, pxToMiles } from '../milestones/milestones'
 
 const store = new LocalEventStore()
+const LOCAL_RAW_EVENT_RETENTION_ENABLED = false
 const LOCAL_RAW_EVENT_RETENTION_DAYS = 30
 const LOCAL_RAW_EVENT_RETENTION_MS = LOCAL_RAW_EVENT_RETENTION_DAYS * 24 * 60 * 60 * 1000
 const LOCAL_RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000
@@ -123,9 +124,11 @@ export default defineBackground(() => {
   // milestones like cursor distance and screen time). Domain milestones
   // additionally fire on navigation — see scheduleMilestoneCheck.
   browser.alarms.create("checkMilestones", { periodInMinutes: 5 });
-  browser.alarms.create(LOCAL_RETENTION_ALARM, {
-    periodInMinutes: LOCAL_RETENTION_ALARM_PERIOD_MINUTES,
-  });
+  if (LOCAL_RAW_EVENT_RETENTION_ENABLED) {
+    browser.alarms.create(LOCAL_RETENTION_ALARM, {
+      periodInMinutes: LOCAL_RETENTION_ALARM_PERIOD_MINUTES,
+    });
+  }
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
     if (alarm.name === "checkMilestones") {
@@ -133,14 +136,16 @@ export default defineBackground(() => {
       return;
     }
 
-    if (alarm.name === LOCAL_RETENTION_ALARM) {
+    if (LOCAL_RAW_EVENT_RETENTION_ENABLED && alarm.name === LOCAL_RETENTION_ALARM) {
       await runLocalRetention({ force: true });
     }
   });
 
-  runLocalRetention().catch((e) => {
-    console.error('[Background] local retention startup error:', e)
-  })
+  if (LOCAL_RAW_EVENT_RETENTION_ENABLED) {
+    runLocalRetention().catch((e) => {
+      console.error('[Background] local retention startup error:', e)
+    })
+  }
 
   // Single-flight + 1s trailing debounce. Rapid navigation events coalesce
   // into one check, and we never run two checks concurrently (the function

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -71,6 +71,7 @@ async function runLocalRetention(options: { force?: boolean } = {}): Promise<voi
     }
 
     await flushPendingUploads()
+    await store.ensureHistoricalStats()
 
     const cutoffTs = now - LOCAL_RAW_EVENT_RETENTION_MS
     const deleted = await store.pruneUploadedEventsOlderThan(cutoffTs)
@@ -597,16 +598,9 @@ export default defineBackground(() => {
             reply({ success: false, error: 'No player identity found' })
             return
           }
-          // Check local bounds so we only fetch what we're missing
-          const stats = await store.getStorageStats().catch(() => null)
-          const localBounds = stats && stats.oldestEvent > 0 && stats.newestEvent > 0
-            ? { oldest: stats.oldestEvent, newest: stats.newestEvent }
-            : undefined
           console.log('[Background] RESTORE_FROM_SERVER starting, pid:', pid.slice(0, 20) + '...',
-            localBounds
-              ? `local range: ${new Date(localBounds.oldest).toISOString()} – ${new Date(localBounds.newest).toISOString()}`
-              : 'no local data')
-          const { events, countsByType } = await fetchEventsByPid(pid, { localBounds })
+            'fetching all server events')
+          const { events, countsByType } = await fetchEventsByPid(pid)
           console.log('[Background] Fetched', events.length, 'events, writing to IDB...')
           await store.addEvents(events)
           console.log('[Background] RESTORE_FROM_SERVER complete')

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -20,6 +20,14 @@ import {
 import { checkAllMilestones, pxToMiles } from '../milestones/milestones'
 
 const store = new LocalEventStore()
+const LOCAL_RAW_EVENT_RETENTION_DAYS = 30
+const LOCAL_RAW_EVENT_RETENTION_MS = LOCAL_RAW_EVENT_RETENTION_DAYS * 24 * 60 * 60 * 1000
+const LOCAL_RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000
+const LOCAL_RETENTION_ALARM_PERIOD_MINUTES = 24 * 60
+const LOCAL_RETENTION_ALARM = 'pruneLocalEvents'
+const LOCAL_RETENTION_LAST_RUN_KEY = 'localRetentionLastRun'
+
+let localRetentionRunning = false
 
 async function flushPendingUploads(): Promise<void> {
   try {
@@ -45,6 +53,38 @@ async function flushPendingUploads(): Promise<void> {
     await store.markEventsAsUploaded(pending.map((e) => e.id))
   } catch (e) {
     console.error('[Background] flushPendingUploads error:', e)
+  }
+}
+
+async function runLocalRetention(options: { force?: boolean } = {}): Promise<void> {
+  if (localRetentionRunning) return
+
+  localRetentionRunning = true
+  try {
+    const now = Date.now()
+    if (!options.force) {
+      const result = await browser.storage.local.get(LOCAL_RETENTION_LAST_RUN_KEY)
+      const lastRun = result[LOCAL_RETENTION_LAST_RUN_KEY]
+      if (typeof lastRun === 'number' && now - lastRun < LOCAL_RETENTION_INTERVAL_MS) {
+        return
+      }
+    }
+
+    await flushPendingUploads()
+
+    const cutoffTs = now - LOCAL_RAW_EVENT_RETENTION_MS
+    const deleted = await store.pruneUploadedEventsOlderThan(cutoffTs)
+    await browser.storage.local.set({ [LOCAL_RETENTION_LAST_RUN_KEY]: Date.now() })
+
+    if (VERBOSE && deleted > 0) {
+      console.log(
+        `[Background] Pruned ${deleted} uploaded local events older than ${LOCAL_RAW_EVENT_RETENTION_DAYS} days`,
+      )
+    }
+  } catch (e) {
+    console.error('[Background] local retention error:', e)
+  } finally {
+    localRetentionRunning = false
   }
 }
 
@@ -82,11 +122,24 @@ export default defineBackground(() => {
   // milestones like cursor distance and screen time). Domain milestones
   // additionally fire on navigation — see scheduleMilestoneCheck.
   browser.alarms.create("checkMilestones", { periodInMinutes: 5 });
+  browser.alarms.create(LOCAL_RETENTION_ALARM, {
+    periodInMinutes: LOCAL_RETENTION_ALARM_PERIOD_MINUTES,
+  });
 
   browser.alarms.onAlarm.addListener(async (alarm) => {
-    if (alarm.name !== "checkMilestones") return;
-    await runMilestoneCheck();
+    if (alarm.name === "checkMilestones") {
+      await runMilestoneCheck();
+      return;
+    }
+
+    if (alarm.name === LOCAL_RETENTION_ALARM) {
+      await runLocalRetention({ force: true });
+    }
   });
+
+  runLocalRetention().catch((e) => {
+    console.error('[Background] local retention startup error:', e)
+  })
 
   // Single-flight + 1s trailing debounce. Rapid navigation events coalesce
   // into one check, and we never run two checks concurrently (the function

--- a/extension/src/entrypoints/portrait/portrait.tsx
+++ b/extension/src/entrypoints/portrait/portrait.tsx
@@ -10,7 +10,10 @@ import "@movement/portrait-styles.scss";
 import type { CollectionEvent, DayCounts } from "@movement/types";
 import { MovementCanvas } from "@movement/components/MovementCanvas";
 import { useCursorTrails } from "@movement/hooks/useCursorTrails";
-import { DEFAULT_ACTIVE_VISUALIZATIONS } from "@movement/components/registry";
+import {
+  DEFAULT_ACTIVE_VISUALIZATIONS,
+  deriveRequiredEventTypes,
+} from "@movement/components/registry";
 import { DomainPortraitExport } from "../../components/DomainPortraitExport";
 import { captureDomPortrait, domainPortraitFilename } from "../../utils/portraitExport";
 import type { PortraitCardProps } from "../../components/PortraitCard";
@@ -43,6 +46,12 @@ const PortraitPage = () => {
     setError(null);
     try {
       const options: Record<string, unknown> = { limit: 10_000 };
+      const requiredTypes = deriveRequiredEventTypes(activeVisualizations);
+      if (requiredTypes.size === 0) {
+        setEvents([]);
+        return;
+      }
+      options.types = Array.from(requiredTypes);
       if (day) {
         options.startTs = new Date(day + "T00:00:00").getTime();
         options.endTs = new Date(day + "T23:59:59.999").getTime();
@@ -64,7 +73,7 @@ const PortraitPage = () => {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [activeVisualizations]);
 
   useEffect(() => {
     loadEvents(selectedDay);
@@ -72,14 +81,30 @@ const PortraitPage = () => {
 
   // Fetch accurate per-day event counts (full scan, not capped like events)
   useEffect(() => {
-    browser.runtime.sendMessage({ type: 'GET_DAY_COUNTS' })
+    if (loading) return;
+
+    const run = () => {
+      browser.runtime.sendMessage({ type: 'GET_DAY_COUNTS' })
       .then((res: any) => {
         if (res?.success && res.counts) {
           setDayCounts(new Map(Object.entries(res.counts) as [string, number][]));
         }
       })
       .catch((e: unknown) => console.error('[Portrait] GET_DAY_COUNTS error:', e));
-  }, []);
+    };
+
+    const idle = (window as typeof window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    });
+    if (idle.requestIdleCallback) {
+      const handle = idle.requestIdleCallback(run, { timeout: 2_000 });
+      return () => idle.cancelIdleCallback?.(handle);
+    }
+
+    const handle = window.setTimeout(run, 250);
+    return () => window.clearTimeout(handle);
+  }, [loading]);
 
   // Screen time stats: uses pre-computed global aggregate for unfiltered view,
   // falls back to GET_SCREEN_TIME for day-filtered views.

--- a/extension/src/entrypoints/stats/stats.tsx
+++ b/extension/src/entrypoints/stats/stats.tsx
@@ -12,6 +12,10 @@ interface DomainEntry {
   domain: string;
   eventCount: number;
   lastVisit: number;
+  firstVisit: number;
+  totalTimeMs: number;
+  uniquePageCount: number;
+  eventCounts: { cursor?: number; keyboard?: number; viewport?: number };
 }
 
 interface PageSession {
@@ -24,10 +28,10 @@ interface PageSession {
 interface DomainStats {
   domain: string;
   totalTimeMs: number | null;
-  sessions: PageSession[];
+  sessions?: PageSession[];
   uniquePageCount: number;
   dateRange: { oldest: string; newest: string } | null;
-  eventCounts: { cursor: number; keyboard: number; viewport: number };
+  eventCounts: { cursor?: number; keyboard?: number; viewport?: number };
 }
 
 interface PageStat {
@@ -40,6 +44,7 @@ interface PageStat {
 interface EnrichedDomain extends DomainEntry {
   stats: DomainStats | null;
   loading: boolean;
+  pagesLoading: boolean;
 }
 
 function formatDuration(ms: number): string {
@@ -95,6 +100,24 @@ function computeTopPages(sessions: PageSession[], limit = 10): PageStat[] {
 const TOP_DOMAINS = 30;
 const TOP_PAGES = 10;
 
+function dateRangeFromDomain(domain: DomainEntry): DomainStats["dateRange"] {
+  if (!domain.firstVisit || !domain.lastVisit) return null;
+  return {
+    oldest: new Date(domain.firstVisit).toLocaleDateString(),
+    newest: new Date(domain.lastVisit).toLocaleDateString(),
+  };
+}
+
+function statsFromDomainEntry(domain: DomainEntry): DomainStats {
+  return {
+    domain: domain.domain,
+    totalTimeMs: domain.totalTimeMs,
+    uniquePageCount: domain.uniquePageCount,
+    dateRange: dateRangeFromDomain(domain),
+    eventCounts: domain.eventCounts ?? {},
+  };
+}
+
 const StatsPage = () => {
   const [domains, setDomains] = useState<EnrichedDomain[]>([]);
   const [loading, setLoading] = useState(true);
@@ -121,25 +144,12 @@ const StatsPage = () => {
         .sort((a, b) => b.eventCount - a.eventCount)
         .slice(0, TOP_DOMAINS);
 
-      // Show domain names immediately while stats load
-      setDomains(topDomains.map((d) => ({ ...d, stats: null, loading: true })));
-      setLoading(false);
-
-      // Fetch per-domain stats in parallel
-      const statsResults = await Promise.allSettled(
-        topDomains.map((d) =>
-          browser.runtime.sendMessage({ type: "GET_DOMAIN_STATS", domain: d.domain }),
-        ),
-      );
-
-      const enrichedWithStats: EnrichedDomain[] = topDomains.map((d, i) => {
-        const result = statsResults[i];
-        const stats =
-          result.status === "fulfilled" && result.value?.success
-            ? (result.value.stats as DomainStats | null)
-            : null;
-        return { ...d, stats, loading: false };
-      });
+      const enrichedWithStats: EnrichedDomain[] = topDomains.map((d) => ({
+        ...d,
+        stats: statsFromDomainEntry(d),
+        loading: false,
+        pagesLoading: false,
+      }));
 
       const sorted = [...enrichedWithStats].sort((a, b) => {
         const ta = a.stats?.totalTimeMs ?? -1;
@@ -157,6 +167,73 @@ const StatsPage = () => {
     }
   };
 
+  const loadPageSessions = async (domain: string) => {
+    const target = domains.find((d) => d.domain === domain);
+    if (!target || target.pagesLoading || target.stats?.sessions) return;
+
+    setDomains((current) =>
+      current.map((d) =>
+        d.domain === domain ? { ...d, pagesLoading: true } : d,
+      ),
+    );
+
+    try {
+      const res = await browser.runtime.sendMessage({
+        type: "GET_DOMAIN_STATS",
+        domain,
+        includePageSessions: true,
+      });
+      if (!res?.success || !res.stats) {
+        setDomains((current) =>
+          current.map((d) =>
+            d.domain === domain
+              ? {
+                  ...d,
+                  stats: {
+                    ...(d.stats ?? statsFromDomainEntry(d)),
+                    sessions: [],
+                  },
+                  pagesLoading: false,
+                }
+              : d,
+          ),
+        );
+        return;
+      }
+
+      setDomains((current) =>
+        current.map((d) =>
+          d.domain === domain
+            ? {
+                ...d,
+                stats: {
+                  ...(d.stats ?? statsFromDomainEntry(d)),
+                  sessions: (res.stats as DomainStats).sessions ?? [],
+                },
+                pagesLoading: false,
+              }
+            : d,
+        ),
+      );
+    } catch (e) {
+      console.error("[Stats] Failed to load page sessions:", e);
+      setDomains((current) =>
+        current.map((d) =>
+          d.domain === domain
+            ? {
+                ...d,
+                stats: {
+                  ...(d.stats ?? statsFromDomainEntry(d)),
+                  sessions: [],
+                },
+                pagesLoading: false,
+              }
+            : d,
+        ),
+      );
+    }
+  };
+
   const sortedDomains = [...domains].sort((a, b) => {
     if (sortBy === "time") {
       return (b.stats?.totalTimeMs ?? -1) - (a.stats?.totalTimeMs ?? -1);
@@ -167,7 +244,13 @@ const StatsPage = () => {
   const maxTime = Math.max(1, ...sortedDomains.map((d) => d.stats?.totalTimeMs ?? 0));
 
   const toggleDomain = (domain: string) => {
-    setExpandedDomain((prev) => (prev === domain ? null : domain));
+    setExpandedDomain((prev) => {
+      const next = prev === domain ? null : domain;
+      if (next) {
+        void loadPageSessions(next);
+      }
+      return next;
+    });
   };
 
   return (
@@ -302,7 +385,13 @@ const StatsPage = () => {
                     </div>
 
                     {/* Expanded pages list */}
-                    {isExpanded && topPages && (
+                    {isExpanded && domain.pagesLoading && (
+                      <div className="domain-row__pages">
+                        <p className="domain-row__pages-empty">loading page sessions…</p>
+                      </div>
+                    )}
+
+                    {isExpanded && !domain.pagesLoading && topPages && (
                       <div className="domain-row__pages">
                         {topPages.length === 0 ? (
                           <p className="domain-row__pages-empty">no page sessions recorded</p>

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -12,10 +12,19 @@ const DB_NAME = "collection_events_db";
 const DB_VERSION = 9;
 const STORE_NAME = "events";
 const STATS_STORE_NAME = "domain_stats";
+const STATS_BACKFILL_STATE_KEY = "__stats_backfill_state__";
 const UPLOAD_STATE_PENDING = "pending";
 const UPLOAD_STATE_UPLOADED = "uploaded";
+const COLLECTION_EVENT_TYPES: CollectionEventType[] = [
+  "cursor",
+  "navigation",
+  "viewport",
+  "keyboard",
+];
+const STORAGE_SIZE_SAMPLE_LIMIT = 200;
 
 type UploadState = typeof UPLOAD_STATE_PENDING | typeof UPLOAD_STATE_UPLOADED;
+type StatsBackfillState = "running" | "complete";
 
 interface StoredCollectionEvent extends CollectionEvent {
   uploaded?: boolean;
@@ -138,6 +147,10 @@ export class LocalEventStore {
   private db: IDBDatabase | null = null;
   private isInitialized = false;
   private initPromise: Promise<void> | null = null;
+  private statsBackfillPromise: Promise<void> | null = null;
+  private statsBackfillComplete = false;
+  private eventsPendingStatsAfterBackfill: CollectionEvent[] = [];
+  private eventIdsPendingStatsAfterBackfill = new Set<string>();
 
   constructor() {
     this.init().catch(console.error);
@@ -169,10 +182,6 @@ export class LocalEventStore {
         }
         this.initPromise = null;
         resolve();
-        // Backfill session stats in the background (non-blocking)
-        this.backfillSessionStats().catch((e) =>
-          console.error("[LocalEventStore] Session stats backfill failed:", e),
-        );
       };
 
       request.onupgradeneeded = (event) => {
@@ -319,6 +328,136 @@ export class LocalEventStore {
     }
   }
 
+  private async ensureSessionStatsBackfilled(): Promise<void> {
+    if (this.statsBackfillComplete) return;
+
+    if (!this.statsBackfillPromise) {
+      this.statsBackfillPromise = this.backfillSessionStats()
+        .then(() => this.flushEventsPendingStatsAfterBackfill())
+        .then(() => this.writeStatsBackfillState("complete"))
+        .then(() => {
+          this.statsBackfillComplete = true;
+        })
+        .finally(() => {
+          this.statsBackfillPromise = null;
+        });
+    }
+
+    return this.statsBackfillPromise;
+  }
+
+  private async canUpdateStatsIncrementally(): Promise<boolean> {
+    if (this.statsBackfillComplete) return true;
+    if (this.statsBackfillPromise) return false;
+
+    if (!this.db) {
+      throw new Error("Database not initialized");
+    }
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        [STORE_NAME, STATS_STORE_NAME],
+        "readonly",
+      );
+      const eventStore = transaction.objectStore(STORE_NAME);
+      const statsStore = transaction.objectStore(STATS_STORE_NAME);
+      const eventCountRequest = eventStore.count();
+      const statsCountRequest = statsStore.count();
+      const stateRequest = statsStore.get(STATS_BACKFILL_STATE_KEY);
+      let eventCount = 0;
+      let statsCount = 0;
+      let state: StatsBackfillState | null = null;
+      let pendingRequests = 3;
+
+      const complete = () => {
+        pendingRequests--;
+        if (pendingRequests > 0) return;
+
+        const canUpdate =
+          state === "complete" ||
+          (state === null && (statsCount > 0 || eventCount === 0));
+        if (canUpdate) {
+          this.statsBackfillComplete = true;
+        }
+        resolve(canUpdate);
+      };
+
+      eventCountRequest.onsuccess = () => {
+        eventCount = eventCountRequest.result;
+        complete();
+      };
+      statsCountRequest.onsuccess = () => {
+        statsCount = statsCountRequest.result;
+        complete();
+      };
+      stateRequest.onsuccess = () => {
+        const result = stateRequest.result as
+          | { state?: StatsBackfillState }
+          | undefined;
+        state =
+          result?.state === "running" || result?.state === "complete"
+            ? result.state
+            : null;
+        complete();
+      };
+      eventCountRequest.onerror = () => reject(eventCountRequest.error);
+      statsCountRequest.onerror = () => reject(statsCountRequest.error);
+      stateRequest.onerror = () => reject(stateRequest.error);
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  async ensureHistoricalStats(): Promise<void> {
+    await this.ensureInitialized();
+    await this.ensureSessionStatsBackfilled();
+  }
+
+  private queueEventsForStatsAfterBackfill(events: CollectionEvent[]): void {
+    for (const event of events) {
+      if (this.eventIdsPendingStatsAfterBackfill.has(event.id)) continue;
+      this.eventIdsPendingStatsAfterBackfill.add(event.id);
+      this.eventsPendingStatsAfterBackfill.push(event);
+    }
+  }
+
+  private removeEventsQueuedForStatsAfterBackfill(events: CollectionEvent[]): void {
+    const idsToRemove = new Set(events.map((event) => event.id));
+    this.eventsPendingStatsAfterBackfill =
+      this.eventsPendingStatsAfterBackfill.filter((event) => {
+        if (!idsToRemove.has(event.id)) return true;
+        this.eventIdsPendingStatsAfterBackfill.delete(event.id);
+        return false;
+      });
+  }
+
+  private async flushEventsPendingStatsAfterBackfill(): Promise<void> {
+    while (this.eventsPendingStatsAfterBackfill.length > 0) {
+      const events = this.eventsPendingStatsAfterBackfill;
+      this.eventsPendingStatsAfterBackfill = [];
+      this.eventIdsPendingStatsAfterBackfill.clear();
+
+      await this.updateDomainStats(
+        events,
+        LocalEventStore.groupEventsByDomain(events),
+      );
+    }
+  }
+
+  private async writeStatsBackfillState(state: StatsBackfillState): Promise<void> {
+    if (!this.db) return;
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = this.db!.transaction([STATS_STORE_NAME], "readwrite");
+      const statsStore = transaction.objectStore(STATS_STORE_NAME);
+      statsStore.put({
+        key: STATS_BACKFILL_STATE_KEY,
+        state,
+      });
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
   /**
    * One-time backfill: compute session aggregates from existing navigation events.
    * Skips if domain_stats already has data (idempotent).
@@ -326,16 +465,50 @@ export class LocalEventStore {
   private async backfillSessionStats(): Promise<void> {
     if (!this.db) return;
 
-    // Check if backfill already ran (any row in domain_stats means it did)
-    const hasData = await new Promise<boolean>((resolve, reject) => {
+    const backfillState = await new Promise<{
+      state: StatsBackfillState | null;
+      statsCount: number;
+    }>((resolve, reject) => {
       const tx = this.db!.transaction([STATS_STORE_NAME], "readonly");
       const store = tx.objectStore(STATS_STORE_NAME);
       const countReq = store.count();
-      countReq.onsuccess = () => resolve(countReq.result > 0);
+      const stateReq = store.get(STATS_BACKFILL_STATE_KEY);
+      let statsCount = 0;
+      let state: StatsBackfillState | null = null;
+      let pendingRequests = 2;
+
+      const complete = () => {
+        pendingRequests--;
+        if (pendingRequests > 0) return;
+        resolve({ state, statsCount });
+      };
+
+      countReq.onsuccess = () => {
+        statsCount = countReq.result;
+        complete();
+      };
+      stateReq.onsuccess = () => {
+        const result = stateReq.result as
+          | { state?: StatsBackfillState }
+          | undefined;
+        state =
+          result?.state === "running" || result?.state === "complete"
+            ? result.state
+            : null;
+        complete();
+      };
       countReq.onerror = () => reject(countReq.error);
+      stateReq.onerror = () => reject(stateReq.error);
     });
 
-    if (hasData) return;
+    if (
+      backfillState.state === "complete" ||
+      (backfillState.state === null && backfillState.statsCount > 0)
+    ) {
+      return;
+    }
+
+    await this.writeStatsBackfillState("running");
 
     if (VERBOSE) {
       console.log("[LocalEventStore] Starting domain stats backfill...");
@@ -351,7 +524,10 @@ export class LocalEventStore {
       req.onsuccess = () => {
         const cursor = req.result;
         if (cursor) {
-          events.push(cursor.value as CollectionEvent);
+          const evt = cursor.value as CollectionEvent;
+          if (!this.eventIdsPendingStatsAfterBackfill.has(evt.id)) {
+            events.push(evt);
+          }
           cursor.continue();
         } else {
           resolve(events);
@@ -393,6 +569,7 @@ export class LocalEventStore {
     // Compute and write aggregates
     const tx = this.db!.transaction([STATS_STORE_NAME], "readwrite");
     const statsStore = tx.objectStore(STATS_STORE_NAME);
+    statsStore.clear();
 
     for (const [key, { domain, events }] of keyToEvents) {
       const agg = LocalEventStore.emptyAggregate(key, domain);
@@ -401,6 +578,10 @@ export class LocalEventStore {
       LocalEventStore.applyEventsToAggregate(agg, events);
       statsStore.put(agg);
     }
+    statsStore.put({
+      key: STATS_BACKFILL_STATE_KEY,
+      state: "running",
+    });
 
     await new Promise<void>((resolve, reject) => {
       tx.oncomplete = () => resolve();
@@ -591,6 +772,7 @@ export class LocalEventStore {
     normalizedUrl?: string,
   ): Promise<DomainStatsAggregate | null> {
     await this.ensureInitialized();
+    await this.ensureSessionStatsBackfilled();
 
     const key = normalizedUrl
       ? pageStatsKey(domain, normalizedUrl)
@@ -616,6 +798,7 @@ export class LocalEventStore {
    */
   async getGlobalStats(): Promise<DomainStatsAggregate | null> {
     await this.ensureInitialized();
+    await this.ensureSessionStatsBackfilled();
 
     return new Promise((resolve, reject) => {
       if (!this.db) {
@@ -639,6 +822,7 @@ export class LocalEventStore {
    */
   async getPageStats(domain: string): Promise<DomainStatsAggregate[]> {
     await this.ensureInitialized();
+    await this.ensureSessionStatsBackfilled();
 
     const prefix = `${domain}::`;
     return new Promise((resolve, reject) => {
@@ -681,6 +865,7 @@ export class LocalEventStore {
     }>
   > {
     await this.ensureInitialized();
+    await this.ensureSessionStatsBackfilled();
 
     return new Promise((resolve, reject) => {
       if (!this.db) {
@@ -739,7 +924,7 @@ export class LocalEventStore {
   }
 
   /**
-   * Get storage usage stats
+   * Get retained raw-event storage stats.
    */
   async getStorageStats(): Promise<StorageStats> {
     await this.ensureInitialized();
@@ -750,27 +935,91 @@ export class LocalEventStore {
         return;
       }
 
-      const transaction = this.db.transaction([STATS_STORE_NAME], "readonly");
-      const statsStore = transaction.objectStore(STATS_STORE_NAME);
-      const request = statsStore.get(GLOBAL_STATS_KEY);
+      const transaction = this.db.transaction([STORE_NAME], "readonly");
+      const store = transaction.objectStore(STORE_NAME);
+      const tsIndex = store.index("ts");
+      const typeIndex = store.index("type");
+      const countsByType: Record<string, number> = {};
+      let totalEvents = 0;
+      let oldestEvent = 0;
+      let newestEvent = 0;
+      let sampleCount = 0;
+      let sampleSizeBytes = 0;
+      let pendingRequests = 4 + COLLECTION_EVENT_TYPES.length;
+      let settled = false;
 
-      request.onsuccess = () => {
-        const aggregate = request.result as DomainStatsAggregate | undefined;
-        const countsByType = aggregate?.eventsByType ?? {};
-        const totalEvents = Object.values(countsByType).reduce(
-          (sum, count) => sum + count,
-          0,
-        );
+      const fail = (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+
+      const complete = () => {
+        pendingRequests--;
+        if (pendingRequests > 0 || settled) return;
+
+        settled = true;
         resolve({
           totalEvents,
-          estimatedSizeBytes: aggregate?.storageSizeBytes ?? 0,
-          oldestEvent: aggregate?.firstVisit ?? 0,
-          newestEvent: aggregate?.lastVisit ?? 0,
+          estimatedSizeBytes:
+            sampleCount > 0
+              ? Math.round((sampleSizeBytes / sampleCount) * totalEvents)
+              : 0,
+          oldestEvent,
+          newestEvent,
           countsByType,
         });
       };
 
-      request.onerror = () => reject(request.error);
+      const countRequest = store.count();
+      countRequest.onsuccess = () => {
+        totalEvents = countRequest.result;
+        complete();
+      };
+      countRequest.onerror = () => fail(countRequest.error);
+
+      const oldestRequest = tsIndex.openCursor();
+      oldestRequest.onsuccess = () => {
+        oldestEvent =
+          (oldestRequest.result?.value as StoredCollectionEvent | undefined)?.ts ?? 0;
+        complete();
+      };
+      oldestRequest.onerror = () => fail(oldestRequest.error);
+
+      const newestRequest = tsIndex.openCursor(null, "prev");
+      newestRequest.onsuccess = () => {
+        newestEvent =
+          (newestRequest.result?.value as StoredCollectionEvent | undefined)?.ts ?? 0;
+        complete();
+      };
+      newestRequest.onerror = () => fail(newestRequest.error);
+
+      const sampleRequest = store.openCursor();
+      sampleRequest.onsuccess = () => {
+        const cursor = sampleRequest.result;
+        if (cursor && sampleCount < STORAGE_SIZE_SAMPLE_LIMIT) {
+          sampleCount++;
+          sampleSizeBytes += JSON.stringify(cursor.value).length;
+          cursor.continue();
+          return;
+        }
+
+        complete();
+      };
+      sampleRequest.onerror = () => fail(sampleRequest.error);
+
+      for (const eventType of COLLECTION_EVENT_TYPES) {
+        const typeCountRequest = typeIndex.count(IDBKeyRange.only(eventType));
+        typeCountRequest.onsuccess = () => {
+          if (typeCountRequest.result > 0) {
+            countsByType[eventType] = typeCountRequest.result;
+          }
+          complete();
+        };
+        typeCountRequest.onerror = () => fail(typeCountRequest.error);
+      }
+
+      transaction.onerror = () => fail(transaction.error);
     });
   }
 
@@ -937,8 +1186,8 @@ export class LocalEventStore {
 
     if (events.length === 0) return;
 
-    // Group events by domain for stats updates
-    const eventsByDomain = new Map<string, CollectionEvent[]>();
+    const canUpdateStats = await this.canUpdateStatsIncrementally();
+
     const storedEvents: StoredCollectionEvent[] = [];
     for (const event of events) {
       const storedEvent = prepareStoredEvent(event);
@@ -950,38 +1199,52 @@ export class LocalEventStore {
           storedEvent.normalizedUrl = normalizeUrl(storedEvent.meta.url);
         }
       }
-      if (storedEvent.domain) {
-        if (!eventsByDomain.has(storedEvent.domain)) {
-          eventsByDomain.set(storedEvent.domain, []);
-        }
-        eventsByDomain.get(storedEvent.domain)!.push(storedEvent);
-      }
       storedEvents.push(storedEvent);
+    }
+    const eventsForStats = storedEvents.map(toCollectionEvent);
+    const eventsByDomain = LocalEventStore.groupEventsByDomain(eventsForStats);
+
+    if (!canUpdateStats) {
+      this.queueEventsForStatsAfterBackfill(eventsForStats);
     }
 
     // Write events to the main store
-    await new Promise<void>((resolve, reject) => {
-      if (!this.db) {
-        reject(new Error("Database not initialized"));
-        return;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        if (!this.db) {
+          reject(new Error("Database not initialized"));
+          return;
+        }
+
+        const transaction = this.db.transaction([STORE_NAME], "readwrite");
+        const evtStore = transaction.objectStore(STORE_NAME);
+
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+
+        for (const event of storedEvents) {
+          evtStore.put(event);
+        }
+      });
+    } catch (e) {
+      if (!canUpdateStats) {
+        this.removeEventsQueuedForStatsAfterBackfill(eventsForStats);
       }
+      throw e;
+    }
 
-      const transaction = this.db.transaction([STORE_NAME], "readwrite");
-      const evtStore = transaction.objectStore(STORE_NAME);
-
-      transaction.oncomplete = () => resolve();
-      transaction.onerror = () => reject(transaction.error);
-
-      for (const event of storedEvents) {
-        evtStore.put(event);
-      }
-    });
+    if (!canUpdateStats) {
+      this.ensureSessionStatsBackfilled().catch((e) =>
+        console.error("[LocalEventStore] Session stats backfill failed:", e),
+      );
+      return;
+    }
 
     // Update domain aggregates in a separate transaction so a stats
     // failure never blocks event storage
     if (events.length > 0) {
       try {
-        await this.updateDomainStats(events, eventsByDomain);
+        await this.updateDomainStats(eventsForStats, eventsByDomain);
       } catch (e) {
         console.error("[LocalEventStore] Failed to update domain stats:", e);
       }
@@ -1004,6 +1267,20 @@ export class LocalEventStore {
       uniqueUrls: [],
       processedNavIds: [],
     };
+  }
+
+  private static groupEventsByDomain(
+    events: CollectionEvent[],
+  ): Map<string, CollectionEvent[]> {
+    const eventsByDomain = new Map<string, CollectionEvent[]>();
+    for (const event of events) {
+      if (!event.domain) continue;
+      if (!eventsByDomain.has(event.domain)) {
+        eventsByDomain.set(event.domain, []);
+      }
+      eventsByDomain.get(event.domain)!.push(event);
+    }
+    return eventsByDomain;
   }
 
   /**

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -1205,10 +1205,6 @@ export class LocalEventStore {
     });
   }
 
-  /**
-   * Prune events older than cutoff timestamp
-   * Returns number of events deleted
-   */
   async clearAll(): Promise<void> {
     await this.ensureInitialized();
 
@@ -1232,63 +1228,59 @@ export class LocalEventStore {
   }
 
   async pruneOlderThan(cutoffTs: number): Promise<number> {
+    return this.pruneUploadedEventsOlderThan(cutoffTs);
+  }
+
+  /**
+   * Prune uploaded events older than cutoff timestamp.
+   * Pending events stay local until a successful upload marks them uploaded.
+   */
+  async pruneUploadedEventsOlderThan(cutoffTs: number): Promise<number> {
     await this.ensureInitialized();
 
-    const deleted = await new Promise<number>((resolve, reject) => {
+    return new Promise<number>((resolve, reject) => {
       if (!this.db) {
         reject(new Error("Database not initialized"));
         return;
       }
 
-      const transaction = this.db.transaction(
-        [STORE_NAME, STATS_STORE_NAME],
-        "readwrite",
-      );
+      let deleted = 0;
+      const transaction = this.db.transaction([STORE_NAME], "readwrite");
       const store = transaction.objectStore(STORE_NAME);
-      const statsStore = transaction.objectStore(STATS_STORE_NAME);
       const tsIndex = store.index("ts");
-
-      // Clear domain_stats — will be rebuilt from remaining events
-      statsStore.clear();
-
-      const idsToDelete: string[] = [];
-      const request = tsIndex.openCursor(IDBKeyRange.upperBound(cutoffTs));
+      const request = tsIndex.openCursor(IDBKeyRange.upperBound(cutoffTs, true));
 
       request.onsuccess = (event) => {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
-          idsToDelete.push(evt.id);
-          cursor.continue();
-        } else {
-          for (const id of idsToDelete) {
-            store.delete(id);
+          const evt = cursor.value as StoredCollectionEvent;
+          if (getUploadState(evt) !== UPLOAD_STATE_UPLOADED) {
+            cursor.continue();
+            return;
           }
-          transaction.oncomplete = () => {
-            if (VERBOSE) {
-              console.log(
-                `[LocalEventStore] Pruned ${idsToDelete.length} events older than ${new Date(
-                  cutoffTs,
-                ).toISOString()}`,
-              );
-            }
-            resolve(idsToDelete.length);
+
+          const deleteRequest = cursor.delete();
+          deleteRequest.onsuccess = () => {
+            deleted++;
+            cursor.continue();
           };
+          deleteRequest.onerror = () => reject(deleteRequest.error);
         }
       };
 
       request.onerror = () => reject(request.error);
+      transaction.oncomplete = () => {
+        if (VERBOSE && deleted > 0) {
+          console.log(
+            `[LocalEventStore] Pruned ${deleted} uploaded events older than ${new Date(
+              cutoffTs,
+            ).toISOString()}`,
+          );
+        }
+        resolve(deleted);
+      };
       transaction.onerror = () => reject(transaction.error);
     });
-
-    // Rebuild domain_stats from remaining events
-    if (deleted > 0) {
-      await this.backfillSessionStats().catch((e) =>
-        console.error("[LocalEventStore] Stats rebuild after prune failed:", e),
-      );
-    }
-
-    return deleted;
   }
 }

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -27,6 +27,7 @@ const GLOBAL_STATS_KEY = "__global__";
 
 export interface QueryOptions {
   type?: CollectionEventType;
+  types?: CollectionEventType[];
   limit?: number;
   startTs?: number;
   endTs?: number;
@@ -263,8 +264,7 @@ export class LocalEventStore {
         // v6: create domain_stats store (keyPath: "domain")
         // v7: recreate with keyPath: "key" to support both domain and page-level aggregates
         // v8: force rebuild to populate page-level + global aggregates added after v7
-        // v9: force rebuild to populate storageSizeBytes in aggregates
-        if (oldVersion < 9) {
+        if (oldVersion < 8) {
           if (db.objectStoreNames.contains(STATS_STORE_NAME)) {
             db.deleteObjectStore(STATS_STORE_NAME);
           }
@@ -272,6 +272,8 @@ export class LocalEventStore {
           if (VERBOSE) {
             console.log("[LocalEventStore] Created domain_stats store (keyPath: key)");
           }
+        } else if (!db.objectStoreNames.contains(STATS_STORE_NAME)) {
+          db.createObjectStore(STATS_STORE_NAME, { keyPath: "key" });
         }
 
         if (oldVersion < 9) {
@@ -672,6 +674,10 @@ export class LocalEventStore {
       domain: string;
       eventCount: number;
       lastVisit: number;
+      firstVisit: number;
+      totalTimeMs: number;
+      uniquePageCount: number;
+      eventCounts: Record<string, number>;
     }>
   > {
     await this.ensureInitialized();
@@ -682,42 +688,47 @@ export class LocalEventStore {
         return;
       }
 
-      const transaction = this.db.transaction([STORE_NAME], "readonly");
-      const store = transaction.objectStore(STORE_NAME);
-      const domainIndex = store.index("domain");
-
-      const domainMap = new Map<string, { count: number; lastVisit: number }>();
-
-      // Walk the domain index — entries are grouped by key so this is efficient
-      const request = domainIndex.openCursor();
+      const transaction = this.db.transaction([STATS_STORE_NAME], "readonly");
+      const statsStore = transaction.objectStore(STATS_STORE_NAME);
+      const request = statsStore.openCursor();
+      const domains: Array<{
+        domain: string;
+        eventCount: number;
+        lastVisit: number;
+        firstVisit: number;
+        totalTimeMs: number;
+        uniquePageCount: number;
+        eventCounts: Record<string, number>;
+      }> = [];
 
       request.onsuccess = (event) => {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
 
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
-          const domain = evt.domain || extractDomain(evt.meta.url);
-
-          if (domain) {
-            const existing = domainMap.get(domain);
-            if (existing) {
-              existing.count++;
-              existing.lastVisit = Math.max(existing.lastVisit, evt.ts);
-            } else {
-              domainMap.set(domain, { count: 1, lastVisit: evt.ts });
-            }
+          const aggregate = cursor.value as DomainStatsAggregate;
+          if (
+            aggregate.key !== GLOBAL_STATS_KEY &&
+            aggregate.domain &&
+            !aggregate.key.includes("::")
+          ) {
+            const eventCounts = aggregate.eventsByType ?? {};
+            const eventCount = Object.values(eventCounts).reduce(
+              (sum, count) => sum + count,
+              0,
+            );
+            domains.push({
+              domain: aggregate.domain,
+              eventCount,
+              lastVisit: aggregate.lastVisit,
+              firstVisit: aggregate.firstVisit,
+              totalTimeMs: aggregate.totalTimeMs,
+              uniquePageCount: aggregate.uniqueUrls?.length ?? 0,
+              eventCounts,
+            });
           }
 
           cursor.continue();
         } else {
-          const domains = Array.from(domainMap.entries()).map(
-            ([domain, data]) => ({
-              domain,
-              eventCount: data.count,
-              lastVisit: data.lastVisit,
-            }),
-          );
-
           domains.sort((a, b) => b.lastVisit - a.lastVisit);
           resolve(domains);
         }
@@ -796,6 +807,7 @@ export class LocalEventStore {
       const request = tsIndex.openCursor(range, direction);
 
       const events: CollectionEvent[] = [];
+      const typeSet = options.types ? new Set(options.types) : null;
 
       request.onsuccess = (event) => {
         const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
@@ -805,6 +817,7 @@ export class LocalEventStore {
           let include = true;
 
           if (options.type && evt.type !== options.type) include = false;
+          if (typeSet && !typeSet.has(evt.type)) include = false;
 
           if (include) {
             events.push(toCollectionEvent(evt));

--- a/extension/src/storage/historyLoader.ts
+++ b/extension/src/storage/historyLoader.ts
@@ -45,33 +45,40 @@ export async function loadHistoricalData(
 
   const allEvents: CollectionEvent[] = [];
 
-  // Query background service worker for each event type
-  for (const type of types) {
-    let localEvents: CollectionEvent[] = [];
-    try {
-      if (actualMode === 'domain') {
-        const res: any = await browser.runtime.sendMessage({
-          type: 'QUERY_EVENTS_BY_DOMAIN',
-          domain,
-          options: { type, limit },
-        });
-        localEvents = res?.events || [];
-      } else {
-        const res: any = await browser.runtime.sendMessage({
-          type: 'QUERY_EVENTS_BY_URL',
-          url: normalizedCurrentUrl,
-          options: { type, limit },
-        });
-        localEvents = res?.events || [];
+  const eventGroups = await Promise.all(
+    types.map(async (type): Promise<CollectionEvent[]> => {
+      try {
+        if (actualMode === 'domain') {
+          const res: any = await browser.runtime.sendMessage({
+            type: 'QUERY_EVENTS_BY_DOMAIN',
+            domain,
+            options: { type, limit },
+          });
+          const localEvents = res?.events || [];
+          if (VERBOSE) console.log(
+            `[HistoryLoader] Found ${localEvents.length} local ${type} events`,
+          );
+          return localEvents;
+        } else {
+          const res: any = await browser.runtime.sendMessage({
+            type: 'QUERY_EVENTS_BY_URL',
+            url: normalizedCurrentUrl,
+            options: { type, limit },
+          });
+          const localEvents = res?.events || [];
+          if (VERBOSE) console.log(
+            `[HistoryLoader] Found ${localEvents.length} local ${type} events`,
+          );
+          return localEvents;
+        }
+      } catch (e) {
+        console.error(`[HistoryLoader] Failed to query ${type} from background:`, e);
+        return [];
       }
-    } catch (e) {
-      console.error(`[HistoryLoader] Failed to query ${type} from background:`, e);
-    }
+    }),
+  );
 
-    if (VERBOSE) console.log(
-      `[HistoryLoader] Found ${localEvents.length} local ${type} events`,
-    );
-
+  for (const localEvents of eventGroups) {
     allEvents.push(...localEvents);
   }
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -49,6 +49,8 @@ import { DEFAULT_SETTINGS } from "./settingsDefaults";
 
 export { CLICK_DEFAULTS } from "./clickDefaults";
 
+const EMPTY_EVENTS: CollectionEvent[] = [];
+
 const READOUT_WRAPPER_STYLE: React.CSSProperties = {
   position: "absolute",
   top: "20px",
@@ -754,6 +756,10 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     maxGroups: 60,
     evictIdsRef,
   });
+  const activeTrailEvents = hasCursorViz ? trailEvents : EMPTY_EVENTS;
+  const activeTypingEvents = showTyping ? filteredEvents : EMPTY_EVENTS;
+  const activeScrollingEvents = showScrolling ? filteredEvents : EMPTY_EVENTS;
+  const activeNavigationEvents = showNavigation ? filteredEvents : EMPTY_EVENTS;
 
   const cursorSettings = useMemo(
     () => ({
@@ -794,7 +800,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     trailStates,
     timeBounds: cursorTimeBounds,
     cycleDuration: cursorCycleDuration,
-  } = useCursorTrails(trailEvents, viewportSize, cursorSettings);
+  } = useCursorTrails(activeTrailEvents, viewportSize, cursorSettings);
 
   // Recent activity (live mode) from the raw event stream, not the capped drawn
   // trails: how many people + the geographic spread of their timezones.
@@ -834,7 +840,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     typingStates,
     timeBounds: keyboardTimeBounds,
     cycleDuration: keyboardCycleDuration,
-  } = useKeyboardTyping(filteredEvents, viewportSize, keyboardSettings);
+  } = useKeyboardTyping(activeTypingEvents, viewportSize, keyboardSettings);
 
   const timeRange = useMemo(() => {
     const allMins: number[] = [];
@@ -873,6 +879,10 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   ]);
 
   const { scheduledClicks, clickCycleDuration } = useMemo(() => {
+    if (!showClicks) {
+      return { scheduledClicks: [], clickCycleDuration: 0 };
+    }
+
     const clickColorRenderer = getTrailRenderer(
       settings.trailVisualStyle ?? "color",
     );
@@ -932,6 +942,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     return { scheduledClicks: normalized, clickCycleDuration };
   }, [
     trailStates,
+    showClicks,
     settings.clickMinDuration,
     settings.clickMaxDuration,
     settings.clickMaxGapMs,
@@ -948,7 +959,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   );
 
   const { animations: scrollAnimations, urlMetadata: scrollUrlMetadata } =
-    useViewportScroll(filteredEvents, viewportSize, viewportSettings);
+    useViewportScroll(activeScrollingEvents, viewportSize, viewportSettings);
 
   // For viewports whose URL has no captured title (no navigation event), ask
   // the worker's /page-meta endpoint to resolve title + favicon live (oEmbed
@@ -983,7 +994,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   );
 
   const { timelineState } = useNavigationTimeline(
-    filteredEvents,
+    activeNavigationEvents,
     navigationTimelineSettings,
   );
 
@@ -1009,7 +1020,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   );
 
   const { radialState } = useNavigationRadial(
-    filteredEvents,
+    activeNavigationEvents,
     navigationRadialSettings,
   );
 


### PR DESCRIPTION
## Summary

This targets slow cold loads and high event volume when a user has a large local IndexedDB history.

- Preserve v8 `domain_stats` aggregates during the v9 open instead of deleting the aggregate store and forcing a full event-store rebuild on service-worker startup.
- Make the time/stats page render from precomputed domain aggregates, then lazy-load per-page sessions only when a domain is expanded.
- Remove an unused popup recent-events query and RAF animation path; `TinyMovementPreview` remains the rendered preview.
- Make portrait loads request only the event types required by active visualizations, defer the full day-count scan until after the first event load, and avoid running inactive MovementCanvas processors over the loaded event set.
- Parallelize overlay history queries when multiple event types are enabled.
- Reduce viewport collector event volume: scroll now samples at 500ms instead of 100ms, resize waits for a 1000ms settle window and ignores tiny size changes, and zoom emits the settled final value with a 5% noise floor.
- Keep the uploaded raw-event retention implementation and tests in place, but leave retention scheduling disabled for this PR. No startup or daily 30-day local pruning runs in the extension.
- Harden aggregate rebuilds with a durable running/complete marker so interrupted backfills are rebuilt from raw rows instead of trusting partial aggregate rows.

## Root Cause

Large local histories were hitting several O(events), high-serialization, or high-frequency collection paths:

- `GET_ALL_DOMAINS` walked every event before the time page could render.
- The time page then fired `GET_DOMAIN_STATS` for 30 domains, each of which could scan cursor/page aggregate data.
- The v9 migration rebuilt stats by deleting the aggregate store, making a cold service-worker start expensive for large databases.
- The full portrait loaded broad event data and still ran inactive visualization hooks.
- The popup had duplicate/dead preview work in `InternetPortraitHome`.
- Viewport scroll was archived up to 10 times per second, resize emitted after only 200ms, and zoom could record an intermediate value instead of the settled final state.
- Raw local events can still grow without a retention bound; the pruning path is intentionally paused until we finish the local-data retention decision.

## Validation

- `cd extension && bun run test -- run src/__tests__/ViewportCollector.test.ts` (20 tests)
- `cd extension && bun run test -- run` (36 files, 260 tests)
- `cd extension && bun run build`
- `cd extension && bun run build:firefox`
- `git diff --check`
- Subagent code review of #180: final pass reported no blockers.

`cd extension && bunx tsc --noEmit` still fails on existing repo type issues around trail renderer props, shared component hook typing, Worker globals, data-transfer buffer typing, and WXT manifest typing; this patch did not add new files to that failure list.
