### PR TITLE
playhtml: keep init options static

### DIFF
--- a/.changeset/blue-spoons-navigate.md
+++ b/.changeset/blue-spoons-navigate.md
@@ -2,4 +2,4 @@
 "playhtml": patch
 ---
 
-Honor updated room options when an SPA remounts playhtml after client-side navigation, so explicit page-derived rooms can move to the new route instead of staying on the first initialized page.
+Keep `playhtml.init()` options static after the first initialization. For SPA room changes, use the default URL-derived room or pass a function-valued `room` so `handleNavigation()` can recompute it on route changes.

--- a/.changeset/blue-spoons-navigate.md
+++ b/.changeset/blue-spoons-navigate.md
@@ -2,4 +2,4 @@
 "playhtml": patch
 ---
 
-Keep `playhtml.init()` options static after the first initialization. For SPA room changes, use the default URL-derived room or pass a function-valued `room` so `handleNavigation()` can recompute it on route changes.
+Allow passing a function-valued `room` so `handleNavigation()` can recompute it on route changes.

--- a/apps/docs/src/content/docs/advanced/navigation.md
+++ b/apps/docs/src/content/docs/advanced/navigation.md
@@ -23,7 +23,7 @@ This covers most cases automatically. The sections below describe framework-spec
 The default room is derived from the URL pathname, so it recomputes automatically on navigation. To control it yourself, pass `room` to `init`:
 
 ```ts
-// Static string — fixed across navigation until init() receives another room.
+// Static string — fixed across navigation.
 playhtml.init({ room: "my-app" });
 
 // Function — re-invoked on every navigation, so a URL-derived room follows the
@@ -31,7 +31,7 @@ playhtml.init({ room: "my-app" });
 playhtml.init({ room: () => `notes${window.location.pathname}` });
 ```
 
-A static string stays fixed across navigation until you call `init()` again with another room (good for a single shared room). A function is called at init and again on each navigation, so the room can follow the URL.
+A static string stays fixed across navigation (good for a single shared room). A function is called at init and again on each navigation, so the room can follow the URL. `init()` options are captured on the first successful call; call `handleNavigation()` after client-side route changes instead of re-running `init()` with different options.
 
 ## Room-scoped data on navigation
 

--- a/apps/docs/src/content/docs/reference/init-options.md
+++ b/apps/docs/src/content/docs/reference/init-options.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Every option below can be passed either to `playhtml.init({…})` (vanilla) or to `<PlayProvider initOptions={{…}}>` (React). The underlying `InitOptions` interface is the same.
+Every option below can be passed either to `playhtml.init({…})` (vanilla) or to `<PlayProvider initOptions={{…}}>` (React). The underlying `InitOptions` interface is the same. Init options are captured on the first successful `init()` call; later calls return the existing readiness promise and do not update the active options.
 
 ```js
 import { playhtml } from "playhtml";
@@ -31,7 +31,7 @@ Override it when you want to decouple state from the URL — for example, a site
 playhtml.init({ room: "global-guestbook" });
 ```
 
