### PR TITLE
Prevent background compaction from dropping live data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ The library revolves around "capabilities" -- interactive behaviors added to HTM
 - `party.ts`: Main PartyKit room implementation (Yjs doc sync, Supabase persistence)
 - `admin.ts`: Admin utilities
 - `db.ts`: Database connection layer
+- Production Worker logs for this backend belong to the Cloudflare Worker named `playhtml` configured by `partykit/wrangler.jsonc`. `wrangler tail --config partykit/wrangler.jsonc` is live-only and can be noisy for Durable Object WebSocket traffic. Historical log searches must use Workers Observability Query Builder in the Cloudflare dashboard, or a dedicated Cloudflare API token with Workers Observability read access; the Wrangler OAuth token in `~/.wrangler/config/default.toml` has tail access but is not sufficient for the stored Workers Observability telemetry API. Useful incident search terms include room ids such as `class.playhtml.fun-%2Fweek%2F1` and persistence strings such as `SUPABASE PERSISTENCE UNAVAILABLE`, `SUPABASE AUTOSAVE FAILED`, `Autosave skipped`, `Hard Reset`, `Restore Snapshot`, `Emergency compacted connected room`, and `Empty-room compacted`.
 
 ### Docs Site (apps/docs/)
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "smoke:partykit:limits": "cd smoke-tests && bun run test:partykit:limits",
     "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",
     "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",
+    "smoke:partykit:stale-compaction": "cd smoke-tests && bun run test:partykit:stale-compaction",
     "smoke:partykit:emergency": "cd smoke-tests && bun run test:partykit:emergency",
     "smoke:partykit:transient": "cd smoke-tests && bun run test:partykit:transient",
     "smoke:partykit:soak": "cd smoke-tests && bun run test:partykit:soak",

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -5,7 +5,7 @@ import {
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
-  shouldCommitBackgroundCompaction,
+  shouldCommitCompactionSnapshot,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "../compactionPolicy";
@@ -26,9 +26,26 @@ describe("isCompactionAutosave", () => {
   });
 });
 
-describe("shouldCommitBackgroundCompaction", () => {
-  it("does not let background compaction replace saved room state", () => {
-    expect(shouldCommitBackgroundCompaction()).toBe(false);
+describe("shouldCommitCompactionSnapshot", () => {
+  it("only commits when the persisted document still matches the compacted source", () => {
+    expect(
+      shouldCommitCompactionSnapshot({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: "source",
+      })
+    ).toBe(true);
+    expect(
+      shouldCommitCompactionSnapshot({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+      })
+    ).toBe(false);
+    expect(
+      shouldCommitCompactionSnapshot({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: null,
+      })
+    ).toBe(false);
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -5,6 +5,7 @@ import {
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
+  shouldCommitBackgroundCompaction,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "../compactionPolicy";
@@ -22,6 +23,12 @@ describe("isCompactionAutosave", () => {
     expect(isCompactionAutosave("snapshot-a", "snapshot-a")).toBe(true);
     expect(isCompactionAutosave("snapshot-b", "snapshot-a")).toBe(false);
     expect(isCompactionAutosave("snapshot-a", null)).toBe(false);
+  });
+});
+
+describe("shouldCommitBackgroundCompaction", () => {
+  it("does not let background compaction replace saved room state", () => {
+    expect(shouldCommitBackgroundCompaction()).toBe(false);
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -56,20 +56,33 @@ describe("getCompactionCommitDecision", () => {
       getCompactionCommitDecision({
         sourceDocumentBase64: "source",
         persistedDocumentBase64: "source",
+        sourceContainsPersistedDocument: false,
       })
     ).toEqual({ kind: "commit-compaction" });
     expect(
       getCompactionCommitDecision({
         sourceDocumentBase64: "source",
         persistedDocumentBase64: "newer",
+        sourceContainsPersistedDocument: true,
       })
     ).toEqual({ kind: "persist-live-document" });
     expect(
       getCompactionCommitDecision({
         sourceDocumentBase64: "source",
         persistedDocumentBase64: null,
+        sourceContainsPersistedDocument: false,
       })
     ).toEqual({ kind: "persist-live-document" });
+  });
+
+  it("leaves persisted data untouched when the live source is missing database updates", () => {
+    expect(
+      getCompactionCommitDecision({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+        sourceContainsPersistedDocument: false,
+      })
+    ).toEqual({ kind: "skip-compaction" });
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -94,8 +94,34 @@ describe("getLiveDocumentPersistenceDecision", () => {
         liveDocumentBase64: "source",
         persistedDocumentBase64: "newer",
         liveDocumentContainsPersistedDocument: false,
+        hasOpenConnections: false,
+        liveDocumentMatchesLastSave: true,
       })
     ).toEqual({ kind: "reload-persisted-document" });
+  });
+
+  it("preserves both sides when connected live data conflicts with persisted data", () => {
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+        liveDocumentContainsPersistedDocument: false,
+        hasOpenConnections: true,
+        liveDocumentMatchesLastSave: true,
+      })
+    ).toEqual({ kind: "skip-live-save" });
+  });
+
+  it("preserves unsaved live data when an empty room conflicts with persisted data", () => {
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+        liveDocumentContainsPersistedDocument: false,
+        hasOpenConnections: false,
+        liveDocumentMatchesLastSave: false,
+      })
+    ).toEqual({ kind: "skip-live-save" });
   });
 
   it("saves live data when autosave contains the persisted document", () => {
@@ -104,6 +130,8 @@ describe("getLiveDocumentPersistenceDecision", () => {
         liveDocumentBase64: "source",
         persistedDocumentBase64: "source",
         liveDocumentContainsPersistedDocument: false,
+        hasOpenConnections: true,
+        liveDocumentMatchesLastSave: false,
       })
     ).toEqual({ kind: "save-live-document" });
     expect(
@@ -111,6 +139,8 @@ describe("getLiveDocumentPersistenceDecision", () => {
         liveDocumentBase64: "source",
         persistedDocumentBase64: "persisted",
         liveDocumentContainsPersistedDocument: true,
+        hasOpenConnections: true,
+        liveDocumentMatchesLastSave: false,
       })
     ).toEqual({ kind: "save-live-document" });
     expect(
@@ -118,6 +148,8 @@ describe("getLiveDocumentPersistenceDecision", () => {
         liveDocumentBase64: "source",
         persistedDocumentBase64: null,
         liveDocumentContainsPersistedDocument: false,
+        hasOpenConnections: true,
+        liveDocumentMatchesLastSave: false,
       })
     ).toEqual({ kind: "save-live-document" });
   });

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   getNextAlarmTime,
+  getCompactionCommitDecision,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
   shouldCommitCompactionSnapshot,
@@ -46,6 +47,29 @@ describe("shouldCommitCompactionSnapshot", () => {
         persistedDocumentBase64: null,
       })
     ).toBe(false);
+  });
+});
+
+describe("getCompactionCommitDecision", () => {
+  it("persists the live document before compaction when persisted data changed", () => {
+    expect(
+      getCompactionCommitDecision({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: "source",
+      })
+    ).toEqual({ kind: "commit-compaction" });
+    expect(
+      getCompactionCommitDecision({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+      })
+    ).toEqual({ kind: "persist-live-document" });
+    expect(
+      getCompactionCommitDecision({
+        sourceDocumentBase64: "source",
+        persistedDocumentBase64: null,
+      })
+    ).toEqual({ kind: "persist-live-document" });
   });
 });
 

--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Keeps hibernation-safe compaction rules testable outside Cloudflare runtime.
 import { describe, expect, it } from "bun:test";
 import {
+  getLiveDocumentPersistenceDecision,
   getNextAlarmTime,
   getCompactionCommitDecision,
   isCompactionAutosave,
@@ -83,6 +84,42 @@ describe("getCompactionCommitDecision", () => {
         sourceContainsPersistedDocument: false,
       })
     ).toEqual({ kind: "skip-compaction" });
+  });
+});
+
+describe("getLiveDocumentPersistenceDecision", () => {
+  it("reloads persisted data when autosave is missing database updates", () => {
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: "newer",
+        liveDocumentContainsPersistedDocument: false,
+      })
+    ).toEqual({ kind: "reload-persisted-document" });
+  });
+
+  it("saves live data when autosave contains the persisted document", () => {
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: "source",
+        liveDocumentContainsPersistedDocument: false,
+      })
+    ).toEqual({ kind: "save-live-document" });
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: "persisted",
+        liveDocumentContainsPersistedDocument: true,
+      })
+    ).toEqual({ kind: "save-live-document" });
+    expect(
+      getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: "source",
+        persistedDocumentBase64: null,
+        liveDocumentContainsPersistedDocument: false,
+      })
+    ).toEqual({ kind: "save-live-document" });
   });
 });
 

