### PR TITLE
Tighten extension storage stats layout

### DIFF
--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -49,11 +49,11 @@ describe("Collections", () => {
         return {
           success: true,
           stats: {
-            totalEvents: 3,
+            totalEvents: 128430,
             estimatedSizeBytes: 1536,
             localUsageBytes: 3145728,
             oldestEvent: Date.now(),
-            countsByType: { cursor: 2, keyboard: 1 },
+            countsByType: { cursor: 88210, keyboard: 8108 },
           },
         };
       }
@@ -74,7 +74,7 @@ describe("Collections", () => {
       const keyboardIndex = text.indexOf("Keyboard");
       const titleIndex = text.indexOf("Local database");
       const storageIndex = text.indexOf("3.0 MBlocal storage");
-      const eventsIndex = text.indexOf("3events");
+      const eventsIndex = text.indexOf("128Kevents");
       const sizeIndex = text.indexOf("1.5 KBevent data");
       const exportIndex = text.indexOf("Export data");
 
@@ -86,8 +86,12 @@ describe("Collections", () => {
       expect(storageIndex).toBeGreaterThan(titleIndex);
       expect(storageIndex).toBeGreaterThan(keyboardIndex);
       expect(exportIndex).toBeGreaterThan(sizeIndex);
-      expect(text).toContain("cursor 2");
-      expect(text).toContain("keyboard 1");
+      expect(
+        container.querySelector('[aria-label="cursor events: 88K"]'),
+      ).not.toBeNull();
+      expect(
+        container.querySelector('[aria-label="keyboard events: 8.1K"]'),
+      ).not.toBeNull();
     } finally {
       cleanupRoot(root, container);
     }

--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -72,20 +72,22 @@ describe("Collections", () => {
     try {
       const text = container.textContent ?? "";
       const keyboardIndex = text.indexOf("Keyboard");
+      const titleIndex = text.indexOf("Local database");
       const storageIndex = text.indexOf("3.0 MBlocal storage");
       const eventsIndex = text.indexOf("3events");
       const sizeIndex = text.indexOf("1.5 KBevent data");
       const exportIndex = text.indexOf("Export data");
 
       expect(keyboardIndex).toBeGreaterThanOrEqual(0);
+      expect(titleIndex).toBeGreaterThan(keyboardIndex);
       expect(storageIndex).toBeGreaterThanOrEqual(0);
       expect(eventsIndex).toBeGreaterThanOrEqual(0);
       expect(sizeIndex).toBeGreaterThanOrEqual(0);
+      expect(storageIndex).toBeGreaterThan(titleIndex);
       expect(storageIndex).toBeGreaterThan(keyboardIndex);
       expect(exportIndex).toBeGreaterThan(sizeIndex);
       expect(text).toContain("cursor 2");
       expect(text).toContain("keyboard 1");
-      expect(text).not.toContain("Local database");
     } finally {
       cleanupRoot(root, container);
     }
@@ -113,6 +115,7 @@ describe("Collections", () => {
     try {
       const text = container.textContent ?? "";
 
+      expect(text).toContain("Local database");
       expect(text).toContain("2.0 KBlocal storage");
       expect(text).toContain("0events");
       expect(text).toContain("0 Bevent data");
@@ -139,6 +142,7 @@ describe("Collections", () => {
 
       expect(text).not.toContain("local storage");
       expect(text).not.toContain("event data");
+      expect(text).not.toContain("Local database");
       expect(text).toContain("Export data");
     } finally {
       cleanupRoot(root, container);

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -74,50 +74,75 @@
   }
 
   &__stats {
-    display: flex;
-    gap: 0;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    background: $border;
     border: 1px solid $border;
     border-radius: 8px;
     overflow: hidden;
   }
 
   &__storage-summary {
+    margin-top: 14px;
     margin-bottom: 12px;
   }
 
+  &__storage-title {
+    margin: 0 0 6px;
+    font-size: 11px;
+    font-weight: 700;
+    color: $text;
+  }
+
   &__stats-detail {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 3px 8px;
     margin-top: 4px;
-    font-size: 10px;
+    font-size: 9px;
+    line-height: 1.3;
     color: $text-muted;
     font-family: $font-mono;
+  }
+
+  &__stats-detail-item {
+    white-space: nowrap;
   }
 
   &__stat {
-    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 8px 4px;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 7px 3px 6px;
+    background: $bg;
     font-family: $font-mono;
-
-    & + & {
-      border-left: 1px solid $border;
-    }
   }
 
   &__stat-value {
-    font-size: 15px;
+    font-size: 12px;
     font-weight: 700;
     color: $text;
-    line-height: 1.2;
+    line-height: 1.1;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: clip;
+    text-align: center;
   }
 
   &__stat-label {
-    font-size: 9px;
+    font-size: 7px;
+    line-height: 1.1;
     color: $text-muted;
     text-transform: uppercase;
-    letter-spacing: 0.5px;
+    letter-spacing: 0;
     margin-top: 1px;
+    text-align: center;
+    white-space: nowrap;
   }
 
   &__context {

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -98,16 +98,36 @@
   &__stats-detail {
     display: flex;
     flex-wrap: wrap;
-    gap: 3px 8px;
-    margin-top: 4px;
+    gap: 4px 7px;
+    margin-top: 5px;
     font-size: 9px;
-    line-height: 1.3;
+    line-height: 1;
     color: $text-muted;
     font-family: $font-mono;
   }
 
   &__stats-detail-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    min-width: 0;
     white-space: nowrap;
+  }
+
+  &__stats-detail-icon {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    width: 10px;
+    height: 10px;
+    color: $text-muted;
+  }
+
+  &__stats-detail-count {
+    display: inline-block;
+    max-width: 4ch;
+    overflow: hidden;
+    text-overflow: clip;
   }
 
   &__stat {

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -48,12 +48,14 @@ function formatAge(ts: number): string {
   return `${months}mo`;
 }
 
-function formatEventTypeCounts(countsByType: Record<string, number>): string {
+function getEventTypeCounts(countsByType: Record<string, number>) {
   const orderedTypes = getValidEventTypes();
   return orderedTypes
     .filter((type) => (countsByType[type] ?? 0) > 0)
-    .map((type) => `${type} ${(countsByType[type] ?? 0).toLocaleString()}`)
-    .join(" · ");
+    .map((type) => ({
+      type,
+      count: (countsByType[type] ?? 0).toLocaleString(),
+    }));
 }
 
 // ── Shared collector list UI ──────────────────────────────────────────────────
@@ -656,9 +658,9 @@ export function Collections({ onBack }: CollectionsProps) {
     return <div className="collections__loading">Loading collections...</div>;
   }
 
-  const eventTypeSummary = storageStats
-    ? formatEventTypeCounts(storageStats.countsByType)
-    : "";
+  const eventTypeCounts = storageStats
+    ? getEventTypeCounts(storageStats.countsByType)
+    : [];
   const hasActiveCollection = Object.values(modes).some((mode) => mode !== "off");
 
   return (
@@ -790,6 +792,7 @@ export function Collections({ onBack }: CollectionsProps) {
 
         {storageStats && hasActiveCollection && (
           <div className="collections__storage-summary">
+            <h3 className="collections__storage-title">Local database</h3>
             <div className="collections__stats">
               <div className="collections__stat">
                 <span className="collections__stat-value">
@@ -820,8 +823,14 @@ export function Collections({ onBack }: CollectionsProps) {
                 </div>
               )}
             </div>
-            {eventTypeSummary && (
-              <div className="collections__stats-detail">{eventTypeSummary}</div>
+            {eventTypeCounts.length > 0 && (
+              <div className="collections__stats-detail">
+                {eventTypeCounts.map(({ type, count }) => (
+                  <span key={type} className="collections__stats-detail-item">
+                    {type} {count}
+                  </span>
+                ))}
+              </div>
             )}
           </div>
         )}

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -38,6 +38,20 @@ function formatSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatCompactCount(count: number): string {
+  if (count < 1000) return String(count);
+
+  const formatDecimal = (value: number) =>
+    (Math.floor(value * 10) / 10).toFixed(1);
+
+  if (count < 10000) return `${formatDecimal(count / 1000)}K`;
+  if (count < 1000000) return `${Math.floor(count / 1000)}K`;
+  if (count < 10000000) return `${formatDecimal(count / 1000000)}M`;
+  if (count < 1000000000) return `${Math.floor(count / 1000000)}M`;
+  if (count < 10000000000) return `${formatDecimal(count / 1000000000)}B`;
+  return `${Math.floor(count / 1000000000)}B`;
+}
+
 function formatAge(ts: number): string {
   if (!ts) return "";
   const days = Math.floor((Date.now() - ts) / (1000 * 60 * 60 * 24));
@@ -54,7 +68,7 @@ function getEventTypeCounts(countsByType: Record<string, number>) {
     .filter((type) => (countsByType[type] ?? 0) > 0)
     .map((type) => ({
       type,
-      count: (countsByType[type] ?? 0).toLocaleString(),
+      count: formatCompactCount(countsByType[type] ?? 0),
     }));
 }
 
@@ -804,7 +818,7 @@ export function Collections({ onBack }: CollectionsProps) {
               </div>
               <div className="collections__stat">
                 <span className="collections__stat-value">
-                  {storageStats.totalEvents.toLocaleString()}
+                  {formatCompactCount(storageStats.totalEvents)}
                 </span>
                 <span className="collections__stat-label">events</span>
               </div>
@@ -826,8 +840,21 @@ export function Collections({ onBack }: CollectionsProps) {
             {eventTypeCounts.length > 0 && (
               <div className="collections__stats-detail">
                 {eventTypeCounts.map(({ type, count }) => (
-                  <span key={type} className="collections__stats-detail-item">
-                    {type} {count}
+                  <span
+                    key={type}
+                    className="collections__stats-detail-item"
+                    aria-label={`${type} events: ${count}`}
+                    title={`${type} events: ${count}`}
+                  >
+                    <span
+                      aria-hidden
+                      className="collections__stats-detail-icon"
+                    >
+                      <CollectorIcon type={type} size={10} />
+                    </span>
+                    <span className="collections__stats-detail-count">
+                      {count}
+                    </span>
                   </span>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- keep the local database stats in a fixed four-column grid in narrow popup widths
- reduce stat value and label sizing so the cards read like the original preview instead of wrapping
- add a Local database header and spacing above the database-specific stats
- render event type counts as compact icon/count pairs so long labels and counts do not overflow
- format stored event totals and per-type counts with compact suffixes like `128K` and `8.1K`

## Validation
- `bun run test -- run src/__tests__/Collections.test.tsx src/__tests__/background-retention.test.ts`
- `bun run build`
- `git diff --check`