### PR TITLE
Surface admin comparison tools

### DIFF
--- a/website/admin.scss
+++ b/website/admin.scss
@@ -603,40 +603,6 @@ section {
   }
 }
 
-.debug-steps {
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-  border-radius: 4px;
-  padding: 15px;
-  margin-bottom: 15px;
-  font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
-  font-size: 0.85rem;
-  line-height: 1.6;
-
-  .debug-step {
-    margin-bottom: 8px;
-    padding: 4px 0;
-    word-break: break-word;
-    overflow-wrap: break-word;
-
-    &.success {
-      color: #28a745;
-    }
-
-    &.warning {
-      color: #ffc107;
-    }
-
-    &.error {
-      color: #dc3545;
-    }
-
-    &.info {
-      color: #17a2b8;
-    }
-  }
-}
-
 .tool-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));

--- a/website/admin.scss
+++ b/website/admin.scss
@@ -1,3 +1,5 @@
+// ABOUTME: Styles the browser admin console for inspecting and managing rooms.
+// ABOUTME: Defines layout, data viewers, debug tools, and moderation controls.
 .admin-container {
   max-width: min(1200px, 100vw);
   margin: 0 auto;
@@ -556,6 +558,48 @@ section {
     padding: 4px 8px;
     border-radius: 4px;
     border: 1px solid #e9ecef;
+  }
+}
+
+.section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  .tool-btn {
+    padding: 6px 10px;
+    font-size: 0.85rem;
+  }
+}
+
+.comparison-status {
+  border: 1px solid #e2e8f0;
+  border-radius: 999px;
+  padding: 4px 8px;
+  background: #f7fafc;
+  color: #4a5568;
+  font-size: 0.8rem;
+  font-weight: 600;
+
+  &.checking {
+    background: #bee3f8;
+    border-color: #90cdf4;
+    color: #2c5282;
+  }
+
+  &.match {
+    background: #c6f6d5;
+    border-color: #9ae6b4;
+    color: #22543d;
+  }
+
+  &.different,
+  &.error {
+    background: #fed7d7;
+    border-color: #fc8181;
+    color: #9b2c2c;
   }
 }
 

--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useCallback } from "react";
 import { createRoot } from "react-dom/client";
 import { useStickyState } from "./hooks/useStickyState";
 import { findDocumentRowInBackup } from "./utils/backup";
+import { createComparisonSummary } from "./utils/adminComparison";
 import { deriveRoomId } from "@playhtml/common";
 import { extractRecords, type ModerationRecord } from "@moderation";
 
@@ -509,9 +510,7 @@ const AdminConsole: React.FC = () => {
   } | null>(null);
 
   // Debug sections visibility
-  const [showRawDbData, setShowRawDbData] = useState(false);
   const [showYDocDebug, setShowYDocDebug] = useState(false);
-  const [showDataComparison, setShowDataComparison] = useState(false);
   const [_showBackupComparison, setShowBackupComparison] = useState(false);
 
   // Section collapse/expand state
@@ -521,9 +520,9 @@ const AdminConsole: React.FC = () => {
     ydocData: true,
     roomMetadata: true,
     sharedData: true,
-    rawDbData: true,
-    yDocDebug: true,
-    dataComparison: true,
+    rawDbData: false,
+    yDocDebug: false,
+    dataComparison: false,
     backupComparison: true,
     cleanupTools: false, // Collapsed by default
   });
