### PR TITLE
docs: init playhtml synchronously so cursors win the init race

### DIFF
--- a/apps/docs/src/components/HeadOverride.astro
+++ b/apps/docs/src/components/HeadOverride.astro
@@ -18,29 +18,29 @@ const { head } = Astro.locals.starlightRoute;
   // it initialises before playhtml.init awaits window.load.
   import '../scripts/enhance-code-blocks';
 
-  // Defer playhtml.init() until after the document is idle so every React
-  // island (`client:load`) has a chance to hydrate and stamp its `can-*`
-  // attributes into the DOM. If we init eagerly at module-execution time,
-  // the WebSocket handshake goes out with `sharedElements=[]` and the server
-  // misses the initial snapshot for React-driven elements. Vanilla elements
-  // (the wordmark `can-toggle` letters) are already in the DOM at this point,
-  // so they still get picked up correctly.
-  function boot() {
-    void playhtml.init({
-      cursors: {
-        enabled: true,
-        // Domain-wide cursor room so the header presence HUD counts ALL readers
-        // across the docs site, and cursors follow you between /docs/* pages
-        // without losing awareness. The per-page shared-data room still keys on
-        // the pathname via the main room — only cursor awareness is widened.
-        room: "domain",
-      },
-    });
-  }
-  if (document.readyState === 'complete') {
-    // Next microtask — lets React's client:load hydrators flush first.
-    queueMicrotask(boot);
-  } else {
-    window.addEventListener('load', () => queueMicrotask(boot), { once: true });
-  }
+  // Initialise playhtml synchronously, here, before any island hydrates.
+  //
+  // The React islands on these pages render @playhtml/react `standalone`
+  // components, which call `playhtml.init()` (with NO options) when they mount.
+  // init() is first-call-wins, so whichever call runs first decides the config.
+  // This <head> script evaluates while the page is still parsing — before the
+  // <body> islands hydrate — so initialising here (not deferred to window.load)
+  // guarantees OUR config (cursors on, domain-wide room) wins the race. When the
+  // defer was in place, an island could win and silently drop the cursor config,
+  // so cursors/presence appeared only on some loads.
+  //
+  // Eager init is safe here: these pages have no live `shared`/`data-source`
+  // elements (those appear only inside fenced code samples), so there's no
+  // initial shared-element snapshot to miss. Island `can-*` elements register
+  // themselves when they mount, independent of when init() runs.
+  void playhtml.init({
+    cursors: {
+      enabled: true,
+      // Domain-wide cursor room so the header presence HUD counts ALL readers
+      // across the docs site, and cursors follow you between /docs/* pages
+      // without losing awareness. The per-page shared-data room still keys on
+      // the pathname via the main room — only cursor awareness is widened.
+      room: "domain",
+    },
+  });
 </script>


### PR DESCRIPTION
## Problem

Cursors and the header presence HUD show up only on *some* docs page loads — intermittent per load.

**Root cause:** the docs init playhtml in `HeadOverride.astro` with cursors enabled, but deferred that `init()` to `window.load`. Meanwhile every React island renders an `@playhtml/react` `standalone` component, which calls `playhtml.init()` (with **no options**) on mount. `init()` is first-call-wins, so when an island's option-less `init()` ran before the deferred HeadOverride `init()`, the island won and the cursor config was silently dropped — `cursorClient` stayed null and cursors/presence never appeared. Whether the island or HeadOverride won varied per load, hence the intermittency.

## Fix

Init playhtml **synchronously** in the `<head>` script instead of deferring to `window.load`. The `<head>` script evaluates while the page is still parsing — before any `<body>` island hydrates — so the configured `init({ cursors })` always wins the race.

The island `init()` calls still happen but are now harmless no-ops (they see playhtml already started and return the existing readiness promise). Each island still wires up its own element via `setupPlayElement`, which is a separate call and unaffected.

**Safe here:** these pages have no live `shared`/`data-source` elements (those appear only in fenced code samples), so there's no initial shared-element snapshot to miss — the original reason for the defer doesn't apply. Island `can-*` elements register themselves on mount regardless of when `init()` runs.

## Scope

This is an interim, **docs-only** fix that works with the currently released library (no library change, no version bump). A follow-up introduces a `playhtml.configure()` API that separates config declaration from connection, which removes the race at the library level and is the proper long-term fix; this PR unblocks the docs in the meantime.

## Verification

Built the docs from a clean `main` worktree and ran a headless browser probe:
- **16/16** loads across 4 pages (`/`, `/getting-started/`, `/capabilities/`, `/data/presence/`) show `cursorClient` + presence HUD up and WebSocket connected.
- **Two-peer presence: 3/3** — each peer sees the other's cursor and the HUD reads 2.

Before this change, the same probe showed `cursorClient` permanently null on a subset of loads.