### PR TITLE
Fix remounted playhtml element handlers

### DIFF
--- a/.changeset/fridge-remount-handlers.md
+++ b/.changeset/fridge-remount-handlers.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Fix local element cleanup so React-remounted playhtml elements can register replacement handlers without keeping stale drag state.

--- a/.changeset/fridge-remount-handlers.md
+++ b/.changeset/fridge-remount-handlers.md
@@ -1,5 +1,6 @@
 ---
 "playhtml": patch
+"@playhtml/react": patch
 ---
 
-Fix local element cleanup so React-remounted playhtml elements can register replacement handlers without keeping stale drag state.
+Fix local element cleanup and React registration stability so remounted playhtml elements can register replacement handlers without keeping stale drag state.

--- a/packages/playhtml/src/__tests__/duplicate-ids.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-ids.test.ts
@@ -50,6 +50,31 @@ describe("duplicate playhtml element IDs", () => {
     );
   });
 
+  it("does not remove the registered element handler when an ignored duplicate is removed", async () => {
+    await playhtml.init({});
+
+    const first = document.createElement("div");
+    first.id = "duplicate-removal";
+    first.setAttribute("can-move", "");
+
+    const second = document.createElement("div");
+    second.id = "duplicate-removal";
+    second.setAttribute("can-move", "");
+
+    document.body.append(first, second);
+
+    await playhtml.setupPlayElementForTag(first, "can-move");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    await playhtml.setupPlayElementForTag(second, "can-move");
+
+    playhtml.removePlayElement(second);
+
+    const handler = playhtml.elementHandlers
+      .get("can-move")!
+      .get("duplicate-removal")!;
+    expect(handler.element).toBe(first);
+  });
+
   it("groups duplicate DOM IDs by capability tag for dev tools", () => {
     const firstToggle = document.createElement("div");
     firstToggle.id = "shared-id";

--- a/packages/playhtml/src/__tests__/duplicate-ids.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-ids.test.ts
@@ -17,6 +17,7 @@ describe("duplicate playhtml element IDs", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     await resetPlayHTML();
     document.body.innerHTML = "";
   });
@@ -73,6 +74,26 @@ describe("duplicate playhtml element IDs", () => {
       .get("can-move")!
       .get("duplicate-removal")!;
     expect(handler.element).toBe(first);
+  });
+
+  it("cancels shared hydration warnings when a data-source element is removed", async () => {
+    await playhtml.init({ developmentMode: true });
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const element = document.createElement("div");
+    element.id = "shared-consumer";
+    element.setAttribute("can-move", "");
+    element.setAttribute("data-source", "/source#shared-removal");
+    document.body.append(element);
+
+    await playhtml.setupPlayElementForTag(element, "can-move");
+    playhtml.removePlayElement(element);
+    vi.advanceTimersByTime(3000);
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Shared reference can-move:shared-removal"),
+    );
   });
 
   it("groups duplicate DOM IDs by capability tag for dev tools", () => {

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Tests basic playhtml element setup and state behavior.
+// ABOUTME: Verifies handler lifecycle, SyncedStore writes, and element cleanup.
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 import { playhtml } from "../index";
 
@@ -85,6 +87,33 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-toggle"]["toggle-test"]).toEqual({
       on: false,
     });