--- a/partykit/__tests__/docUtils.test.ts
+++ b/partykit/__tests__/docUtils.test.ts
@@ -1,0 +1,64 @@
+// ABOUTME: Verifies Y.Doc snapshot relationship helpers with real encoded updates.
+// ABOUTME: Covers compaction safety checks that depend on live-vs-persisted history.
+import { describe, expect, it } from "bun:test";
+import {
+  documentContainsSnapshot,
+  encodeDocToBase64,
+  jsonToDoc,
+  replaceDocState,
+} from "../docUtils";
+
+describe("documentContainsSnapshot", () => {
+  it("recognizes a live document that contains the persisted snapshot", () => {
+    const liveDoc = jsonToDoc({
+      "can-play": {
+        "week-attendance": {
+          attendees: [{ pid: "a", name: "Ada" }],
+        },
+      },
+    });
+    const persistedBase64 = encodeDocToBase64(liveDoc);
+
+    replaceDocState(liveDoc, {
+      "can-play": {
+        "week-attendance": {
+          attendees: [
+            { pid: "a", name: "Ada" },
+            { pid: "b", name: "Ben" },
+          ],
+        },
+      },
+    });
+
+    expect(
+      documentContainsSnapshot(encodeDocToBase64(liveDoc), persistedBase64)
+    ).toBe(true);
+  });
+
+  it("rejects a stale live document that is missing persisted updates", () => {
+    const liveDoc = jsonToDoc({
+      "can-play": {
+        "week-attendance": {
+          attendees: [{ pid: "a", name: "Ada" }],
+        },
+      },
+    });
+    const persistedDoc = jsonToDoc({
+      "can-play": {
+        "week-attendance": {
+          attendees: [
+            { pid: "a", name: "Ada" },
+            { pid: "b", name: "Ben" },
+          ],
+        },
+      },
+    });
+
+    expect(
+      documentContainsSnapshot(
+        encodeDocToBase64(liveDoc),
+        encodeDocToBase64(persistedDoc)
+      )
+    ).toBe(false);
+  });
+});

--- a/partykit/__tests__/docUtils.test.ts
+++ b/partykit/__tests__/docUtils.test.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Verifies Y.Doc snapshot relationship helpers with real encoded updates.
 // ABOUTME: Covers compaction safety checks that depend on live-vs-persisted history.
 import { describe, expect, it } from "bun:test";
