### PR TITLE
Rename can-toggle active class to toggled

### DIFF
--- a/.changeset/tidy-buttons-toggle.md
+++ b/.changeset/tidy-buttons-toggle.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Can-toggle elements now apply the `toggled` class when active while continuing to apply `clicked` for existing styles.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ Bun handles workspace linking automatically. Changes across packages are immedia
 
 - **Commits:** Short imperative subject; scope paths when helpful (e.g., `react:`, `extension:`). Group mechanical changes separately.
 - **Changesets:** ALWAYS add a changeset whenever you modify code under `packages/` (core libraries: `playhtml`, `@playhtml/react`, `@playhtml/common`). Create the file directly in `.changeset/<short-slug>.md` with the standard frontmatter (`"<package>": patch|minor|major`) and a one-paragraph user-facing description of the change and why. `bun run changeset` is the interactive equivalent. Config in `.changeset/config.json` (public access, patch for internal deps). Skip changesets only for changes outside `packages/` (website, extension, docs, internal-docs).
+- **Docs audit for package changes:** Whenever you change code under `packages/`, check whether public documentation in `apps/docs/` needs to change. Update the relevant user-facing docs in the same PR when behavior, APIs, attributes, classes, examples, or gotchas change. Common places to check are `apps/docs/src/content/docs/capabilities.mdx`, `apps/docs/src/content/docs/getting-started.mdx`, `apps/docs/src/content/docs/reference/react-api.md`, and the `data/`, `advanced/`, and `integrations/` docs. If no docs change is needed, mention why in the PR summary.
 - **Releases:** `bun run version-packages` then `bun run release` (builds + publishes via changesets).
 - **PRs:** Include summary, rationale, screenshots for UI/site/extension changes, reproduction for fixes, and link issues.
 
@@ -181,6 +182,7 @@ When building or modifying playhtml elements, follow the `building-playhtml-elem
 ## Documentation
 
 - `apps/docs/`: Public developer-facing and user-facing documentation. All user-visible docs live here as Astro + Starlight pages. DO NOT PUT PLANS IN HERE.
+- Package behavior changes should be reflected in `apps/docs/` when they affect how users write HTML, React components, CSS, shared data, setup code, or troubleshooting steps.
 - `internal-docs/`: Internal planning and decision records (gitignored, not committed). Specs go in `internal-docs/specs/`, plans go in `internal-docs/plans/`. Date-prefix files (e.g., `2026-03-13-feature-name.md`).
 
 ## Security & Configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,12 @@ There is future work I'm planning on getting to in the Issues section. If you ha
 
 Bun automatically handles workspace linking, so changes in `common` will be immediately available in `playhtml` and `react` packages without any additional setup. Just run `bun install` at the root to set up the workspace dependencies.
 
+### Updating docs for package changes
+
+When a change under `packages/` affects user-facing behavior, APIs, attributes, CSS classes, examples, or gotchas, update the matching docs under `apps/docs/` in the same PR. Start with the pages most likely to mention the changed surface: capabilities, getting started, React API reference, data, advanced, and integrations docs.
+
+If you checked the docs and no update is needed, call that out in your PR summary so reviewers know it was considered.
+
 ## Release Process
 
 This project uses [Changesets](https://github.com/changesets/changesets) for managing package versions and releases.

--- a/apps/docs/src/components/playground/recipes/_starter.ts
+++ b/apps/docs/src/components/playground/recipes/_starter.ts
@@ -39,14 +39,14 @@ export const starterRecipe: { id: string; html: string } = {
     h2 { color: #2800ff; }
     .illustration:active { transform: translateY(5px); }
     .dipped { transform: translateY(5px); }
-    #lamp.clicked { filter: brightness(1.2) saturate(1.6) drop-shadow(0px 0px 50px rgba(247, 220, 156, 0.85)); }
+    #lamp.toggled { filter: brightness(1.2) saturate(1.6) drop-shadow(0px 0px 50px rgba(247, 220, 156, 0.85)); }
     .highlighted { box-shadow: 0px 0px 30px 10px rgb(245, 169, 15) !important; background: rgb(245 169 15 / 80%); }
     .capabilities li { width: fit-content; cursor: zoom-in; padding: 4px 0; }
     .capabilities li:hover { text-shadow: 0px 0px 4px rgb(245, 169, 15); }
     #colorBox { width: 200px; height: 60px; margin-bottom: 10px; background-color: white; display: block; }
     #shootingStar { top: -36px; left: -36px; font-size: 36px; position: fixed; text-shadow: 0 0 4px yellow; }
     #catOrDog { width: 200px; }
-    #catOrDog.clicked { content: url("${IMG_BASE}/dog.png"); }
+    #catOrDog.toggled { content: url("${IMG_BASE}/dog.png"); }
     #plant { width: 200px; }
     #hoverBox.hovered { background: blue !important; transform: scale(1.1); }
     .reaction { transition: all 0.2s ease; cursor: pointer; }

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -158,10 +158,12 @@ import { CanMoveElement } from "@playhtml/react";
 <button id="my-switch" class="switch" can-toggle>off</button>
 
 <style>
-  .switch.clicked { background: #6cd97e; }
-  .switch.clicked::after { content: "on"; }
+  .switch.toggled { background: #6cd97e; }
+  .switch.toggled::after { content: "on"; }
 </style>
 ```
