### PR TITLE
Handle server room resets without reloading

### DIFF
--- a/.changeset/quiet-admin-room-resets.md
+++ b/.changeset/quiet-admin-room-resets.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Handle server room-reset messages by reconnecting the current room in place before falling back to a page reload, so admin data restores can update connected clients with less visible disruption.

--- a/packages/playhtml/src/__tests__/navigation.integration.test.ts
+++ b/packages/playhtml/src/__tests__/navigation.integration.test.ts
@@ -7,6 +7,9 @@ describe("playhtml.handleNavigation", () => {
   beforeEach(async () => {
     try { await resetPlayHTML(); } catch {}
     document.body.innerHTML = "";
+    localStorage.clear();
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
     delete (window as any).playhtml;
     delete document.documentElement.dataset.playhtml;
     document.head.querySelectorAll("link[href*='playhtml']").forEach((n) => n.remove());
@@ -610,6 +613,136 @@ describe("playhtml.handleNavigation", () => {
     } finally {
       document.body.innerHTML = "";
       history.replaceState(null, "", origPath);
+    }
+  });
+
+  it("handles server room-reset by reconnecting the current room without a page reload", async () => {
+    const origPath = window.location.pathname + window.location.search;
+    const providers = ((globalThis as any).PLAYHTML_TEST_PROVIDERS = []);
+    try {
+      history.replaceState(null, "", "/server-reset");
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: "/server-reset",
+      } as any);
+
+      const room = playhtml.roomId;
+      const page = playhtml.createPageData("p", { v: 0 });
+      page.setData({ v: 9 });
+      await new Promise((r) => queueMicrotask(r));
+      expect(page.getData()).toEqual({ v: 9 });
+
+      const providerBefore = providers[providers.length - 1];
+      expect(providerBefore).toBeTruthy();
+
+      providerBefore.emit(
+        "custom-message",
+        JSON.stringify({ type: "room-reset", resetEpoch: 12345 }),
+      );
+      await new Promise((r) => queueMicrotask(r));
+      await new Promise((r) => queueMicrotask(r));
+
+      expect(localStorage.getItem(`playhtml_resetEpoch_${room}`)).toBe("12345");
+      expect(providers.length).toBeGreaterThan(1);
+      expect(playhtml.roomId).toBe(room);
+      expect(page.getData()).toEqual({ v: 0 });
+    } finally {
+      history.replaceState(null, "", origPath);
+      localStorage.clear();
+    }
+  });
+
+  it("runs another reconnect when a newer server reset arrives during reconnect", async () => {
+    const origPath = window.location.pathname + window.location.search;
+    const providers = ((globalThis as any).PLAYHTML_TEST_PROVIDERS = []);
+    try {
+      history.replaceState(null, "", "/server-reset-overlap");
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: "/server-reset-overlap",
+      } as any);
+
+      const room = playhtml.roomId;
+      const page = playhtml.createPageData("p", { v: 0 });
+      page.setData({ v: 9 });
+      await new Promise((r) => queueMicrotask(r));
+
+      const providerBefore = providers[providers.length - 1];
+      (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = true;
+      providerBefore.emit(
+        "custom-message",
+        JSON.stringify({ type: "room-reset", resetEpoch: 100 }),
+      );
+      await new Promise((r) => queueMicrotask(r));
+
+      const reconnectingProvider = providers[providers.length - 1];
+      expect(reconnectingProvider).not.toBe(providerBefore);
+      reconnectingProvider.emit(
+        "custom-message",
+        JSON.stringify({ type: "room-reset", resetEpoch: 101 }),
+      );
+      await new Promise((r) => queueMicrotask(r));
+      expect(localStorage.getItem(`playhtml_resetEpoch_${room}`)).toBe("101");
+
+      reconnectingProvider.emit("sync", true);
+      await new Promise((r) => queueMicrotask(r));
+      await new Promise((r) => queueMicrotask(r));
+
+      expect(providers.length).toBe(3);
+      providers[providers.length - 1].emit("sync", true);
+      await new Promise((r) => queueMicrotask(r));
+      await new Promise((r) => queueMicrotask(r));
+
+      expect(page.getData()).toEqual({ v: 0 });
+    } finally {
+      (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+      history.replaceState(null, "", origPath);
+      localStorage.clear();
+    }
+  });
+
+  it("allows another reset attempt after a reconnect never syncs", async () => {
+    const origPath = window.location.pathname + window.location.search;
+    const providers = ((globalThis as any).PLAYHTML_TEST_PROVIDERS = []);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    vi.useFakeTimers();
+
+    try {
+      history.replaceState(null, "", "/server-reset-timeout");
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: "/server-reset-timeout",
+      } as any);
+
+      const providerBefore = providers[providers.length - 1];
+      (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = true;
+      providerBefore.emit(
+        "custom-message",
+        JSON.stringify({ type: "room-reset", resetEpoch: 200 }),
+      );
+      await new Promise((r) => queueMicrotask(r));
+
+      expect(providers.length).toBe(2);
+      const timedOutProvider = providers[providers.length - 1];
+
+      await vi.advanceTimersByTimeAsync(6000);
+      await new Promise((r) => queueMicrotask(r));
+
+      timedOutProvider.emit(
+        "custom-message",
+        JSON.stringify({ type: "room-reset", resetEpoch: 201 }),
+      );
+      await new Promise((r) => queueMicrotask(r));
+
+      expect(providers.length).toBe(3);
+    } finally {
+      vi.useRealTimers();
+      consoleError.mockRestore();
+      (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+      history.replaceState(null, "", origPath);
+      localStorage.clear();
     }
   });
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -46,7 +46,11 @@ import {
 } from "./sharing";
 import { parseDataSource, normalizeHost } from "@playhtml/common";
 import type { PageDataChannel } from "@playhtml/common";
-import { createPageDataChannel, PAGE_TAG } from "./page-data";
+import {
+  createPageDataChannel,
+  PAGE_TAG,
+  refreshPageDataChannels,
+} from "./page-data";
 import { createReadOnlyStore, type ReadOnlyStore } from "./readOnlyStore";
 
 const DefaultPartykitHost = "playhtml.spencerc99.workers.dev";
@@ -457,19 +461,14 @@ function onMessage(data: string) {
 
   // Handle system messages
   if (message.type === "room-reset") {
-    console.warn(
-      `[PLAYHTML] Received room-reset message with epoch=${message.resetEpoch}. Storing and reloading...`,
-    );
-    // Store the reset epoch if provided
-    if (message.resetEpoch) {
-      const storageKey = `playhtml_resetEpoch_${__currentRoomId}`;
-      localStorage.setItem(storageKey, String(message.resetEpoch));
-      console.log(
-        `[PLAYHTML] Stored resetEpoch=${message.resetEpoch} in localStorage key=${storageKey}`,
-      );
+    const resetEpoch = Number(message.resetEpoch);
+    if (!Number.isFinite(resetEpoch)) {
+      console.error("[PLAYHTML] Received room-reset without a resetEpoch");
+      window.location.reload();
+      return;
     }
-    // Force reload to fetch fresh state
-    window.location.reload();
+
+    queueServerRoomReset(resetEpoch);
     return;
   }
 
@@ -576,6 +575,10 @@ function resolveExplicitRoom(): string | undefined {
 let cachedDefaultRoomOptions: DefaultRoomOptions = { includeSearch: false };
 let cursorOptionsCache: CursorOptions | undefined = undefined;
 let cachedOnError: (() => void) | undefined = undefined;
+let roomResetPromise: Promise<void> | null = null;
+let pendingRoomResetEpoch: number | null = null;
+const SERVER_ROOM_RESET_SYNC_TIMEOUT_MS = 5000;
+const mainProviderSyncWaiters = new Set<(error?: Error) => void>();
 
 /**
  * Builds a fresh main Yjs provider for the given room. Side effects:
@@ -617,6 +620,7 @@ function buildMainProvider(args: {
   yprovider.on("error", () => {
     onError?.();
   });
+  yprovider.on("sync", handleMainProviderSync);
 
   // Register custom-message handler once, outside the sync callback,
   // to avoid duplicate registrations on reconnect.
@@ -754,6 +758,130 @@ function buildCursors(args: {
   cursorClient = new CursorClientAwareness(providerForCursors, cursorOptions);
 }
 
+function storeResetEpochForRoom(room: string, resetEpoch: number): void {
+  const storageKey = `playhtml_resetEpoch_${room}`;
+  localStorage.setItem(storageKey, String(resetEpoch));
+  console.log(
+    `[PLAYHTML] Stored resetEpoch=${resetEpoch} in localStorage key=${storageKey}`,
+  );
+}
+
+function waitForMainProviderSync(timeoutMs?: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (hasSynced) {
+      resolve();
+      return;
+    }
+
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      if (timeout !== null) clearTimeout(timeout);
+      mainProviderSyncWaiters.delete(finish);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+
+    mainProviderSyncWaiters.add(finish);
+
+    if (timeoutMs !== undefined) {
+      timeout = setTimeout(() => {
+        finish(new Error("Timed out waiting for playhtml room reset sync"));
+      }, timeoutMs);
+    }
+  });
+}
+
+function handleMainProviderSync(connected: boolean): void {
+  if (!connected) console.error("Issue connecting to yjs...");
+  if (hasSynced) return;
+  hasSynced = true;
+  const waiters = [...mainProviderSyncWaiters];
+  mainProviderSyncWaiters.clear();
+  waiters.forEach((finish) => finish());
+}
+
+function queueServerRoomReset(resetEpoch: number): void {
+  storeResetEpochForRoom(__currentRoomId, resetEpoch);
+
+  if (roomResetPromise) {
+    pendingRoomResetEpoch = Math.max(pendingRoomResetEpoch ?? 0, resetEpoch);
+    return;
+  }
+
+  roomResetPromise = runQueuedServerRoomReset(resetEpoch)
+    .catch((error) => {
+      console.error("[PLAYHTML] Failed to reconnect after room-reset:", error);
+      window.location.reload();
+    })
+    .finally(() => {
+      roomResetPromise = null;
+      pendingRoomResetEpoch = null;
+    });
+}
+
+async function runQueuedServerRoomReset(resetEpoch: number): Promise<void> {
+  let nextResetEpoch = resetEpoch;
+
+  while (true) {
+    const completedResetEpoch = nextResetEpoch;
+    pendingRoomResetEpoch = null;
+    await resetCurrentRoomFromServer();
+
+    if (
+      pendingRoomResetEpoch === null ||
+      pendingRoomResetEpoch <= completedResetEpoch
+    ) {
+      return;
+    }
+
+    nextResetEpoch = pendingRoomResetEpoch;
+  }
+}
+
+async function resetCurrentRoomFromServer(): Promise<void> {
+  if (!__currentRoomId || !__currentHost) {
+    throw new Error("playhtml cannot reset before init()");
+  }
+
+  teardownMainProvider();
+  teardownCursors();
+  hasSynced = false;
+  lastElementAwarenessFingerprint = null;
+  recreateStore();
+
+  buildMainProvider({
+    room: __currentRoomId,
+    partykitHost: __currentHost,
+    onError: cachedOnError,
+    onMessage,
+  });
+
+  if (cursorOptionsCache?.enabled) {
+    buildCursors({
+      cursors: cursorOptionsCache,
+      mainRoom: __currentRoomId,
+      partykitHost: __currentHost,
+      onError: cachedOnError,
+    });
+  }
+
+  bindAwarenessListener();
+  markAllElementsAsLoading();
+  await waitForMainProviderSync(SERVER_ROOM_RESET_SYNC_TIMEOUT_MS);
+  refreshPageDataChannels(getPageDataDeps());
+  setupElements();
+  markAllElementsAsReady();
+  cursorClient?.refreshContainer?.();
+  cursorClient?.refreshCursorStyles?.();
+  dispatchNavigated(__currentRoomId);
+}
+
 async function runHandleNavigation(): Promise<void> {
   // firstSetup is true before init and after resetPlayHTML — skip nav in both.
   if (firstSetup) return;
@@ -840,18 +968,8 @@ async function runHandleNavigation(): Promise<void> {
   markAllElementsAsLoading();
 
   if (mainRoomChanged) {
-    await new Promise<void>((resolve) => {
-      if (hasSynced) {
-        resolve();
-        return;
-      }
-      yprovider.on("sync", (connected: boolean) => {
-        if (!connected) console.error("Issue connecting to yjs...");
-        if (hasSynced) return;
-        hasSynced = true;
-        resolve();
-      });
-    });
+    await waitForMainProviderSync();
+    refreshPageDataChannels(getPageDataDeps());
   }
 
   setupElements();
@@ -1024,43 +1142,27 @@ async function initPlayHTMLOnce({
   // Mark all discovered playhtml elements as loading before sync
   markAllElementsAsLoading();
 
-  // await until yprovider is synced
-  await new Promise((resolve) => {
-    if (hasSynced) {
-      resolve(true);
+  await waitForMainProviderSync();
+  console.log("[PLAYHTML]: Setting up elements... Time to have some fun 🛝");
+
+  setupElements();
+
+  // Mark all elements as ready after sync completes and elements are set up
+  markAllElementsAsReady();
+  isLoading = false;
+  readyResolve();
+
+  // Fetch simple permissions for referenced shared elements so clients can block writes locally
+  if (sharedReferences.length > 0) {
+    try {
+      const elementIds = sharedReferences.map((r) => r.elementId);
+      yprovider.sendMessage(
+        JSON.stringify({ type: "export-permissions", elementIds })
+      );
+    } catch (error) {
+      console.error("[PLAYHTML] Error during post-sync setup:", error);
     }
-    yprovider.on("sync", (connected: boolean) => {
-      if (!connected) {
-        console.error("Issue connecting to yjs...");
-      }
-      if (hasSynced) {
-        return;
-      }
-      hasSynced = true;
-      console.log("[PLAYHTML]: Setting up elements... Time to have some fun 🛝");
-
-      setupElements();
-
-      // Mark all elements as ready after sync completes and elements are set up
-      markAllElementsAsReady();
-      isLoading = false;
-      readyResolve();
-
-      // Fetch simple permissions for referenced shared elements so clients can block writes locally
-      if (sharedReferences.length > 0) {
-        try {
-          const elementIds = sharedReferences.map((r) => r.elementId);
-          yprovider.sendMessage(
-            JSON.stringify({ type: "export-permissions", elementIds })
-          );
-        } catch (error) {
-          console.error("[PLAYHTML] Error during post-sync setup:", error);
-        }
-      }
-
-      resolve(true);
-    });
-  });
+  }
 
   return yprovider;
 }
@@ -1393,13 +1495,10 @@ function setupElements(): void {
   firstSetup = false;
 }
 
-function createPageData<T>(name: string, defaultValue: T): PageDataChannel<T> {
-  if (!hasSynced) {
-    throw new Error("playhtml.createPageData is not available before init()");
-  }
-  return createPageDataChannel(name, defaultValue, {
+function getPageDataDeps() {
+  return {
     ensureProxy: ensureElementProxy,
-    getProxy: (tag, id) => proxyByTagAndId.get(tag)?.get(id),
+    getProxy: (tag: string, id: string) => proxyByTagAndId.get(tag)?.get(id),
     // Getters so a handle held across a room change (which recreates store/doc)
     // reads the current ones, not stale references captured at creation.
     getDoc: () => doc,
@@ -1408,7 +1507,14 @@ function createPageData<T>(name: string, defaultValue: T): PageDataChannel<T> {
     yObserverByKey,
     channelRefCounts: pageDataRefCounts,
     channelListeners: pageDataListeners,
-  });
+  };
+}
+
+function createPageData<T>(name: string, defaultValue: T): PageDataChannel<T> {
+  if (!hasSynced) {
+    throw new Error("playhtml.createPageData is not available before init()");
+  }
+  return createPageDataChannel(name, defaultValue, getPageDataDeps());
 }
 
 function createPresenceRoom(name: string): PresenceRoom {
@@ -1518,6 +1624,9 @@ export async function resetPlayHTML(): Promise<void> {
       map.clear();
     }
     elementHandlers.clear();
+    pageDataRefCounts.clear();
+    pageDataListeners.clear();
+    mainProviderSyncWaiters.clear();
 
     teardownCursors();
     teardownMainProvider();
@@ -1549,6 +1658,8 @@ export async function resetPlayHTML(): Promise<void> {
     cachedDefaultRoomOptions = { includeSearch: false };
     cursorOptionsCache = undefined;
     cachedOnError = undefined;
+    roomResetPromise = null;
+    pendingRoomResetEpoch = null;
   } finally {
     // firstSetup = true (set above) is the canonical "not initialized"
     // flag — runHandleNavigation checks it to skip nav after reset.

--- a/packages/playhtml/src/page-data.ts
+++ b/packages/playhtml/src/page-data.ts
@@ -25,6 +25,53 @@ interface PageDataDeps {
   channelListeners: Map<string, Set<(data: any) => void>>;
 }
 
+function pageDataObserverKey(name: string): string {
+  return `${PAGE_TAG}:${name}`;
+}
+
+function attachPageDataObserver<T>(
+  name: string,
+  deps: PageDataDeps,
+  listeners: Set<(data: T) => void>
+): void {
+  const { getStorePlay, yObserverByKey } = deps;
+  const observerKey = pageDataObserverKey(name);
+  if (yObserverByKey.has(observerKey)) return;
+  const yVal = getYjsValue(getStorePlay()[PAGE_TAG]?.[name]);
+  if (!yVal || typeof (yVal as any).observeDeep !== "function") return;
+  let scheduled = false;
+  const observer = () => {
+    if (scheduled) return;
+    scheduled = true;
+    queueMicrotask(() => {
+      scheduled = false;
+      const currentProxy = getStorePlay()[PAGE_TAG]?.[name];
+      if (!currentProxy) return;
+      const plain = clonePlain(currentProxy) as T;
+      for (const cb of listeners) {
+        cb(plain);
+      }
+    });
+  };
+  (yVal as any).observeDeep(observer);
+  yObserverByKey.set(observerKey, observer);
+}
+
+export function refreshPageDataChannels(deps: PageDataDeps): void {
+  const { channelListeners, getStorePlay } = deps;
+
+  for (const [name, listeners] of channelListeners) {
+    const currentProxy = getStorePlay()[PAGE_TAG]?.[name];
+    if (!currentProxy) continue;
+
+    attachPageDataObserver(name, deps, listeners);
+    const plain = clonePlain(currentProxy);
+    for (const cb of listeners) {
+      cb(plain);
+    }
+  }
+}
+
 export function createPageDataChannel<T>(
   name: string,
   defaultValue: T,
@@ -56,27 +103,8 @@ export function createPageDataChannel<T>(
   // handle opens the channel, and again if setData re-seeds the proxy after a
   // room change (otherwise the re-seeded value has no observer and onUpdate
   // goes silently dead for handles that survived the reset).
-  const observerKey = `${PAGE_TAG}:${name}`;
   function attachObserver(): void {
-    if (yObserverByKey.has(observerKey)) return;
-    const yVal = getYjsValue(storePlay()[PAGE_TAG]?.[name]);
-    if (!yVal || typeof (yVal as any).observeDeep !== "function") return;
-    let scheduled = false;
-    const observer = () => {
-      if (scheduled) return;
-      scheduled = true;
-      queueMicrotask(() => {
-        scheduled = false;
-        const currentProxy = storePlay()[PAGE_TAG]?.[name];
-        if (!currentProxy) return;
-        const plain = clonePlain(currentProxy) as T;
-        for (const cb of listeners) {
-          cb(plain);
-        }
-      });
-    };
-    (yVal as any).observeDeep(observer);
-    yObserverByKey.set(observerKey, observer);
+    attachPageDataObserver(name, deps, listeners);
   }
 
   const refCount = (channelRefCounts.get(name) ?? 0) + 1;
@@ -144,7 +172,7 @@ export function createPageDataChannel<T>(
         channelRefCounts.delete(name);
         channelListeners.delete(name);
 
-        const key = `${PAGE_TAG}:${name}`;
+        const key = pageDataObserverKey(name);
         const obs = yObserverByKey.get(key);
         if (obs) {
           const yVal = getYjsValue(storePlay()[PAGE_TAG]?.[name]);

--- a/partykit/__tests__/adminMutation.test.ts
+++ b/partykit/__tests__/adminMutation.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Tests admin snapshot helpers that turn edited play data into resettable documents.
+// ABOUTME: Keeps database-edit routes pinned to fresh Y.Doc snapshots with reset metadata.
+import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+import { Buffer } from "node:buffer";
+import {
+  createAdminSnapshotFromPlayData,
+  resolveRoomResetEpoch,
+} from "../adminMutation";
+import { docToJson, getDocResetEpoch } from "../docUtils";
+
+describe("createAdminSnapshotFromPlayData", () => {
+  it("stores play data in a fresh document with the provided reset epoch", () => {
+    const play = {
+      "can-play": {
+        counter: { count: 3 },
+      },
+      "can-post": {
+        guestbook: [{ name: "Ada", message: "hello" }],
+      },
+    };
+
+    const snapshot = createAdminSnapshotFromPlayData(play, 98765);
+    const doc = new Y.Doc();
+    Y.applyUpdate(doc, new Uint8Array(Buffer.from(snapshot.base64, "base64")));
+
+    expect(docToJson(doc)).toEqual(play);
+    expect(getDocResetEpoch(doc)).toBe(98765);
+    expect(snapshot.documentSize).toBe(snapshot.base64.length);
+    expect(snapshot.resetEpoch).toBe(98765);
+  });
+});
+
+describe("resolveRoomResetEpoch", () => {
+  it("does not move an existing room reset epoch backward", () => {
+    expect(
+      resolveRoomResetEpoch({
+        snapshotEpoch: 100,
+        storedEpoch: 200,
+        bumpEpoch: false,
+        now: 250,
+      })
+    ).toBe(200);
+  });
+
+  it("creates a monotonic epoch when bumping the reset boundary", () => {
+    expect(
+      resolveRoomResetEpoch({
+        snapshotEpoch: 100,
+        storedEpoch: 300,
+        bumpEpoch: true,
+        now: 250,
+      })
+    ).toBe(301);
+  });
+});

--- a/partykit/__tests__/moderationPersistence.test.ts
+++ b/partykit/__tests__/moderationPersistence.test.ts
@@ -1,11 +1,12 @@
 // ABOUTME: Round-trip test for the moderation-remove persistence path on a real Y.Doc.
-// ABOUTME: Mirrors handleModerationRemove's docToJson -> remove -> replaceDocState -> re-extract chain.
+// ABOUTME: Mirrors database snapshot extraction, moderation removal, fresh snapshot commit.
 import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+import { Buffer } from "node:buffer";
+import { createAdminSnapshotFromPlayData } from "../adminMutation";
 import {
   jsonToDoc,
   docToJson,
-  replaceDocState,
-  encodeDocToBase64,
 } from "../docUtils";
 import {
   extractRecords,
@@ -40,8 +41,8 @@ function targetFor(play: Record<string, unknown>, key: string): RemoveTarget {
   return { key, contentHash: rec.contentHash };
 }
 
-// Performs the exact mutation handleModerationRemove does, minus the Supabase
-// upsert (a network call). Returns the re-extracted play after the round-trip.
+// Performs the exact data mutation handleModerationRemove does, minus network I/O.
+// Returns the play data re-extracted from the fresh snapshot that would be saved.
 function runRemovalThroughDoc(
   play: Record<string, unknown>,
   targets: RemoveTarget[]
@@ -51,12 +52,17 @@ function runRemovalThroughDoc(
   if (!livePlay) throw new Error("doc has no play data");
 
   const result = removeRecordsByTargets(livePlay, targets);
-  if (result.removed > 0) {
-    replaceDocState(doc, result.play);
-    // Exercise the encode step the handler runs before persisting.
-    encodeDocToBase64(doc);
+  if (result.removed === 0) {
+    return { result, rePlay: docToJson(doc) };
   }
-  return { result, rePlay: docToJson(doc) };
+
+  const snapshot = createAdminSnapshotFromPlayData(result.play, 1234);
+  const reDoc = new Y.Doc();
+  Y.applyUpdate(
+    reDoc,
+    new Uint8Array(Buffer.from(snapshot.base64, "base64"))
+  );
+  return { result, rePlay: docToJson(reDoc) };
 }
 
 describe("moderation removal persistence round-trip", () => {

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -1,12 +1,11 @@
 // ABOUTME: Provides authenticated room inspection and maintenance endpoints.
-// ABOUTME: Coordinates live Y.Doc admin edits with Supabase persistence safeguards.
-import { syncedStore } from "@syncedstore/core";
+// ABOUTME: Coordinates database snapshots, client resets, and Supabase persistence safeguards.
 import { Buffer } from "node:buffer";
 import { env } from "cloudflare:workers";
 import * as Y from "yjs";
 import { supabase } from "./db";
 import { PartyServer } from "./party";
-import { docToJson, replaceDocState, encodeDocToBase64 } from "./docUtils";
+import { docToJson, encodeDocToBase64 } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
 
 function compareKeys(
@@ -29,10 +28,10 @@ function compareKeys(
  * AdminHandler provides endpoints for inspecting and managing PlayHTML rooms.
  *
  * Data Flow:
- * - Normal admin edits (save-edited-data, cleanup-orphans) mutate the live Y.Doc directly,
- *   then persist to database. The background autosave will naturally keep DB in sync.
- * - Force-reload-live is an escape hatch for when DB was modified externally (e.g., scripts)
- *   and we need to sync the live doc to match the database state.
+ * - Admin edits load the database snapshot as source of truth, commit a fresh
+ *   snapshot, then reset connected clients onto that snapshot.
+ * - Force-save-live is an escape hatch for persisting the live in-memory doc.
+ * - Force-reload-live syncs the live doc to match the database state.
  * - All Y.Doc conversions use shared utilities in docUtils.ts for consistency.
  */
 export class AdminHandler {
@@ -132,6 +131,34 @@ export class AdminHandler {
 
   private checkPersistenceWriteAvailable(): Response | null {
     return this.context.getPersistenceUnavailableResponse();
+  }
+
+  private async loadDatabasePlayData(): Promise<{
+    play: Record<string, any> | null;
+    documentSize: number;
+  }> {
+    const { data, error } = await supabase
+      .from("documents")
+      .select("document")
+      .eq("name", this.context.name)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    if (!data?.document) {
+      return { play: null, documentSize: 0 };
+    }
+
+    const yDoc = new Y.Doc();
+    const buffer = new Uint8Array(Buffer.from(data.document, "base64"));
+    Y.applyUpdate(yDoc, buffer);
+
+    return {
+      play: docToJson(yDoc),
+      documentSize: data.document.length,
+    };
   }
 
   private async handleAdminInspect(request: Request): Promise<Response> {
@@ -471,6 +498,7 @@ export class AdminHandler {
           message: "Live doc reloaded from database",
           documentSize: result.documentSize,
           resetEpoch: result.resetEpoch,
+          closedConnections: result.closedConnections,
         }),
         {
           headers: { "content-type": "application/json" },
@@ -487,9 +515,7 @@ export class AdminHandler {
   }
 
   /**
-   * Save edited JSON data to the live Y.Doc and persist to database.
-   * This mutates the live doc directly, so the background autosave will
-   * naturally persist the same state. No force-reload needed.
+   * Save edited JSON data as the authoritative room snapshot.
    */
   private async handleAdminSaveEditedData(request: Request): Promise<Response> {
     const authError = this.checkAdminAuth(request);
@@ -511,38 +537,18 @@ export class AdminHandler {
         );
       }
 
-      // Get the live Y.Doc and mutate it directly
-      const liveYDoc = this.context.document;
-
       console.log(`[Admin] Saving edited data for room ${this.context.name}`);
       console.log(
         `[Admin] Edited data keys: ${Object.keys(editedData).length}`
       );
 
-      // Replace live doc state with edited data
-      replaceDocState(liveYDoc, editedData);
+      const result = await this.context.commitAdminPlayData(editedData);
 
-      // Persist immediately to database
-      const base64 = encodeDocToBase64(liveYDoc);
-      console.log(`[Admin] Encoded content length: ${base64.length}`);
-
-      const { error } = await supabase.from("documents").upsert(
-        {
-          name: this.context.name,
-          document: base64,
-        },
-        { onConflict: "name" }
+      console.log(
+        `[Admin] Saved authoritative snapshot and reset ${result.closedConnections} clients`
       );
 
-      if (error) {
-        console.error(`[Admin] Database error:`, error);
-        throw new Error(error.message);
-      }
-      this.context.markDocumentPersisted(base64);
-
-      console.log(`[Admin] Successfully saved to database and live doc`);
-
-      return new Response(JSON.stringify({ ok: true }), {
+      return new Response(JSON.stringify({ ok: true, ...result }), {
         headers: {
           "content-type": "application/json",
           "Access-Control-Allow-Origin": "*",
@@ -577,8 +583,7 @@ export class AdminHandler {
         );
       }
 
-      const liveYDoc = this.context.document;
-      const play = docToJson(liveYDoc);
+      const { play } = await this.loadDatabasePlayData();
       if (!play) {
         return new Response(
           JSON.stringify({ error: "Room has no play data" }),
@@ -587,19 +592,26 @@ export class AdminHandler {
       }
 
       const result = removeRecordsByTargets(play, targets);
+      let resetResult:
+        | {
+            documentSize: number;
+            resetEpoch: number;
+            closedConnections: number;
+          }
+        | null = null;
 
       if (result.removed > 0) {
-        replaceDocState(liveYDoc, result.play);
-        const base64 = encodeDocToBase64(liveYDoc);
-        const { error } = await supabase
-          .from("documents")
-          .upsert({ name: this.context.name, document: base64 }, { onConflict: "name" });
-        if (error) throw new Error(error.message);
-        this.context.markDocumentPersisted(base64);
+        resetResult = await this.context.commitAdminPlayData(result.play);
       }
 
       return new Response(
-        JSON.stringify({ removed: result.removed, skipped: result.skipped }),
+        JSON.stringify({
+          removed: result.removed,
+          skipped: result.skipped,
+          documentSize: resetResult?.documentSize ?? null,
+          resetEpoch: resetResult?.resetEpoch ?? null,
+          closedConnections: resetResult?.closedConnections ?? 0,
+        }),
         {
           headers: {
             "content-type": "application/json",
@@ -720,16 +732,8 @@ export class AdminHandler {
       }
 
       const activeIdSet = new Set(activeIds);
-
-      // Load the room document
-      const yDoc = this.context.document;
-      const store = syncedStore<{ play: Record<string, any> }>(
-        { play: {} },
-        yDoc
-      );
-
-      // Get all entries for the specified tag
-      const tagData = store.play[tag];
+      const { play } = await this.loadDatabasePlayData();
+      const tagData = play?.[tag];
       if (!tagData || typeof tagData !== "object") {
         return new Response(
           JSON.stringify({
@@ -773,7 +777,6 @@ export class AdminHandler {
         );
       }
 
-      // Remove orphaned entries (mutates live doc directly)
       let removedCount = 0;
       for (const orphanedId of orphanedIds) {
         try {
@@ -787,22 +790,10 @@ export class AdminHandler {
         }
       }
 
-      // Persist the updated live doc to database
-      const base64 = encodeDocToBase64(yDoc);
-      const { error: saveError } = await supabase.from("documents").upsert(
-        {
-          name: this.context.name,
-          document: base64,
-        },
-        { onConflict: "name" }
-      );
-
-      if (saveError) {
-        throw new Error(
-          `Failed to save cleaned document: ${saveError.message}`
-        );
-      }
-      this.context.markDocumentPersisted(base64);
+      const resetResult =
+        removedCount > 0 && play
+          ? await this.context.commitAdminPlayData(play)
+          : null;
 
       return new Response(
         JSON.stringify({
@@ -813,6 +804,9 @@ export class AdminHandler {
           removed: removedCount,
           orphanedIds,
           message: `Removed ${removedCount} orphaned entries`,
+          documentSize: resetResult?.documentSize ?? null,
+          resetEpoch: resetResult?.resetEpoch ?? null,
+          closedConnections: resetResult?.closedConnections ?? 0,
         }),
         {
           headers: {
@@ -874,6 +868,7 @@ export class AdminHandler {
           sizeReduction,
           sizeReductionPercent: `${sizeReductionPercent}%`,
           resetEpoch: result.resetEpoch,
+          closedConnections: result.closedConnections,
         }),
         {
           headers: {
@@ -977,6 +972,7 @@ export class AdminHandler {
           message: "Raw document restored successfully",
           documentSize: result.documentSize,
           resetEpoch: result.resetEpoch,
+          closedConnections: result.closedConnections,
         }),
         {
           headers: {

--- a/partykit/adminMutation.ts
+++ b/partykit/adminMutation.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Builds authoritative room snapshots for admin data mutations.
+// ABOUTME: Keeps manual edits and moderation writes on the same reset-safe path.
+import {
+  encodeDocToBase64,
+  jsonToDoc,
+  setDocResetEpoch,
+} from "./docUtils";
+
+export interface AdminSnapshot {
+  base64: string;
+  documentSize: number;
+  resetEpoch: number;
+}
+
+export interface RoomResetEpochOptions {
+  snapshotEpoch: number | null;
+  storedEpoch: number | null;
+  bumpEpoch: boolean;
+  now: number;
+}
+
+export function resolveRoomResetEpoch({
+  snapshotEpoch,
+  storedEpoch,
+  bumpEpoch,
+  now,
+}: RoomResetEpochOptions): number {
+  if (bumpEpoch) {
+    return Math.max(now, (storedEpoch ?? 0) + 1);
+  }
+
+  if (snapshotEpoch === null) {
+    return storedEpoch ?? now;
+  }
+
+  return Math.max(snapshotEpoch, storedEpoch ?? snapshotEpoch);
+}
+
+export function createAdminSnapshotFromPlayData(
+  playData: Record<string, any>,
+  resetEpoch: number
+): AdminSnapshot {
+  const doc = jsonToDoc(playData);
+  setDocResetEpoch(doc, resetEpoch);
+  const base64 = encodeDocToBase64(doc);
+
+  return {
+    base64,
+    documentSize: base64.length,
+    resetEpoch,
+  };
+}

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -20,6 +20,10 @@ import {
   getDocResetEpoch,
 } from "./docUtils";
 import {
+  createAdminSnapshotFromPlayData,
+  resolveRoomResetEpoch,
+} from "./adminMutation";
+import {
   STORAGE_KEYS,
   DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS,
   DEFAULT_EMERGENCY_COMPACT_CHECK_BYTES,
@@ -644,6 +648,16 @@ export class PartyServer extends YServer {
     return connections.length;
   }
 
+  private async createResetEpoch(): Promise<number> {
+    const storedEpoch = await this.getResetEpoch();
+    return resolveRoomResetEpoch({
+      snapshotEpoch: null,
+      storedEpoch,
+      bumpEpoch: true,
+      now: Date.now(),
+    });
+  }
+
   /**
    * Determine whether a candidate epoch (from a doc, client, or bridge message)
    * is stale relative to the authoritative epoch stored in room storage.
@@ -685,6 +699,7 @@ export class PartyServer extends YServer {
   ): Promise<{
     documentSize: number;
     resetEpoch: number;
+    closedConnections: number;
   }> {
     const roomId = this.name;
     console.log(`[Restore Snapshot] Starting for room: ${roomId}`);
@@ -701,12 +716,12 @@ export class PartyServer extends YServer {
       );
 
       const storedEpoch = await this.getResetEpoch();
-      let resetEpoch = getDocResetEpoch(snapshotDoc);
-      if (options?.bumpEpoch) {
-        resetEpoch = Date.now();
-      } else if (resetEpoch === null) {
-        resetEpoch = storedEpoch ?? Date.now();
-      }
+      const resetEpoch = resolveRoomResetEpoch({
+        snapshotEpoch: getDocResetEpoch(snapshotDoc),
+        storedEpoch,
+        bumpEpoch: Boolean(options?.bumpEpoch),
+        now: Date.now(),
+      });
       setDocResetEpoch(snapshotDoc, resetEpoch);
 
       const updatedBase64 = encodeDocToBase64(snapshotDoc);
@@ -733,13 +748,6 @@ export class PartyServer extends YServer {
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
       this.markDocumentPersisted(updatedBase64);
 
-      // Reload the live server from the snapshot
-      console.log(`[Restore Snapshot] Reloading live server from snapshot...`);
-      const liveYDoc = this.document;
-      replaceDocFromSnapshot(liveYDoc, updatedBase64);
-      setDocResetEpoch(liveYDoc, resetEpoch);
-      console.log(`[Restore Snapshot] Successfully reloaded live server`);
-
       // Set reset epoch for client detection
       await this.setResetEpoch(resetEpoch);
       console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
@@ -756,16 +764,24 @@ export class PartyServer extends YServer {
         `[Restore Snapshot] Closed ${closedCount} connections`
       );
 
+      // Flush disconnect work before installing the authoritative snapshot.
+      await Promise.resolve();
+
+      // Reload the live server from the snapshot
+      console.log(`[Restore Snapshot] Reloading live server from snapshot...`);
+      const liveYDoc = this.document;
+      replaceDocFromSnapshot(liveYDoc, updatedBase64);
+      setDocResetEpoch(liveYDoc, resetEpoch);
+      console.log(`[Restore Snapshot] Successfully reloaded live server`);
+
       console.log(
         `[Restore Snapshot] Completed successfully: ${documentSize} bytes`
       );
 
-      // Flush pending microtasks
-      await Promise.resolve();
-
       return {
         documentSize,
         resetEpoch,
+        closedConnections: closedCount,
       };
     } catch (error: unknown) {
       const errorMessage =
@@ -786,6 +802,16 @@ export class PartyServer extends YServer {
         console.log("[Restore Snapshot] Autosave re-enabled");
       }, 1000);
     }
+  }
+
+  async commitAdminPlayData(playData: Record<string, any>): Promise<{
+    documentSize: number;
+    resetEpoch: number;
+    closedConnections: number;
+  }> {
+    const resetEpoch = await this.createResetEpoch();
+    const snapshot = createAdminSnapshotFromPlayData(playData, resetEpoch);
+    return this.restoreFromSnapshot(snapshot.base64, { bumpEpoch: false });
   }
 
   // Ensure an alarm is set for bridge lease pruning or empty-room compaction.
@@ -1742,6 +1768,7 @@ export class PartyServer extends YServer {
     beforeSize: number;
     afterSize: number;
     resetEpoch: number;
+    closedConnections: number;
   }> {
     const roomId = this.name;
     console.log(`[Hard Reset] Starting for room: ${roomId}`);
@@ -1805,7 +1832,7 @@ export class PartyServer extends YServer {
         ).toFixed(2)} MB)`
       );
 
-      const resetEpoch = Date.now();
+      const resetEpoch = await this.createResetEpoch();
       let freshBase64: string;
       let afterSize: number;
 
@@ -1859,12 +1886,6 @@ export class PartyServer extends YServer {
       console.log(`[Hard Reset] Successfully saved fresh doc to database`);
       this.markDocumentPersisted(freshBase64);
 
-      // Reload the live server from the new snapshot
-      console.log(`[Hard Reset] Reloading live server from snapshot...`);
-      replaceDocFromSnapshot(liveYDoc, freshBase64);
-      setDocResetEpoch(liveYDoc, resetEpoch);
-      console.log(`[Hard Reset] Successfully reloaded live server`);
-
       // Set reset epoch for client detection
       await this.setResetEpoch(resetEpoch);
       console.log(`[Hard Reset] Set resetEpoch: ${resetEpoch}`);
@@ -1878,6 +1899,15 @@ export class PartyServer extends YServer {
       const closedCount = this.closeConnections("Room Reset by Admin");
       console.log(`[Hard Reset] Closed ${closedCount} connections`);
 
+      // Flush disconnect work before installing the authoritative snapshot.
+      await Promise.resolve();
+
+      // Reload the live server from the snapshot
+      console.log(`[Hard Reset] Reloading live server from snapshot...`);
+      replaceDocFromSnapshot(liveYDoc, freshBase64);
+      setDocResetEpoch(liveYDoc, resetEpoch);
+      console.log(`[Hard Reset] Successfully reloaded live server`);
+
       const sizeReduction = beforeSize - afterSize;
       const sizeReductionPercent = ((sizeReduction / beforeSize) * 100).toFixed(
         1
@@ -1887,14 +1917,11 @@ export class PartyServer extends YServer {
         `[Hard Reset] Completed successfully: ${beforeSize} -> ${afterSize} bytes (${sizeReductionPercent}% reduction)`
       );
 
-      // Flush pending microtasks to ensure any queued autosave callbacks are processed
-      // before we release the lock
-      await Promise.resolve();
-
       return {
         beforeSize,
         afterSize,
         resetEpoch,
+        closedConnections: closedCount,
       };
     } catch (error: unknown) {
       const errorMessage =

--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -7,6 +7,10 @@ import { findDocumentRowInBackup } from "./utils/backup";
 import { createComparisonSummary } from "./utils/adminComparison";
 import { deriveRoomId } from "@playhtml/common";
 import { extractRecords, type ModerationRecord } from "@moderation";
+import {
+  formatAdminResetSuccess,
+  formatAdminResetWarning,
+} from "./adminMessages";
 
 // Types from the original admin.ts
 interface RoomData {
@@ -560,7 +564,13 @@ const AdminConsole: React.FC = () => {
   const [modSelected, setModSelected] = useState<Set<string>>(new Set());
   const [modPaste, setModPaste] = useState("");
   const [modResult, setModResult] = useState<
-    { removed: number; skipped: { key: string; reason: string }[] } | null
+    {
+      removed: number;
+      skipped: { key: string; reason: string }[];
+      closedConnections?: number | null;
+      documentSize?: number | null;
+      resetEpoch?: number | null;
+    } | null
   >(null);
   const [modExpanded, setModExpanded] = useState<Set<string>>(new Set());
   const [activeToolTab, setActiveToolTab] = useStickyState<"moderate" | "tools">(
@@ -624,6 +634,19 @@ const AdminConsole: React.FC = () => {
 
   const getPartykitHost = () => HOSTS[hostEnv];
 
+  const getActiveConnectionCount = () => roomData?.connections ?? 0;
+
+  const confirmAdminReset = (options: {
+    action: string;
+    detail?: string;
+  }) =>
+    confirm(
+      formatAdminResetWarning({
+        ...options,
+        activeConnections: getActiveConnectionCount(),
+      })
+    );
+
   const decodeRoomId = (encodedId: string): string => {
     try {
       return decodeURIComponent(encodedId);
@@ -647,6 +670,9 @@ const AdminConsole: React.FC = () => {
       return encodeURIComponent(roomId);
     }
   };
+
+  const getRoomBaseUrl = (roomId: string): string =>
+    `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(roomId)}`;
 
   // Derive room ID from URL
   const deriveRoomIdFromUrl = (urlString: string): string | null => {
@@ -977,7 +1003,7 @@ const AdminConsole: React.FC = () => {
       );
     }
 
-    const baseUrl = `${getPartykitHost()}/parties/main/${roomId}`;
+    const baseUrl = getRoomBaseUrl(roomId);
     const url = `${baseUrl}/admin/inspect?token=${encodeURIComponent(
       adminToken
     )}`;
@@ -1029,9 +1055,7 @@ const AdminConsole: React.FC = () => {
     if (!currentRoomId || !adminToken) return;
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/raw-data?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1080,15 +1104,15 @@ const AdminConsole: React.FC = () => {
   const restoreRawDocument = async () => {
     if (!currentRoomId || !adminToken) return;
 
-    const ok = confirm(
-      "⚠️ Restore Raw Document\n\n" +
+    const ok = confirmAdminReset({
+      action: "Restore raw document",
+      detail:
         "This will replace the current room's document with the uploaded base64 document.\n\n" +
         "This is a DESTRUCTIVE operation that will:\n" +
         "- Overwrite the current database document\n" +
         "- Replace the live server's document\n" +
-        "- May cause data loss if the uploaded document is incorrect\n\n" +
-        "Continue?"
-    );
+        "- May cause data loss if the uploaded document is incorrect",
+    });
     if (!ok) return;
 
     try {
@@ -1114,9 +1138,7 @@ const AdminConsole: React.FC = () => {
           `Restoring raw document (${base64Document.length} chars)...`
         );
 
-        const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-          currentRoomId
-        )}`;
+        const baseUrl = getRoomBaseUrl(currentRoomId);
         const url = `${baseUrl}/admin/restore-raw-document?token=${encodeURIComponent(
           adminToken
         )}`;
@@ -1137,11 +1159,11 @@ const AdminConsole: React.FC = () => {
         const result = await response.json();
         addLog("info", "Raw document restored successfully", result);
         alert(
-          `✅ Raw document restored!\n\n` +
-            `Document size: ${(result.documentSize / 1024 / 1024).toFixed(
-              2
-            )}MB\n\n` +
-            `Reloading room data...`
+          formatAdminResetSuccess({
+            action: "Raw document restored.",
+            closedConnections: result.closedConnections,
+            documentSize: result.documentSize,
+          }) + "\n\nReloading room data..."
         );
 
         // Reload room data to show updated state
@@ -1162,7 +1184,7 @@ const AdminConsole: React.FC = () => {
     if (!currentRoomId || !adminToken) return;
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/raw-data?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1188,6 +1210,105 @@ const AdminConsole: React.FC = () => {
     }
   };
 
+  const debugYDocLoading = async () => {
+    if (!currentRoomId || !adminToken) return;
+
+    setShowYDocDebug(true);
+    setDebugSteps([]);
+    setReconstructedDoc(null);
+
+    const addStep = (
+      message: string,
+      type: "info" | "success" | "warning" | "error" = "info"
+    ) => {
+      setDebugSteps((prev) => [
+        ...prev,
+        { message: `[${new Date().toLocaleTimeString()}] ${message}`, type },
+      ]);
+      const level: DebugLog["level"] =
+        type === "success" ? "info" : type === "warning" ? "warn" : type;
+      addLog(level, message);
+    };
+
+    try {
+      addStep("🔍 Starting Y.Doc reconstruction debug...", "info");
+      addStep("📁 Fetching raw database document...", "info");
+
+      const baseUrl = getRoomBaseUrl(currentRoomId);
+      const rawUrl = `${baseUrl}/admin/raw-data?token=${encodeURIComponent(
+        adminToken
+      )}`;
+
+      const rawResponse = await fetch(rawUrl);
+      const rawData = await rawResponse.json();
+
+      if (!rawData.document) {
+        addStep("❌ No document found in database", "error");
+        return;
+      }
+
+      addStep(
+        `✅ Found document: ${rawData.document.base64Length} bytes`,
+        "success"
+      );
+      addStep("🔧 Attempting to reconstruct Y.Doc from base64...", "info");
+
+      try {
+        // Import Y.js dynamically
+        const Y = await import("yjs");
+        const doc = new Y.Doc();
+
+        const base64 = rawData.document.document;
+        const buffer = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+
+        addStep(`📦 Decoded ${buffer.length} bytes from base64`, "success");
+
+        Y.applyUpdate(doc, buffer);
+        addStep("✅ Successfully applied update to new Y.Doc", "success");
+
+        addStep("🔧 Using SyncedStore to extract data...", "info");
+        const { syncedStore } = await import("@syncedstore/core");
+        const store = syncedStore<{ play: Record<string, any> }>(
+          { play: {} },
+          doc
+        );
+
+        // Clone using same logic as original
+        const reconstructedData = JSON.parse(JSON.stringify(store.play));
+        const hasAnyData = Object.keys(reconstructedData).some(
+          (tag) => Object.keys(reconstructedData[tag] || {}).length > 0
+        );
+
+        if (hasAnyData) {
+          addStep(
+            `🎯 Extracted ${
+              Object.keys(reconstructedData).length
+            } capability types`,
+            "success"
+          );
+          const totalElements = Object.values(reconstructedData).reduce(
+            (sum: number, tagData: any) => sum + Object.keys(tagData).length,
+            0
+          );
+          addStep(`📊 Found ${totalElements} total elements`, "success");
+        } else {
+          addStep("⚠️  Y.Doc loaded but contains no PlayHTML data", "warning");
+        }
+
+        setReconstructedDoc(reconstructedData);
+        addStep("✅ Debug reconstruction complete!", "success");
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : String(error);
+        addStep(`❌ Y.Doc reconstruction failed: ${msg}`, "error");
+        addLog("error", "Y.Doc reconstruction error", error);
+      }
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      addStep(`❌ Debug process failed: ${msg}`, "error");
+      addLog("error", "Debug Y.Doc loading error", error);
+    }
+  };
+
   const compareDataMethods = async (
     options: { roomId?: string; forceShow?: boolean } = {}
   ) => {
@@ -1199,8 +1320,7 @@ const AdminConsole: React.FC = () => {
       setComparisonError(null);
       addLog("info", "Comparing data extraction methods...");
 
-      const encodedRoomId = ensureEncodedRoomId(targetRoomId);
-      const baseUrl = `${getPartykitHost()}/parties/main/${encodedRoomId}`;
+      const baseUrl = getRoomBaseUrl(targetRoomId);
       const url = `${baseUrl}/admin/live-compare?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1243,7 +1363,7 @@ const AdminConsole: React.FC = () => {
     if (!ok) return;
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/force-save-live?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1261,20 +1381,29 @@ const AdminConsole: React.FC = () => {
 
   const handleForceReloadLive = async () => {
     if (!currentRoomId || !adminToken) return;
-    const ok = confirm(
-      "Force reload LIVE doc from DB? This merges DB snapshot into memory."
-    );
+    const ok = confirmAdminReset({
+      action: "Force reload live document from database",
+      detail:
+        "This will replace the live in-memory document with the current database snapshot.",
+    });
     if (!ok) return;
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/force-reload-live?token=${encodeURIComponent(
         adminToken
       )}`;
       const res = await fetch(url, { method: "POST" });
       if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-      addLog("info", "Force-reloaded live doc from DB");
-      alert("✅ Live doc reloaded from DB. Re-running comparison.");
+      const result = await res.json();
+      addLog("info", "Force-reloaded live doc from DB", result);
+      alert(
+        formatAdminResetSuccess({
+          action: "Live document reloaded from database.",
+          closedConnections: result.closedConnections,
+          documentSize: result.documentSize,
+        }) + "\n\nRe-running comparison."
+      );
       await compareDataMethods();
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
@@ -1285,22 +1414,20 @@ const AdminConsole: React.FC = () => {
 
   const handleHardReset = async () => {
     if (!currentRoomId || !adminToken) return;
-    const ok = confirm(
-      "⚠️ Hard Reset (Garbage Collection)\n\n" +
+    const ok = confirmAdminReset({
+      action: "Hard reset room document",
+      detail:
         "This will recreate the Y.Doc from scratch, removing all history and tombstones.\n\n" +
         "This is a DESTRUCTIVE operation that:\n" +
         "- Strips all YJS deletion history\n" +
         "- Reduces document size significantly\n" +
-        "- May cause offline clients to need a refresh\n\n" +
-        "Continue?"
-    );
+        "- May cause offline clients to need a refresh",
+    });
     if (!ok) return;
 
     try {
       addLog("info", "Starting Hard Reset (GC)...");
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/hard-reset?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1326,7 +1453,12 @@ const AdminConsole: React.FC = () => {
         result
       );
       alert(
-        `✅ Hard Reset completed!\n\n` +
+        formatAdminResetSuccess({
+          action: "Hard reset completed.",
+          closedConnections: result.closedConnections,
+          documentSize: result.afterSize,
+        }) +
+          "\n\n" +
           `Size: ${beforeMB}MB -> ${afterMB}MB\n` +
           `Reduction: ${result.sizeReductionPercent}\n\n` +
           `Reloading room data...`
@@ -1347,10 +1479,8 @@ const AdminConsole: React.FC = () => {
       addLog("info", "Parsing edited JSON...");
       const parsedData = JSON.parse(editedJson);
 
-      addLog("info", "Saving to database via admin endpoint...");
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      addLog("info", "Saving authoritative database snapshot...");
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/save-edited-data?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1366,10 +1496,19 @@ const AdminConsole: React.FC = () => {
         throw new Error(errorData.message || `HTTP ${response.status}`);
       }
 
-      addLog("info", "Successfully saved edited data to live doc and database");
+      const result = await response.json();
+      addLog(
+        "info",
+        "Successfully saved edited data and reset clients",
+        result
+      );
 
       alert(
-        "✅ Edited data saved! The live doc has been updated and persisted to the database."
+        formatAdminResetSuccess({
+          action: "Edited data saved.",
+          closedConnections: result.closedConnections,
+          documentSize: result.documentSize,
+        })
       );
 
       // Reload room data to show updated state
@@ -1448,9 +1587,10 @@ const AdminConsole: React.FC = () => {
   const removeSelectedRecords = async () => {
     if (!currentRoomId || !adminToken || modSelected.size === 0) return;
     if (
-      !window.confirm(
-        `Remove ${modSelected.size} record(s) from the live document? This cannot be undone.`
-      )
+      !confirmAdminReset({
+        action: "Remove selected records",
+        detail: `Remove ${modSelected.size} record(s) from the database snapshot. This cannot be undone.`,
+      })
     ) {
       return;
     }
@@ -1460,9 +1600,7 @@ const AdminConsole: React.FC = () => {
       .map((r) => ({ key: r.key, contentHash: r.contentHash }));
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/moderation-remove?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1479,7 +1617,7 @@ const AdminConsole: React.FC = () => {
       setModSelected(new Set());
       addLog(
         "info",
-        `Removed ${json.removed}, skipped ${json.skipped?.length ?? 0}`
+        `Removed ${json.removed}, skipped ${json.skipped?.length ?? 0}, reset ${json.closedConnections ?? 0} clients`
       );
       await loadRoom(currentRoomId);
     } catch (error: unknown) {
@@ -1543,9 +1681,7 @@ const AdminConsole: React.FC = () => {
 
       addLog("info", `Running dry run cleanup for ${selectedCleanupTag}...`);
 
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/cleanup-orphans?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1593,15 +1729,17 @@ const AdminConsole: React.FC = () => {
       return;
     }
 
-    const confirmed = confirm(
-      `Are you sure you want to remove ${cleanupDryRunResult.orphaned} orphaned entries?\n\n` +
+    const confirmed = confirmAdminReset({
+      action: "Remove orphaned database entries",
+      detail:
+        `Remove ${cleanupDryRunResult.orphaned} orphaned entries?\n\n` +
         `This will permanently delete data for tag "${selectedCleanupTag}".` +
         (cleanupDryRunResult.orphanedIds?.length > 0
           ? `\n\nFirst 5 IDs to be removed:\n${cleanupDryRunResult.orphanedIds
               .slice(0, 5)
               .join("\n")}`
-          : "")
-    );
+          : ""),
+    });
 
     if (!confirmed) return;
 
@@ -1612,9 +1750,7 @@ const AdminConsole: React.FC = () => {
 
       addLog("info", `Executing cleanup for ${selectedCleanupTag}...`);
 
-      const baseUrl = `${getPartykitHost()}/parties/main/${ensureEncodedRoomId(
-        currentRoomId
-      )}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/cleanup-orphans?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -1641,7 +1777,11 @@ const AdminConsole: React.FC = () => {
         result
       );
       alert(
-        `✅ Cleanup completed!\n\nRemoved ${result.removed} orphaned entries.`
+        formatAdminResetSuccess({
+          action: `Cleanup completed. Removed ${result.removed} orphaned entries.`,
+          closedConnections: result.closedConnections,
+          documentSize: result.documentSize,
+        })
       );
 
       // Clear dry run result and reload room data
@@ -1917,7 +2057,7 @@ const AdminConsole: React.FC = () => {
     if (!currentRoomId || !adminToken) return;
 
     try {
-      const baseUrl = `${getPartykitHost()}/parties/main/${currentRoomId}`;
+      const baseUrl = getRoomBaseUrl(currentRoomId);
       const url = `${baseUrl}/admin/remove-subscriber?token=${encodeURIComponent(
         adminToken
       )}`;
@@ -2812,9 +2952,11 @@ const AdminConsole: React.FC = () => {
                           return;
                         }
                         setJsonError("");
-                        const ok = confirm(
-                          "Save this edited data to the database? This will overwrite the current database state."
-                        );
+                        const ok = confirmAdminReset({
+                          action: "Save edited database data",
+                          detail:
+                            "This will make the edited JSON authoritative and overwrite the current database state.",
+                        });
                         if (ok) saveEditedDataToDb(editableJson);
                       }}
                       disabled={!editableJson.trim()}

--- a/website/adminMessages.ts
+++ b/website/adminMessages.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Formats admin console warnings and results for room reset operations.
+// ABOUTME: Keeps client-disconnect copy consistent across database edit routes.
+export interface AdminResetWarningOptions {
+  action: string;
+  activeConnections: number;
+  detail?: string;
+}
+
+export interface AdminResetSuccessOptions {
+  action: string;
+  closedConnections?: number | null;
+  documentSize?: number | null;
+}
+
+function formatActiveClients(count: number): string {
+  return `${count} active ${count === 1 ? "client" : "clients"}`;
+}
+
+function formatDocumentSize(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(2)}MB`;
+}
+
+export function formatAdminResetWarning({
+  action,
+  activeConnections,
+  detail,
+}: AdminResetWarningOptions): string {
+  return [
+    action,
+    detail,
+    `This will reset the room and briefly disconnect ${formatActiveClients(
+      activeConnections
+    )}. Connected clients should reconnect automatically with the saved data.`,
+    "Continue?",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+export function formatAdminResetSuccess({
+  action,
+  closedConnections,
+  documentSize,
+}: AdminResetSuccessOptions): string {
+  const lines = [action];
+
+  if (typeof closedConnections === "number") {
+    lines.push(`Reset ${formatActiveClients(closedConnections)}.`);
+  }
+
+  if (typeof documentSize === "number") {
+    lines.push(`Document size: ${formatDocumentSize(documentSize)}.`);
+  }
+
+  return lines.join("\n\n");
+}

--- a/website/test/adminMessages.test.ts
+++ b/website/test/adminMessages.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Tests admin console messages for disruptive saved-data operations.
+// ABOUTME: Ensures operators see how many active clients a database reset will affect.
+import { describe, expect, test } from "bun:test";
+import {
+  formatAdminResetSuccess,
+  formatAdminResetWarning,
+} from "../adminMessages";
+
+describe("admin reset messages", () => {
+  test("warns with the active client count before an admin reset", () => {
+    expect(
+      formatAdminResetWarning({
+        action: "Save edited database data",
+        activeConnections: 4,
+        detail: "This will make the edited database data authoritative.",
+      }),
+    ).toContain("briefly disconnect 4 active clients");
+  });
+
+  test("uses singular client copy", () => {
+    expect(
+      formatAdminResetWarning({
+        action: "Remove selected records",
+        activeConnections: 1,
+      }),
+    ).toContain("briefly disconnect 1 active client");
+  });
+
+  test("summarizes the committed reset result", () => {
+    expect(
+      formatAdminResetSuccess({
+        action: "Saved edited database data",
+        closedConnections: 3,
+        documentSize: 120,
+      }),
+    ).toContain("Reset 3 active clients");
+  });
+});


### PR DESCRIPTION
## Summary
- Reconnect the current room in place when the server sends `room-reset`, instead of forcing a full page reload
- Refresh page-data channels after room recreation so surviving handles keep receiving updates
- Tighten admin snapshot/reset flows and return connection counts for reset operations

## Testing
- Added integration coverage for reconnecting on room reset, handling overlapping resets, and timing out safely when reconnect never syncs
- Added a moderation persistence round-trip test against a fresh Y.Doc snapshot