+import { syncedStore } from "@syncedstore/core";
+import * as Y from "yjs";
 import {
   documentContainsSnapshot,
   encodeDocToBase64,
@@ -8,27 +10,31 @@ import {
   replaceDocState,
 } from "../docUtils";
 
+function attendancePlayData(names: string[]): Record<string, any> {
+  return {
+    "can-play": {
+      "week-attendance": {
+        attendees: names.map((name) => ({
+          pid: name.toLowerCase(),
+          name,
+        })),
+      },
+    },
+  };
+}
+
+function cloneDoc(doc: Y.Doc): Y.Doc {
+  const clone = new Y.Doc();
+  Y.applyUpdate(clone, Y.encodeStateAsUpdate(doc));
+  return clone;
+}
+
 describe("documentContainsSnapshot", () => {
   it("recognizes a live document that contains the persisted snapshot", () => {
-    const liveDoc = jsonToDoc({
-      "can-play": {
-        "week-attendance": {
-          attendees: [{ pid: "a", name: "Ada" }],
-        },
-      },
-    });
+    const liveDoc = jsonToDoc(attendancePlayData(["Ada"]));
     const persistedBase64 = encodeDocToBase64(liveDoc);
 
-    replaceDocState(liveDoc, {
-      "can-play": {
-        "week-attendance": {
-          attendees: [
-            { pid: "a", name: "Ada" },
-            { pid: "b", name: "Ben" },
-          ],
-        },
-      },
-    });
+    replaceDocState(liveDoc, attendancePlayData(["Ada", "Ben"]));
 
     expect(
       documentContainsSnapshot(encodeDocToBase64(liveDoc), persistedBase64)
@@ -36,22 +42,50 @@ describe("documentContainsSnapshot", () => {
   });
 
   it("rejects a stale live document that is missing persisted updates", () => {
-    const liveDoc = jsonToDoc({
-      "can-play": {
-        "week-attendance": {
-          attendees: [{ pid: "a", name: "Ada" }],
-        },
-      },
-    });
-    const persistedDoc = jsonToDoc({
-      "can-play": {
-        "week-attendance": {
-          attendees: [
-            { pid: "a", name: "Ada" },
-            { pid: "b", name: "Ben" },
-          ],
-        },
-      },
+    const liveDoc = jsonToDoc(attendancePlayData(["Ada"]));
+    const persistedDoc = jsonToDoc(attendancePlayData(["Ada", "Ben"]));
+
+    expect(
+      documentContainsSnapshot(
+        encodeDocToBase64(liveDoc),
+        encodeDocToBase64(persistedDoc)
+      )
+    ).toBe(false);
+  });
+
+  it("rejects forked documents that each contain unique updates", () => {
+    const baseDoc = jsonToDoc(attendancePlayData(["Ada"]));
+    const liveDoc = cloneDoc(baseDoc);
+    const persistedDoc = cloneDoc(baseDoc);
+
+    replaceDocState(liveDoc, attendancePlayData(["Ada", "Ben"]));
+    replaceDocState(persistedDoc, attendancePlayData(["Ada", "Cam"]));
+
+    expect(
+      documentContainsSnapshot(
+        encodeDocToBase64(liveDoc),
+        encodeDocToBase64(persistedDoc)
+      )
+    ).toBe(false);
+    expect(
+      documentContainsSnapshot(
+        encodeDocToBase64(persistedDoc),
+        encodeDocToBase64(liveDoc)
+      )
+    ).toBe(false);
+  });
+
+  it("rejects snapshots with deletion-only updates missing from the live document", () => {
+    const baseDoc = jsonToDoc(attendancePlayData(["Ada", "Ben"]));
+    const liveDoc = cloneDoc(baseDoc);
+    const persistedDoc = cloneDoc(baseDoc);
+    const store = syncedStore<{ play: Record<string, any> }>(
+      { play: {} },
+      persistedDoc
+    );
+
+    persistedDoc.transact(() => {
+      store.play["can-play"]["week-attendance"].attendees.splice(1, 1);
     });
 
     expect(
@@ -60,5 +94,16 @@ describe("documentContainsSnapshot", () => {
         encodeDocToBase64(persistedDoc)
       )
     ).toBe(false);
+  });
+
+  it("handles empty document boundaries", () => {
+    const emptyDoc = new Y.Doc();
+    const populatedDoc = jsonToDoc(attendancePlayData(["Ada"]));
+    const emptyBase64 = encodeDocToBase64(emptyDoc);
+    const populatedBase64 = encodeDocToBase64(populatedDoc);
+
+    expect(documentContainsSnapshot(emptyBase64, emptyBase64)).toBe(true);
+    expect(documentContainsSnapshot(populatedBase64, emptyBase64)).toBe(true);
+    expect(documentContainsSnapshot(emptyBase64, populatedBase64)).toBe(false);
   });
 });

--- a/partykit/__tests__/resetEpochPolicy.test.ts
+++ b/partykit/__tests__/resetEpochPolicy.test.ts
@@ -1,7 +1,11 @@
 // ABOUTME: Verifies reset-epoch parsing and stale-boundary decisions for PartyServer.
 // ABOUTME: Covers malformed client epochs that must not bypass room reset enforcement.
 import { describe, expect, it } from "bun:test";
-import { isResetEpochStale, parseClientResetEpoch } from "../resetEpochPolicy";
+import {
+  getAutosaveResetEpochDecision,
+  isResetEpochStale,
+  parseClientResetEpoch,
+} from "../resetEpochPolicy";
 
 describe("parseClientResetEpoch", () => {
   it("parses finite numeric epoch params", () => {
@@ -25,5 +29,38 @@ describe("isResetEpochStale", () => {
     expect(isResetEpochStale(99, 100)).toBe(true);
     expect(isResetEpochStale(100, 100)).toBe(false);
     expect(isResetEpochStale(101, 100)).toBe(false);
+  });
+});
+
+describe("getAutosaveResetEpochDecision", () => {
+  it("skips saves from docs that are older than the server reset epoch", () => {
+    expect(getAutosaveResetEpochDecision(null, 100)).toEqual({
+      kind: "skip",
+      reason: "doc reset epoch missing while server epoch=100",
+    });
+    expect(getAutosaveResetEpochDecision(99, 100)).toEqual({
+      kind: "skip",
+      reason: "doc reset epoch 99 < server epoch 100",
+    });
+  });
+
+  it("promotes the server epoch when the live doc has a newer reset boundary", () => {
+    expect(getAutosaveResetEpochDecision(101, 100)).toEqual({
+      kind: "promote-server-epoch",
+      resetEpoch: 101,
+    });
+    expect(getAutosaveResetEpochDecision(101, null)).toEqual({
+      kind: "promote-server-epoch",
+      resetEpoch: 101,
+    });
+  });
+
+  it("allows saves when the doc and server agree about the reset boundary", () => {
+    expect(getAutosaveResetEpochDecision(null, null)).toEqual({
+      kind: "save",
+    });
+    expect(getAutosaveResetEpochDecision(100, 100)).toEqual({
+      kind: "save",
+    });
   });
 });

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -416,6 +416,7 @@ export class AdminHandler {
         { onConflict: "name" }
       );
       if (error) throw new Error(error.message);
+      this.context.markDocumentPersisted(base64);
       return new Response(JSON.stringify({ ok: true }), {
         headers: { "content-type": "application/json" },
       });
@@ -537,6 +538,7 @@ export class AdminHandler {
         console.error(`[Admin] Database error:`, error);
         throw new Error(error.message);
       }
+      this.context.markDocumentPersisted(base64);
 
       console.log(`[Admin] Successfully saved to database and live doc`);
 
@@ -593,6 +595,7 @@ export class AdminHandler {
           .from("documents")
           .upsert({ name: this.context.name, document: base64 }, { onConflict: "name" });
         if (error) throw new Error(error.message);
+        this.context.markDocumentPersisted(base64);
       }
 
       return new Response(
@@ -799,6 +802,7 @@ export class AdminHandler {
           `Failed to save cleaned document: ${saveError.message}`
         );
       }
+      this.context.markDocumentPersisted(base64);
 
       return new Response(
         JSON.stringify({

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -40,16 +40,21 @@ export type CompactionCommitDecision =
 
 export type LiveDocumentPersistenceDecision =
   | { kind: "save-live-document" }
-  | { kind: "reload-persisted-document" };
+  | { kind: "reload-persisted-document" }
+  | { kind: "skip-live-save" };
 
 export function getLiveDocumentPersistenceDecision({
   liveDocumentBase64,
   persistedDocumentBase64,
   liveDocumentContainsPersistedDocument,
+  hasOpenConnections,
+  liveDocumentMatchesLastSave,
 }: {
   liveDocumentBase64: string;
   persistedDocumentBase64: string | null;
   liveDocumentContainsPersistedDocument: boolean;
+  hasOpenConnections: boolean;
+  liveDocumentMatchesLastSave: boolean;
 }): LiveDocumentPersistenceDecision {
   if (persistedDocumentBase64 === null) {
     return { kind: "save-live-document" };
@@ -60,6 +65,10 @@ export function getLiveDocumentPersistenceDecision({
     liveDocumentContainsPersistedDocument
   ) {
     return { kind: "save-live-document" };
+  }
+
+  if (hasOpenConnections || !liveDocumentMatchesLastSave) {
+    return { kind: "skip-live-save" };
   }
 
   return { kind: "reload-persisted-document" };

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -38,6 +38,33 @@ export type CompactionCommitDecision =
   | { kind: "persist-live-document" }
   | { kind: "skip-compaction" };
 
+export type LiveDocumentPersistenceDecision =
+  | { kind: "save-live-document" }
+  | { kind: "reload-persisted-document" };
+
+export function getLiveDocumentPersistenceDecision({
+  liveDocumentBase64,
+  persistedDocumentBase64,
+  liveDocumentContainsPersistedDocument,
+}: {
+  liveDocumentBase64: string;
+  persistedDocumentBase64: string | null;
+  liveDocumentContainsPersistedDocument: boolean;
+}): LiveDocumentPersistenceDecision {
+  if (persistedDocumentBase64 === null) {
+    return { kind: "save-live-document" };
+  }
+
+  if (
+    persistedDocumentBase64 === liveDocumentBase64 ||
+    liveDocumentContainsPersistedDocument
+  ) {
+    return { kind: "save-live-document" };
+  }
+
+  return { kind: "reload-persisted-document" };
+}
+
 export function getCompactionCommitDecision({
   sourceDocumentBase64,
   persistedDocumentBase64,

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -17,8 +17,14 @@ export function isCompactionAutosave(
   );
 }
 
-export function shouldCommitBackgroundCompaction(): boolean {
-  return false;
+export function shouldCommitCompactionSnapshot({
+  sourceDocumentBase64,
+  persistedDocumentBase64,
+}: {
+  sourceDocumentBase64: string;
+  persistedDocumentBase64: string | null;
+}): boolean {
+  return persistedDocumentBase64 === sourceDocumentBase64;
 }
 
 // Emergency compaction protects rooms that stay continuously connected and

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -17,6 +17,10 @@ export function isCompactionAutosave(
   );
 }
 
+export function shouldCommitBackgroundCompaction(): boolean {
+  return false;
+}
+
 // Emergency compaction protects rooms that stay continuously connected and
 // therefore never reach the empty-room compaction path. The check is split in
 // two parts: this cheap predicate runs on every autosave using the encoded

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -28,23 +28,31 @@ export function shouldCommitCompactionSnapshot({
     getCompactionCommitDecision({
       sourceDocumentBase64,
       persistedDocumentBase64,
+      sourceContainsPersistedDocument: false,
     }).kind === "commit-compaction"
   );
 }
 
 export type CompactionCommitDecision =
   | { kind: "commit-compaction" }
-  | { kind: "persist-live-document" };
+  | { kind: "persist-live-document" }
+  | { kind: "skip-compaction" };
 
 export function getCompactionCommitDecision({
   sourceDocumentBase64,
   persistedDocumentBase64,
+  sourceContainsPersistedDocument,
 }: {
   sourceDocumentBase64: string;
   persistedDocumentBase64: string | null;
+  sourceContainsPersistedDocument: boolean;
 }): CompactionCommitDecision {
   if (persistedDocumentBase64 === sourceDocumentBase64) {
     return { kind: "commit-compaction" };
+  }
+
+  if (persistedDocumentBase64 !== null && !sourceContainsPersistedDocument) {
+    return { kind: "skip-compaction" };
   }
 
   return { kind: "persist-live-document" };

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -24,7 +24,30 @@ export function shouldCommitCompactionSnapshot({
   sourceDocumentBase64: string;
   persistedDocumentBase64: string | null;
 }): boolean {
-  return persistedDocumentBase64 === sourceDocumentBase64;
+  return (
+    getCompactionCommitDecision({
+      sourceDocumentBase64,
+      persistedDocumentBase64,
+    }).kind === "commit-compaction"
+  );
+}
+
+export type CompactionCommitDecision =
+  | { kind: "commit-compaction" }
+  | { kind: "persist-live-document" };
+
+export function getCompactionCommitDecision({
+  sourceDocumentBase64,
+  persistedDocumentBase64,
+}: {
+  sourceDocumentBase64: string;
+  persistedDocumentBase64: string | null;
+}): CompactionCommitDecision {
+  if (persistedDocumentBase64 === sourceDocumentBase64) {
+    return { kind: "commit-compaction" };
+  }
+
+  return { kind: "persist-live-document" };
 }
 
 // Emergency compaction protects rooms that stay continuously connected and

--- a/partykit/docUtils.ts
+++ b/partykit/docUtils.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Converts PlayHTML Y.Doc state to and from persisted database snapshots.
+// ABOUTME: Provides reset metadata and snapshot relationship helpers for PartyServer.
+
 /**
  * Shared utilities for working with Y.Doc and PlayHTML data structures.
  * These functions ensure consistent conversion between Y.Doc, SyncedStore proxies,
@@ -154,6 +157,32 @@ export function getDocResetEpoch(doc: Y.Doc): number | null {
 export function encodeDocToBase64(doc: Y.Doc): string {
   const content = Y.encodeStateAsUpdate(doc);
   return Buffer.from(content).toString("base64");
+}
+
+function updateHasContent(update: Uint8Array): boolean {
+  const decoded = Y.decodeUpdate(update);
+  return decoded.structs.length > 0 || decoded.ds.clients.size > 0;
+}
+
+/**
+ * Returns whether `documentBase64` contains every Yjs update from
+ * `snapshotBase64`.
+ */
+export function documentContainsSnapshot(
+  documentBase64: string,
+  snapshotBase64: string
+): boolean {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, new Uint8Array(Buffer.from(documentBase64, "base64")));
+
+  const snapshot = new Y.Doc();
+  Y.applyUpdate(snapshot, new Uint8Array(Buffer.from(snapshotBase64, "base64")));
+
+  const missingFromDocument = Y.encodeStateAsUpdate(
+    snapshot,
+    Y.encodeStateVector(doc)
+  );
+  return !updateHasContent(missingFromDocument);
 }
 
 /**

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -20,7 +20,6 @@ import {
 } from "./docUtils";
 import {
   STORAGE_KEYS,
-  DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
   DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
   DEFAULT_DOCUMENT_WARNING_BYTES,
@@ -64,10 +63,15 @@ import {
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
+  shouldCommitBackgroundCompaction,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
-import { isResetEpochStale, parseClientResetEpoch } from "./resetEpochPolicy";
+import {
+  getAutosaveResetEpochDecision,
+  isResetEpochStale,
+  parseClientResetEpoch,
+} from "./resetEpochPolicy";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
@@ -221,10 +225,6 @@ export class PartyServer extends YServer {
   private async getEmptyRoomCompactAfter(): Promise<number | null> {
     const value = await this.ctx.storage.get(STORAGE_KEYS.emptyRoomCompactAfter);
     return typeof value === "number" ? value : null;
-  }
-
-  private async setEmptyRoomCompactAfter(timestamp: number): Promise<void> {
-    await this.ctx.storage.put(STORAGE_KEYS.emptyRoomCompactAfter, timestamp);
   }
 
   private async clearEmptyRoomCompactAfter(): Promise<void> {
@@ -753,17 +753,7 @@ export class PartyServer extends YServer {
   }
 
   private async scheduleEmptyRoomCompaction(): Promise<void> {
-    if (this.isSkippingSave) return;
-    if (!this.isPersistenceAvailable()) return;
-    if (this.getOpenConnectionCount() !== 0) return;
-
-    const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
-    await this.setEmptyRoomCompactAfter(compactAfter);
-    await this.scheduleNextAlarm();
-
-    console.log(
-      `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
-    );
+    await Promise.resolve();
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -1238,33 +1228,30 @@ export class PartyServer extends YServer {
     }
 
     // Get current reset epoch for logging and validation
-    const serverResetEpoch = await this.getResetEpoch();
+    let serverResetEpoch = await this.getResetEpoch();
     const docResetEpoch = getDocResetEpoch(doc);
+    const resetEpochDecision = getAutosaveResetEpochDecision(
+      docResetEpoch,
+      serverResetEpoch
+    );
 
-    if (this.isEpochStale(docResetEpoch, serverResetEpoch)) {
-      const reason =
-        docResetEpoch === null
-          ? `doc reset epoch missing while server epoch=${serverResetEpoch}`
-          : `doc reset epoch ${docResetEpoch} < server epoch ${serverResetEpoch}`;
+    if (resetEpochDecision.kind === "skip") {
       console.warn(
-        `[PartyServer] Autosave skipped for room ${this.name}: ${reason}`
+        `[PartyServer] Autosave skipped for room ${this.name}: ${resetEpochDecision.reason}`
       );
       return;
     }
 
-    if (
-      docResetEpoch !== null &&
-      serverResetEpoch !== null &&
-      docResetEpoch > serverResetEpoch
-    ) {
+    if (resetEpochDecision.kind === "promote-server-epoch") {
+      await this.setResetEpoch(resetEpochDecision.resetEpoch);
+      serverResetEpoch = resetEpochDecision.resetEpoch;
       console.warn(
-        `[PartyServer] Autosave skipped for room ${this.name}: doc reset epoch (${docResetEpoch}) is ahead of server epoch (${serverResetEpoch})`
+        `[PartyServer] Autosave promoted server reset epoch for room ${this.name}: doc reset epoch=${resetEpochDecision.resetEpoch}`
       );
-      return;
     }
 
     // Ordinary autosave preserves Yjs history so reconnecting clients can merge
-    // safely. Empty-room compaction is handled as a reset boundary by alarms.
+    // safely.
     const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
     this.lastKnownDocumentBytes = documentSize;
@@ -1354,16 +1341,18 @@ export class PartyServer extends YServer {
 
     const recheckAfter = now + this.getEmergencyCompactRecheckDelayMs();
 
-    // Connected rooms normally keep raw Yjs history so hibernated clients can
-    // resume without merging against a rewritten snapshot. This path is the
-    // exception: once a never-empty room crosses the high-watermark threshold,
-    // the server pays the expensive docToJson/jsonToDoc/encode check at most
-    // once per cooldown window. If compaction is useful, it is enforced as a
-    // reset boundary by broadcasting room-reset and closing active sockets.
-    // That disruption is intentional because silently replacing Yjs history
-    // while clients are connected can merge stale client history back into the
-    // room. If compaction is not useful, the cooldown prevents every later
-    // autosave of a naturally large document from rebuilding the whole Y.Doc.
+    if (!shouldCommitBackgroundCompaction()) {
+      await this.setEmergencyCompactCheckAfter(recheckAfter);
+      console.warn(
+        `[PartyServer] Background compaction skipped: room=${this.name}, documentBytes=${documentSize}, nextCheckAt=${recheckAfter}`
+      );
+      return false;
+    }
+
+    // Connected rooms keep raw Yjs history so hibernated clients can resume
+    // without merging against a rewritten snapshot. This path pays the
+    // expensive docToJson/jsonToDoc/encode check at most once per cooldown
+    // window.
     const compactedDocument = this.buildCompactedDocument(this.document);
     if (compactedDocument === null) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
@@ -1849,6 +1838,14 @@ export class PartyServer extends YServer {
     if (this.getOpenConnectionCount() !== 0) return;
 
     const run = async () => {
+      if (!shouldCommitBackgroundCompaction()) {
+        await this.clearEmptyRoomCompactAfter();
+        console.warn(
+          `[PartyServer] Empty-room compaction skipped: room=${this.name}, background compaction is disabled`
+        );
+        return;
+      }
+
       const compactedDocument = this.buildCompactedDocument(this.document);
       if (compactedDocument === null) {
         await this.clearEmptyRoomCompactAfter();

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -63,6 +63,7 @@ import {
 } from "./sharing";
 import {
   getCompactionCommitDecision,
+  getLiveDocumentPersistenceDecision,
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
@@ -552,6 +553,76 @@ export class PartyServer extends YServer {
       if (autosavePaused) {
         this.isSkippingSave = false;
       }
+    }
+  }
+
+  private async reloadLiveDocumentFromPersistedSnapshot(
+    persistedDocumentBase64: string
+  ): Promise<void> {
+    const activeConnectionCount = this.getOpenConnectionCount();
+    const rollbackResetEpoch = await this.getResetEpoch();
+    let resetEpochChanged = false;
+    let snapshotBase64 = persistedDocumentBase64;
+
+    this.isSkippingSave = true;
+
+    try {
+      if (activeConnectionCount > 0) {
+        const snapshotDoc = new Y.Doc();
+        Y.applyUpdate(
+          snapshotDoc,
+          new Uint8Array(Buffer.from(persistedDocumentBase64, "base64"))
+        );
+
+        const resetEpoch = Date.now();
+        setDocResetEpoch(snapshotDoc, resetEpoch);
+        snapshotBase64 = encodeDocToBase64(snapshotDoc);
+
+        await this.setResetEpoch(resetEpoch);
+        resetEpochChanged = true;
+
+        const { error } = await supabase.from("documents").upsert(
+          {
+            name: this.name,
+            document: snapshotBase64,
+          },
+          { onConflict: "name" }
+        );
+
+        if (error) {
+          throw new Error(error.message);
+        }
+      }
+
+      replaceDocFromSnapshot(this.document, snapshotBase64);
+      this.lastKnownDocumentBytes = snapshotBase64.length;
+
+      if (activeConnectionCount > 0) {
+        const resetEpoch = await this.getResetEpoch();
+        if (resetEpoch !== null) {
+          this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
+        }
+        const closedCount = this.closeConnections(
+          "Room Reloaded from Persisted Data"
+        );
+        console.warn(
+          `[PartyServer] Reloaded stale live document for room=${this.name}; closedConnections=${closedCount}`
+        );
+      }
+
+      await Promise.resolve();
+    } catch (error) {
+      if (resetEpochChanged) {
+        await this.restoreResetEpoch(rollbackResetEpoch);
+      }
+      throw error;
+    } finally {
+      setTimeout(() => {
+        this.isSkippingSave = false;
+        console.log(
+          `[PartyServer] Autosave re-enabled after live document reload`
+        );
+      }, 1000);
     }
   }
 
@@ -1330,8 +1401,40 @@ export class PartyServer extends YServer {
     // safely.
     const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
-    this.lastKnownDocumentBytes = documentSize;
     const activeConnectionCount = this.getOpenConnectionCount();
+
+    try {
+      const persistedDocumentBase64 = await this.getPersistedDocumentBase64();
+      const liveDocumentContainsPersistedDocument =
+        persistedDocumentBase64 !== null &&
+        documentContainsSnapshot(documentBase64, persistedDocumentBase64);
+      const persistenceDecision = getLiveDocumentPersistenceDecision({
+        liveDocumentBase64: documentBase64,
+        persistedDocumentBase64,
+        liveDocumentContainsPersistedDocument,
+      });
+
+      if (
+        persistenceDecision.kind === "reload-persisted-document" &&
+        persistedDocumentBase64 !== null
+      ) {
+        console.warn(
+          `[PartyServer] Autosave skipped for room ${this.name}: live document is missing persisted updates; reloading persisted document`
+        );
+        await this.reloadLiveDocumentFromPersistedSnapshot(
+          persistedDocumentBase64
+        );
+        return false;
+      }
+    } catch (error) {
+      console.error(
+        `[PartyServer] SUPABASE AUTOSAVE SAFETY CHECK FAILED for room ${this.name}:`,
+        error
+      );
+      return false;
+    }
+
+    this.lastKnownDocumentBytes = documentSize;
 
     const serverLimits = this.getServerLimits();
     if (

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -149,6 +149,7 @@ export class PartyServer extends YServer {
   private compactionAutosaveSnapshot: string | null = null;
   private cachedResetEpoch: number | null | undefined;
   private lastKnownDocumentBytes = 0;
+  private lastPersistedDocumentBase64: string | null = null;
   private hasWarnedDocumentSize = false;
 
   // In-memory caches for hot-path data that rarely changes.
@@ -228,6 +229,11 @@ export class PartyServer extends YServer {
 
   private getOpenConnectionCount(): number {
     return Array.from(this.getConnections()).length;
+  }
+
+  markDocumentPersisted(documentBase64: string): void {
+    this.lastPersistedDocumentBase64 = documentBase64;
+    this.lastKnownDocumentBytes = documentBase64.length;
   }
 
   private async getEmptyRoomCompactAfter(): Promise<number | null> {
@@ -539,6 +545,7 @@ export class PartyServer extends YServer {
       }
 
       documentSaved = true;
+      this.markDocumentPersisted(compactedDocument.base64);
       this.compactionAutosaveSnapshot = compactedDocument.base64;
       replaceDocFromSnapshot(this.document, compactedDocument.base64);
       await afterReplace?.();
@@ -558,64 +565,22 @@ export class PartyServer extends YServer {
 
   private async reloadLiveDocumentFromPersistedSnapshot(
     persistedDocumentBase64: string
-  ): Promise<void> {
-    const activeConnectionCount = this.getOpenConnectionCount();
-    const rollbackResetEpoch = await this.getResetEpoch();
-    let resetEpochChanged = false;
-    let snapshotBase64 = persistedDocumentBase64;
+  ): Promise<boolean> {
+    if (this.getOpenConnectionCount() !== 0) {
+      console.warn(
+        `[PartyServer] Persisted document reload skipped for room=${this.name}: clients connected before reload`
+      );
+      return false;
+    }
 
     this.isSkippingSave = true;
 
     try {
-      if (activeConnectionCount > 0) {
-        const snapshotDoc = new Y.Doc();
-        Y.applyUpdate(
-          snapshotDoc,
-          new Uint8Array(Buffer.from(persistedDocumentBase64, "base64"))
-        );
-
-        const resetEpoch = Date.now();
-        setDocResetEpoch(snapshotDoc, resetEpoch);
-        snapshotBase64 = encodeDocToBase64(snapshotDoc);
-
-        await this.setResetEpoch(resetEpoch);
-        resetEpochChanged = true;
-
-        const { error } = await supabase.from("documents").upsert(
-          {
-            name: this.name,
-            document: snapshotBase64,
-          },
-          { onConflict: "name" }
-        );
-
-        if (error) {
-          throw new Error(error.message);
-        }
-      }
-
-      replaceDocFromSnapshot(this.document, snapshotBase64);
-      this.lastKnownDocumentBytes = snapshotBase64.length;
-
-      if (activeConnectionCount > 0) {
-        const resetEpoch = await this.getResetEpoch();
-        if (resetEpoch !== null) {
-          this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
-        }
-        const closedCount = this.closeConnections(
-          "Room Reloaded from Persisted Data"
-        );
-        console.warn(
-          `[PartyServer] Reloaded stale live document for room=${this.name}; closedConnections=${closedCount}`
-        );
-      }
+      replaceDocFromSnapshot(this.document, persistedDocumentBase64);
+      this.markDocumentPersisted(persistedDocumentBase64);
 
       await Promise.resolve();
-    } catch (error) {
-      if (resetEpochChanged) {
-        await this.restoreResetEpoch(rollbackResetEpoch);
-      }
-      throw error;
+      return true;
     } finally {
       setTimeout(() => {
         this.isSkippingSave = false;
@@ -797,6 +762,7 @@ export class PartyServer extends YServer {
         throw new Error(`Failed to save snapshot: ${saveError.message}`);
       }
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
+      this.markDocumentPersisted(updatedBase64);
 
       // Reload the live server from the snapshot
       console.log(`[Restore Snapshot] Reloading live server from snapshot...`);
@@ -1339,10 +1305,7 @@ export class PartyServer extends YServer {
     this.markPersistenceAvailable();
 
     if (result.data) {
-      this.lastKnownDocumentBytes =
-        typeof result.data.document === "string"
-          ? result.data.document.length
-          : 0;
+      this.markDocumentPersisted(result.data.document);
       Y.applyUpdate(
         this.document,
         new Uint8Array(Buffer.from(result.data.document, "base64"))
@@ -1412,6 +1375,9 @@ export class PartyServer extends YServer {
         liveDocumentBase64: documentBase64,
         persistedDocumentBase64,
         liveDocumentContainsPersistedDocument,
+        hasOpenConnections: activeConnectionCount > 0,
+        liveDocumentMatchesLastSave:
+          this.lastPersistedDocumentBase64 === documentBase64,
       });
 
       if (
@@ -1423,6 +1389,13 @@ export class PartyServer extends YServer {
         );
         await this.reloadLiveDocumentFromPersistedSnapshot(
           persistedDocumentBase64
+        );
+        return false;
+      }
+
+      if (persistenceDecision.kind === "skip-live-save") {
+        console.warn(
+          `[PartyServer] Autosave skipped for room ${this.name}: live document conflicts with persisted updates; leaving live and persisted documents unchanged`
         );
         return false;
       }
@@ -1471,6 +1444,7 @@ export class PartyServer extends YServer {
       );
       return false;
     }
+    this.markDocumentPersisted(documentBase64);
 
     if (this.consumeCompactionAutosave(documentBase64)) {
       console.log(
@@ -1948,6 +1922,7 @@ export class PartyServer extends YServer {
         throw new Error(`Failed to save reset document: ${saveError.message}`);
       }
       console.log(`[Hard Reset] Successfully saved fresh doc to database`);
+      this.markDocumentPersisted(freshBase64);
 
       // Reload the live server from the new snapshot
       console.log(`[Hard Reset] Reloading live server from snapshot...`);

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -20,6 +20,7 @@ import {
 } from "./docUtils";
 import {
   STORAGE_KEYS,
+  DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
   DEFAULT_EMERGENCY_COMPACT_RECHECK_DELAY_MS,
   DEFAULT_DOCUMENT_WARNING_BYTES,
@@ -63,7 +64,7 @@ import {
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
-  shouldCommitBackgroundCompaction,
+  shouldCommitCompactionSnapshot,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
@@ -90,6 +91,7 @@ type PartyServerConnectionState = Record<string, unknown> & {
 
 type CompactedDocument = {
   base64: string;
+  sourceBase64: string;
   beforeSize: number;
   afterSize: number;
   resetEpoch: number;
@@ -229,6 +231,10 @@ export class PartyServer extends YServer {
 
   private async clearEmptyRoomCompactAfter(): Promise<void> {
     await this.ctx.storage.delete(STORAGE_KEYS.emptyRoomCompactAfter);
+  }
+
+  private async setEmptyRoomCompactAfter(timestamp: number): Promise<void> {
+    await this.ctx.storage.put(STORAGE_KEYS.emptyRoomCompactAfter, timestamp);
   }
 
   private async getEmergencyCompactCheckAfter(): Promise<number | null> {
@@ -428,7 +434,8 @@ export class PartyServer extends YServer {
       return null;
     }
 
-    const beforeSize = encodeDocToBase64(doc).length;
+    const sourceBase64 = encodeDocToBase64(doc);
+    const beforeSize = sourceBase64.length;
     const resetEpoch = Date.now();
     const compactDoc = jsonToDoc(currentPlayData);
     setDocResetEpoch(compactDoc, resetEpoch);
@@ -436,6 +443,7 @@ export class PartyServer extends YServer {
 
     return {
       base64,
+      sourceBase64,
       beforeSize,
       afterSize: base64.length,
       resetEpoch,
@@ -451,6 +459,20 @@ export class PartyServer extends YServer {
     await this.setResetEpoch(resetEpoch);
   }
 
+  private async getPersistedDocumentBase64(): Promise<string | null> {
+    const { data, error } = await supabase
+      .from("documents")
+      .select("document")
+      .eq("name", this.name)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return typeof data?.document === "string" ? data.document : null;
+  }
+
   private async commitCompactedDocument({
     compactedDocument,
     beforeCommit,
@@ -461,6 +483,19 @@ export class PartyServer extends YServer {
     let documentSaved = false;
 
     try {
+      const persistedDocumentBase64 = await this.getPersistedDocumentBase64();
+      if (
+        !shouldCommitCompactionSnapshot({
+          sourceDocumentBase64: compactedDocument.sourceBase64,
+          persistedDocumentBase64,
+        })
+      ) {
+        console.warn(
+          `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source`
+        );
+        return false;
+      }
+
       if (beforeCommit && !(await beforeCommit())) {
         return false;
       }
@@ -753,7 +788,17 @@ export class PartyServer extends YServer {
   }
 
   private async scheduleEmptyRoomCompaction(): Promise<void> {
-    await Promise.resolve();
+    if (this.isSkippingSave) return;
+    if (!this.isPersistenceAvailable()) return;
+    if (this.getOpenConnectionCount() !== 0) return;
+
+    const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
+    await this.setEmptyRoomCompactAfter(compactAfter);
+    await this.scheduleNextAlarm();
+
+    console.log(
+      `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
+    );
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -1341,18 +1386,16 @@ export class PartyServer extends YServer {
 
     const recheckAfter = now + this.getEmergencyCompactRecheckDelayMs();
 
-    if (!shouldCommitBackgroundCompaction()) {
-      await this.setEmergencyCompactCheckAfter(recheckAfter);
-      console.warn(
-        `[PartyServer] Background compaction skipped: room=${this.name}, documentBytes=${documentSize}, nextCheckAt=${recheckAfter}`
-      );
-      return false;
-    }
-
-    // Connected rooms keep raw Yjs history so hibernated clients can resume
-    // without merging against a rewritten snapshot. This path pays the
-    // expensive docToJson/jsonToDoc/encode check at most once per cooldown
-    // window.
+    // Connected rooms normally keep raw Yjs history so hibernated clients can
+    // resume without merging against a rewritten snapshot. This path is the
+    // exception: once a never-empty room crosses the high-watermark threshold,
+    // the server pays the expensive docToJson/jsonToDoc/encode check at most
+    // once per cooldown window. If compaction is useful, it is enforced as a
+    // reset boundary by broadcasting room-reset and closing active sockets.
+    // That disruption is intentional because silently replacing Yjs history
+    // while clients are connected can merge stale client history back into the
+    // room. If compaction is not useful, the cooldown prevents every later
+    // autosave of a naturally large document from rebuilding the whole Y.Doc.
     const compactedDocument = this.buildCompactedDocument(this.document);
     if (compactedDocument === null) {
       await this.setEmergencyCompactCheckAfter(recheckAfter);
@@ -1373,7 +1416,7 @@ export class PartyServer extends YServer {
       return false;
     }
 
-    await this.commitCompactedDocument({
+    const committed = await this.commitCompactedDocument({
       compactedDocument,
       afterReplace: async () => {
         await this.setEmergencyCompactCheckAfter(recheckAfter);
@@ -1388,7 +1431,10 @@ export class PartyServer extends YServer {
         );
       },
     });
-    return true;
+    if (!committed) {
+      await this.setEmergencyCompactCheckAfter(recheckAfter);
+    }
+    return committed;
   }
 
   override async onRequest(request: Request): Promise<Response> {
@@ -1838,14 +1884,6 @@ export class PartyServer extends YServer {
     if (this.getOpenConnectionCount() !== 0) return;
 
     const run = async () => {
-      if (!shouldCommitBackgroundCompaction()) {
-        await this.clearEmptyRoomCompactAfter();
-        console.warn(
-          `[PartyServer] Empty-room compaction skipped: room=${this.name}, background compaction is disabled`
-        );
-        return;
-      }
-
       const compactedDocument = this.buildCompactedDocument(this.document);
       if (compactedDocument === null) {
         await this.clearEmptyRoomCompactAfter();
@@ -1878,6 +1916,9 @@ export class PartyServer extends YServer {
           await this.clearEmptyRoomCompactAfter();
         },
       });
+      if (!committed) {
+        await this.clearEmptyRoomCompactAfter();
+      }
       if (committed) {
         console.log(
           `[PartyServer] Empty-room compacted: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes (${((1 - compactedDocument.afterSize / compactedDocument.beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${compactedDocument.resetEpoch}`

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -14,6 +14,7 @@ import {
   docToJson,
   jsonToDoc,
   encodeDocToBase64,
+  documentContainsSnapshot,
   replaceDocFromSnapshot,
   setDocResetEpoch,
   getDocResetEpoch,
@@ -488,9 +489,16 @@ export class PartyServer extends YServer {
 
     try {
       const persistedDocumentBase64 = await this.getPersistedDocumentBase64();
+      const sourceContainsPersistedDocument =
+        persistedDocumentBase64 !== null &&
+        documentContainsSnapshot(
+          compactedDocument.sourceBase64,
+          persistedDocumentBase64
+        );
       const commitDecision = getCompactionCommitDecision({
         sourceDocumentBase64: compactedDocument.sourceBase64,
         persistedDocumentBase64,
+        sourceContainsPersistedDocument,
       });
 
       if (commitDecision.kind === "persist-live-document") {
@@ -498,6 +506,13 @@ export class PartyServer extends YServer {
           `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source; saving live document first`
         );
         await this.persistLiveDocument({ allowCompaction: false });
+        return false;
+      }
+
+      if (commitDecision.kind === "skip-compaction") {
+        console.warn(
+          `[PartyServer] Compaction skipped for room=${this.name}: persisted document has updates missing from live source`
+        );
         return false;
       }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -61,10 +61,10 @@ import {
   SharedElementPermissions,
 } from "./sharing";
 import {
+  getCompactionCommitDecision,
   getNextAlarmTime,
   isCompactionAutosave,
   shouldCheckEmergencyCompaction,
-  shouldCommitCompactionSnapshot,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
 } from "./compactionPolicy";
@@ -101,6 +101,10 @@ type CommitCompactedDocumentOptions = {
   compactedDocument: CompactedDocument;
   beforeCommit?: () => Promise<boolean>;
   afterReplace?: () => Promise<void>;
+};
+
+type PersistLiveDocumentOptions = {
+  allowCompaction: boolean;
 };
 
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
@@ -478,23 +482,27 @@ export class PartyServer extends YServer {
     beforeCommit,
     afterReplace,
   }: CommitCompactedDocumentOptions): Promise<boolean> {
-    this.isSkippingSave = true;
     const rollbackResetEpoch = await this.getResetEpoch();
     let documentSaved = false;
+    let autosavePaused = false;
 
     try {
       const persistedDocumentBase64 = await this.getPersistedDocumentBase64();
-      if (
-        !shouldCommitCompactionSnapshot({
-          sourceDocumentBase64: compactedDocument.sourceBase64,
-          persistedDocumentBase64,
-        })
-      ) {
+      const commitDecision = getCompactionCommitDecision({
+        sourceDocumentBase64: compactedDocument.sourceBase64,
+        persistedDocumentBase64,
+      });
+
+      if (commitDecision.kind === "persist-live-document") {
         console.warn(
-          `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source`
+          `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source; saving live document first`
         );
+        await this.persistLiveDocument({ allowCompaction: false });
         return false;
       }
+
+      this.isSkippingSave = true;
+      autosavePaused = true;
 
       if (beforeCommit && !(await beforeCommit())) {
         return false;
@@ -526,7 +534,9 @@ export class PartyServer extends YServer {
       this.compactionAutosaveSnapshot = null;
       throw error;
     } finally {
-      this.isSkippingSave = false;
+      if (autosavePaused) {
+        this.isSkippingSave = false;
+      }
     }
   }
 
@@ -1255,13 +1265,19 @@ export class PartyServer extends YServer {
   }
 
   override async onSave(): Promise<void> {
+    await this.persistLiveDocument({ allowCompaction: true });
+  }
+
+  private async persistLiveDocument({
+    allowCompaction,
+  }: PersistLiveDocumentOptions): Promise<boolean> {
     const doc = this.document;
 
     if (!this.isPersistenceAvailable()) {
       console.warn(
         `[PartyServer] Autosave skipped for room ${this.name}: Supabase persistence unavailable, room is in transient mode.`
       );
-      return;
+      return false;
     }
 
     // Skip autosave if we are performing a reset operation
@@ -1269,7 +1285,7 @@ export class PartyServer extends YServer {
       console.log(
         "[PartyServer] Skipping autosave due to active reset operation"
       );
-      return;
+      return false;
     }
 
     // Get current reset epoch for logging and validation
@@ -1284,7 +1300,7 @@ export class PartyServer extends YServer {
       console.warn(
         `[PartyServer] Autosave skipped for room ${this.name}: ${resetEpochDecision.reason}`
       );
-      return;
+      return false;
     }
 
     if (resetEpochDecision.kind === "promote-server-epoch") {
@@ -1335,30 +1351,31 @@ export class PartyServer extends YServer {
         `[PartyServer] SUPABASE AUTOSAVE FAILED for room ${this.name}:`,
         error
       );
+      return false;
     }
 
-    if (!error) {
-      if (this.consumeCompactionAutosave(documentBase64)) {
-        console.log(
-          `[PartyServer] Compaction autosave completed: room=${this.name}`
-        );
-        return;
-      }
+    if (this.consumeCompactionAutosave(documentBase64)) {
+      console.log(
+        `[PartyServer] Compaction autosave completed: room=${this.name}`
+      );
+      return true;
     }
 
-    if (!error && activeConnectionCount > 0) {
+    if (allowCompaction && activeConnectionCount > 0) {
       const compacted = await this.maybeCompactLargeConnectedRoom({
         documentSize,
         now: Date.now(),
       });
       if (compacted) {
-        return;
+        return true;
       }
     }
 
-    if (!error && activeConnectionCount === 0) {
+    if (allowCompaction && activeConnectionCount === 0) {
       await this.scheduleEmptyRoomCompaction();
     }
+
+    return true;
   }
 
   private async maybeCompactLargeConnectedRoom({

--- a/partykit/resetEpochPolicy.ts
+++ b/partykit/resetEpochPolicy.ts
@@ -18,3 +18,30 @@ export function isResetEpochStale(
     (candidateEpoch === null || candidateEpoch < serverEpoch)
   );
 }
+
+export type AutosaveResetEpochDecision =
+  | { kind: "save" }
+  | { kind: "skip"; reason: string }
+  | { kind: "promote-server-epoch"; resetEpoch: number };
+
+export function getAutosaveResetEpochDecision(
+  docResetEpoch: number | null,
+  serverResetEpoch: number | null
+): AutosaveResetEpochDecision {
+  if (isResetEpochStale(docResetEpoch, serverResetEpoch)) {
+    const reason =
+      docResetEpoch === null
+        ? `doc reset epoch missing while server epoch=${serverResetEpoch}`
+        : `doc reset epoch ${docResetEpoch} < server epoch ${serverResetEpoch}`;
+    return { kind: "skip", reason };
+  }
+
+  if (
+    docResetEpoch !== null &&
+    (serverResetEpoch === null || docResetEpoch > serverResetEpoch)
+  ) {
+    return { kind: "promote-server-epoch", resetEpoch: docResetEpoch };
+  }
+
+  return { kind: "save" };
+}

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -43,6 +43,10 @@ bun smoke:partykit:limits
 # Verifies empty-room compaction, reset rejection, and fresh reconnect.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:compaction
 
+# Recreates a stale live compaction source while the documents row contains
+# newer data, and verifies automatic compaction leaves the newer row intact.
+SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:stale-compaction
+
 # Verifies connected-room high-watermark compaction.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:emergency
 
@@ -93,6 +97,7 @@ Config:
 - `ADMIN_TOKEN`: required for `test:partykit:compaction`.
 - `PARTYKIT_HIBERNATION_WAIT_MS`: idle wait for the hibernation smoke. Defaults to `90000`.
 - `PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS`: expected server empty-room compaction delay. Defaults to `300000`.
+- `PARTYKIT_STALE_COMPACTION_SETTLE_MS`: extra wait after the empty-room compaction delay for the stale-source smoke. Defaults to `20000`.
 - `PARTYKIT_SKIP_COMPACTION_SETTLE_CHECK=1`: skips the extra no-op alarm wait after reconnect.
 - `PARTYKIT_EMERGENCY_TARGET_RAW_BYTES`: target local raw Y.Doc size for the emergency smoke. Defaults to `120000`.
 - `PARTYKIT_EMERGENCY_BATCH_SIZE`: temp entry batch size while building the emergency smoke doc. Defaults to `2000`.

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -10,6 +10,7 @@
     "test:partykit:limits": "node partykit/server-limits-smoke.mjs",
     "test:partykit:hibernation": "node partykit/hibernation-bridge-smoke.mjs",
     "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",
+    "test:partykit:stale-compaction": "node partykit/stale-compaction-source-smoke.mjs",
     "test:partykit:emergency": "node partykit/emergency-compaction-smoke.mjs",
     "test:partykit:transient": "node partykit/supabase-transient-smoke.mjs",
     "test:partykit:soak": "node partykit/multi-client-soak-smoke.mjs",

--- a/smoke-tests/partykit/shared.mjs
+++ b/smoke-tests/partykit/shared.mjs
@@ -179,7 +179,7 @@ export function waitForProviderStatus(
 
 export async function inspectRoom({ host, room, adminToken }) {
   const response = await fetch(
-    `https://${host}/parties/main/${encodeURIComponent(room)}/admin/inspect`,
+    `${getPartyHttpUrl(host, room)}/admin/inspect`,
     {
       headers: { Authorization: `Bearer ${adminToken}` },
     }

--- a/smoke-tests/partykit/stale-compaction-source-smoke.mjs
+++ b/smoke-tests/partykit/stale-compaction-source-smoke.mjs
@@ -1,0 +1,195 @@
+// ABOUTME: Recreates a stale live compaction source racing a newer persisted document.
+// ABOUTME: Verifies automatic compaction does not overwrite newer Supabase room data.
+import {
+  Y,
+  connectRoom,
+  createStore,
+  getHost,
+  getNumberEnv,
+  getPartyHttpUrl,
+  inspectRoom as inspectPartyRoom,
+  loadSmokeEnv,
+  sleep,
+  waitForSync,
+} from "./shared.mjs";
+
+const loadedEnvFile = loadSmokeEnv();
+const host = getHost();
+const adminToken = process.env.ADMIN_TOKEN;
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_KEY;
+const room = `codex-stale-compaction-source-${Date.now()}`;
+const compactDelayMs = getNumberEnv(
+  "PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS",
+  5 * 60 * 1000
+);
+const settleMs = getNumberEnv("PARTYKIT_STALE_COMPACTION_SETTLE_MS", 20_000);
+
+if (!adminToken) {
+  throw new Error(
+    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file."
+  );
+}
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error(
+    "SUPABASE_URL and SUPABASE_KEY are required for direct documents-row setup."
+  );
+}
+
+function encodeDoc(doc) {
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+}
+
+function setWeekAttendance(store, label) {
+  store.play["can-play"] = {
+    "week-attendance": {
+      attendees: [{ pid: `pid-${label}`, name: label, color: "#ffae00" }],
+    },
+  };
+}
+
+function buildCompactionBloat(store) {
+  store.play.canMove = {};
+  for (let i = 1; i <= 2_000; i += 1) {
+    store.play.canMove[`temp-${i}`] = { x: i, y: i };
+  }
+  for (let i = 1; i <= 2_000; i += 1) {
+    delete store.play.canMove[`temp-${i}`];
+  }
+}
+
+function buildPersistedGoodDocument() {
+  const doc = new Y.Doc();
+  const store = createStore(doc);
+  setWeekAttendance(store, "persisted-good");
+  return encodeDoc(doc);
+}
+
+function getAttendanceLabel(playData) {
+  return playData?.["can-play"]?.["week-attendance"]?.attendees?.[0]?.name;
+}
+
+async function adminJson(path, init = {}) {
+  const response = await fetch(`${getPartyHttpUrl(host, room)}/admin/${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    throw new Error(`${path} returned non-JSON ${response.status}: ${text}`);
+  }
+  if (!response.ok) {
+    throw new Error(`${path} failed ${response.status}: ${text}`);
+  }
+  return body;
+}
+
+async function inspectRoom() {
+  return inspectPartyRoom({ host, room, adminToken });
+}
+
+async function writePersistedDocument(base64Document) {
+  const baseUrl = supabaseUrl.replace(/\/+$/, "");
+  const response = await fetch(
+    `${baseUrl}/rest/v1/documents?name=eq.${encodeURIComponent(room)}`,
+    {
+      method: "PATCH",
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        "content-type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify({ document: base64Document }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `direct documents update failed ${response.status}: ${await response.text()}`
+    );
+  }
+}
+
+console.log(`host=${host}`);
+console.log(`env=${loadedEnvFile ?? "process.env"}`);
+console.log(`room=${room}`);
+
+const liveDoc = new Y.Doc();
+const liveStore = createStore(liveDoc);
+const provider = connectRoom(host, room, liveDoc);
+
+try {
+  await waitForSync(provider, "initial");
+
+  liveDoc.transact(() => {
+    setWeekAttendance(liveStore, "stale-live-source");
+    buildCompactionBloat(liveStore);
+  });
+
+  await adminJson("force-save-live", { method: "POST" });
+  console.log("saved stale live source as the initial row");
+
+  await writePersistedDocument(buildPersistedGoodDocument());
+  console.log("replaced persisted row with newer database data");
+
+  const comparison = await adminJson("live-compare");
+  const directLabel = getAttendanceLabel(comparison.methods.direct.data);
+  const liveLabel = getAttendanceLabel(comparison.methods.live.data);
+  console.log(`before compaction: db=${directLabel}, live=${liveLabel}`);
+  if (directLabel !== "persisted-good") {
+    throw new Error(`expected DB label persisted-good, got ${directLabel}`);
+  }
+  if (liveLabel !== "stale-live-source") {
+    throw new Error(`expected live label stale-live-source, got ${liveLabel}`);
+  }
+
+  const before = await inspectRoom();
+  provider.destroy();
+  console.log(
+    `waiting ${compactDelayMs / 1000}s for empty-room compaction alarm`
+  );
+  await sleep(compactDelayMs + settleMs);
+
+  const after = await inspectRoom();
+  const afterLabel = getAttendanceLabel(after.ydoc.play);
+  console.log(
+    `after compaction window: db=${afterLabel}, resetEpoch=${after.resetEpoch}`
+  );
+
+  if (afterLabel !== "persisted-good") {
+    throw new Error(
+      `expected persisted data to survive compaction, got ${afterLabel}`
+    );
+  }
+  if (after.resetEpoch !== before.resetEpoch) {
+    throw new Error(
+      `expected resetEpoch to remain ${before.resetEpoch}, got ${after.resetEpoch}`
+    );
+  }
+
+  const freshDoc = new Y.Doc();
+  const freshStore = createStore(freshDoc);
+  const freshProvider = connectRoom(host, room, freshDoc);
+  try {
+    await waitForSync(freshProvider, "fresh");
+    const freshLabel = getAttendanceLabel(freshStore.play);
+    console.log(`fresh reconnect observed ${freshLabel}`);
+    if (freshLabel !== "persisted-good") {
+      throw new Error(`expected fresh client to observe persisted-good`);
+    }
+  } finally {
+    freshProvider.destroy();
+    freshDoc.destroy();
+  }
+
+  console.log("stale compaction source smoke passed");
+} finally {
+  provider.destroy();
+  liveDoc.destroy();
+}


### PR DESCRIPTION
## Summary

- Keep automatic empty-room and connected-room compaction enabled.
- Guard every automatic compaction commit by first confirming the persisted document still matches the exact Y.Doc snapshot that was compacted.
- Guard normal autosave before the Supabase upsert: live can write only when it matches the persisted row or its Yjs history contains every update from the persisted row.
- If autosave sees a live document that is missing persisted updates, it only reloads from the persisted snapshot when the room is empty and the live snapshot still matches the last successful Worker/admin save. Connected rooms or live snapshots with unsaved changes skip the write and leave both sides unchanged instead of choosing a loser automatically.
- Let autosave heal reset-epoch divergence when the live Y.Doc has a newer reset epoch than Durable Object storage, then persist the live document instead of skipping forever.
- Add a manual stale-source smoke test that recreates the dangerous shape: live compaction source is stale while the `documents` row has newer data.
- Document where PartyKit production Worker logs live and which incident strings are useful for future searches.

## Root Cause

The live smoke reproduced the unsafe path more precisely: a stale live Durable Object could autosave over the newer `documents` row after the room emptied, before automatic compaction made its commit decision. A compaction-only guard was not enough because the persisted row had already been replaced by the stale live snapshot. The fix now protects both Worker-owned write paths: normal autosave and automatic compaction.

## Edge Cases Covered

- If live contains the persisted row plus newer Yjs updates, autosave proceeds and makes live canonical.
- If persisted contains updates missing from live, and live has not changed since the Worker/admin last saved it, an empty room reloads live from DB without raising `resetEpoch`.
- If clients are still connected while live and DB conflict, autosave skips and preserves both sides for operator investigation.
- If the room is empty but live has changed since the last successful save, autosave also skips instead of throwing away unsaved live-only data.
- Explicit admin reset/restore flows remain authoritative and update the Worker’s last-persisted marker after their DB writes succeed.
- `documentContainsSnapshot` is covered for superset, stale-missing, forked Yjs histories, deletion-only diffs, and empty-doc boundaries.

## Impact After Deploy

Automatic compaction still runs for large/idle rooms, but it can only commit after the persisted row is safe relative to the live source snapshot. Normal autosave now refuses to overwrite Supabase when the live Y.Doc is missing updates already persisted in the row. It also refuses to discard unresolved live-only changes. Live room data should continue autosaving when it contains the persisted row plus newer updates.

## Validation

- `bun test partykit/__tests__/docUtils.test.ts` - 5 pass, 0 fail
- `bun test partykit/__tests__/compactionPolicy.test.ts` - 15 pass, 0 fail
- `bun test partykit/__tests__` - 66 pass, 0 fail
- `bunx tsc -p partykit`
- `git diff --check`
- `PARTYKIT_HOST=localhost:2007 SMOKE_ENV_FILE=/path/to/.env bun smoke:partykit:stale-compaction` - passed against local Worker dev plus real Supabase secrets

## Live Smoke Evidence

The smoke creates a unique room where DB has `persisted-good` and live has `stale-live-source`, then disconnects and waits for the real empty-room compaction window.

Observed Worker log during the latest passing run:

```text
Autosave skipped for room codex-stale-compaction-source-1782255994863: live document is missing persisted updates; reloading persisted document
Autosave re-enabled after live document reload
Empty-room compaction skipped: room=codex-stale-compaction-source-1782255994863, 224 -> 276 bytes
```

Observed smoke result:

```text
before compaction: db=persisted-good, live=stale-live-source
after compaction window: db=persisted-good, resetEpoch=null
fresh reconnect observed persisted-good
stale compaction source smoke passed
```

## Manual Smoke

- `SMOKE_ENV_FILE=/path/to/.env bun smoke:partykit:stale-compaction`

This runs against a real PartyKit Worker and Supabase, directly prepares a unique `documents` row with newer data while the live room has a stale compaction source, waits for the real empty-room compaction alarm, and asserts that the newer row survives and reconnecting clients observe it.

## Notes

This is a Worker-owned-write guard, not a database RPC-level compare-and-swap. It protects the normal PartyKit autosave and compaction paths we control. Explicit admin reset/restore/hard-reset routes remain intentionally authoritative, but an already in-flight background write still has a narrow safety-read-to-write window. Closing that completely should be a dedicated Postgres RPC that compares and updates in one database transaction. A PostgREST `.eq("document", ...)` pseudo-CAS is not a good substitute here because these Yjs document blobs can be large enough to make query-string filtering fragile.

The integration coverage for the full PartyServer orchestration is smoke-only. Unit tests cover the pure policy and Yjs containment helpers; the live Worker + Supabase behavior is verified by `smoke:partykit:stale-compaction`, which is intentionally manual because it needs real secrets and waits for the real empty-room compaction alarm.

The admin-save-reset-flow branch should be rebased or ported on top of this before deployment. It should preserve this PR's distinction between explicit admin resets and automatic compaction safeguards.