+
+`can-toggle` adds the `toggled` class when the element is on. The older `clicked` class is still applied for existing styles.
   </TabItem>
   <TabItem label="React">
 ```tsx

--- a/apps/docs/src/styles/docs-extras.css
+++ b/apps/docs/src/styles/docs-extras.css
@@ -318,8 +318,8 @@ header.header {
 .ph-wordmark__letter:hover {
   transform: translateY(-1px);
 }
-/* playhtml adds the `clicked` class when a can-toggle element is toggled on */
-.ph-wordmark__letter.clicked {
+/* playhtml adds the `toggled` class when a can-toggle element is toggled on */
+.ph-wordmark__letter.toggled {
   color: var(--ph-mustard);
   text-shadow: 0 0 0.6rem rgba(232, 166, 58, 0.55),
     0 0 1.6rem rgba(232, 166, 58, 0.25);

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -503,6 +503,7 @@ export const TagTypeToElement: DefaultTagInitializers = {
     updateElement: ({ element, data }) => {
       // handling migration from "boolean" to "{on: boolean}" type
       const on = typeof data === "object" ? data.on : data;
+      element.classList.toggle("toggled", on);
       element.classList.toggle("clicked", on);
     },
     onClick: (e: MouseEvent, { data, setData }) => {

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -75,6 +75,8 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-toggle"]["toggle-test"]).toEqual({
       on: true,
     });
+    expect(el.classList.contains("toggled")).toBe(true);
+    expect(el.classList.contains("clicked")).toBe(true);
 
     // Test mutator form
     handler.setData((draft: any) => {
@@ -87,6 +89,8 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-toggle"]["toggle-test"]).toEqual({
       on: false,
     });
+    expect(el.classList.contains("toggled")).toBe(false);
+    expect(el.classList.contains("clicked")).toBe(false);
   });
 
   it("removes handlers for unmounted elements so replacements can register", async () => {


### PR DESCRIPTION
## Summary

- Add `toggled` as the canonical active class for `can-toggle` elements.
- Keep `clicked` applied as a compatibility alias for existing styles.
- Update public docs and playground starter examples to use `.toggled`.
- Add contributor guidance requiring an `apps/docs` audit for package changes.

## Review

- No blocking issues found in the branch review.
- Existing `.clicked` references outside `apps/docs` are preserved by the runtime alias and can continue working.
- Changesets is configured with `updateInternalDependencies: "patch"`, so the `@playhtml/common` patch changeset should propagate dependent package bumps during the release PR.

## Validation

- `bun run test -- run src/__tests__/main.basic.test.ts` in `packages/playhtml` passed: 5 tests.
- `bun run build` in `packages/common` passed.
- `bun run test` in `packages/playhtml` passed: 24 files / 186 tests.
- `bun run build` in `packages/playhtml` passed.
- `bun run build` in `apps/docs` passed. Existing warnings remain for `/docs/fire-hydrant.png`, React re-export chunking, large chunks, and missing Astro `site`.
- `git diff --check` passed.