### PR TITLE
react: avoid shared-state setup loops after room changes

### DIFF
--- a/.changeset/quiet-paths-navigate.md
+++ b/.changeset/quiet-paths-navigate.md
@@ -1,0 +1,3 @@
+"@playhtml/react": patch
+
+Prevent React shared-state components from re-registering their playhtml element when synced data updates only React state, avoiding render loops after room-change rebinds.

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Verifies that built-in capability updateElement functions are called alongside React state updates.
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import "@testing-library/dom";
 import { CanPlayElement } from "../index";
 import { CanMoveElement } from "../elements";
@@ -160,7 +160,43 @@ describe("CanPlayElement with built-in capabilities", () => {
       });
     });
 
+    expect(setupSpy).toHaveBeenCalledTimes(1);
     expect(removeSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not re-register when synced data only updates React state", async () => {
+    const setupSpy = vi
+      .spyOn(playhtml, "setupPlayElement")
+      .mockImplementation(() => {});
+
+    const { container } = render(
+      <CanPlayElement defaultData={{ count: 0 }}>
+        {({ data }) => <div id="sync-count">{data.count}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-play]") as HTMLElement;
+    expect(element).toBeTruthy();
+    await waitFor(() => expect(setupSpy).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      (element as any).updateElement({
+        data: { count: 1 },
+        awareness: [],
+        awarenessByStableId: new Map(),
+        myAwareness: undefined,
+        element,
+        localData: undefined,
+        setData: vi.fn(),
+        setLocalData: vi.fn(),
+        setMyAwareness: vi.fn(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(document.getElementById("sync-count")?.textContent).toBe("1");
+    });
+    expect(setupSpy).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes element handler props without removing the element", () => {
@@ -236,9 +272,7 @@ describe("CanPlayElement with built-in capabilities", () => {
 
     unmount();
 
-    expect(setupSpy).toHaveBeenCalledWith(element, {
-      ignoreIfAlreadySetup: true,
-    });
+    expect(setupSpy).toHaveBeenCalledWith(element);
     expect(removeSpy).toHaveBeenCalledWith(element);
   });
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,3 +1,5 @@
+// ABOUTME: Exposes React wrappers that bind components to playhtml shared state.
+// ABOUTME: Keeps DOM element registration in sync with React props and lifecycle.
 // TODO: idk why but this is not getting registered otherwise??
 import React from "react";
 import { useContext, useEffect, useRef, useState } from "react";
@@ -115,6 +117,7 @@ export function CanPlayElement<T extends object, V = any>({
     loadingAttributes["loading-style"] = loading.style;
   }
   const ref = useRef<HTMLElement>(null);
+  const lastSetupInputsRef = useRef<unknown[] | null>(null);
   const { defaultData, myDefaultAwareness } = elementProps;
   const resolveDefaultData = (fnOrValue: T | ((el: HTMLElement) => T)) =>
     typeof fnOrValue === "function"
@@ -179,6 +182,22 @@ export function CanPlayElement<T extends object, V = any>({
     capabilityUpdateElementAwareness?.(handlerData);
   };
 
+  const setupInputs = [
+    ...Object.entries(computedTagInfo).flat(),
+    dataSource,
+    shared,
+    dataSourceReadOnly,
+    loading?.behavior,
+    loading?.customClass,
+    loading?.style,
+    ...Object.entries(elementProps).flat(),
+  ];
+
+  const setupInputsChanged = (previous: unknown[] | null): boolean => {
+    if (!previous || previous.length !== setupInputs.length) return true;
+    return previous.some((value, index) => value !== setupInputs[index]);
+  };
+
   useEffect(() => {
     if (ref.current) {
       for (const [key, value] of Object.entries(elementProps)) {
@@ -193,11 +212,14 @@ export function CanPlayElement<T extends object, V = any>({
       // @ts-ignore
       ref.current.updateElementAwareness = updateElementAwareness;
 
+      if (!setupInputsChanged(lastSetupInputsRef.current)) {
+        return;
+      }
+      lastSetupInputsRef.current = setupInputs;
+
       // Setup the element, which will handle data-source discovery if needed
       try {
-        playhtml.setupPlayElement(ref.current, {
-          ignoreIfAlreadySetup: true,
-        });
+        playhtml.setupPlayElement(ref.current);
       } catch (error) {
         console.warn("[@playhtml/react] Failed to setup play element:", error);
 


### PR DESCRIPTION
## Summary

- Prevent `CanPlayElement` from re-running `setupPlayElement` when synced data only updates React state.
- Keep per-render DOM prop refreshes intact, but gate element re-registration on meaningful setup input changes.
- Add a React regression test for synced data updates that should not re-register the element.

## Verification

- `bun run -C packages/react test`
- `bun run -C packages/react build`
- `bun build-site`
- `bun smoke` (rerun with local process/temp escalation after sandbox tempdir blocked Playwright webServer startup)
- Built and browser-tested `spencers-website`: `/` navigates to `/about`, `window.playhtml.roomId` changes from `...-%2F` to `...-%2Fabout`, and no React maximum-depth loop appears.

## Docs

No public docs update: this is an internal React lifecycle fix and does not change the published API.