### PR TITLE
Add Edge install links

### DIFF
--- a/extension/website/src/components/DownloadGate.module.scss
+++ b/extension/website/src/components/DownloadGate.module.scss
@@ -131,36 +131,42 @@ $mobile-query: "(hover: none) and (pointer: coarse)";
 }
 
 .downloadGroup {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
   justify-content: center;
+  white-space: nowrap;
+  font-family: $font-body;
+  font-size: 0.9375rem;
+  color: $text-muted;
 }
 
 .downloadGroupLarge {
-  gap: 16px;
+  font-size: 1.0625rem;
 }
 
-.downloadButton {
-  font-family: $font-body;
-  font-size: 0.9375rem;
+.downloadLabel {
+  margin-right: 0.45rem;
+}
+
+.downloadItem {
+  display: inline-flex;
+  align-items: baseline;
+}
+
+.downloadLink {
   color: $text;
-  background: rgba($bg, 0.7);
-  border: 1.5px solid rgba($text, 0.35);
-  border-radius: 4px;
-  padding: 10px 18px;
-  text-decoration: none;
-  transition: background 0.15s, border-color 0.15s, transform 0.15s;
-  backdrop-filter: blur(2px);
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
+  transition: color 0.15s;
 
   &:hover {
-    background: rgba($bg, 0.95);
-    border-color: $text;
-    transform: translateY(-1px);
+    color: $accent-teal;
   }
+}
 
-  .downloadGroupLarge & {
-    font-size: 1.0625rem;
-    padding: 14px 24px;
-  }
+.downloadSeparator {
+  color: $text-muted;
+  margin: 0 0.45rem;
 }

--- a/extension/website/src/components/DownloadGate.module.scss
+++ b/extension/website/src/components/DownloadGate.module.scss
@@ -141,8 +141,18 @@ $mobile-query: "(hover: none) and (pointer: coarse)";
   color: $text-muted;
 }
 
