### PR TITLE
Fix html starter direct file loading

### DIFF
--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -194,7 +194,7 @@
 
         <!-- Option 1 (simplest, no customization) -->
     <script type="module">
-      import { playhtml } from "https://unpkg.com/playhtml@2.9.0";
+      import { playhtml } from "https://unpkg.com/playhtml@latest";
 
       // Initialize with cursor tracking
       playhtml.init({

--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -17,7 +17,7 @@
     <title>playhtml starter</title>
 
     <!-- The website stylesheet -->
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <!--
@@ -208,6 +208,6 @@
       window.playhtml = playhtml;
     </script>
     <!-- The website JavaScript file -->
-    <script src="/script.js" defer></script>
+    <script src="script.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Use relative `style.css` and `script.js` paths in the HTML starter so opening `index.html` directly loads local assets from the template folder.
- Change the starter CDN import from `playhtml@2.9.0` to `playhtml@latest` so new copies use the current published package.

## Rationale

The template README tells users to open `index.html` directly. With root-relative local asset paths, a `file://` load resolves `/style.css` and `/script.js` against the filesystem root, so the stylesheet and local script are not found.

## Validation

- `node -e` URL-resolution check confirms `style.css` and `script.js` resolve to files inside `templates/html-starter/` under `file://`.
- `node -e` import check confirms the starter imports `https://unpkg.com/playhtml@latest`.
- `rg` check confirms no remaining root-local starter asset paths or `playhtml@2.9.0` reference.
- `git diff --check HEAD`