@@ -542,6 +541,8 @@ const AdminConsole: React.FC = () => {
   >([]);
   const [reconstructedDoc, setReconstructedDoc] = useState<any>(null);
   const [comparisonData, setComparisonData] = useState<any>(null);
+  const [comparisonLoading, setComparisonLoading] = useState(false);
+  const [comparisonError, setComparisonError] = useState<string | null>(null);
   const [backupComparisonData, setBackupComparisonData] = useState<any>(null);
 
   const [debugToolsEnabled, setDebugToolsEnabled] = useState(false);
@@ -733,9 +734,10 @@ const AdminConsole: React.FC = () => {
         // Clear previous room data immediately
         setRoomData(null);
         setRoomStatus(null);
-        setShowRawDbData(false);
+        setRawDbData(null);
         setShowYDocDebug(false);
-        setShowDataComparison(false);
+        setComparisonData(null);
+        setComparisonError(null);
         setShowBackupComparison(false);
         setBackupComparisonData(null);
         setBackupBase64(null);
@@ -748,9 +750,10 @@ const AdminConsole: React.FC = () => {
         setCurrentRoomId("");
         setRoomData(null);
         setRoomStatus(null);
-        setShowRawDbData(false);
+        setRawDbData(null);
         setShowYDocDebug(false);
-        setShowDataComparison(false);
+        setComparisonData(null);
+        setComparisonError(null);
         setShowBackupComparison(false);
         setBackupComparisonData(null);
         setBackupBase64(null);
@@ -927,9 +930,16 @@ const AdminConsole: React.FC = () => {
     // Clear previous data immediately when starting a new load
     setRoomData(null);
     setDebugToolsEnabled(false);
-    setShowRawDbData(false);
+    setRawDbData(null);
     setShowYDocDebug(false);
-    setShowDataComparison(false);
+    setComparisonData(null);
+    setComparisonError(null);
+    setSectionsExpanded((prev) => ({
+      ...prev,
+      rawDbData: false,
+      yDocDebug: false,
+      dataComparison: false,
+    }));
     setShowBackupComparison(false);
     setBackupComparisonData(null);
     setBackupBase64(null);
@@ -961,6 +971,7 @@ const AdminConsole: React.FC = () => {
         type: "success",
       });
       addLog("info", `Loaded room data for ${displayRoomId}`, data);
+      void compareDataMethods({ roomId: encodedRoomId });
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       const displayRoomId = decodeRoomId(encodedRoomId);
@@ -1180,7 +1191,7 @@ const AdminConsole: React.FC = () => {
 
       const data = await response.json();
       setRawDbData(data);
-      setShowRawDbData(true);
+      setSectionsExpanded((prev) => ({ ...prev, rawDbData: true }));
       addLog("info", "Loaded raw database data", data);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -1192,6 +1203,7 @@ const AdminConsole: React.FC = () => {
     if (!currentRoomId || !adminToken) return;
 
     setShowYDocDebug(true);
+    setSectionsExpanded((prev) => ({ ...prev, yDocDebug: true }));
     setDebugSteps([]);
     setReconstructedDoc(null);
 
@@ -1287,13 +1299,19 @@ const AdminConsole: React.FC = () => {
     }
   };
 
-  const compareDataMethods = async () => {
-    if (!currentRoomId || !adminToken) return;
+  const compareDataMethods = async (
+    options: { roomId?: string; forceShow?: boolean } = {}
+  ) => {
+    const targetRoomId = options.roomId || currentRoomId;
+    if (!targetRoomId || !adminToken) return;
 
     try {
+      setComparisonLoading(true);
+      setComparisonError(null);
       addLog("info", "Comparing data extraction methods...");
 
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
+      const encodedRoomId = ensureEncodedRoomId(targetRoomId);
+      const baseUrl = `${getPartykitHost()}/parties/main/${encodedRoomId}`;
       const url = `${baseUrl}/admin/live-compare?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1311,53 +1329,20 @@ const AdminConsole: React.FC = () => {
 
       const comparison = await response.json();
       setComparisonData(comparison);
-      setShowDataComparison(true);
+      const summary = createComparisonSummary(comparison);
+      const shouldShowDetails = options.forceShow || summary.shouldShowDetails;
+      setSectionsExpanded((prev) => ({
+        ...prev,
+        dataComparison: shouldShowDetails ? true : prev.dataComparison,
+      }));
       addLog("info", "Data method comparison results:", comparison);
-
-      // Show summary alert
-      const directHasData = comparison.methods?.direct?.hasData;
-      const liveHasData = comparison.methods?.live?.hasData;
-      const dataMatch = comparison.differences?.dataMatch;
-
-      const directData = comparison.methods?.direct?.data || {};
-      const liveData = comparison.methods?.live?.data || {};
-      const directKeyCount = Object.keys(directData).reduce(
-        (sum, tag) => sum + Object.keys(directData[tag] || {}).length,
-        0
-      );
-      const liveKeyCount = Object.keys(liveData).reduce(
-        (sum, tag) => sum + Object.keys(liveData[tag] || {}).length,
-        0
-      );
-
-      let summary = "🔍 Data Comparison Results:\n\n";
-      summary += `Direct method: ${
-        directHasData ? `✅ ${directKeyCount} elements` : "❌ No data"
-      }\n`;
-      summary += `Live method: ${
-        liveHasData ? `✅ ${liveKeyCount} elements` : "❌ No data"
-      }\n`;
-      summary += `Data match: ${
-        dataMatch ? "✅ Identical" : "❌ Different"
-      }\n\n`;
-
-      if (!dataMatch && directHasData && liveHasData) {
-        const keyDiffs = comparison.differences?.sameKeys;
-        if (keyDiffs) {
-          summary += `Capability differences:\n`;
-          summary += `- Direct only: ${
-            keyDiffs.directOnly.join(", ") || "none"
-          }\n`;
-          summary += `- Live only: ${keyDiffs.liveOnly.join(", ") || "none"}\n`;
-          summary += `- Common: ${keyDiffs.common.join(", ") || "none"}\n`;
-        }
-      }
-
-      summary += "\nSee comparison section below for detailed view.";
-      alert(summary);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
+      setComparisonError(msg);
+      setSectionsExpanded((prev) => ({ ...prev, dataComparison: true }));
       addLog("error", `Failed to compare data methods: ${msg}`, error);
+    } finally {
+      setComparisonLoading(false);
     }
   };
 
@@ -2150,6 +2135,11 @@ const AdminConsole: React.FC = () => {
     ));
   };
 
+  const comparisonSummary = React.useMemo(
+    () => createComparisonSummary(comparisonData),
+    [comparisonData]
+  );
+
   if (!adminToken) {
     return (
       <LoginScreen
@@ -2399,170 +2389,223 @@ const AdminConsole: React.FC = () => {
             </>
           )}
 
-          {showRawDbData && rawDbData && (
+          {roomData && (
             <div className="data-section">
               <SectionHeader
                 title="Raw Database Data"
                 sectionKey="rawDbData"
                 isExpanded={sectionsExpanded.rawDbData}
                 onToggle={toggleSection}
+                actions={
+                  <button
+                    className="tool-btn"
+                    disabled={!debugToolsEnabled}
+                    onClick={loadRawDatabaseData}
+                  >
+                    Load Raw DB Data
+                  </button>
+                }
               />
               {sectionsExpanded.rawDbData && (
-                <>
-                  <div className="debug-info">
-                    <div className="debug-item">
-                      <strong>Document Size:</strong>
-                      <span>
-                        {rawDbData.document
-                          ? `${
-                              Math.round(
-                                (rawDbData.document.base64Length / 1024) * 100
-                              ) / 100
-                            } KB`
-                          : "No data"}
-                      </span>
+                rawDbData ? (
+                  <>
+                    <div className="debug-info">
+                      <div className="debug-item">
+                        <strong>Document Size:</strong>
+                        <span>
+                          {rawDbData.document
+                            ? `${
+                                Math.round(
+                                  (rawDbData.document.base64Length / 1024) *
+                                    100
+                                ) / 100
+                              } KB`
+                            : "No data"}
+                        </span>
+                      </div>
+                      <div className="debug-item">
+                        <strong>Base64 Length:</strong>
+                        <span>
+                          {rawDbData.document
+                            ? rawDbData.document.base64Length.toLocaleString()
+                            : "0"}
+                        </span>
+                      </div>
+                      <div className="debug-item">
+                        <strong>Last Updated:</strong>
+                        <span>
+                          {rawDbData.document
+                            ? new Date(
+                                rawDbData.document.created_at
+                              ).toLocaleString()
+                            : "Never"}
+                        </span>
+                      </div>
                     </div>
-                    <div className="debug-item">
-                      <strong>Base64 Length:</strong>
-                      <span>
-                        {rawDbData.document
-                          ? rawDbData.document.base64Length.toLocaleString()
-                          : "0"}
-                      </span>
-                    </div>
-                    <div className="debug-item">
-                      <strong>Last Updated:</strong>
-                      <span>
-                        {rawDbData.document
-                          ? new Date(
-                              rawDbData.document.created_at
-                            ).toLocaleString()
-                          : "Never"}
-                      </span>
-                    </div>
+                    <JSONViewer data={rawDbData} />
+                  </>
+                ) : (
+                  <div className="empty">
+                    Load raw database data to inspect the stored base64
+                    snapshot.
                   </div>
-                  <JSONViewer data={rawDbData} />
-                </>
+                )
               )}
             </div>
           )}
 
-          {showYDocDebug && (
+          {roomData && (
             <div className="data-section">
               <SectionHeader
                 title="Y.Doc Loading Debug"
                 sectionKey="yDocDebug"
                 isExpanded={sectionsExpanded.yDocDebug}
                 onToggle={toggleSection}
+                actions={
+                  <button
+                    className="tool-btn"
+                    disabled={!debugToolsEnabled}
+                    onClick={debugYDocLoading}
+                  >
+                    Run Y.Doc Debug
+                  </button>
+                }
               />
               {sectionsExpanded.yDocDebug && (
-                <>
-                  <div className="debug-steps">
-                    {debugSteps.map((step, index) => (
-                      <div key={index} className={`debug-step ${step.type}`}>
-                        {step.message}
-                      </div>
-                    ))}
+                showYDocDebug ? (
+                  <>
+                    <div className="debug-steps">
+                      {debugSteps.map((step, index) => (
+                        <div key={index} className={`debug-step ${step.type}`}>
+                          {step.message}
+                        </div>
+                      ))}
+                    </div>
+                    {reconstructedDoc && (
+                      <JSONViewer data={reconstructedDoc} />
+                    )}
+                  </>
+                ) : (
+                  <div className="empty">
+                    Run the Y.Doc debug flow to reconstruct the stored snapshot
+                    from base64.
                   </div>
-                  {reconstructedDoc && <JSONViewer data={reconstructedDoc} />}
-                </>
+                )
               )}
             </div>
           )}
 
-          {showDataComparison && comparisonData && (
+          {roomData && (
             <div className="data-section">
               <SectionHeader
                 title="Live vs Admin Data Comparison"
                 sectionKey="dataComparison"
                 isExpanded={sectionsExpanded.dataComparison}
                 onToggle={toggleSection}
-              />
-              {sectionsExpanded.dataComparison && (
-                <>
-                  <div className="debug-info">
-                    <div className="debug-item">
-                      <strong>Direct Method Keys:</strong>
-                      <span>
-                        {Object.keys(
-                          comparisonData.methods?.direct?.data || {}
-                        ).reduce(
-                          (sum, tag) =>
-                            sum +
-                            Object.keys(
-                              comparisonData.methods.direct.data[tag] || {}
-                            ).length,
-                          0
-                        )}
-                      </span>
-                    </div>
-                    <div className="debug-item">
-                      <strong>Live Method Keys:</strong>
-                      <span>
-                        {Object.keys(
-                          comparisonData.methods?.live?.data || {}
-                        ).reduce(
-                          (sum, tag) =>
-                            sum +
-                            Object.keys(
-                              comparisonData.methods.live.data[tag] || {}
-                            ).length,
-                          0
-                        )}
-                      </span>
-                    </div>
-                    <div className="debug-item">
-                      <strong>Data Match:</strong>
-                      <span
-                        style={{
-                          color: comparisonData.differences?.dataMatch
-                            ? "#38a169"
-                            : "#e53e3e",
-                        }}
-                      >
-                        {comparisonData.differences?.dataMatch
-                          ? "✅ Yes"
-                          : "❌ No"}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="tool-grid" style={{ marginBottom: "10px" }}>
-                    <button
-                      className="tool-btn destructive"
-                      disabled={!debugToolsEnabled}
-                      onClick={handleForceReloadLive}
+                actions={
+                  <div className="section-actions">
+                    <span
+                      className={`comparison-status ${
+                        comparisonError
+                          ? "error"
+                          : comparisonLoading
+                            ? "checking"
+                            : comparisonSummary.status
+                      }`}
                     >
-                      Force DB → Live
-                    </button>
+                      {comparisonError
+                        ? "Comparison failed"
+                        : comparisonLoading
+                          ? "Checking..."
+                          : comparisonSummary.statusLabel}
+                    </span>
                     <button
                       className="tool-btn"
-                      disabled={!debugToolsEnabled}
-                      onClick={handleForceSaveLive}
+                      disabled={!debugToolsEnabled || comparisonLoading}
+                      onClick={() => compareDataMethods({ forceShow: true })}
                     >
-                      Force Save DB ← Live
+                      {comparisonLoading ? "Checking..." : "Compare Now"}
                     </button>
                   </div>
-                  <div className="shared-data-grid">
-                    <div className="shared-section">
-                      <h4>Direct Method Data (Admin Console)</h4>
-                      <JSONViewer
-                        data={comparisonData.methods?.direct?.data || {}}
-                      />
+                }
+              />
+              {sectionsExpanded.dataComparison && (
+                comparisonError ? (
+                  <div className="status-display error">{comparisonError}</div>
+                ) : comparisonData ? (
+                  <>
+                    <div className="debug-info">
+                      <div className="debug-item">
+                        <strong>Direct Method Keys:</strong>
+                        <span>{comparisonSummary.directElementCount}</span>
+                      </div>
+                      <div className="debug-item">
+                        <strong>Live Method Keys:</strong>
+                        <span>{comparisonSummary.liveElementCount}</span>
+                      </div>
+                      <div className="debug-item">
+                        <strong>Data Match:</strong>
+                        <span
+                          style={{
+                            color: comparisonSummary.dataMatch
+                              ? "#38a169"
+                              : "#e53e3e",
+                          }}
+                        >
+                          {comparisonSummary.dataMatch ? "Yes" : "No"}
+                        </span>
+                      </div>
                     </div>
-                    <div className="shared-section">
-                      <h4>Live Method Data (unstable_getYDoc)</h4>
-                      {comparisonData.methods?.live?.data?.error ? (
-                        <div className="empty">
-                          Error: {comparisonData.methods.live.data.error}
-                        </div>
-                      ) : (
+                    <div
+                      className="tool-grid"
+                      style={{ marginBottom: "10px" }}
+                    >
+                      <button
+                        className="tool-btn destructive"
+                        disabled={!debugToolsEnabled}
+                        onClick={handleForceReloadLive}
+                      >
+                        Force DB → Live
+                      </button>
+                      <button
+                        className="tool-btn"
+                        disabled={!debugToolsEnabled}
+                        onClick={handleForceSaveLive}
+                      >
+                        Force Save DB ← Live
+                      </button>
+                    </div>
+                    <div className="shared-data-grid">
+                      <div className="shared-section">
+                        <h4>Direct Method Data (Admin Console)</h4>
                         <JSONViewer
-                          data={comparisonData.methods?.live?.data || {}}
+                          data={comparisonData.methods?.direct?.data || {}}
                         />
-                      )}
+                      </div>
+                      <div className="shared-section">
+                        <h4>Live Method Data (unstable_getYDoc)</h4>
+                        {comparisonData.methods?.live?.data?.error ? (
+                          <div className="empty">
+                            Error: {comparisonData.methods.live.data.error}
+                          </div>
+                        ) : (
+                          <JSONViewer
+                            data={comparisonData.methods?.live?.data || {}}
+                          />
+                        )}
+                      </div>
                     </div>
+                  </>
+                ) : comparisonLoading ? (
+                  <div className="status-display loading">
+                    Comparing live and admin data...
                   </div>
-                </>
+                ) : (
+                  <div className="empty">
+                    The comparison runs automatically after room load. Use
+                    Compare Now to run it again.
+                  </div>
+                )
               )}
             </div>
           )}
@@ -3117,33 +3160,12 @@ const AdminConsole: React.FC = () => {
               Export Raw Document
             </button>
             <button
-              className="tool-btn"
-              disabled={!debugToolsEnabled}
-              onClick={loadRawDatabaseData}
-            >
-              Load Raw DB Data
-            </button>
-            <button
               className="tool-btn destructive"
               disabled={!debugToolsEnabled}
               onClick={restoreRawDocument}
               title="Restore from a raw base64-encoded YJS document file"
             >
               Restore Raw Document
-            </button>
-            <button
-              className="tool-btn"
-              disabled={!debugToolsEnabled}
-              onClick={debugYDocLoading}
-            >
-              Debug Y.Doc Loading
-            </button>
-            <button
-              className="tool-btn"
-              disabled={!debugToolsEnabled}
-              onClick={compareDataMethods}
-            >
-              Compare Live vs Admin Data
             </button>
             <button
               className="tool-btn destructive"

--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -509,8 +509,6 @@ const AdminConsole: React.FC = () => {
     type: "loading" | "success" | "error" | "empty";
   } | null>(null);
 
-  // Debug sections visibility
-  const [showYDocDebug, setShowYDocDebug] = useState(false);
   const [_showBackupComparison, setShowBackupComparison] = useState(false);
 
   // Section collapse/expand state
@@ -521,7 +519,6 @@ const AdminConsole: React.FC = () => {
     roomMetadata: true,
     sharedData: true,
     rawDbData: false,
-    yDocDebug: false,
     dataComparison: false,
     backupComparison: true,
     cleanupTools: false, // Collapsed by default
@@ -536,10 +533,6 @@ const AdminConsole: React.FC = () => {
 
   // Debug data
   const [rawDbData, setRawDbData] = useState<any>(null);
-  const [debugSteps, setDebugSteps] = useState<
-    Array<{ message: string; type: string }>
-  >([]);
-  const [reconstructedDoc, setReconstructedDoc] = useState<any>(null);
   const [comparisonData, setComparisonData] = useState<any>(null);
   const [comparisonLoading, setComparisonLoading] = useState(false);
   const [comparisonError, setComparisonError] = useState<string | null>(null);
@@ -735,7 +728,6 @@ const AdminConsole: React.FC = () => {
         setRoomData(null);
         setRoomStatus(null);
         setRawDbData(null);
-        setShowYDocDebug(false);
         setComparisonData(null);
         setComparisonError(null);
         setShowBackupComparison(false);
@@ -751,7 +743,6 @@ const AdminConsole: React.FC = () => {
         setRoomData(null);
         setRoomStatus(null);
         setRawDbData(null);
-        setShowYDocDebug(false);
         setComparisonData(null);
         setComparisonError(null);
         setShowBackupComparison(false);
@@ -931,13 +922,11 @@ const AdminConsole: React.FC = () => {
     setRoomData(null);
     setDebugToolsEnabled(false);
     setRawDbData(null);
-    setShowYDocDebug(false);
     setComparisonData(null);
     setComparisonError(null);
     setSectionsExpanded((prev) => ({
       ...prev,
       rawDbData: false,
-      yDocDebug: false,
       dataComparison: false,
     }));
     setShowBackupComparison(false);
@@ -1196,106 +1185,6 @@ const AdminConsole: React.FC = () => {
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       addLog("error", `Failed to load raw data: ${msg}`, error);
-    }
-  };
-
-  const debugYDocLoading = async () => {
-    if (!currentRoomId || !adminToken) return;
-
-    setShowYDocDebug(true);
-    setSectionsExpanded((prev) => ({ ...prev, yDocDebug: true }));
-    setDebugSteps([]);
-    setReconstructedDoc(null);
-
-    const addStep = (
-      message: string,
-      type: "info" | "success" | "warning" | "error" = "info"
-    ) => {
-      setDebugSteps((prev) => [
-        ...prev,
-        { message: `[${new Date().toLocaleTimeString()}] ${message}`, type },
-      ]);
-      const level: DebugLog["level"] =
-        type === "success" ? "info" : type === "warning" ? "warn" : type;
-      addLog(level, message);
-    };
-
-    try {
-      addStep("🔍 Starting Y.Doc reconstruction debug...", "info");
-      addStep("📁 Fetching raw database document...", "info");
-
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
-      const rawUrl = `${baseUrl}/admin/raw-data?token=${encodeURIComponent(
-        adminToken
-      )}`;
-
-      const rawResponse = await fetch(rawUrl);
-      const rawData = await rawResponse.json();
-
-      if (!rawData.document) {
-        addStep("❌ No document found in database", "error");
-        return;
-      }
-
-      addStep(
-        `✅ Found document: ${rawData.document.base64Length} bytes`,
-        "success"
-      );
-      addStep("🔧 Attempting to reconstruct Y.Doc from base64...", "info");
-
-      try {
-        // Import Y.js dynamically
-        const Y = await import("yjs");
-        const doc = new Y.Doc();
-
-        const base64 = rawData.document.document;
-        const buffer = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
-
-        addStep(`📦 Decoded ${buffer.length} bytes from base64`, "success");
-
-        Y.applyUpdate(doc, buffer);
-        addStep("✅ Successfully applied update to new Y.Doc", "success");
-
-        addStep("🔧 Using SyncedStore to extract data...", "info");
-        const { syncedStore } = await import("@syncedstore/core");
-        const store = syncedStore<{ play: Record<string, any> }>(
-          { play: {} },
-          doc
-        );
-
-        // Clone using same logic as original
-        const reconstructedData = JSON.parse(JSON.stringify(store.play));
-        const hasAnyData = Object.keys(reconstructedData).some(
-          (tag) => Object.keys(reconstructedData[tag] || {}).length > 0
-        );
-
-        if (hasAnyData) {
-          addStep(
-            `🎯 Extracted ${
-              Object.keys(reconstructedData).length
-            } capability types`,
-            "success"
-          );
-          const totalElements = Object.values(reconstructedData).reduce(
-            (sum: number, tagData: any) => sum + Object.keys(tagData).length,
-            0
-          );
-          addStep(`📊 Found ${totalElements} total elements`, "success");
-        } else {
-          addStep("⚠️  Y.Doc loaded but contains no PlayHTML data", "warning");
-        }
-
-        setReconstructedDoc(reconstructedData);
-        addStep("✅ Debug reconstruction complete!", "success");
-      } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        addStep(`❌ Y.Doc reconstruction failed: ${msg}`, "error");
-        addLog("error", "Y.Doc reconstruction error", error);
-      }
-    } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : String(error);
-      addStep(`❌ Debug process failed: ${msg}`, "error");
-      addLog("error", "Debug Y.Doc loading error", error);
     }
   };
 
@@ -2448,47 +2337,6 @@ const AdminConsole: React.FC = () => {
                   <div className="empty">
                     Load raw database data to inspect the stored base64
                     snapshot.
-                  </div>
-                )
-              )}
-            </div>
-          )}
-
-          {roomData && (
-            <div className="data-section">
-              <SectionHeader
-                title="Y.Doc Loading Debug"
-                sectionKey="yDocDebug"
-                isExpanded={sectionsExpanded.yDocDebug}
-                onToggle={toggleSection}
-                actions={
-                  <button
-                    className="tool-btn"
-                    disabled={!debugToolsEnabled}
-                    onClick={debugYDocLoading}
-                  >
-                    Run Y.Doc Debug
-                  </button>
-                }
-              />
-              {sectionsExpanded.yDocDebug && (
-                showYDocDebug ? (
-                  <>
-                    <div className="debug-steps">
-                      {debugSteps.map((step, index) => (
-                        <div key={index} className={`debug-step ${step.type}`}>
-                          {step.message}
-                        </div>
-                      ))}
-                    </div>
-                    {reconstructedDoc && (
-                      <JSONViewer data={reconstructedDoc} />
-                    )}
-                  </>
-                ) : (
-                  <div className="empty">
-                    Run the Y.Doc debug flow to reconstruct the stored snapshot
-                    from base64.
                   </div>
                 )
               )}

--- a/website/utils/adminComparison.test.ts
+++ b/website/utils/adminComparison.test.ts
@@ -1,0 +1,87 @@
+// ABOUTME: Verifies admin comparison summaries for live and database room data.
+// ABOUTME: Keeps drift detection behavior independent from the admin console UI.
+import { describe, expect, test } from "bun:test";
+
+import { createComparisonSummary } from "./adminComparison";
+
+describe("createComparisonSummary", () => {
+  test("summarizes matching live and admin data without showing details", () => {
+    const summary = createComparisonSummary({
+      methods: {
+        direct: {
+          data: {
+            "can-move": {
+              box: { x: 1 },
+            },
+          },
+        },
+        live: {
+          data: {
+            "can-move": {
+              box: { x: 1 },
+            },
+          },
+        },
+      },
+      differences: {
+        dataMatch: true,
+      },
+    });
+
+    expect(summary).toEqual({
+      dataMatch: true,
+      directElementCount: 1,
+      liveElementCount: 1,
+      shouldShowDetails: false,
+      status: "match",
+      statusLabel: "Live and admin data match",
+    });
+  });
+
+  test("flags drift and asks the admin console to show comparison details", () => {
+    const summary = createComparisonSummary({
+      methods: {
+        direct: {
+          data: {
+            "can-move": {
+              box: { x: 1 },
+            },
+          },
+        },
+        live: {
+          data: {
+            "can-move": {
+              box: { x: 2 },
+              circle: { x: 3 },
+            },
+          },
+        },
+      },
+      differences: {
+        dataMatch: false,
+      },
+    });
+
+    expect(summary).toEqual({
+      dataMatch: false,
+      directElementCount: 1,
+      liveElementCount: 2,
+      shouldShowDetails: true,
+      status: "different",
+      statusLabel: "Live and admin data differ",
+    });
+  });
+
+  test("treats missing comparison data as unavailable", () => {
+    const summary = createComparisonSummary(null);
+
+    expect(summary).toEqual({
+      dataMatch: null,
+      directElementCount: 0,
+      liveElementCount: 0,
+      shouldShowDetails: false,
+      status: "unavailable",
+      statusLabel: "Comparison not run",
+    });
+  });
+});

--- a/website/utils/adminComparison.ts
+++ b/website/utils/adminComparison.ts
@@ -1,0 +1,79 @@
+// ABOUTME: Summarizes admin comparisons between persisted and live room data.
+// ABOUTME: Provides small pure helpers for rendering admin console drift state.
+type ComparisonStatus = "different" | "match" | "unavailable";
+
+export interface AdminComparisonSummary {
+  dataMatch: boolean | null;
+  directElementCount: number;
+  liveElementCount: number;
+  shouldShowDetails: boolean;
+  status: ComparisonStatus;
+  statusLabel: string;
+}
+
+function countElements(data: unknown): number {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return 0;
+  }
+
+  return Object.values(data).reduce((sum, tagData) => {
+    if (!tagData || typeof tagData !== "object" || Array.isArray(tagData)) {
+      return sum;
+    }
+
+    return sum + Object.keys(tagData).length;
+  }, 0);
+}
+
+export function createComparisonSummary(
+  comparison: any
+): AdminComparisonSummary {
+  if (!comparison) {
+    return {
+      dataMatch: null,
+      directElementCount: 0,
+      liveElementCount: 0,
+      shouldShowDetails: false,
+      status: "unavailable",
+      statusLabel: "Comparison not run",
+    };
+  }
+
+  const dataMatch =
+    typeof comparison.differences?.dataMatch === "boolean"
+      ? comparison.differences.dataMatch
+      : null;
+  const directElementCount = countElements(comparison.methods?.direct?.data);
+  const liveElementCount = countElements(comparison.methods?.live?.data);
+
+  if (dataMatch === false) {
+    return {
+      dataMatch,
+      directElementCount,
+      liveElementCount,
+      shouldShowDetails: true,
+      status: "different",
+      statusLabel: "Live and admin data differ",
+    };
+  }
+
+  if (dataMatch === true) {
+    return {
+      dataMatch,
+      directElementCount,
+      liveElementCount,
+      shouldShowDetails: false,
+      status: "match",
+      statusLabel: "Live and admin data match",
+    };
+  }
+
+  return {
+    dataMatch,
+    directElementCount,
+    liveElementCount,
+    shouldShowDetails: false,
+    status: "unavailable",
+    statusLabel: "Comparison unavailable",
+  };
+}


### PR DESCRIPTION
## Summary

- Run the live-vs-admin comparison automatically after room load and show a status badge in the main inspector.
- Expand the comparison section automatically when live/admin data differs.
- Move raw DB access into a collapsed main section next to the UI it populates.
- Remove the redundant Y.Doc loading debug panel.
- Add a focused helper and tests for comparison summary behavior.

## Notes

- No changeset: this only changes the website admin console, not a published package.

## Verification

- `bun test website/utils/backup.test.ts website/utils/adminComparison.test.ts`
- `cd website && bunx tsc`
- `git diff --check`
- `bun run build-site`