+.downloadSurface {
+  background: rgba($bg, 0.74);
+  border: 1.5px solid rgba($text, 0.28);
+  border-radius: 999px;
+  padding: 8px 16px;
+  backdrop-filter: blur(2px);
+  box-shadow: 0 1px 0 rgba($text, 0.06);
+}
+
 .downloadGroupLarge {
   font-size: 1.0625rem;
+  padding: 11px 20px;
 }
 
 .downloadLabel {

--- a/extension/website/src/components/DownloadGate.tsx
+++ b/extension/website/src/components/DownloadGate.tsx
@@ -55,16 +55,23 @@ function DownloadButtons({ size = 'default' }: { size?: 'default' | 'large' }) {
       : styles.downloadGroup;
   return (
     <div className={className}>
-      {DOWNLOAD_LINKS.map(({ browser, url }) => (
-        <a
-          key={browser}
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.downloadButton}
-        >
-          install for {browser}
-        </a>
+      <span className={styles.downloadLabel}>install:</span>
+      {DOWNLOAD_LINKS.map(({ browser, url }, index) => (
+        <span key={browser} className={styles.downloadItem}>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.downloadLink}
+          >
+            {browser}
+          </a>
+          {index < DOWNLOAD_LINKS.length - 1 ? (
+            <span className={styles.downloadSeparator} aria-hidden="true">
+              ·
+            </span>
+          ) : null}
+        </span>
       ))}
     </div>
   );

--- a/extension/website/src/components/DownloadGate.tsx
+++ b/extension/website/src/components/DownloadGate.tsx
@@ -9,6 +9,14 @@ const CHROME_DOWNLOAD_URL =
   'https://chromewebstore.google.com/detail/we-were-online/bhkdblmogjkgeipehaphdocclmijnkhc?authuser=0&hl=en';
 const FIREFOX_DOWNLOAD_URL =
   'https://addons.mozilla.org/en-US/firefox/addon/we-were-online/';
+const EDGE_DOWNLOAD_URL =
+  'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
+
+const DOWNLOAD_LINKS = [
+  { browser: 'Chrome', url: CHROME_DOWNLOAD_URL },
+  { browser: 'Firefox', url: FIREFOX_DOWNLOAD_URL },
+  { browser: 'Edge', url: EDGE_DOWNLOAD_URL },
+];
 
 const SUBSCRIBED_KEY = 'wewere.subscribed';
 
@@ -47,22 +55,17 @@ function DownloadButtons({ size = 'default' }: { size?: 'default' | 'large' }) {
       : styles.downloadGroup;
   return (
     <div className={className}>
-      <a
-        href={CHROME_DOWNLOAD_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={styles.downloadButton}
-      >
-        install for Chrome
-      </a>
-      <a
-        href={FIREFOX_DOWNLOAD_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={styles.downloadButton}
-      >
-        install for Firefox
-      </a>
+      {DOWNLOAD_LINKS.map(({ browser, url }) => (
+        <a
+          key={browser}
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.downloadButton}
+        >
+          install for {browser}
+        </a>
+      ))}
     </div>
   );
 }

--- a/extension/website/src/components/DownloadGate.tsx
+++ b/extension/website/src/components/DownloadGate.tsx
@@ -51,8 +51,8 @@ function markSubscribed(): void {
 function DownloadButtons({ size = 'default' }: { size?: 'default' | 'large' }) {
   const className =
     size === 'large'
-      ? `${styles.downloadGroup} ${styles.downloadGroupLarge}`
-      : styles.downloadGroup;
+      ? `${styles.downloadGroup} ${styles.downloadSurface} ${styles.downloadGroupLarge}`
+      : `${styles.downloadGroup} ${styles.downloadSurface}`;
   return (
     <div className={className}>
       <span className={styles.downloadLabel}>install:</span>

--- a/extension/website/src/components/__tests__/DownloadGate.test.tsx
+++ b/extension/website/src/components/__tests__/DownloadGate.test.tsx
@@ -1,0 +1,34 @@
+// ABOUTME: Tests for browser install links in the homepage download gate.
+// ABOUTME: Verifies desktop visitors get direct install links for supported browsers.
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { DownloadGate } from "../DownloadGate";
+
+const EDGE_DOWNLOAD_URL =
+  "https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl";
+
+vi.mock("../DownloadGate.module.scss", () => ({
+  default: {
+    gate: "gate",
+    desktopOnly: "desktopOnly",
+    mobileOnly: "mobileOnly",
+    downloadGroup: "downloadGroup",
+    downloadGroupLarge: "downloadGroupLarge",
+    downloadButton: "downloadButton",
+    form: "form",
+    row: "row",
+    input: "input",
+    submit: "submit",
+    subtext: "subtext",
+  },
+}));
+
+describe("DownloadGate", () => {
+  it("renders an Edge install link with the desktop browser downloads", () => {
+    const html = renderToStaticMarkup(<DownloadGate />);
+
+    expect(html).toContain('install for Edge');
+    expect(html).toContain(`href="${EDGE_DOWNLOAD_URL}"`);
+  });
+});

--- a/extension/website/src/components/__tests__/DownloadGate.test.tsx
+++ b/extension/website/src/components/__tests__/DownloadGate.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../DownloadGate.module.scss", () => ({
     desktopOnly: "desktopOnly",
     mobileOnly: "mobileOnly",
     downloadGroup: "downloadGroup",
+    downloadSurface: "downloadSurface",
     downloadGroupLarge: "downloadGroupLarge",
     downloadLabel: "downloadLabel",
     downloadLink: "downloadLink",
@@ -30,6 +31,7 @@ describe("DownloadGate", () => {
     const html = renderToStaticMarkup(<DownloadGate />);
 
     expect(html).toContain('install:');
+    expect(html).toContain('downloadSurface');
     expect(html).toContain('>Chrome</a>');
     expect(html).toContain('>Firefox</a>');
     expect(html).toContain('>Edge</a>');

--- a/extension/website/src/components/__tests__/DownloadGate.test.tsx
+++ b/extension/website/src/components/__tests__/DownloadGate.test.tsx
@@ -15,7 +15,8 @@ vi.mock("../DownloadGate.module.scss", () => ({
     mobileOnly: "mobileOnly",
     downloadGroup: "downloadGroup",
     downloadGroupLarge: "downloadGroupLarge",
-    downloadButton: "downloadButton",
+    downloadLabel: "downloadLabel",
+    downloadLink: "downloadLink",
     form: "form",
     row: "row",
     input: "input",
@@ -25,10 +26,16 @@ vi.mock("../DownloadGate.module.scss", () => ({
 }));
 
 describe("DownloadGate", () => {
-  it("renders an Edge install link with the desktop browser downloads", () => {
+  it("renders compact desktop browser download links", () => {
     const html = renderToStaticMarkup(<DownloadGate />);
 
-    expect(html).toContain('install for Edge');
+    expect(html).toContain('install:');
+    expect(html).toContain('>Chrome</a>');
+    expect(html).toContain('>Firefox</a>');
+    expect(html).toContain('>Edge</a>');
+    expect(html).not.toContain('install for Chrome');
+    expect(html).not.toContain('install for Firefox');
+    expect(html).not.toContain('install for Edge');
     expect(html).toContain(`href="${EDGE_DOWNLOAD_URL}"`);
   });
 });

--- a/extension/worker/src/emails/WelcomeEmail.tsx
+++ b/extension/worker/src/emails/WelcomeEmail.tsx
@@ -5,6 +5,8 @@ const CHROME_URL =
   'https://chromewebstore.google.com/detail/we-were-online/bhkdblmogjkgeipehaphdocclmijnkhc?authuser=0&hl=en';
 const FIREFOX_URL =
   'https://addons.mozilla.org/en-US/firefox/addon/we-were-online/';
+const EDGE_URL =
+  'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
 const HOMEPAGE_URL = 'https://wewere.online/';
 const PLAYHTML_URL = 'https://playhtml.fun/';
 const DISCORD_INVITE_URL = 'https://discord.gg/SKbsSf4ptU';
@@ -15,6 +17,25 @@ const REPLY_EMAIL = 'hi@spencer.place';
 export const WELCOME_EMAIL_SUBJECT = 'welcome to we were online!';
 
 export const UPDATES_EMAIL_SUBJECT = 'updates from we were online';
+
+const DOWNLOAD_LINKS = [
+  { browser: 'Chrome', textBrowser: 'Chrome (or chromium equivalents)', url: CHROME_URL },
+  { browser: 'Firefox', textBrowser: 'Firefox', url: FIREFOX_URL },
+  { browser: 'Edge', textBrowser: 'Edge', url: EDGE_URL },
+];
+
+const DOWNLOAD_BUTTON_STYLE =
+  'display:inline-block;background-color:#4a9a8a;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px;margin-right:8px;margin-bottom:8px';
+
+const WELCOME_DOWNLOAD_TEXT = DOWNLOAD_LINKS.map(
+  ({ textBrowser, url }) => `- Download on ${textBrowser}: ${url}`,
+).join('\n');
+
+const WELCOME_DOWNLOAD_HTML = DOWNLOAD_LINKS.map(
+  ({ browser, url }) => `<a href="${url}" style="${DOWNLOAD_BUTTON_STYLE}" target="_blank">
+                Download on ${browser}
+              </a>`,
+).join('\n              ');
 
 const SHARED_EMAIL_TEXT = `As a reminder, we were online is a browser extension—part game, artwork, and tool—that turns the existing Internet into a living, shared world, actively shaped by its inhabitants. Eventually, I want this to be a space where we can bump into each other all over the web and other creatives can create more embodied social media from their personal websites to bring belonging to the open web (building on top of playhtml: ${PLAYHTML_URL}).
 
@@ -38,8 +59,7 @@ export const WELCOME_EMAIL_TEXT = `Hi everyone!
 
 Thanks for signing up and being willing to try something that makes the Internet hopefully feel a bit more alive :) I'm excited to share the beta of we were online (${HOMEPAGE_URL}) with you.
 
-- Download on Chrome (or chromium equivalents): ${CHROME_URL}
-- Download on Firefox: ${FIREFOX_URL}
+${WELCOME_DOWNLOAD_TEXT}
 - Use another browser or run into any issues? let me know
 
 ${SHARED_EMAIL_TEXT}`;
@@ -118,12 +138,7 @@ const WELCOME_EMAIL_HTML = buildEmailHtml(
               with you.
             </p>
             <div style="margin:24px 0">
-              <a href="${CHROME_URL}" style="display:inline-block;background-color:#4a9a8a;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px;margin-right:8px;margin-bottom:8px" target="_blank">
-                Download on Chrome
-              </a>
-              <a href="${FIREFOX_URL}" style="display:inline-block;background-color:#4a9a8a;color:#faf7f2;padding:12px 20px;border-radius:4px;text-decoration:none;font-weight:600;font-size:15px;margin-right:8px;margin-bottom:8px" target="_blank">
-                Download on Firefox
-              </a>
+              ${WELCOME_DOWNLOAD_HTML}
             </div>
             <p style="font-size:16px;line-height:1.6;margin:0 0 16px 0">
               (Chrome download also works for Chromium-equivalents.) Use another browser or run into any issues?

--- a/extension/worker/src/emails/__tests__/WelcomeEmail.test.ts
+++ b/extension/worker/src/emails/__tests__/WelcomeEmail.test.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Tests for rendered signup email download links.
+// ABOUTME: Verifies welcome email bodies include every supported browser install target.
+
+import { describe, expect, it } from 'vitest';
+import { WELCOME_EMAIL_TEXT, renderWelcomeEmail } from '../WelcomeEmail';
+
+const EDGE_DOWNLOAD_URL =
+  'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
+
+describe('WelcomeEmail', () => {
+  it('includes an Edge install link in the plaintext welcome email', () => {
+    expect(WELCOME_EMAIL_TEXT).toContain(`- Download on Edge: ${EDGE_DOWNLOAD_URL}`);
+  });
+
+  it('includes an Edge install link in the HTML welcome email', async () => {
+    const html = await renderWelcomeEmail();
+
+    expect(html).toContain('Download on Edge');
+    expect(html).toContain(`href="${EDGE_DOWNLOAD_URL}"`);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Microsoft Edge as a homepage install option in the wewere.online download gate
- Add the Edge add-on link to both plaintext and HTML welcome emails
- Add focused tests covering the homepage and welcome-email Edge links

## Validation
- `cd extension/worker && bun run test`
- `node_modules/.bin/vitest run --config extension/website/vite.config.ts --environment node extension/website/src/components/__tests__/DownloadGate.test.tsx`
- `cd extension/website && bun run build`
- `git diff --check origin/main...HEAD`