+  });
+
+  it("removes handlers for unmounted elements so replacements can register", async () => {
+    const first = document.createElement("div");
+    first.id = "remount-test";
+    first.setAttribute("can-move", "");
+    document.body.appendChild(first);
+    await playhtml.setupPlayElementForTag(first, "can-move");
+
+    expect(
+      playhtml.elementHandlers!.get("can-move")!.get("remount-test")!.element,
+    ).toBe(first);
+
+    playhtml.removePlayElement(first);
+    expect(playhtml.elementHandlers!.get("can-move")!.has("remount-test")).toBe(
+      false,
+    );
+
+    const replacement = document.createElement("div");
+    replacement.id = "remount-test";
+    replacement.setAttribute("can-move", "");
+    document.body.appendChild(replacement);
+    await playhtml.setupPlayElementForTag(replacement, "can-move");
+
+    expect(
+      playhtml.elementHandlers!.get("can-move")!.get("remount-test")!.element,
+    ).toBe(replacement);
   });
 
   it("deleteElementData cleans up all data and handlers", async () => {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1816,10 +1816,26 @@ function removePlayElement(element: Element | null) {
     return;
   }
 
-  for (const tag of Object.keys(elementHandlers)) {
-    const tagElementHandler = elementHandlers.get(tag)!;
-    if (tagElementHandler.has(element.id)) {
-      tagElementHandler.delete(element.id);
+  const elementId = getIdForElement(element as HTMLElement);
+  if (!elementId) {
+    return;
+  }
+
+  for (const [tag, tagElementHandler] of elementHandlers) {
+    if (tagElementHandler.has(elementId)) {
+      const key = `${tag}:${elementId}`;
+      const yVal = getYjsValue(store.play[tag]?.[elementId]);
+      const observer = yObserverByKey.get(key);
+      if (
+        yVal &&
+        observer &&
+        typeof (yVal as any).unobserveDeep === "function"
+      ) {
+        // @ts-ignore
+        (yVal as any).unobserveDeep(observer);
+      }
+      yObserverByKey.delete(key);
+      tagElementHandler.delete(elementId);
     }
   }
 }

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1822,21 +1822,24 @@ function removePlayElement(element: Element | null) {
   }
 
   for (const [tag, tagElementHandler] of elementHandlers) {
-    if (tagElementHandler.has(elementId)) {
-      const key = `${tag}:${elementId}`;
-      const yVal = getYjsValue(store.play[tag]?.[elementId]);
-      const observer = yObserverByKey.get(key);
-      if (
-        yVal &&
-        observer &&
-        typeof (yVal as any).unobserveDeep === "function"
-      ) {
-        // @ts-ignore
-        (yVal as any).unobserveDeep(observer);
-      }
-      yObserverByKey.delete(key);
-      tagElementHandler.delete(elementId);
+    const handler = tagElementHandler.get(elementId);
+    if (!handler || handler.element !== element) {
+      continue;
     }
+
+    const key = `${tag}:${elementId}`;
+    const yVal = getYjsValue(store.play[tag]?.[elementId]);
+    const observer = yObserverByKey.get(key);
+    if (
+      yVal &&
+      observer &&
+      typeof (yVal as any).unobserveDeep === "function"
+    ) {
+      // @ts-ignore
+      (yVal as any).unobserveDeep(observer);
+    }
+    yObserverByKey.delete(key);
+    tagElementHandler.delete(elementId);
   }
 }
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1839,6 +1839,12 @@ function removePlayElement(element: Element | null) {
       (yVal as any).unobserveDeep(observer);
     }
     yObserverByKey.delete(key);
+    sharedUpdateSeen.delete(key);
+    const timerId = sharedHydrationTimers.get(key);
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+      sharedHydrationTimers.delete(key);
+    }
     tagElementHandler.delete(elementId);
   }
 }

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -208,6 +208,37 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect(removeSpy).not.toHaveBeenCalled();
   });
 
