### PR TITLE
Admin console uses deployed Worker hosts

### DIFF
--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -35,8 +35,8 @@ interface DebugLog {
 type EnvName = "production" | "staging" | "development";
 
 const HOSTS: Record<EnvName, string> = {
-  production: "https://playhtml.spencerc99.partykit.dev",
-  staging: "https://staging.playhtml.spencerc99.partykit.dev",
+  production: "https://playhtml.spencerc99.workers.dev",
+  staging: "https://playhtml-staging.spencerc99.workers.dev",
   development: "http://localhost:1999",
 };
 

--- a/website/components/ExperimentsArchive.tsx
+++ b/website/components/ExperimentsArchive.tsx
@@ -572,7 +572,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
       (event: MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
 
-        if (!hasSynced || !dispatchPlayEvent) return;
+        if (!hasSynced) return;
 
         const availableExperiments = experiments.filter(
           (experiment) => experiment.href,
@@ -662,12 +662,10 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
           </span>
           <button
             type="button"
-            disabled={!hasSynced || !dispatchPlayEvent}
+            disabled={!hasSynced}
             onClick={handleRandomExperiment}
           >
-            {hasSynced && dispatchPlayEvent
-              ? "random experiment"
-              : "syncing..."}
+            {hasSynced ? "random experiment" : "syncing..."}
           </button>
         </div>
       </section>

--- a/website/components/FeaturesGrid.tsx
+++ b/website/components/FeaturesGrid.tsx
@@ -1,10 +1,10 @@
+// ABOUTME: Renders the homepage feature gallery for core PlayHTML capabilities.
+// ABOUTME: Hosts embedded demos and links to example source for each feature.
 import React from "react";
 import { RainSprinkler } from "../../packages/react/examples/RainSprinkler";
 import { ReactiveOrb } from "../../packages/react/examples/ReactiveOrb";
 import { DataModes } from "./DataModes";
 import { ComponentStore } from "./ComponentStore";
-import { ScheduledBehaviors } from "./ScheduledBehaviors";
-import { Permissions } from "./Permissions";
 import "./FeaturesGrid.scss";
 import { withSharedState } from "@playhtml/react";
 import { invertColor } from "../utils/color";
@@ -21,7 +21,7 @@ interface ExperimentOneData {
 
 // Component to fetch shared color data and make it available to parent
 // TODO: fix this, somehow it is clearing the data with the defaultData?
-const _SharedColorProvider = withSharedState<
+export const SharedColorProvider = withSharedState<
   ExperimentOneData,
   undefined,
   { children: React.ReactNode }

--- a/website/components/Permissions.tsx
+++ b/website/components/Permissions.tsx
@@ -1,19 +1,23 @@
+// ABOUTME: Renders a feature demo for role-based capability permissions.
+// ABOUTME: Cycles sample users through locked and unlocked permission states.
 import { useEffect, useState } from "react";
 import "./Permissions.scss";
+
+type PermissionKey = "silver" | "gold";
 
 interface Permission {
   id: string;
   name: string;
   isLocked: boolean;
   hasKey: boolean;
-  keyType?: "silver" | "gold";
+  keyType?: PermissionKey;
   action: string;
 }
 
 interface User {
   id: string;
   name: string;
-  keys: string[];
+  keys: PermissionKey[];
   color: string;
 }
 
@@ -58,6 +62,8 @@ export function Permissions() {
   const [currentUser, setCurrentUser] = useState(0);
   const [permissionStates, setPermissionStates] = useState(permissions);
   const [attemptingUnlock, setAttemptingUnlock] = useState<string | null>(null);
+  const userHasPermissionKey = (keyType?: PermissionKey) =>
+    !keyType || users[currentUser].keys.includes(keyType);
 
   // Rotate through users
   useEffect(() => {
@@ -71,11 +77,14 @@ export function Permissions() {
   useEffect(() => {
     const user = users[currentUser];
     setPermissionStates((prev) =>
-      prev.map((perm) => ({
-        ...perm,
-        hasKey: user.keys.includes(perm.keyType),
-        isLocked: !user.keys.includes(perm.keyType),
-      }))
+      prev.map((perm) => {
+        const hasKey = !perm.keyType || user.keys.includes(perm.keyType);
+        return {
+          ...perm,
+          hasKey,
+          isLocked: Boolean(perm.keyType && !hasKey),
+        };
+      })
     );
   }, [currentUser]);
 
@@ -83,7 +92,7 @@ export function Permissions() {
     const perm = permissionStates.find((p) => p.id === permId);
     const user = users[currentUser];
 
-    if (perm && perm.isLocked && !user.keys.includes(perm.keyType)) {
+    if (perm && perm.isLocked && !userHasPermissionKey(perm.keyType)) {
       setAttemptingUnlock(permId);
       setTimeout(() => setAttemptingUnlock(null), 1000);
     } else if (perm && !perm.isLocked) {
@@ -94,7 +103,7 @@ export function Permissions() {
     }
   };
 
-  const getKeyIcon = (keyType: string) => {
+  const getKeyIcon = (keyType?: PermissionKey) => {
     switch (keyType) {
       case "silver":
         return "🔵";

--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -262,7 +262,7 @@ function getCanPlayData(elementId?: string): MoveData | undefined {
   return playhtml?.syncedStore?.["can-play"]?.[elementId];
 }
 
-const FridgeWord = withSharedState<MoveData, any, Props>(
+const FridgeWord = withSharedState<MoveData, MoveLocalData, Props>(
   (props: Props) => {
     // Check for "can-play" data to migrate to "can-move" (reverse migration)
     const canPlayData = getCanPlayData(props.id);
@@ -339,7 +339,7 @@ const FridgeWord = withSharedState<MoveData, any, Props>(
                   border: "2px dotted red",
                 }
               : {}),
-          }}
+          } as React.CSSProperties}
         >
           {word}
           {deleteMode ? (
@@ -1080,8 +1080,8 @@ const AdminSettings = ({
           type="checkbox"
           checked={data.showDefaultWords}
           onChange={(e) =>
-            setData((d) => {
-              d.showDefaultWords = e.target.checked;
+            setData({
+              showDefaultWords: e.target.checked,
             })
           }
         />
@@ -1137,7 +1137,7 @@ const FridgeWordsContent = withSharedState(
       >
         Finding the words...
       </div>
-    ) : props.hasError ? (
+    ) : hasError ? (
       <div
         style={{
           position: "absolute",

--- a/website/test/admin.tsx
+++ b/website/test/admin.tsx
@@ -34,8 +34,8 @@ interface DebugLog {
 type EnvName = "production" | "staging" | "development";
 
 const HOSTS: Record<EnvName, string> = {
-  production: "https://playhtml.spencerc99.partykit.dev",
-  staging: "https://staging.playhtml.spencerc99.partykit.dev",
+  production: "https://playhtml.spencerc99.workers.dev",
+  staging: "https://playhtml-staging.spencerc99.workers.dev",
   development: "http://localhost:1999",
 };
 


### PR DESCRIPTION
## Summary
- Point the admin console production and staging hosts at the Wrangler-deployed Workers hosts.
- Fix narrow website TypeScript errors surfaced while verifying the branch.

## Root cause
The admin console posted moderation requests to the stale `*.partykit.dev` host. The deployed Worker with `admin/moderation-remove` is available at `*.workers.dev`, which returned the expected auth response during a live bogus-token probe.

## Validation
- `bun install --frozen-lockfile`
- `bun run build-packages`
- `bunx tsc -p partykit`
- `bunx tsc` from `website/`
- `for dir in packages/*; do (cd "$dir" && bunx tsc) || exit 1; done`
- `git diff --check`

Note: full `bun run lint` still fails locally in unrelated extension and worker TypeScript files after the verified surfaces pass.