### PR TITLE
Show extension local storage and event stats

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -13,3 +13,4 @@ Format suggestion: "- short user-facing description (#PR)"
 - Preserved pending event uploads when upgrading existing local browsing databases.
 - Stored click events sooner to avoid losing them during fast page exits.
 - Cursor trails now render as smooth, hand-drawn ink strokes with tapered ends (perfect-freehand)
+- Fixed the data collection settings panel to show local storage usage and stored event counts.

--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -66,19 +66,22 @@ describe("Collections", () => {
     document.body.innerHTML = "";
   });
 
-  it("shows local storage size and stored event counts in the top stats card", async () => {
+  it("shows local storage size and stored event counts below collector choices", async () => {
     const { container, root } = await renderCollections();
 
     try {
       const text = container.textContent ?? "";
+      const keyboardIndex = text.indexOf("Keyboard");
       const storageIndex = text.indexOf("3.0 MBlocal storage");
       const eventsIndex = text.indexOf("3events");
       const sizeIndex = text.indexOf("1.5 KBevent data");
       const exportIndex = text.indexOf("Export data");
 
+      expect(keyboardIndex).toBeGreaterThanOrEqual(0);
       expect(storageIndex).toBeGreaterThanOrEqual(0);
       expect(eventsIndex).toBeGreaterThanOrEqual(0);
       expect(sizeIndex).toBeGreaterThanOrEqual(0);
+      expect(storageIndex).toBeGreaterThan(keyboardIndex);
       expect(exportIndex).toBeGreaterThan(sizeIndex);
       expect(text).toContain("cursor 2");
       expect(text).toContain("keyboard 1");
@@ -113,6 +116,30 @@ describe("Collections", () => {
       expect(text).toContain("2.0 KBlocal storage");
       expect(text).toContain("0events");
       expect(text).toContain("0 Bevent data");
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+
+  it("hides local storage stats when all collectors are off", async () => {
+    vi.mocked(browser.storage.local.get).mockImplementation(async (keys) => {
+      if (
+        Array.isArray(keys) &&
+        keys.every((key) => key.startsWith("collection_mode_"))
+      ) {
+        return Object.fromEntries(keys.map((key) => [key, "off"]));
+      }
+      return {};
+    });
+
+    const { container, root } = await renderCollections();
+
+    try {
+      const text = container.textContent ?? "";
+
+      expect(text).not.toContain("local storage");
+      expect(text).not.toContain("event data");
+      expect(text).toContain("Export data");
     } finally {
       cleanupRoot(root, container);
     }

--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -38,6 +38,12 @@ describe("Collections", () => {
     vi.resetModules();
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
       true;
+    vi.mocked(browser.storage.local.get).mockResolvedValue({});
+    vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
+    vi.mocked(browser.tabs.query).mockResolvedValue([
+      { id: 1, url: "https://example.com" } as any,
+    ]);
+    vi.mocked(browser.tabs.sendMessage).mockResolvedValue({ statuses: [] });
     vi.mocked(browser.runtime.sendMessage).mockImplementation(async (message) => {
       if (message?.type === "GET_STORAGE_STATS") {
         return {
@@ -45,6 +51,7 @@ describe("Collections", () => {
           stats: {
             totalEvents: 3,
             estimatedSizeBytes: 1536,
+            localUsageBytes: 3145728,
             oldestEvent: Date.now(),
             countsByType: { cursor: 2, keyboard: 1 },
           },
@@ -59,19 +66,53 @@ describe("Collections", () => {
     document.body.innerHTML = "";
   });
 
-  it("shows local database size in the top stats card", async () => {
+  it("shows local storage size and stored event counts in the top stats card", async () => {
     const { container, root } = await renderCollections();
 
     try {
       const text = container.textContent ?? "";
+      const storageIndex = text.indexOf("3.0 MBlocal storage");
       const eventsIndex = text.indexOf("3events");
-      const sizeIndex = text.indexOf("1.5 KBstored");
+      const sizeIndex = text.indexOf("1.5 KBevent data");
       const exportIndex = text.indexOf("Export data");
 
+      expect(storageIndex).toBeGreaterThanOrEqual(0);
       expect(eventsIndex).toBeGreaterThanOrEqual(0);
       expect(sizeIndex).toBeGreaterThanOrEqual(0);
       expect(exportIndex).toBeGreaterThan(sizeIndex);
+      expect(text).toContain("cursor 2");
+      expect(text).toContain("keyboard 1");
       expect(text).not.toContain("Local database");
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+
+  it("shows local storage size even when no collection events are stored", async () => {
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(async (message) => {
+      if (message?.type === "GET_STORAGE_STATS") {
+        return {
+          success: true,
+          stats: {
+            totalEvents: 0,
+            estimatedSizeBytes: 0,
+            localUsageBytes: 2048,
+            oldestEvent: 0,
+            countsByType: {},
+          },
+        };
+      }
+      return { success: true };
+    });
+
+    const { container, root } = await renderCollections();
+
+    try {
+      const text = container.textContent ?? "";
+
+      expect(text).toContain("2.0 KBlocal storage");
+      expect(text).toContain("0events");
+      expect(text).toContain("0 Bevent data");
     } finally {
       cleanupRoot(root, container);
     }

--- a/extension/src/__tests__/background-retention.test.ts
+++ b/extension/src/__tests__/background-retention.test.ts
@@ -5,10 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const browserMock = vi.hoisted(() => ({
   storage: {
-    local: {
-      get: vi.fn().mockResolvedValue({}),
-      set: vi.fn().mockResolvedValue(undefined),
-    },
+      local: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+        getBytesInUse: vi.fn().mockResolvedValue(1024),
+      },
     session: {
       setAccessLevel: vi.fn().mockResolvedValue(undefined),
     },
@@ -38,6 +39,13 @@ const storeMock = vi.hoisted(() => ({
   markEventsAsUploaded: vi.fn().mockResolvedValue(undefined),
   ensureHistoricalStats: vi.fn().mockResolvedValue(undefined),
   pruneUploadedEventsOlderThan: vi.fn().mockResolvedValue(0),
+  getStorageStats: vi.fn().mockResolvedValue({
+    totalEvents: 2,
+    estimatedSizeBytes: 512,
+    oldestEvent: 1_000,
+    newestEvent: 2_000,
+    countsByType: { cursor: 1, keyboard: 1 },
+  }),
 }));
 
 vi.mock("webextension-polyfill", () => ({
@@ -61,6 +69,15 @@ describe("background local retention", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    Object.defineProperty(globalThis.navigator, "storage", {
+      value: {
+        estimate: vi.fn().mockResolvedValue({
+          usage: 4096,
+          quota: 100_000,
+        }),
+      },
+      configurable: true,
+    });
     vi.stubGlobal("defineBackground", (setup: () => void) => setup);
   });
 
@@ -87,5 +104,32 @@ describe("background local retention", () => {
     await alarmListener?.({ name: "pruneLocalEvents" });
 
     expect(storeMock.pruneUploadedEventsOlderThan).not.toHaveBeenCalled();
+  });
+
+  it("reports extension local storage usage with collection event stats", async () => {
+    const background = await import("../entrypoints/background");
+
+    const startBackground = background.default as unknown as () => void;
+    startBackground();
+
+    const messageListener =
+      browserMock.runtime.onMessage.addListener.mock.calls[0]?.[0];
+    const reply = vi.fn();
+
+    const keepAlive = messageListener?.({ type: "GET_STORAGE_STATS" }, {}, reply);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(keepAlive).toBe(true);
+    expect(reply).toHaveBeenCalledWith({
+      success: true,
+      stats: {
+        totalEvents: 2,
+        estimatedSizeBytes: 512,
+        localUsageBytes: 5120,
+        oldestEvent: 1_000,
+        newestEvent: 2_000,
+        countsByType: { cursor: 1, keyboard: 1 },
+      },
+    });
   });
 });

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -76,10 +76,20 @@
   &__stats {
     display: flex;
     gap: 0;
-    margin-bottom: 12px;
     border: 1px solid $border;
     border-radius: 8px;
     overflow: hidden;
+  }
+
+  &__storage-summary {
+    margin-bottom: 12px;
+  }
+
+  &__stats-detail {
+    margin-top: 4px;
+    font-size: 10px;
+    color: $text-muted;
+    font-family: $font-mono;
   }
 
   &__stat {

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -659,6 +659,7 @@ export function Collections({ onBack }: CollectionsProps) {
   const eventTypeSummary = storageStats
     ? formatEventTypeCounts(storageStats.countsByType)
     : "";
+  const hasActiveCollection = Object.values(modes).some((mode) => mode !== "off");
 
   return (
     <div className="collections">
@@ -682,44 +683,6 @@ export function Collections({ onBack }: CollectionsProps) {
             <span>
               Try refreshing the page or navigating to a regular website.
             </span>
-          </div>
-        )}
-
-        {storageStats && (
-          <div className="collections__storage-summary">
-            <div className="collections__stats">
-              <div className="collections__stat">
-                <span className="collections__stat-value">
-                  {storageStats.localUsageBytes === null
-                    ? "unknown"
-                    : formatSize(storageStats.localUsageBytes)}
-                </span>
-                <span className="collections__stat-label">local storage</span>
-              </div>
-              <div className="collections__stat">
-                <span className="collections__stat-value">
-                  {storageStats.totalEvents.toLocaleString()}
-                </span>
-                <span className="collections__stat-label">events</span>
-              </div>
-              <div className="collections__stat">
-                <span className="collections__stat-value">
-                  {formatSize(storageStats.estimatedSizeBytes)}
-                </span>
-                <span className="collections__stat-label">event data</span>
-              </div>
-              {storageStats.oldestEvent > 0 && (
-                <div className="collections__stat">
-                  <span className="collections__stat-value">
-                    {formatAge(storageStats.oldestEvent)}
-                  </span>
-                  <span className="collections__stat-label">collecting</span>
-                </div>
-              )}
-            </div>
-            {eventTypeSummary && (
-              <div className="collections__stats-detail">{eventTypeSummary}</div>
-            )}
           </div>
         )}
 
@@ -824,6 +787,44 @@ export function Collections({ onBack }: CollectionsProps) {
             </>
           )}
         </div>
+
+        {storageStats && hasActiveCollection && (
+          <div className="collections__storage-summary">
+            <div className="collections__stats">
+              <div className="collections__stat">
+                <span className="collections__stat-value">
+                  {storageStats.localUsageBytes === null
+                    ? "unknown"
+                    : formatSize(storageStats.localUsageBytes)}
+                </span>
+                <span className="collections__stat-label">local storage</span>
+              </div>
+              <div className="collections__stat">
+                <span className="collections__stat-value">
+                  {storageStats.totalEvents.toLocaleString()}
+                </span>
+                <span className="collections__stat-label">events</span>
+              </div>
+              <div className="collections__stat">
+                <span className="collections__stat-value">
+                  {formatSize(storageStats.estimatedSizeBytes)}
+                </span>
+                <span className="collections__stat-label">event data</span>
+              </div>
+              {storageStats.oldestEvent > 0 && (
+                <div className="collections__stat">
+                  <span className="collections__stat-value">
+                    {formatAge(storageStats.oldestEvent)}
+                  </span>
+                  <span className="collections__stat-label">collecting</span>
+                </div>
+              )}
+            </div>
+            {eventTypeSummary && (
+              <div className="collections__stats-detail">{eventTypeSummary}</div>
+            )}
+          </div>
+        )}
 
         <div className="collections__transfer">
           <div className="collections__transfer-buttons">

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -26,7 +26,9 @@ const DEV_MODE_KEY = "dev_mode";
 interface StorageStats {
   totalEvents: number;
   estimatedSizeBytes: number;
+  localUsageBytes: number | null;
   oldestEvent: number;
+  newestEvent?: number;
   countsByType: Record<string, number>;
 }
 
@@ -44,6 +46,14 @@ function formatAge(ts: number): string {
   if (weeks < 8) return `${weeks}w`;
   const months = Math.floor(days / 30);
   return `${months}mo`;
+}
+
+function formatEventTypeCounts(countsByType: Record<string, number>): string {
+  const orderedTypes = getValidEventTypes();
+  return orderedTypes
+    .filter((type) => (countsByType[type] ?? 0) > 0)
+    .map((type) => `${type} ${(countsByType[type] ?? 0).toLocaleString()}`)
+    .join(" · ");
 }
 
 // ── Shared collector list UI ──────────────────────────────────────────────────
@@ -282,12 +292,7 @@ export function Collections({ onBack }: CollectionsProps) {
         type: "CLEAR_ALL_EVENTS",
       });
       if (response?.success) {
-        setStorageStats({
-          totalEvents: 0,
-          estimatedSizeBytes: 0,
-          oldestEvent: 0,
-          countsByType: {},
-        });
+        await loadStorageStats();
       } else {
         alert("Failed to clear data. Please try again.");
       }
@@ -651,6 +656,10 @@ export function Collections({ onBack }: CollectionsProps) {
     return <div className="collections__loading">Loading collections...</div>;
   }
 
+  const eventTypeSummary = storageStats
+    ? formatEventTypeCounts(storageStats.countsByType)
+    : "";
+
   return (
     <div className="collections">
       <header className="collections__header">
@@ -676,27 +685,40 @@ export function Collections({ onBack }: CollectionsProps) {
           </div>
         )}
 
-        {storageStats && storageStats.totalEvents > 0 && (
-          <div className="collections__stats">
-            <div className="collections__stat">
-              <span className="collections__stat-value">
-                {storageStats.totalEvents.toLocaleString()}
-              </span>
-              <span className="collections__stat-label">events</span>
-            </div>
-            <div className="collections__stat">
-              <span className="collections__stat-value">
-                {formatSize(storageStats.estimatedSizeBytes)}
-              </span>
-              <span className="collections__stat-label">stored</span>
-            </div>
-            {storageStats.oldestEvent > 0 && (
+        {storageStats && (
+          <div className="collections__storage-summary">
+            <div className="collections__stats">
               <div className="collections__stat">
                 <span className="collections__stat-value">
-                  {formatAge(storageStats.oldestEvent)}
+                  {storageStats.localUsageBytes === null
+                    ? "unknown"
+                    : formatSize(storageStats.localUsageBytes)}
                 </span>
-                <span className="collections__stat-label">collecting</span>
+                <span className="collections__stat-label">local storage</span>
               </div>
+              <div className="collections__stat">
+                <span className="collections__stat-value">
+                  {storageStats.totalEvents.toLocaleString()}
+                </span>
+                <span className="collections__stat-label">events</span>
+              </div>
+              <div className="collections__stat">
+                <span className="collections__stat-value">
+                  {formatSize(storageStats.estimatedSizeBytes)}
+                </span>
+                <span className="collections__stat-label">event data</span>
+              </div>
+              {storageStats.oldestEvent > 0 && (
+                <div className="collections__stat">
+                  <span className="collections__stat-value">
+                    {formatAge(storageStats.oldestEvent)}
+                  </span>
+                  <span className="collections__stat-label">collecting</span>
+                </div>
+              )}
+            </div>
+            {eventTypeSummary && (
+              <div className="collections__stats-detail">{eventTypeSummary}</div>
             )}
           </div>
         )}

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -30,6 +30,41 @@ const LOCAL_RETENTION_LAST_RUN_KEY = 'localRetentionLastRun'
 
 let localRetentionRunning = false
 
+async function getBrowserStorageUsageBytes(): Promise<number | null> {
+  const storageArea = browser.storage.local as typeof browser.storage.local & {
+    getBytesInUse?: (keys?: string | string[] | null) => Promise<number>
+  }
+
+  if (!storageArea.getBytesInUse) return null
+
+  try {
+    const bytes = await storageArea.getBytesInUse(null)
+    return typeof bytes === 'number' ? bytes : null
+  } catch {
+    return null
+  }
+}
+
+async function getExtensionLocalUsageBytes(): Promise<number | null> {
+  const [originUsageBytes, browserStorageUsageBytes] = await Promise.all([
+    typeof navigator !== 'undefined' && navigator.storage?.estimate
+      ? navigator.storage.estimate()
+          .then((estimate) =>
+            typeof estimate.usage === 'number' ? estimate.usage : null,
+          )
+          .catch(() => null)
+      : Promise.resolve(null),
+    getBrowserStorageUsageBytes(),
+  ])
+
+  const usageParts = [originUsageBytes, browserStorageUsageBytes].filter(
+    (bytes): bytes is number => typeof bytes === 'number',
+  )
+
+  if (usageParts.length === 0) return null
+  return usageParts.reduce((sum, bytes) => sum + bytes, 0)
+}
+
 async function flushPendingUploads(): Promise<void> {
   try {
     const pending = await store.getPendingEvents(500)
@@ -473,8 +508,16 @@ export default defineBackground(() => {
     }
 
     if (message.type === 'GET_STORAGE_STATS') {
-      store.getStorageStats()
-        .then((stats) => reply({ success: true, stats }))
+      Promise.all([store.getStorageStats(), getExtensionLocalUsageBytes()])
+        .then(([stats, localUsageBytes]) => {
+          reply({
+            success: true,
+            stats: {
+              ...stats,
+              localUsageBytes,
+            },
+          })
+        })
         .catch((e) => {
           console.error('[Background] GET_STORAGE_STATS error:', e)
           reply({ success: false })


### PR DESCRIPTION
## Summary

- Show extension-local storage usage in the data collection settings popup.
- Keep collection event count and estimated event data size visible as separate stats.
- Move the stats below the collector mode choices and hide them when all collectors are off.

## Rationale

The previous popup stat only represented retained raw event data and was easy to miss. This gives users a clearer sense of both total local extension storage usage and how many collection events are stored.

## Validation

- `bun run test -- run src/__tests__/Collections.test.tsx src/__tests__/background-retention.test.ts`
- `bun run build-packages`
- `bun run build` from `extension/`