+  it("removes the mounted element on unmount", () => {
+    const setupSpy = vi
+      .spyOn(playhtml, "setupPlayElement")
+      .mockImplementation(() => {});
+    const removeSpy = vi
+      .spyOn(playhtml, "removePlayElement")
+      .mockImplementation(() => {});
+
+    const { container, unmount } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={{ x: 0, y: 0 }}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+      >
+        {({ data }) => <div id="cleanup-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-move]") as HTMLElement;
+    expect(element).toBeTruthy();
+
+    unmount();
+
+    expect(setupSpy).toHaveBeenCalledWith(element, {
+      ignoreIfAlreadySetup: true,
+    });
+    expect(removeSpy).toHaveBeenCalledWith(element);
+  });
+
   it("CanMoveElement forwards bounds props as can-move-bounds* DOM attributes", () => {
     const { container } = render(
       <CanMoveElement

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -2,10 +2,11 @@
 // ABOUTME: Verifies that built-in capability updateElement functions are called alongside React state updates.
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import "@testing-library/dom";
 import { CanPlayElement } from "../index";
 import { CanMoveElement } from "../elements";
+import playhtml from "../playhtml-singleton";
 import { TagType } from "@playhtml/common";
 import type { ElementAwarenessEventHandlerData } from "@playhtml/common";
 
@@ -119,6 +120,48 @@ describe("CanPlayElement with built-in capabilities", () => {
 
     // onDrag should still be set on the element
     expect((element as any).onDrag).toBe(capabilityOnDrag);
+  });
+
+  it("keeps element setup stable when synced data updates React state", () => {
+    const setupSpy = vi
+      .spyOn(playhtml, "setupPlayElement")
+      .mockImplementation(() => {});
+    const removeSpy = vi
+      .spyOn(playhtml, "removePlayElement")
+      .mockImplementation(() => {});
+
+    const { container } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={{ x: 0, y: 0 }}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+      >
+        {({ data }) => <div id="stable-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-move]") as HTMLElement;
+    expect(element).toBeTruthy();
+    expect(setupSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      (element as any).updateElement({
+        data: { x: 10, y: 5 },
+        awareness: [],
+        awarenessByStableId: new Map(),
+        myAwareness: undefined,
+        element,
+        localData: { startMouseX: 0, startMouseY: 0 },
+        setData: vi.fn(),
+        setLocalData: vi.fn(),
+        setMyAwareness: vi.fn(),
+      });
+    });
+
+    expect(setupSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).not.toHaveBeenCalled();
   });
 
   it("CanMoveElement forwards bounds props as can-move-bounds* DOM attributes", () => {

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -164,6 +164,50 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect(removeSpy).not.toHaveBeenCalled();
   });
 
+  it("updates element handler props without re-registering the element", () => {
+    const setupSpy = vi
+      .spyOn(playhtml, "setupPlayElement")
+      .mockImplementation(() => {});
+    const removeSpy = vi
+      .spyOn(playhtml, "removePlayElement")
+      .mockImplementation(() => {});
+    const firstOnDrag = vi.fn();
+    const secondOnDrag = vi.fn();
+
+    const { container, rerender } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={{ x: 0, y: 0 }}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+        onDrag={firstOnDrag}
+      >
+        {({ data }) => <div id="prop-update-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-move]") as HTMLElement;
+    expect((element as any).onDrag).toBe(firstOnDrag);
+
+    rerender(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={{ x: 0, y: 0 }}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+        onDrag={secondOnDrag}
+      >
+        {({ data }) => <div id="prop-update-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    expect((element as any).onDrag).toBe(secondOnDrag);
+    expect(setupSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+
   it("CanMoveElement forwards bounds props as can-move-bounds* DOM attributes", () => {
     const { container } = render(
       <CanMoveElement

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -122,7 +122,7 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect((element as any).onDrag).toBe(capabilityOnDrag);
   });
 
-  it("keeps element setup stable when synced data updates React state", () => {
+  it("does not remove the element when synced data updates React state", () => {
     const setupSpy = vi
       .spyOn(playhtml, "setupPlayElement")
       .mockImplementation(() => {});
@@ -160,14 +160,16 @@ describe("CanPlayElement with built-in capabilities", () => {
       });
     });
 
-    expect(setupSpy).toHaveBeenCalledTimes(1);
     expect(removeSpy).not.toHaveBeenCalled();
   });
 
-  it("updates element handler props without re-registering the element", () => {
+  it("refreshes element handler props without removing the element", () => {
+    const observedOnDragCallbacks: Array<unknown> = [];
     const setupSpy = vi
       .spyOn(playhtml, "setupPlayElement")
-      .mockImplementation(() => {});
+      .mockImplementation((element) => {
+        observedOnDragCallbacks.push((element as any).onDrag);
+      });
     const removeSpy = vi
       .spyOn(playhtml, "removePlayElement")
       .mockImplementation(() => {});
@@ -204,7 +206,8 @@ describe("CanPlayElement with built-in capabilities", () => {
     );
 
     expect((element as any).onDrag).toBe(secondOnDrag);
-    expect(setupSpy).toHaveBeenCalledTimes(1);
+    expect(setupSpy).toHaveBeenCalledTimes(2);
+    expect(observedOnDragCallbacks).toEqual([firstOnDrag, secondOnDrag]);
     expect(removeSpy).not.toHaveBeenCalled();
   });
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -192,16 +192,10 @@ export function CanPlayElement<T extends object, V = any>({
       ref.current.updateElement = updateElement;
       // @ts-ignore
       ref.current.updateElementAwareness = updateElementAwareness;
-    }
-  });
 
-  useEffect(() => {
-    const mountedElement = ref.current;
-
-    if (mountedElement) {
       // Setup the element, which will handle data-source discovery if needed
       try {
-        playhtml.setupPlayElement(mountedElement, {
+        playhtml.setupPlayElement(ref.current, {
           ignoreIfAlreadySetup: true,
         });
       } catch (error) {
@@ -215,6 +209,11 @@ export function CanPlayElement<T extends object, V = any>({
         }
       }
     }
+  });
+
+  useEffect(() => {
+    const mountedElement = ref.current;
+
     // console.log("setting up", elementProps.defaultData, ref.current);
 
     return () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -196,10 +196,14 @@ export function CanPlayElement<T extends object, V = any>({
   });
 
   useEffect(() => {
-    if (ref.current) {
+    const mountedElement = ref.current;
+
+    if (mountedElement) {
       // Setup the element, which will handle data-source discovery if needed
       try {
-        playhtml.setupPlayElement(ref.current, { ignoreIfAlreadySetup: true });
+        playhtml.setupPlayElement(mountedElement, {
+          ignoreIfAlreadySetup: true,
+        });
       } catch (error) {
         console.warn("[@playhtml/react] Failed to setup play element:", error);
 
@@ -214,8 +218,8 @@ export function CanPlayElement<T extends object, V = any>({
     // console.log("setting up", elementProps.defaultData, ref.current);
 
     return () => {
-      if (!ref.current || !playhtml.elementHandlers) return;
-      playhtml.removePlayElement(ref.current);
+      if (!mountedElement || !playhtml.elementHandlers) return;
+      playhtml.removePlayElement(mountedElement);
     };
   }, []);
   const renderedChildren = children({

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -192,7 +192,11 @@ export function CanPlayElement<T extends object, V = any>({
       ref.current.updateElement = updateElement;
       // @ts-ignore
       ref.current.updateElementAwareness = updateElementAwareness;
+    }
+  });
 
+  useEffect(() => {
+    if (ref.current) {
       // Setup the element, which will handle data-source discovery if needed
       try {
         playhtml.setupPlayElement(ref.current, { ignoreIfAlreadySetup: true });

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -213,7 +213,7 @@ export function CanPlayElement<T extends object, V = any>({
       if (!ref.current || !playhtml.elementHandlers) return;
       playhtml.removePlayElement(ref.current);
     };
-  }, [elementProps, ref.current]);
+  }, []);
   const renderedChildren = children({
     // @ts-ignore
     data,


### PR DESCRIPTION
## Summary

- Fix `removePlayElement()` so it unregisters local handlers from the `elementHandlers` Map and only removes the handler owned by the exact DOM element being cleaned up.
- Detach the associated SyncedStore/Yjs observer during local unmount cleanup while preserving shared element data.
- Clear local shared-reference tracking during unmount cleanup so removed data-source elements do not leave stale hydration timers or update markers.
- Keep React play element cleanup stable across synced data renders so active drags are not interrupted after the first update.
- Capture the mounted React DOM element for unmount cleanup instead of reading `ref.current` after React has cleared it.
- Refresh changed React handler props through setup after each render without removing/re-registering the element on ordinary rerenders.
- Add regression coverage for replacing a removed `can-move` element with the same id, ignored duplicate IDs not deleting the registered handler, removed data-source elements not warning after cleanup, React data updates not removing the element, changed handler props reaching setup, and React cleanup removing the mounted element.
- Add a patch changeset for `playhtml` and `@playhtml/react`.

## Root Cause

React unmount cleanup called `playhtml.removePlayElement()`, but that function iterated `elementHandlers` with `Object.keys(...)`. Because `elementHandlers` is a `Map`, cleanup was effectively a no-op. Remounted elements with the same id could keep stale handlers attached to old DOM nodes, preventing replacements from registering correctly.

Live testing also showed a second issue: `CanPlayElement` re-ran element setup/cleanup after synced data updates because its registration effect depended on a freshly-created props object. Once local cleanup actually worked, that interrupted active drags after the first movement and triggered React maximum-update-depth warnings. The React binding now separates prop refresh/setup from element removal: props update each render and setup can refresh the live handler, while cleanup only happens at unmount.

Follow-up reviews found additional cleanup and prop-refresh edge cases: React clears object refs before passive cleanup runs, duplicate IDs mean removal by id alone can delete a different element's registered handler, removed data-source elements can leave dev hydration tracking behind, and updating DOM callback props alone does not refresh the live `ElementHandler`. The implementation now handles those by cleaning up the captured mounted element, requiring handler element identity before deleting, clearing per-key shared-reference tracking, and running setup after DOM prop refresh without running unmount cleanup.

## Claude Review

- Ran `omegacode` Claude Code review: `wf_bf754b2a5aad`.
- Refuted/stale from Claude: the current branch no longer uses `Object.keys(elementHandlers)` in `removePlayElement`, and current cleanup already detaches the Yjs observer.
- Fixed from Claude: removed data-source elements now clear `sharedHydrationTimers`/`sharedUpdateSeen`, and React rerenders now refresh live handler props through setup instead of only mutating DOM properties.
- Left as low-priority follow-up: in-flight document drag listeners still live until pointer-up if an element unmounts mid-drag. That is bounded to the active drag and needs a broader `ElementHandler` teardown API, so I did not mix it into this PR.

## Validation

- RED: `bun run test -- src/__tests__/elements.test.tsx` in `packages/react` failed because unmount cleanup made zero `removePlayElement()` calls.
- RED: `bun run test -- src/__tests__/duplicate-ids.test.ts` in `packages/playhtml` failed because removing an ignored duplicate deleted the registered handler.
- RED: `bun run test -- src/__tests__/duplicate-ids.test.ts` in `packages/playhtml` failed because a removed data-source element still emitted the delayed shared-reference hydration warning.
- RED: `bun run test -- src/__tests__/elements.test.tsx` in `packages/react` failed because rerendered handler props did not reach setup.
- GREEN: `bun run test -- src/__tests__/elements.test.tsx` in `packages/react` passed: 10 tests.
- GREEN: `bun run test -- src/__tests__/duplicate-ids.test.ts` in `packages/playhtml` passed: 5 tests.
- `bun run test` in `packages/react` passed: 5 files, 29 tests.
- `bun run test` in `packages/playhtml` passed: 24 files, 186 tests.
- `bun run build` in `packages/react` passed.
- `bun run build` in `packages/playhtml` passed.
- `git diff --check` passed.
- Live `/fridge` check passed against local dev servers: persisted custom word `codexlive1781624194146` dragged exactly +80/+40, and captured no Yjs remove-handler warning, shared-reference warning, setup warning, or React maximum-update-depth error. The browser plugin's virtual clipboard layer blocked adding another brand-new word during this final pass, so I verified against the previously added custom word that persisted after reload.