-A **string** stays fixed across [client-side navigation](/docs/advanced/navigation/) until you call `init()` again with a different room. Pass a **function** to compute the room on each navigation, so a custom URL-derived room follows the route the way the default does:
+A **string** stays fixed across [client-side navigation](/docs/advanced/navigation/). Pass a **function** to compute the room on each navigation, so a custom URL-derived room follows the route the way the default does:
 
 ```js
 playhtml.init({ room: () => `notes${window.location.pathname}` });

--- a/packages/playhtml/src/__tests__/navigation.integration.test.ts
+++ b/packages/playhtml/src/__tests__/navigation.integration.test.ts
@@ -136,7 +136,7 @@ describe("playhtml.handleNavigation", () => {
     expect(before).not.toEqual(after);
   });
 
-  it("uses a new explicit room from a later init call", async () => {
+  it("keeps the first explicit room when a later init passes a different room", async () => {
     const origPath = window.location.pathname + window.location.search;
     try {
       history.replaceState(null, "", "/");
@@ -152,8 +152,9 @@ describe("playhtml.handleNavigation", () => {
         room: "/about",
       } as any);
 
-      expect(playhtml.roomId).toContain("%2Fabout");
-      expect(playhtml.roomId).not.toEqual(before);
+      expect(playhtml.roomId).toEqual(before);
+      expect(playhtml.roomId).toContain("%2F");
+      expect(playhtml.roomId).not.toContain("%2Fabout");
     } finally {
       history.replaceState(null, "", origPath);
     }
@@ -180,10 +181,7 @@ describe("playhtml.handleNavigation", () => {
     }
   });
 
-  it("enables cursors via a later init on an unchanged URL", async () => {
-    // A re-init that turns cursors ON must actually build them, even when the
-    // room hasn't changed — the cursor rebuild was gated on a cursor-ROOM
-    // change, so an enable transition on the same URL was silently dropped.
+  it("keeps cursor options from the first init when a later init enables cursors", async () => {
     await playhtml.init({
       host: "http://localhost:1999",
       room: "/cursors-toggle",
@@ -196,10 +194,10 @@ describe("playhtml.handleNavigation", () => {
       cursors: { enabled: true },
     } as any);
 
-    expect(playhtml.cursorClient).not.toBeNull();
+    expect(playhtml.cursorClient).toBeNull();
   });
 
-  it("disables cursors via a later init on an unchanged URL", async () => {
+  it("keeps cursor options from the first init when a later init disables cursors", async () => {
     await playhtml.init({
       host: "http://localhost:1999",
       room: "/cursors-toggle-off",
@@ -212,7 +210,7 @@ describe("playhtml.handleNavigation", () => {
       cursors: { enabled: false },
     } as any);
 
-    expect(playhtml.cursorClient).toBeNull();
+    expect(playhtml.cursorClient).not.toBeNull();
   });
 
   it("strips filename extension from pathname when deriving default room", async () => {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -559,11 +559,11 @@ let awarenessChangeTarget: {
   awareness: { off: (event: string, cb: () => void) => void };
 } | null = null;
 
-// If init() receives an explicit `room`, we store it for future navigation
-// checks. A string stays fixed across navigation until init() receives another
-// room; a function is re-invoked on each nav so a path-derived room switches
-// correctly. If no explicit room was given, we store the default-room options
-// and re-derive on each nav so pathname-based rooms switch correctly.
+// If the first init() receives an explicit `room`, we store it for future
+// navigation checks. A string stays fixed across navigation; a function is
+// re-invoked on each nav so a path-derived room switches correctly. If no
+// explicit room was given, we store the default-room options and re-derive on
+// each nav so pathname-based rooms switch correctly.
 let explicitRoomOption: string | (() => string) | undefined = undefined;
 
 /** Resolve the explicit room option to a string, calling it if it's a function
@@ -576,40 +576,6 @@ function resolveExplicitRoom(): string | undefined {
 let cachedDefaultRoomOptions: DefaultRoomOptions = { includeSearch: false };
 let cursorOptionsCache: CursorOptions | undefined = undefined;
 let cachedOnError: (() => void) | undefined = undefined;
-
-function hasInitOption<K extends keyof InitOptions>(
-  options: InitOptions,
-  key: K,
-): options is InitOptions & Required<Pick<InitOptions, K>> {
-  return Object.prototype.hasOwnProperty.call(options, key);
-}
-
-function applyActiveInitOptions(options: InitOptions): boolean {
-  let shouldHandleNavigation = false;
-
-  if (hasInitOption(options, "room")) {
-    explicitRoomOption = options.room;
-    shouldHandleNavigation = true;
-  }
-
-  if (hasInitOption(options, "defaultRoomOptions")) {
-    cachedDefaultRoomOptions = options.defaultRoomOptions ?? {
-      includeSearch: false,
-    };
-    shouldHandleNavigation = true;
-  }
-
-  if (hasInitOption(options, "cursors")) {
-    cursorOptionsCache = options.cursors ?? {};
-    shouldHandleNavigation = true;
-  }
-
-  if (hasInitOption(options, "onError")) {
-    cachedOnError = options.onError;
-  }
-
-  return shouldHandleNavigation;
-}
 
 /**
  * Builds a fresh main Yjs provider for the given room. Side effects:
@@ -799,8 +765,8 @@ async function runHandleNavigation(): Promise<void> {
 
   const cursorsWanted = Boolean(cursorOptionsCache?.enabled);
   const cursorsActive = cursorClient !== null;
-  // An enable/disable transition must (re)build or tear down cursors regardless
-  // of room change — a later init({ cursors }) can flip this on an unchanged URL.
+  // Cursor setup is static after init, but the cursor client can still be
+  // rebuilt when navigation changes the cursor room.
   const cursorEnabledChanged = cursorsWanted !== cursorsActive;
 
   let cursorRoomChanged = false;
@@ -899,14 +865,7 @@ async function runHandleNavigation(): Promise<void> {
 
 function initPlayHTML(options: InitOptions = {}) {
   if (initStarted) {
-    const shouldHandleNavigation = applyActiveInitOptions(options);
-    if (!shouldHandleNavigation) {
-      return readyPromise;
-    }
-
-    return readyPromise.then(async () => {
-      await navigationController?.trigger();
-    });
+    return readyPromise;
   }
 
   const existingPlayhtml = (window as any).playhtml;


### PR DESCRIPTION
## Summary

- Remove the post-init path that let later `playhtml.init()` calls mutate active room, cursor, default-room, and error options.
- Keep SPA room changes on the explicit navigation path: default URL-derived rooms or function-valued `room` options recomputed by `handleNavigation()`.
- Update navigation coverage and docs to make the first-init-only contract clear.

## Root Cause

The dynamic init-options change made `init()` double as a runtime config updater, but it did not solve the Astro SPA case because the site was not re-running `init()` on navigation. The correct SPA mechanism is for navigation handling to recompute dynamic room functions, while `init()` remains one-time setup.

## Verification

- `bun run test -- navigation.integration.test.ts` in `packages/playhtml`
- `bun run test` in `packages/playhtml` (204 tests)
- `bun run build` in `packages/playhtml`
- `bun run build-site`
- `cd smoke-tests && bunx playwright test --workers=1` (21 passed)
- `git diff --check`

`bun run lint` still fails in unrelated existing website TypeScript errors under `website/components/*` and `website/fridge.tsx`; the changed package build/typecheck passed.