### PR TITLE
ci: add configurable-tag snapshot publish workflow

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,0 +1,58 @@
+name: Publish snapshot
+
+# Manually publish a prerelease of the packages to a chosen npm dist-tag
+# (default `next`), from any branch — so a PR's changes can be tested in real
+# projects via `npm install playhtml@<tag>` before it merges to `latest`.
+# Parallel PRs can publish under distinct tags (e.g. `view`) without clobbering
+# each other.
+#
+# Versions are snapshot-stamped (e.g. 2.11.0-next-<sha>) and NOT committed or
+# git-tagged; this only publishes to npm. Runs `bun run release:snapshot`.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "npm dist-tag to publish to (e.g. next, view)"
+        required: false
+        default: "next"
+      ref:
+        description: "Branch/ref to publish from (defaults to the branch this is run on)"
+        required: false
+        default: ""
+
+concurrency: release-snapshot-${{ github.event.inputs.ref || github.ref }}
+
+jobs:
+  snapshot:
+    name: Publish snapshot to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # for npm provenance / OIDC trusted publishing
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install
+
+      - name: Publish snapshot to npm
+        run: bun run release:snapshot
+        env:
+          SNAPSHOT_TAG: ${{ github.event.inputs.tag || 'next' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "version-packages": "changeset version",
     "rewrite-workspace-deps": "bun run scripts/rewrite-workspace-deps.ts",
     "release": "bun run build-packages && bun run rewrite-workspace-deps && changeset publish",
-    "release:snapshot": "bun run build-packages && changeset version --snapshot next && bun run rewrite-workspace-deps && changeset publish --tag next --no-git-tag && git checkout -- .changeset packages/*/package.json packages/*/CHANGELOG.md",
+    "release:snapshot": "bun run build-packages && changeset version --snapshot ${SNAPSHOT_TAG:-next} && bun run rewrite-workspace-deps && changeset publish --tag ${SNAPSHOT_TAG:-next} --no-git-tag && git checkout -- .changeset packages/*/package.json packages/*/CHANGELOG.md",
     "lint": "bunx tsc -p partykit && cd website && bunx tsc && cd .. && for dir in packages/*; do (cd \"$dir\" && bunx tsc); done && cd extension && bunx tsc",
     "load-test": "bun load-test/src/runner.ts",
     "load-test:full": "bun load-test/src/runner.ts --config full-suite",


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` GitHub Actions workflow (`.github/workflows/release-snapshot.yml`) to publish snapshot prereleases of the packages to a **configurable npm dist-tag**, defaulting to `next`. Cherry-picked from #190 with the dist-tag made configurable.

The `release:snapshot` script and `scripts/rewrite-workspace-deps.ts` **already existed on `main`** — the only thing missing was the workflow YAML. This PR adds it and parametrizes the script's hardcoded `next`.

## Changes

- **`package.json`**: `release:snapshot` now reads `${SNAPSHOT_TAG:-next}` in both `changeset version --snapshot` and `changeset publish --tag`, so a bare `bun run release:snapshot` still publishes to `next` (unchanged local behavior) while CI can override the tag.
- **`.github/workflows/release-snapshot.yml`**: manual workflow with a `tag` input (default `next`) plus the existing `ref` input. The tag is passed to the script via the `SNAPSHOT_TAG` env var on the publish step. Keeps the reference workflow's `concurrency`, `permissions` (incl. `id-token: write`), Node/Bun setup, and `NODE_AUTH_TOKEN` / `NPM_CONFIG_PROVENANCE`.

## Why

Lets parallel PRs be tested in real projects under distinct dist-tags (e.g. `view`) via `npm install playhtml@<tag>` without clobbering `next`. Snapshot-stamped versions (e.g. `2.11.0-next-<sha>`) are published to npm only — not committed or git-tagged.

Source of the workflow: https://github.com/spencerc99/playhtml/pull/190

## Verification

- YAML parses (`yaml.safe_load`): OK
- Tag defaulting confirmed without publishing: unset → `next`, `SNAPSHOT_TAG=view` → `view`. Bun runs package scripts through a shell that supports `${VAR:-default}`, verified in an isolated test.

No changeset needed (changes are outside `packages/`).