### PR TITLE
Fix Chromium cursor flicker

### DIFF
--- a/.changeset/steady-cursor-color.md
+++ b/.changeset/steady-cursor-color.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Fix Chromium browsers briefly reverting PlayHTML's colored cursor under page cursor styles while moving the pointer.

--- a/packages/playhtml/src/cursors/__tests__/cursor-container.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/cursor-container.test.ts
@@ -1,9 +1,11 @@
 // ABOUTME: Tests for cursor container resolution — element, selector, getter.
 // ABOUTME: Null handling and getter-on-every-call semantics.
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as Y from "yjs";
 import { resolveCursorContainer } from "../container";
 import { CursorClientAwareness } from "../cursor-client";
+
+const originalElementFromPoint = document.elementFromPoint;
 
 describe("resolveCursorContainer", () => {
   beforeEach(() => {
@@ -48,9 +50,31 @@ describe("resolveCursorContainer", () => {
 });
 
 describe("cursor client with container option", () => {
+  const clients: CursorClientAwareness[] = [];
+
   beforeEach(() => {
     document.body.innerHTML = "";
     document.head.querySelectorAll("#playhtml-cursor-styles").forEach((n) => n.remove());
+  });
+
+  afterEach(() => {
+    for (const client of clients.splice(0)) {
+      client.destroy();
+    }
+    document.body.style.cursor = "";
+    document.documentElement.style.cursor = "";
+    document.documentElement.style.removeProperty("--playhtml-cursor");
+    document.documentElement.removeAttribute("data-playhtml-cursors-active");
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalElementFromPoint) {
+      Object.defineProperty(document, "elementFromPoint", {
+        configurable: true,
+        value: originalElementFromPoint,
+      });
+    } else {
+      delete (document as any).elementFromPoint;
+    }
   });
 
   function makeFakeProvider() {
@@ -74,7 +98,12 @@ describe("cursor client with container option", () => {
       on(_event: string, cb: (args: any) => void) {
         listeners.push(cb);
       },
-      off() {},
+      off(_event: string, cb: (args: any) => void) {
+        const index = listeners.indexOf(cb);
+        if (index !== -1) {
+          listeners.splice(index, 1);
+        }
+      },
       emit(args: any) {
         listeners.forEach((cb) => cb(args));
       },
@@ -90,13 +119,22 @@ describe("cursor client with container option", () => {
     } as any;
   }
 
+  function makeClient(
+    provider: ReturnType<typeof makeFakeProvider>,
+    options: ConstructorParameters<typeof CursorClientAwareness>[1],
+  ) {
+    const client = new CursorClientAwareness(provider, options);
+    clients.push(client);
+    return client;
+  }
+
   it("appends cursor DOM into the container element", () => {
     const layer = document.createElement("div");
     layer.id = "cursor-layer";
     document.body.appendChild(layer);
 
     const provider = makeFakeProvider();
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       container: layer,
       playerIdentity: {
@@ -133,7 +171,7 @@ describe("cursor client with container option", () => {
     document.body.appendChild(layer);
 
     const provider = makeFakeProvider();
-    new CursorClientAwareness(provider, {
+    makeClient(provider, {
       enabled: true,
       container: layer,
       playerIdentity: {
@@ -148,7 +186,7 @@ describe("cursor client with container option", () => {
 
   it("falls back to document.head when container is document.body (default)", () => {
     const provider = makeFakeProvider();
-    new CursorClientAwareness(provider, {
+    makeClient(provider, {
       enabled: true,
       playerIdentity: {
         publicKey: "local-key",
@@ -170,7 +208,7 @@ describe("cursor client with container option", () => {
 
     let active: HTMLElement = layerA;
     const provider = makeFakeProvider();
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       container: () => active,
       playerIdentity: {
@@ -212,7 +250,7 @@ describe("cursor client with container option", () => {
     const provider = makeFakeProvider();
     const calls: string[] = [];
 
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       playerIdentity: {
         publicKey: "local-key",
@@ -256,7 +294,7 @@ describe("cursor client with container option", () => {
       backgroundColor: "rgb(255, 0, 0)",
     };
 
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       playerIdentity: {
         publicKey: "local-key",
@@ -309,7 +347,7 @@ describe("cursor client with container option", () => {
     document.body.appendChild(zoneEl);
 
     const provider = makeFakeProvider();
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       playerIdentity: {
         publicKey: "local-key",
@@ -362,7 +400,7 @@ describe("cursor client with container option", () => {
     const provider = makeFakeProvider();
     const pagesSeen: string[] = [];
 
-    const client = new CursorClientAwareness(provider, {
+    const client = makeClient(provider, {
       enabled: true,
       playerIdentity: {
         publicKey: "local-key",
@@ -408,4 +446,213 @@ describe("cursor client with container option", () => {
     expect(pagesSeen).toContain("/b");
     void client;
   });
+
+  it("keeps the colored cursor when the browser normalizes its own cursor data URL", () => {
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    const coloredCursor =
+      document.documentElement.style.getPropertyValue("--playhtml-cursor");
+    const urlMatch = coloredCursor.match(/^url\("(.*)"\), auto$/);
+    expect(urlMatch).not.toBeNull();
+
+    const decodedCursor = `url("${decodeURIComponent(urlMatch![1])}"), auto`;
+    document.body.style.cursor = decodedCursor;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => document.body),
+    });
+
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    expect(document.documentElement.getAttribute("data-playhtml-cursors-active")).toBe(
+      "true",
+    );
+    expect(document.documentElement.style.getPropertyValue("--playhtml-cursor")).toBe(
+      coloredCursor,
+    );
+    client.destroy();
+  });
+
+  it("does not publish pending cursor updates after destroy", () => {
+    vi.useFakeTimers();
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => document.body),
+    });
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+    client.destroy();
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 20,
+        clientY: 20,
+      }),
+    );
+    vi.runOnlyPendingTimers();
+
+    expect(provider.awareness.getLocalState().__playhtml_cursors__).toBeNull();
+  });
+
+  it("does not render remote cursor updates after destroy", () => {
+    const layer = document.createElement("div");
+    layer.id = "cursor-layer";
+    document.body.appendChild(layer);
+
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      container: layer,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    client.destroy();
+    provider.awareness._states.set(99, {
+      __playhtml_cursors__: {
+        cursor: { x: 10, y: 10, pointer: "mouse" },
+        page: "/",
+        playerIdentity: {
+          publicKey: "remote-1",
+          playerStyle: { colorPalette: ["#00ff00"] },
+        },
+        lastSeen: Date.now(),
+      },
+    });
+    provider.awareness.emit({ added: [99], updated: [], removed: [] });
+
+    expect(layer.querySelectorAll(".playhtml-cursor-other")).toHaveLength(0);
+  });
+
+  it("uses the native cursor while hovering a different custom cursor", () => {
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    const customCursor =
+      "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=";
+    document.body.style.cursor = `url("${customCursor}"), auto`;
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => document.body),
+    });
+
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    const state = provider.awareness.getLocalState().__playhtml_cursors__;
+    expect(document.documentElement.getAttribute("data-playhtml-cursors-active")).toBeNull();
+    expect(state.cursor.pointer).toBe(customCursor);
+    client.destroy();
+  });
+
+  it("activates a document-level cursor override for descendants with normal cursor keywords", () => {
+    const target = document.createElement("button");
+    target.style.cursor = "pointer";
+    document.body.appendChild(target);
+
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    const coloredCursor =
+      document.documentElement.style.getPropertyValue("--playhtml-cursor");
+
+    expect(document.documentElement.getAttribute("data-playhtml-cursors-active")).toBe(
+      "true",
+    );
+    expect(document.documentElement.style.getPropertyValue("--playhtml-cursor")).toBe(
+      coloredCursor,
+    );
+    expect(document.getElementById("playhtml-cursor-styles")?.textContent).toContain(
+      "html[data-playhtml-cursors-active=\"true\"] *",
+    );
+    client.destroy();
+  });
+
+  it("does not churn the cursor override while moving over normal cursor keywords", () => {
+    const target = document.createElement("button");
+    target.style.cursor = "pointer";
+    document.body.appendChild(target);
+    Object.defineProperty(document, "elementFromPoint", {
+      configurable: true,
+      value: vi.fn(() => target),
+    });
+
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, {
+      enabled: true,
+      playerIdentity: {
+        publicKey: "local-key",
+        playerStyle: { colorPalette: ["#ff0000"] },
+      } as any,
+    });
+
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    const removeAttribute = vi.spyOn(document.documentElement, "removeAttribute");
+    const setAttribute = vi.spyOn(document.documentElement, "setAttribute");
+
+    document.dispatchEvent(
+      new MouseEvent("mousemove", {
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    expect(removeAttribute).not.toHaveBeenCalledWith(
+      "data-playhtml-cursors-active",
+    );
+    expect(setAttribute).not.toHaveBeenCalledWith(
+      "data-playhtml-cursors-active",
+      "true",
+    );
+    client.destroy();
+  });
+
 });

--- a/packages/playhtml/src/cursors/cursor-client.ts
+++ b/packages/playhtml/src/cursors/cursor-client.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Implements collaborative cursor presence, rendering, styling, and proximity.
+// ABOUTME: Publishes local pointer state and renders remote cursor awareness updates.
 import type YProvider from "y-partyserver/provider";
 import {
   CursorPresence,
@@ -305,6 +307,52 @@ function getCursorStyleForUser(color: string): string {
   return `url("data:image/svg+xml,${userCursorSvgEncoded}"), auto`;
 }
 
+function updateDocumentCursorStyle(cursorStyle: string): void {
+  if (
+    document.documentElement.style.getPropertyValue("--playhtml-cursor") !==
+    cursorStyle
+  ) {
+    document.documentElement.style.setProperty("--playhtml-cursor", cursorStyle);
+  }
+}
+
+function setDocumentCursorStyle(cursorStyle: string): void {
+  updateDocumentCursorStyle(cursorStyle);
+  if (
+    document.documentElement.getAttribute("data-playhtml-cursors-active") !==
+    "true"
+  ) {
+    document.documentElement.setAttribute("data-playhtml-cursors-active", "true");
+  }
+}
+
+function setDocumentNativeCursor(): void {
+  if (document.documentElement.hasAttribute("data-playhtml-cursors-active")) {
+    document.documentElement.removeAttribute("data-playhtml-cursors-active");
+  }
+}
+
+function clearDocumentCursorStyle(): void {
+  setDocumentNativeCursor();
+  document.documentElement.style.removeProperty("--playhtml-cursor");
+}
+
+function decodeCursorUrl(cursorUrl: string): string {
+  try {
+    return decodeURIComponent(cursorUrl);
+  } catch {
+    return cursorUrl;
+  }
+}
+
+function isOwnCursorUrl(cursorUrl: string, color: string): boolean {
+  const ownCursorUrl = `data:image/svg+xml,${encodeSVG(getSvgForCursor(color))}`;
+  return (
+    cursorUrl === ownCursorUrl ||
+    decodeCursorUrl(cursorUrl) === decodeCursorUrl(ownCursorUrl)
+  );
+}
+
 /**
  * Convert a camelCase CSS property (e.g. "backgroundColor") to kebab-case
  * (e.g. "background-color") for use with CSSStyleDeclaration.setProperty /
@@ -361,6 +409,17 @@ function extractUrlFromCursorStyle(cursorStyle: string): string | undefined {
     return;
   }
   return cursorStyle.slice(5, closeQuote);
+}
+
+function getNearestInlineCursorStyle(element: Element): string | undefined {
+  let current: Element | null = element;
+  while (current) {
+    if (current instanceof HTMLElement && current.style.cursor) {
+      return current.style.cursor;
+    }
+    current = current.parentElement;
+  }
+  return;
 }
 
 export class CursorClientAwareness {
@@ -466,6 +525,9 @@ export class CursorClientAwareness {
   // properties than the previous call.
   private cursorStyleKeys: Map<string, Set<string>> = new Map();
   private lastKnownContainer: HTMLElement | null = null;
+  private pendingUpdateTimeout: ReturnType<typeof setTimeout> | null = null;
+  private removeCursorTrackingListeners: (() => void) | null = null;
+  private awarenessChangeHandler: ((args: any) => void) | null = null;
   // Maps Yjs clientId -> stableId (publicKey). Multiple clientIds can map to
   // the same stableId when a user has multiple tabs open. Used to:
   // (a) skip rendering our own cursor from other tabs
@@ -506,16 +568,24 @@ export class CursorClientAwareness {
     this.setupAwarenessHandling();
 
     // Set initial cursor style (throws if identity has no primary color)
-    document.documentElement.style.cursor = getCursorStyleForUser(
-      getPrimaryColor(this.playerIdentity),
-    );
+    this.updateDocumentCursorForColor(getPrimaryColor(this.playerIdentity));
+  }
+
+  private updateDocumentCursorForColor(color: string): void {
+    const cursorStyle = getCursorStyleForUser(color);
+    if (!this.currentCursor || this.currentCursor.pointer === "mouse") {
+      setDocumentCursorStyle(cursorStyle);
+      return;
+    }
+    updateDocumentCursorStyle(cursorStyle);
   }
 
   private setupAwarenessHandling(): void {
     // Listen to awareness changes for cursor updates
-    this.provider.awareness.on("change", ({ added, updated, removed }: any) => {
+    this.awarenessChangeHandler = ({ added, updated, removed }: any) => {
       this.handleAwarenessChange(added, updated, removed);
-    });
+    };
+    this.provider.awareness.on("change", this.awarenessChangeHandler);
 
     // Initial sync of existing awareness states
     // First, publish our own player identity so others (and us) see it immediately
@@ -736,6 +806,11 @@ export class CursorClientAwareness {
         transition: all 0.1s ease;
         transform-origin: center;
       }
+
+      html[data-playhtml-cursors-active="true"],
+      html[data-playhtml-cursors-active="true"] * {
+        cursor: var(--playhtml-cursor) !important;
+      }
       
       .playhtml-cursor-fade-in {
         animation: cursorFadeIn 0.3s ease-out;
@@ -880,27 +955,28 @@ export class CursorClientAwareness {
       const element = document.elementFromPoint(e.clientX, e.clientY);
 
       if (element) {
-        const style = window.getComputedStyle(element);
-        const maybeCustomCursor = extractUrlFromCursorStyle(style.cursor);
-
-        if (maybeCustomCursor) {
-          const ourCursorSvg = encodeSVG(
-            getSvgForCursor(getPrimaryColor(this.playerIdentity)),
-          );
-
-          if (!maybeCustomCursor.includes(ourCursorSvg)) {
-            pointer = maybeCustomCursor;
-          }
+        const inlineCursorStyle = getNearestInlineCursorStyle(element);
+        const maybeCustomCursor = inlineCursorStyle
+          ? extractUrlFromCursorStyle(inlineCursorStyle)
+          : undefined;
+        if (
+          maybeCustomCursor &&
+          !isOwnCursorUrl(
+            maybeCustomCursor,
+            getPrimaryColor(this.playerIdentity),
+          )
+        ) {
+          pointer = maybeCustomCursor;
         }
       }
 
       // Show/hide our own cursor based on pointer type (like cursor-party)
       if (pointer === "mouse") {
-        document.documentElement.style.cursor = getCursorStyleForUser(
-          getPrimaryColor(this.playerIdentity),
+        setDocumentCursorStyle(
+          getCursorStyleForUser(getPrimaryColor(this.playerIdentity)),
         );
       } else {
-        document.documentElement.style.cursor = "auto";
+        setDocumentNativeCursor();
       }
 
       // Convert to storage coordinates based on mode
@@ -947,9 +1023,10 @@ export class CursorClientAwareness {
     // When mouse leaves the window, keep presence alive but stop updating position.
     // The cursor freezes at its last known position for other clients.
     // TODO: consider displaying inactive cursors differently (faded, grayed out, etc.)
-    document.addEventListener("mouseleave", () => {
+    const handleMouseLeave = () => {
       this.showAllCursors();
-    });
+    };
+    document.addEventListener("mouseleave", handleMouseLeave);
 
     // Reposition remote cursors on scroll/zoom/resize. In relative mode,
     // cursors use position:fixed so viewport coords must be recalculated.
@@ -979,9 +1056,34 @@ export class CursorClientAwareness {
     }
 
     // Clean up presence when the page is actually closed/navigated away
-    window.addEventListener("beforeunload", () => {
+    const handleBeforeUnload = () => {
       this.provider.awareness.setLocalStateField(CURSOR_AWARENESS_FIELD, null);
-    });
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    this.removeCursorTrackingListeners = () => {
+      document.removeEventListener("mousemove", updateCursor);
+      document.removeEventListener("touchmove", updateTouchCursor);
+      document.removeEventListener("touchend", handleTouchEnd);
+      document.removeEventListener("mouseleave", handleMouseLeave);
+      window.removeEventListener("scroll", repositionOnViewportChange);
+      window.removeEventListener("resize", repositionOnViewportChange);
+      if (window.visualViewport) {
+        window.visualViewport.removeEventListener(
+          "scroll",
+          repositionOnViewportChange,
+        );
+        window.visualViewport.removeEventListener(
+          "resize",
+          repositionOnViewportChange,
+        );
+      }
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      if (viewportChangeRaf !== null) {
+        cancelAnimationFrame(viewportChangeRaf);
+        viewportChangeRaf = null;
+      }
+    };
   }
 
   // Re-derive positions for all remote cursors. In relative mode, this is
@@ -1062,7 +1164,8 @@ export class CursorClientAwareness {
       this.lastUpdate = now;
       this.updateThrottled = false;
     } else {
-      setTimeout(() => {
+      this.pendingUpdateTimeout = setTimeout(() => {
+        this.pendingUpdateTimeout = null;
         this.updateCursorAwareness();
         this.lastUpdate = performance.now();
         this.updateThrottled = false;
@@ -1497,7 +1600,7 @@ export class CursorClientAwareness {
         const oldColor = self.playerIdentity.playerStyle.colorPalette[0];
         self.playerIdentity.playerStyle.colorPalette[0] = newColor;
         self.savePlayerIdentityToStorage();
-        document.documentElement.style.cursor = getCursorStyleForUser(newColor);
+        self.updateDocumentCursorForColor(newColor);
         if (oldColor !== newColor) {
           self.emitGlobalEvent("color", newColor);
         }
@@ -1773,7 +1876,7 @@ export class CursorClientAwareness {
       this.savePlayerIdentityToStorage();
       // Re-broadcast awareness with new identity and update local cursor style
       const nextColor = getPrimaryColor(this.playerIdentity);
-      document.documentElement.style.cursor = getCursorStyleForUser(nextColor);
+      this.updateDocumentCursorForColor(nextColor);
       this.updateCursorAwareness();
       // Emit color/name events so subscribers (e.g. the React context behind
       // usePlayerIdentity) react to identity injected through configure() —
@@ -1814,6 +1917,20 @@ export class CursorClientAwareness {
   }
 
   destroy(): void {
+    if (this.awarenessChangeHandler) {
+      this.provider.awareness.off("change", this.awarenessChangeHandler);
+      this.awarenessChangeHandler = null;
+    }
+    if (this.removeCursorTrackingListeners) {
+      this.removeCursorTrackingListeners();
+      this.removeCursorTrackingListeners = null;
+    }
+    if (this.pendingUpdateTimeout) {
+      clearTimeout(this.pendingUpdateTimeout);
+      this.pendingUpdateTimeout = null;
+      this.updateThrottled = false;
+    }
+
     // Clean up cursors
     this.cursors.forEach((element) => element.remove());
     this.cursors.clear();
@@ -1840,6 +1957,7 @@ export class CursorClientAwareness {
 
     // Remove awareness data
     this.provider.awareness.setLocalStateField(CURSOR_AWARENESS_FIELD, null);
+    clearDocumentCursorStyle();
   }
 
   // Debug method to inspect spatial partitioning efficiency


### PR DESCRIPTION
## Summary

- Keep PlayHTML's colored cursor in `--playhtml-cursor` behind `data-playhtml-cursors-active`, with idempotent writes so normal movement does not churn the override.
- Apply that cursor through a document-level rule so normal descendant cursor keywords like `pointer` cannot override the colored cursor in Chromium.
- Normalize PlayHTML cursor data URLs before deciding whether a cursor URL belongs to PlayHTML or the page.
- Preserve explicit page-owned custom cursor URLs from inline styles on the hovered element or its ancestors, without scanning stylesheets or temporarily removing the PlayHTML override on mousemove.
- Clean up cursor tracking listeners, awareness listeners, and pending throttled awareness updates when the cursor client is destroyed.
- Add focused regression coverage plus a patch changeset for `playhtml`.

## Root Cause

There were three cursor paths involved:

1. Chromium can report PlayHTML's own SVG cursor data URL in a normalized/decoded form from `getComputedStyle(...).cursor`. The old raw substring check failed to recognize that URL as PlayHTML's own cursor.
2. Normal descendant cursor rules like `cursor: pointer` can beat a cursor set only on `html`, so the colored cursor needs a document-level active override.
3. The previous fix sampled the underlying page cursor by removing and restoring `data-playhtml-cursors-active` on every mousemove. On the deployed preview, a MutationObserver reproduced the remaining bug directly: 75 active-attribute mutations over 25 Chromium moves on `#lamp-hanging`.

The current fix keeps the document-level override and removes mousemove sampling. Normal movement no longer mutates the active cursor attribute. Page-authored custom cursor URLs are still honored when they are explicit inline cursor styles on the hovered element or one of its ancestors.

This kept regressing because the old tests only checked URL classification and jsdom behavior. They did not cover Chromium's real cursor cascade or mutation churn caused by our own override toggling.

## Validation

- Pre-fix deployed preview `https://bf2a9e2d.playhtml.pages.dev`: reproduced in Chromium with 75 `data-playhtml-cursors-active` mutations over 25 moves on `#lamp-hanging`.
- `bun run test -- src/cursors/__tests__/cursor-container.test.ts` in `packages/playhtml`: 20/20 passing.
- `bun run test` in `packages/playhtml`: 192/192 passing.
- `bun run build` in `packages/playhtml`: passed. Existing API Extractor warning remains: bundled TS 5.4.2 vs project TS 5.9.3.
- GitHub Actions on `5de00df`: `PR Validation` passed, `pkg.pr.new` passed.
- Headless Chromium probe against local `http://127.0.0.1:4188/`: 25 moves over `#lamp-hanging` caused 0 active-attribute mutations and the computed cursor stayed PlayHTML's colored data URL.
- Headless Chromium probe against local `http://127.0.0.1:4188/` with an injected inline custom cursor target: PlayHTML removed its override once, left it off, and Chromium computed the page-owned custom cursor URL.
- Final Cloudflare preview `https://88f9170a.playhtml.pages.dev`: 25 moves over `#lamp-hanging` caused 0 active-attribute mutations and the computed cursor stayed PlayHTML's colored data URL.
- Final Cloudflare preview `https://88f9170a.playhtml.pages.dev` with an injected inline custom cursor target: PlayHTML removed its override once, left it off, and Chromium computed the page-owned custom cursor URL.