### PR TITLE
playhtml: separate config from bootstrap via playhtml.configure()

### DIFF
--- a/.changeset/configure-init-split.md
+++ b/.changeset/configure-init-split.md
@@ -1,0 +1,7 @@
+---
+"playhtml": minor
+---
+
+Add `playhtml.configure(options)` to declare init options separately from connecting, and make config first-declaration-wins uniformly across all options.
+
+Previously `init(options)` both declared config and connected, first-call-wins — so on a page with no single top-level init (Astro islands, multi-page apps, multiple React roots), an option-less `init()` from one place could win the race and silently drop the config another place intended (e.g. cursors never turning on). Now you can call `configure({ cursors: { enabled: true }, ... })` once, up front, from wherever owns the config; later `init()` / component mounts just ensure playhtml is running and pick up the declared config regardless of order. `init(options)` still works exactly as before when you only have one call site. A later call that passes genuinely conflicting options warns and is ignored (config is locked to the first declaration); passing the same options again, or none, is quiet.

--- a/apps/docs/src/components/HeadOverride.astro
+++ b/apps/docs/src/components/HeadOverride.astro
@@ -18,22 +18,16 @@ const { head } = Astro.locals.starlightRoute;
   // it initialises before playhtml.init awaits window.load.
   import '../scripts/enhance-code-blocks';
 
-  // Initialise playhtml synchronously, here, before any island hydrates.
+  // Declare playhtml's config synchronously, here, before anything connects.
   //
   // The React islands on these pages render @playhtml/react `standalone`
-  // components, which call `playhtml.init()` (with NO options) when they mount.
-  // init() is first-call-wins, so whichever call runs first decides the config.
-  // This <head> script evaluates while the page is still parsing — before the
-  // <body> islands hydrate — so initialising here (not deferred to window.load)
-  // guarantees OUR config (cursors on, domain-wide room) wins the race. When the
-  // defer was in place, an island could win and silently drop the cursor config,
-  // so cursors/presence appeared only on some loads.
-  //
-  // Eager init is safe here: these pages have no live `shared`/`data-source`
-  // elements (those appear only inside fenced code samples), so there's no
-  // initial shared-element snapshot to miss. Island `can-*` elements register
-  // themselves when they mount, independent of when init() runs.
-  void playhtml.init({
+  // components, which call `playhtml.init()` (with NO options) on mount to
+  // ensure playhtml is running. There's no single React root we can put a
+  // <PlayProvider> on, so this <head> script is the one place that owns the
+  // config. configure() is connection-free and config-only, so declaring it
+  // here means the islands' "ensure running" calls pick up OUR config no matter
+  // which runs first — no ordering race.
+  playhtml.configure({
     cursors: {
       enabled: true,
       // Domain-wide cursor room so the header presence HUD counts ALL readers
@@ -43,4 +37,6 @@ const { head } = Astro.locals.starlightRoute;
       room: "domain",
     },
   });
+  // Connect now; islands that mount later just call init() (no-op once running).
+  void playhtml.init();
 </script>

--- a/apps/docs/src/content/docs/reference/init-options.md
+++ b/apps/docs/src/content/docs/reference/init-options.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Every option below can be passed either to `playhtml.init({…})` (vanilla) or to `<PlayProvider initOptions={{…}}>` (React). The underlying `InitOptions` interface is the same. Init options are captured on the first successful `init()` call; later calls return the existing readiness promise and do not update the active options.
+Every option below can be passed either to `playhtml.init({…})` (vanilla) or to `<PlayProvider initOptions={{…}}>` (React). The underlying `InitOptions` interface is the same. Options are locked to the first declaration: a later call that passes genuinely conflicting options warns and is ignored. Passing the same options again — or none — is fine and silent.
 
 ```js
 import { playhtml } from "playhtml";
@@ -16,6 +16,22 @@ playhtml.init({
   // …
 });
 ```
+
+### Declaring options when there's no single `init()`
+
+If you can't put one `init()` (or one `<PlayProvider>`) at the top of your app — for example with framework "islands", multi-page sites, or several independent component roots — declare your options once with `playhtml.configure({…})`, then let each piece call `init()` (or render a component) to ensure playhtml is running:
+
+```js
+import { playhtml } from "playhtml";
+
+// In a script that runs early (e.g. in <head>), before any component mounts:
+playhtml.configure({ cursors: { enabled: true, room: "domain" } });
+
+// Anywhere later — these just ensure playhtml is running and use the config above:
+playhtml.init();
+```
+
+`configure()` only declares options; it doesn't connect. Connection happens on the first `init()` (or first component mount). Declaring options up front this way means they apply no matter which "ensure running" call happens to run first.
 
 ## `room`
 

--- a/packages/playhtml/src/__tests__/init-configure.test.ts
+++ b/packages/playhtml/src/__tests__/init-configure.test.ts
@@ -1,0 +1,120 @@
+// ABOUTME: Tests the configure()/init() split — config is declared once up
+// ABOUTME: front and survives option-less "ensure running" calls (e.g. islands).
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playhtml, resetPlayHTML } from "../index";
+
+describe("playhtml configure() + init()", () => {
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+  });
+
+  it("uses config declared via configure() when a later init() passes none", async () => {
+    // The owner (e.g. a <head> script) declares config; islands just ensure
+    // running with no options. The declared config must win regardless of order.
+    playhtml.configure({ cursors: { enabled: true } });
+    await playhtml.init();
+    expect(playhtml.cursorClient).not.toBeNull();
+  });
+
+  it("a repeated empty configure() before init() does not lock config", async () => {
+    // configure() with no options is a true no-op: it must not freeze config, so
+    // a later real configure() still wins. (configure() is connection-free, so
+    // unlike init() it doesn't trigger the bootstrap lock.)
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      playhtml.configure({}); // no-op, must not lock
+      playhtml.configure({ cursors: { enabled: true } }); // real config wins
+      await playhtml.init();
+      expect(warn).not.toHaveBeenCalled();
+      expect(playhtml.cursorClient).not.toBeNull();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("connects immediately with defaults; a configure() after connect warns", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // No config declared → init() connects right away with defaults (off).
+      await playhtml.init();
+      expect(playhtml.cursorClient).toBeNull();
+
+      // Too late — already connected with defaults.
+      playhtml.configure({ cursors: { enabled: true } });
+      expect(warn).toHaveBeenCalled();
+      expect(playhtml.cursorClient).toBeNull();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("locks config to the first init() and warns on a genuine conflict", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({ cursors: { enabled: true } });
+      const client = playhtml.cursorClient;
+      expect(client).not.toBeNull();
+
+      // A later init with a CONFLICTING value warns and is ignored.
+      await playhtml.init({ cursors: { enabled: false } });
+      expect(warn).toHaveBeenCalled();
+      expect(playhtml.cursorClient).toBe(client);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does NOT warn when the same options are passed again (lenient)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({ cursors: { enabled: true }, room: "/x" });
+      // Same options from another call site — the 'pass identical options
+      // everywhere' pattern must stay quiet.
+      await playhtml.init({ cursors: { enabled: true }, room: "/x" });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does NOT warn when later calls pass no options", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      playhtml.configure({ cursors: { enabled: true } });
+      await playhtml.init();
+      await playhtml.init();
+      await playhtml.init();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // Regression guard for #198: repeated init() calls must NOT rebuild providers
+  // or trigger navigation. The earlier "apply later options" behavior re-ran
+  // navigationController.trigger() on every repeated init(), which — because
+  // @playhtml/react components call init() across renders/effects — caused an
+  // infinite teardown/rebuild → re-render loop. Bootstrap runs exactly once;
+  // later init()s are pure ensure-running no-ops.
+  it("connects exactly once across repeated init calls", async () => {
+    playhtml.configure({ cursors: { enabled: true, room: "domain" } });
+    await playhtml.init();
+    const afterFirst = (globalThis as any).PLAYHTML_TEST_PROVIDERS.length;
+
+    // Simulate many islands/effects each ensuring running.
+    for (let i = 0; i < 10; i++) {
+      await playhtml.init();
+    }
+
+    expect(playhtml.cursorClient).not.toBeNull();
+    // No new providers built — no churn, no rebuild loop.
+    expect((globalThis as any).PLAYHTML_TEST_PROVIDERS.length).toBe(afterFirst);
+  });
+});

--- a/packages/playhtml/src/__tests__/init-configure.test.ts
+++ b/packages/playhtml/src/__tests__/init-configure.test.ts
@@ -97,12 +97,10 @@ describe("playhtml configure() + init()", () => {
     }
   });
 
-  // Regression guard for #198: repeated init() calls must NOT rebuild providers
-  // or trigger navigation. The earlier "apply later options" behavior re-ran
-  // navigationController.trigger() on every repeated init(), which — because
-  // @playhtml/react components call init() across renders/effects — caused an
-  // infinite teardown/rebuild → re-render loop. Bootstrap runs exactly once;
-  // later init()s are pure ensure-running no-ops.
+  // Repeated init() calls must NOT rebuild providers or trigger navigation:
+  // @playhtml/react components call init() across renders/effects, so a rebuild
+  // per call would cause an infinite teardown/rebuild → re-render loop. Bootstrap
+  // runs exactly once; later init()s are pure ensure-running no-ops.
   it("connects exactly once across repeated init calls", async () => {
     playhtml.configure({ cursors: { enabled: true, room: "domain" } });
     await playhtml.init();
@@ -116,5 +114,82 @@ describe("playhtml configure() + init()", () => {
     expect(playhtml.cursorClient).not.toBeNull();
     // No new providers built — no churn, no rebuild loop.
     expect((globalThis as any).PLAYHTML_TEST_PROVIDERS.length).toBe(afterFirst);
+  });
+
+  it("treats an empty nested option object as no config (does not lock)", async () => {
+    // {cursors: {}} declares no opinion — it must not lock config to cursors-off,
+    // or the owner's later configure() would be ignored.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      playhtml.configure({ cursors: {} }); // no-op, must not lock
+      playhtml.configure({ cursors: { enabled: true } }); // real config wins
+      await playhtml.init();
+      expect(warn).not.toHaveBeenCalled();
+      expect(playhtml.cursorClient).not.toBeNull();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not warn when a later call adds a default-valued option the owner omitted", async () => {
+    // Owner declares cursors only. A second call site passes the same cursors
+    // plus defaultRoomOptions:{includeSearch:false} — which is the default. The
+    // owner never declared that key, so it's not a conflict.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({ cursors: { enabled: true } });
+      await playhtml.init({
+        cursors: { enabled: true },
+        defaultRoomOptions: { includeSearch: false },
+      });
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns when a later call changes a locked concrete option to a function", async () => {
+    // A function-room can't be value-compared, but replacing a locked string
+    // room with a function is a real change — it must not be silently dropped.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({ host: "http://localhost:1999", room: "/fixed" });
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: () => "/dynamic",
+      } as any);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not warn when both calls pass a function for the same option", async () => {
+    // Two functions for the same key can't be compared and must not warn — the
+    // first declaration wins (the deliberate lenient policy).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: () => "/a",
+      } as any);
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: () => "/b",
+      } as any);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("does not lock config when a caller mutates its options object after configure()", async () => {
+    // configure() must snapshot config; a caller reusing/mutating the object
+    // can't retroactively change the locked config.
+    const opts = { cursors: { enabled: true } };
+    playhtml.configure(opts);
+    opts.cursors.enabled = false; // mutate after declaring
+    await playhtml.init();
+    expect(playhtml.cursorClient).not.toBeNull();
   });
 });

--- a/packages/playhtml/src/__tests__/navigation.integration.test.ts
+++ b/packages/playhtml/src/__tests__/navigation.integration.test.ts
@@ -184,20 +184,31 @@ describe("playhtml.handleNavigation", () => {
     }
   });
 
-  it("keeps cursor options from the first init when a later init enables cursors", async () => {
-    await playhtml.init({
-      host: "http://localhost:1999",
-      room: "/cursors-toggle",
-      cursors: { enabled: false },
-    } as any);
-    expect(playhtml.cursorClient).toBeNull();
+  it("locks cursor config to the first init; a later conflicting init is ignored", async () => {
+    // Config is first-declaration-wins for ALL options uniformly — cursors are
+    // not special. To enable cursors when you can't put a single init at the
+    // top, declare them up front (here, the first init / or playhtml.configure).
+    // A later init that disagrees warns and is ignored.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: "/cursors-toggle",
+        cursors: { enabled: false },
+      } as any);
+      expect(playhtml.cursorClient).toBeNull();
 
-    await playhtml.init({
-      host: "http://localhost:1999",
-      cursors: { enabled: true },
-    } as any);
+      await playhtml.init({
+        host: "http://localhost:1999",
+        cursors: { enabled: true },
+      } as any);
 
-    expect(playhtml.cursorClient).toBeNull();
+      // Locked to the first declaration (cursors off) — later enable ignored.
+      expect(playhtml.cursorClient).toBeNull();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("keeps cursor options from the first init when a later init disables cursors", async () => {

--- a/packages/playhtml/src/__tests__/navigation.integration.test.ts
+++ b/packages/playhtml/src/__tests__/navigation.integration.test.ts
@@ -141,6 +141,8 @@ describe("playhtml.handleNavigation", () => {
 
   it("keeps the first explicit room when a later init passes a different room", async () => {
     const origPath = window.location.pathname + window.location.search;
+    // The conflicting second init() warns; capture it so test output stays clean.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
       history.replaceState(null, "", "/");
       await playhtml.init({
@@ -158,7 +160,9 @@ describe("playhtml.handleNavigation", () => {
       expect(playhtml.roomId).toEqual(before);
       expect(playhtml.roomId).toContain("%2F");
       expect(playhtml.roomId).not.toContain("%2Fabout");
+      expect(warn).toHaveBeenCalled();
     } finally {
+      warn.mockRestore();
       history.replaceState(null, "", origPath);
     }
   });
@@ -212,19 +216,26 @@ describe("playhtml.handleNavigation", () => {
   });
 
   it("keeps cursor options from the first init when a later init disables cursors", async () => {
-    await playhtml.init({
-      host: "http://localhost:1999",
-      room: "/cursors-toggle-off",
-      cursors: { enabled: true },
-    } as any);
-    expect(playhtml.cursorClient).not.toBeNull();
+    // The conflicting second init() warns; capture it so test output stays clean.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await playhtml.init({
+        host: "http://localhost:1999",
+        room: "/cursors-toggle-off",
+        cursors: { enabled: true },
+      } as any);
+      expect(playhtml.cursorClient).not.toBeNull();
 
-    await playhtml.init({
-      host: "http://localhost:1999",
-      cursors: { enabled: false },
-    } as any);
+      await playhtml.init({
+        host: "http://localhost:1999",
+        cursors: { enabled: false },
+      } as any);
 
-    expect(playhtml.cursorClient).not.toBeNull();
+      expect(playhtml.cursorClient).not.toBeNull();
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("strips filename extension from pathname when deriving default room", async () => {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -531,7 +531,6 @@ function isPromiseLike(value: unknown): value is Promise<void> {
 }
 /** Last fingerprint of element-awareness only; skip handler updates when unchanged (e.g. cursor-only moves). */
 let lastElementAwarenessFingerprint: string | null = null;
-let isDevelopmentMode = false;
 // NOTE: Potential optimization: allowlist/blocklist collaborative paths
 // In complex nested data scenarios, SyncedStore CRDT proxies on every nested object can add overhead.
 // Idea: expose an opt-in config to restrict which properties are collaborative (proxied) vs. local-only.
@@ -579,6 +578,116 @@ let roomResetPromise: Promise<void> | null = null;
 let pendingRoomResetEpoch: number | null = null;
 const SERVER_ROOM_RESET_SYNC_TIMEOUT_MS = 5000;
 const mainProviderSyncWaiters = new Set<(error?: Error) => void>();
+let isDevelopmentMode = false;
+
+// The config declared for this playhtml instance. Captured by the first call
+// that supplies config — whether configure() or a config-bearing init() — and
+// locked from then on. Later differing config warns and is ignored (see
+// applyConfig). Bootstrap reads everything it needs from here, so config has a
+// single source of truth regardless of which call site declared it.
+let configuredOptions: InitOptions | null = null;
+
+/**
+ * Returns true if `incoming` config conflicts with the already-locked config.
+ *
+ * Lenient and directional: only keys that `incoming` actually specifies are
+ * checked, and only against `locked`'s value for that same key. So:
+ *  - passing NO/empty options (an "ensure running" init()) never conflicts,
+ *  - passing the SAME options from another call site never conflicts (the
+ *    "declare identical options everywhere" pattern stays quiet),
+ *  - a genuine value difference on a key the caller specified DOES conflict.
+ *
+ * Function-valued options (`room` as a function, `events`, `onError`, cursor
+ * callbacks) are stripped before comparison: closures never compare equal
+ * across call sites, so comparing them would yield false conflicts — the first
+ * declaration's functions win. Object keys are sorted so key order is ignored.
+ */
+function configsConflict(locked: InitOptions, incoming: InitOptions): boolean {
+  // Declared inside so it can't land in a temporal dead zone during this
+  // module's import cycle (a top-level helper referenced here intermittently
+  // resolved as undefined under the test bundler).
+  const serialize = (value: unknown): unknown => {
+    if (typeof value === "function") return undefined;
+    if (Array.isArray(value)) return value.map(serialize);
+    if (value && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+        const s = serialize((value as Record<string, unknown>)[key]);
+        if (s !== undefined) out[key] = s;
+      }
+      return out;
+    }
+    return value;
+  };
+
+  for (const key of Object.keys(incoming) as (keyof InitOptions)[]) {
+    const incomingVal = serialize(incoming[key]);
+    // A key whose value strips to undefined (e.g. a function-only option)
+    // carries no comparable opinion — skip it.
+    if (incomingVal === undefined) continue;
+    const lockedVal = serialize(locked[key]);
+    if (JSON.stringify(incomingVal) !== JSON.stringify(lockedVal)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** True if these options declare no config worth locking (an "ensure running"
+ * call). Such a call must NOT lock config, so a real configure() can still win
+ * before connection. */
+function isEmptyConfig(options: InitOptions): boolean {
+  return Object.values(options).every((v) => v === undefined);
+}
+
+/**
+ * Capture init config into module state. The first caller to supply real config
+ * wins and locks it; a later call with conflicting values warns and is ignored.
+ * An empty "ensure running" call does NOT lock — config stays open for a later
+ * configure(). Bootstrap locks whatever config is current when it starts (see
+ * lockConfigForBootstrap), so config can't change once connected.
+ */
+function applyConfig(options: InitOptions): void {
+  if (configuredOptions) {
+    if (configsConflict(configuredOptions, options)) {
+      console.warn(
+        "[playhtml] Ignoring conflicting config passed after playhtml was already configured. " +
+          "Config is locked to the first declaration. Declare it once up front with " +
+          "playhtml.configure(...) (or matching options at every call site).",
+      );
+    }
+    return;
+  }
+
+  if (isEmptyConfig(options)) return;
+
+  configuredOptions = options;
+  explicitRoomOption = options.room;
+  cachedDefaultRoomOptions = options.defaultRoomOptions ?? {
+    includeSearch: false,
+  };
+  cursorOptionsCache = options.cursors ?? {};
+  cachedOnError = options.onError;
+  isDevelopmentMode = options.developmentMode ?? false;
+
+  if (options.extraCapabilities) {
+    for (const [tag, tagInfo] of Object.entries(options.extraCapabilities)) {
+      capabilitiesToInitializer[tag] = tagInfo;
+    }
+  }
+  if (options.events) {
+    for (const [eventType, event] of Object.entries(options.events)) {
+      registerPlayEventListener(eventType, event);
+    }
+  }
+}
+
+/** Lock config at the moment bootstrap starts. If no real config was declared,
+ * lock to empty so a configure() that arrives AFTER connection warns rather
+ * than silently doing nothing — config genuinely can't change post-connect. */
+function lockConfigForBootstrap(): void {
+  if (!configuredOptions) configuredOptions = {};
+}
 
 /**
  * Builds a fresh main Yjs provider for the given room. Side effects:
@@ -882,6 +991,49 @@ async function resetCurrentRoomFromServer(): Promise<void> {
   dispatchNavigated(__currentRoomId);
 }
 
+/**
+ * Wires the listener that lets the browser extension inject a player identity.
+ * The extension runs in Chrome's isolated world and can't call
+ * cursorClient.configure() directly, so it dispatches a CustomEvent on the
+ * shared DOM instead.
+ *
+ * The extension only provides publicKey and playerStyle (the canonical stable
+ * identity + chosen color). All other fields on the page's current identity are
+ * preserved — the page may have arbitrary fields the extension doesn't know
+ * about.
+ *
+ * Idempotent: only attaches once. Safe to call from both the initial
+ * cursor-enabled path and the late-enable path.
+ */
+function setupExtensionIdentityListener(): void {
+  if (configureIdentityListener) return;
+
+  // TODO: The extension should also be able to set `name` — currently
+  // there's no UI for it in the extension, so we preserve the page's
+  // value. Once the extension has a name field, include it in the merge.
+  configureIdentityListener = ((e: CustomEvent) => {
+    const incoming = e.detail?.playerIdentity;
+    if (!incoming || !cursorClient) return;
+
+    const current = cursorClient.getMyPlayerIdentity();
+    const merged = {
+      ...current,
+      publicKey: incoming.publicKey,
+      playerStyle: incoming.playerStyle,
+    };
+
+    cursorClient.configure({ playerIdentity: merged });
+    console.log("[playhtml] Merged extension identity via CustomEvent");
+  }) as EventListener;
+  document.addEventListener(
+    "playhtml:configure-identity",
+    configureIdentityListener,
+  );
+
+  // Signal that we're ready to receive identity injection events
+  document.dispatchEvent(new CustomEvent("playhtml:ready"));
+}
+
 async function runHandleNavigation(): Promise<void> {
   // firstSetup is true before init and after resetPlayHTML — skip nav in both.
   if (firstSetup) return;
@@ -981,8 +1133,28 @@ async function runHandleNavigation(): Promise<void> {
   dispatchNavigated(__currentRoomId);
 }
 
+/**
+ * Declare config for this playhtml instance without connecting. Idempotent and
+ * framework-agnostic: call it once, up front, from wherever owns the config (a
+ * <head> script, PlayProvider, an island). Connection happens later via init()
+ * / standalone component mount, which read whatever config was declared here.
+ *
+ * Use this when you can't put a single init() at the top of your app — Astro
+ * islands, multi-page apps, multiple React roots — so config doesn't depend on
+ * which "ensure running" call happens to run first. The first declaration wins;
+ * a later conflicting one warns and is ignored.
+ */
+function configurePlayHTML(options: InitOptions = {}): void {
+  applyConfig(options);
+}
+
 function initPlayHTML(options: InitOptions = {}) {
   if (initStarted) {
+    // Already bootstrapping/running. init() here means "ensure running" — the
+    // connection is already in flight. Still funnel options through applyConfig
+    // so a conflicting late config warns (and a matching/empty one is a quiet
+    // no-op). Config is locked to the first declaration.
+    applyConfig(options);
     return readyPromise;
   }
 
@@ -1009,30 +1181,35 @@ function initPlayHTML(options: InitOptions = {}) {
   }
 
   initStarted = true;
-  const initPromise = initPlayHTMLOnce(options);
+  // Capture config (honoring any earlier configure() call — applyConfig is a
+  // no-op if config is already locked) before bootstrapping.
+  applyConfig(options);
+  const initPromise = initPlayHTMLOnce();
   initPromise.catch((error) => {
     readyReject(error);
   });
   return initPromise;
 }
 
-async function initPlayHTMLOnce({
-  // TODO: if it is a localhost url, need to make some deterministic way to connect to the same room.
-  host,
-  extraCapabilities,
-  events,
-  defaultRoomOptions = { includeSearch: false },
-  room: explicitRoom,
-  onError,
-  developmentMode = false,
-  cursors = {},
-}: InitOptions = {}) {
-  explicitRoomOption = explicitRoom;
-  cachedDefaultRoomOptions = defaultRoomOptions;
-  const inputRoom = resolveExplicitRoom() ?? getDefaultRoom(defaultRoomOptions);
-  cursorOptionsCache = cursors;
-  cachedOnError = onError;
-  isDevelopmentMode = developmentMode;
+/**
+ * Connect and set up playhtml. Reads config exclusively from module state
+ * (populated by applyConfig), so there is a single source of truth regardless
+ * of which call site declared the config.
+ *
+ * TODO: if it is a localhost url, need to make some deterministic way to connect
+ * to the same room.
+ */
+async function initPlayHTMLOnce() {
+  // Connection is about to read config; freeze it. A later configure() now
+  // warns instead of silently no-op'ing — config can't change post-connect.
+  lockConfigForBootstrap();
+  // host/onError/developmentMode are not mirrored into long-lived module state
+  // beyond cachedOnError/isDevelopmentMode, so read them from configuredOptions.
+  const host = configuredOptions?.host;
+  const cursors = cursorOptionsCache ?? {};
+  const inputRoom =
+    resolveExplicitRoom() ?? getDefaultRoom(cachedDefaultRoomOptions);
+  const onError = cachedOnError;
   // @ts-ignore
   window.playhtml = playhtml;
   // DOM marker visible to browser extension content scripts (which run in an
@@ -1073,38 +1250,7 @@ async function initPlayHTMLOnce({
   });
 
   if (cursors.enabled) {
-    // Listen for identity injection from the browser extension. The extension
-    // runs in Chrome's isolated world and can't call cursorClient.configure()
-    // directly, so it dispatches a CustomEvent on the shared DOM instead.
-    //
-    // The extension only provides publicKey and playerStyle (the canonical
-    // stable identity + chosen color). All other fields on the page's
-    // current identity are preserved — the page may have arbitrary fields
-    // the extension doesn't know about.
-    // TODO: The extension should also be able to set `name` — currently
-    // there's no UI for it in the extension, so we preserve the page's
-    // value. Once the extension has a name field, include it in the merge.
-    configureIdentityListener = ((e: CustomEvent) => {
-      const incoming = e.detail?.playerIdentity;
-      if (!incoming || !cursorClient) return;
-
-      const current = cursorClient.getMyPlayerIdentity();
-      const merged = {
-        ...current,
-        publicKey: incoming.publicKey,
-        playerStyle: incoming.playerStyle,
-      };
-
-      cursorClient.configure({ playerIdentity: merged });
-      console.log("[playhtml] Merged extension identity via CustomEvent");
-    }) as EventListener;
-    document.addEventListener(
-      "playhtml:configure-identity",
-      configureIdentityListener,
-    );
-
-    // Signal that we're ready to receive identity injection events
-    document.dispatchEvent(new CustomEvent("playhtml:ready"));
+    setupExtensionIdentityListener();
   }
 
   // Create presence API — always available, wraps whichever awareness provider exists
@@ -1114,24 +1260,16 @@ async function initPlayHTMLOnce({
       cursorClient?.getMyPlayerIdentity() ?? generatePersistentPlayerIdentity(),
   });
 
-  if (extraCapabilities) {
-    for (const [tag, tagInfo] of Object.entries(extraCapabilities)) {
-      capabilitiesToInitializer[tag] = tagInfo;
-    }
-  }
+  // extraCapabilities and events were applied by applyConfig when config was
+  // declared, so they're available before this connect step runs.
 
-  if (events) {
-    for (const [eventType, event] of Object.entries(events)) {
-      registerPlayEventListener(eventType, event);
-    }
-  }
   // Import default styles
   const playStyles = document.createElement("link");
   playStyles.rel = "stylesheet";
   playStyles.href = "https://unpkg.com/playhtml@latest/dist/style.css";
   document.head.appendChild(playStyles);
 
-  if (developmentMode) {
+  if (isDevelopmentMode) {
     setupDevUI(playhtml);
   }
   // TODO: expose a way to activate the dev tools UI on any page at runtime
@@ -1546,6 +1684,7 @@ function createPresenceRoom(name: string): PresenceRoom {
 
 export interface PlayHTMLComponents {
   init: typeof initPlayHTML;
+  configure: typeof configurePlayHTML;
   readonly isLoading: boolean;
   readonly ready: Promise<void>;
   handleNavigation: () => Promise<void>;
@@ -1660,6 +1799,8 @@ export async function resetPlayHTML(): Promise<void> {
     cachedOnError = undefined;
     roomResetPromise = null;
     pendingRoomResetEpoch = null;
+    isDevelopmentMode = false;
+    configuredOptions = null;
   } finally {
     // firstSetup = true (set above) is the canonical "not initialized"
     // flag — runHandleNavigation checks it to skip nav after reset.
@@ -1669,6 +1810,7 @@ export async function resetPlayHTML(): Promise<void> {
 // Expose big variables to the window object for debugging purposes.
 export const playhtml: PlayHTMLComponents = {
   init: initPlayHTML,
+  configure: configurePlayHTML,
   get isLoading() {
     return isLoading;
   },

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -586,47 +586,81 @@ let isDevelopmentMode = false;
 // applyConfig). Bootstrap reads everything it needs from here, so config has a
 // single source of truth regardless of which call site declared it.
 let configuredOptions: InitOptions | null = null;
+// True once bootstrap has read config and started connecting. Config is frozen
+// from this point — a later configure()/init(options) warns instead of applying.
+let hasBootstrapped = false;
 
 /**
- * Returns true if `incoming` config conflicts with the already-locked config.
+ * Normalize a config value into a stable, comparable form that captures only
+ * what it actually declares:
+ *  - function-valued options (`room` as a function, `events`, `onError`, cursor
+ *    callbacks) become undefined — closures never compare equal across call
+ *    sites, so comparing them yields false conflicts; the first declaration's
+ *    functions win,
+ *  - object keys are sorted so key order is ignored,
+ *  - a key whose value normalizes to undefined OR to an empty object/array is
+ *    dropped, so an option-less object collapses: `{}`, `{ cursors: {} }`, and
+ *    `{ room: undefined }` all normalize to `{}` ("declares nothing").
+ * Used by both isEmptyConfig and configsConflict so "declares nothing" means
+ * the same thing in both.
+ */
+function normalizeConfig(value: unknown): unknown {
+  if (typeof value === "function") return undefined;
+  if (Array.isArray(value)) {
+    const arr = value.map(normalizeConfig);
+    return arr.length === 0 ? undefined : arr;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      const normalized = normalizeConfig((value as Record<string, unknown>)[key]);
+      if (normalized !== undefined) out[key] = normalized;
+    }
+    return Object.keys(out).length === 0 ? undefined : out;
+  }
+  return value;
+}
+
+/**
+ * Returns true if `incoming` conflicts with the already-locked config.
  *
- * Lenient and directional: only keys that `incoming` actually specifies are
- * checked, and only against `locked`'s value for that same key. So:
+ * Lenient and directional: a conflict requires a key that BOTH sides declare
+ * with different values. So:
  *  - passing NO/empty options (an "ensure running" init()) never conflicts,
  *  - passing the SAME options from another call site never conflicts (the
  *    "declare identical options everywhere" pattern stays quiet),
- *  - a genuine value difference on a key the caller specified DOES conflict.
+ *  - adding a key the locked config never declared is not a conflict (it's
+ *    ignored anyway, since config is locked) — this avoids false positives when
+ *    a later call passes a default-valued option the owner simply omitted,
+ *  - a genuine value difference on a key BOTH sides declared DOES conflict.
  *
- * Function-valued options (`room` as a function, `events`, `onError`, cursor
- * callbacks) are stripped before comparison: closures never compare equal
- * across call sites, so comparing them would yield false conflicts — the first
- * declaration's functions win. Object keys are sorted so key order is ignored.
+ * Function-valued options can't be compared by value (closures never compare
+ * equal), so two functions for the same key are treated as non-conflicting (the
+ * first wins). But a key that's a function on one side and a concrete value on
+ * the other IS a conflict — otherwise a later `room: () => ...` silently
+ * replacing a locked `room: "/x"` would be swallowed with no warning.
  */
 function configsConflict(locked: InitOptions, incoming: InitOptions): boolean {
-  // Declared inside so it can't land in a temporal dead zone during this
-  // module's import cycle (a top-level helper referenced here intermittently
-  // resolved as undefined under the test bundler).
-  const serialize = (value: unknown): unknown => {
-    if (typeof value === "function") return undefined;
-    if (Array.isArray(value)) return value.map(serialize);
-    if (value && typeof value === "object") {
-      const out: Record<string, unknown> = {};
-      for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-        const s = serialize((value as Record<string, unknown>)[key]);
-        if (s !== undefined) out[key] = s;
-      }
-      return out;
-    }
-    return value;
-  };
-
+  // A function-vs-non-function declaration for the same key is a real
+  // divergence we can detect even though we can't compare the values.
   for (const key of Object.keys(incoming) as (keyof InitOptions)[]) {
-    const incomingVal = serialize(incoming[key]);
-    // A key whose value strips to undefined (e.g. a function-only option)
-    // carries no comparable opinion — skip it.
-    if (incomingVal === undefined) continue;
-    const lockedVal = serialize(locked[key]);
-    if (JSON.stringify(incomingVal) !== JSON.stringify(lockedVal)) {
+    const incomingIsFn = typeof incoming[key] === "function";
+    const lockedIsFn = typeof locked[key] === "function";
+    const lockedDeclares = locked[key] !== undefined;
+    if (incomingIsFn && lockedDeclares && !lockedIsFn) return true;
+    if (lockedIsFn && incoming[key] !== undefined && !incomingIsFn) return true;
+  }
+
+  const normalizedLocked = (normalizeConfig(locked) ?? {}) as Record<string, unknown>;
+  const normalizedIncoming = (normalizeConfig(incoming) ?? {}) as Record<string, unknown>;
+
+  for (const key of Object.keys(normalizedIncoming)) {
+    // Can't conflict on a key the locked config never declared.
+    if (!(key in normalizedLocked)) continue;
+    if (
+      JSON.stringify(normalizedIncoming[key]) !==
+      JSON.stringify(normalizedLocked[key])
+    ) {
       return true;
     }
   }
@@ -635,17 +669,17 @@ function configsConflict(locked: InitOptions, incoming: InitOptions): boolean {
 
 /** True if these options declare no config worth locking (an "ensure running"
  * call). Such a call must NOT lock config, so a real configure() can still win
- * before connection. */
+ * before connection. Uses the same normalization as configsConflict, so
+ * `{}`, `{ cursors: {} }`, and `{ room: undefined }` all count as empty. */
 function isEmptyConfig(options: InitOptions): boolean {
-  return Object.values(options).every((v) => v === undefined);
+  return normalizeConfig(options) === undefined;
 }
 
 /**
  * Capture init config into module state. The first caller to supply real config
  * wins and locks it; a later call with conflicting values warns and is ignored.
  * An empty "ensure running" call does NOT lock — config stays open for a later
- * configure(). Bootstrap locks whatever config is current when it starts (see
- * lockConfigForBootstrap), so config can't change once connected.
+ * configure() (until bootstrap connects, after which config can't change).
  */
 function applyConfig(options: InitOptions): void {
   if (configuredOptions) {
@@ -661,12 +695,25 @@ function applyConfig(options: InitOptions): void {
 
   if (isEmptyConfig(options)) return;
 
-  configuredOptions = options;
+  // Real config arriving after connection can't be applied — warn and ignore.
+  if (hasBootstrapped) {
+    console.warn(
+      "[playhtml] Ignoring config passed after playhtml already connected. " +
+        "Declare it before init() — e.g. with playhtml.configure(...) in a script " +
+        "that runs before any component mounts.",
+    );
+    return;
+  }
+
+  // Shallow-copy so a caller that mutates or reuses its options object after
+  // declaring config can't silently change the locked config. cursors is
+  // copied too since it's the most commonly nested-and-mutated option.
+  configuredOptions = { ...options };
   explicitRoomOption = options.room;
-  cachedDefaultRoomOptions = options.defaultRoomOptions ?? {
-    includeSearch: false,
-  };
-  cursorOptionsCache = options.cursors ?? {};
+  cachedDefaultRoomOptions = options.defaultRoomOptions
+    ? { ...options.defaultRoomOptions }
+    : { includeSearch: false };
+  cursorOptionsCache = options.cursors ? { ...options.cursors } : {};
   cachedOnError = options.onError;
   isDevelopmentMode = options.developmentMode ?? false;
 
@@ -682,11 +729,11 @@ function applyConfig(options: InitOptions): void {
   }
 }
 
-/** Lock config at the moment bootstrap starts. If no real config was declared,
- * lock to empty so a configure() that arrives AFTER connection warns rather
- * than silently doing nothing — config genuinely can't change post-connect. */
+/** Mark that bootstrap has begun reading config. After this, config is frozen:
+ * a configure()/init(options) that arrives later warns rather than silently
+ * doing nothing — config genuinely can't change once connected. */
 function lockConfigForBootstrap(): void {
-  if (!configuredOptions) configuredOptions = {};
+  hasBootstrapped = true;
 }
 
 /**
@@ -1801,6 +1848,7 @@ export async function resetPlayHTML(): Promise<void> {
     pendingRoomResetEpoch = null;
     isDevelopmentMode = false;
     configuredOptions = null;
+    hasBootstrapped = false;
   } finally {
     // firstSetup = true (set above) is the canonical "not initialized"
     // flag — runHandleNavigation checks it to skip nav after reset.

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -183,6 +183,13 @@ export function PlayProvider({
 
   useEffect(() => {
     let cancelled = false;
+    // Declare config before connecting so it's the single source of truth even
+    // if a `standalone` component elsewhere calls init() (with no options)
+    // first. configure() is a no-op once config is locked, so this is safe to
+    // run regardless of ordering.
+    if (processedInitOptions) {
+      playhtml.configure(processedInitOptions);
+    }
     const initPromise = playhtml.init(processedInitOptions);
     const readyPromise = isReadyPromise(playhtml.ready) ? playhtml.ready : initPromise;
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -124,10 +124,15 @@ export function CanPlayElement<T extends object, V = any>({
     );
   }
 
-  // Ensure playhtml is initialized if in standalone mode
+  // Ensure playhtml is running when this component is used outside a
+  // PlayProvider. This is purely "ensure running" — it passes NO options, so it
+  // never competes with config the page declared elsewhere (e.g. a global
+  // playhtml.configure({ cursors }) in a <head> script). If playhtml is already
+  // started, init() is a no-op that resolves to the existing readiness. The
+  // element itself is registered separately via setupPlayElement below, which
+  // is what actually wires it up regardless of who started playhtml.
   useEffect(() => {
     if (standalone && playContext.isProviderMissing) {
-      // Initialize playhtml in standalone mode
       playhtml
         .init()
         .catch((err) =>


### PR DESCRIPTION
## Problem

`playhtml.init(options)` fused two intents into one first-call-wins function: **declare config** (cursors, room, host, …) and **bootstrap** (connect, set up elements). That breaks down whenever there's no single top-level owner of init — Astro islands, multi-page apps, multiple React roots. Multiple independent things each call `init()` to *ensure playhtml is running*, but only one of them owns the config. Because init is first-call-wins, an option-less "ensure running" call can win the race and **silently drop** the owner's config.

This is the root cause of the docs site's intermittent cursors/presence: `HeadOverride` called `init({ cursors })`, while every `@playhtml/react` `standalone` island called `init()` (no options) on mount. Whichever ran first decided whether cursors existed — so they appeared only on some loads.

Symptoms of the old model: ordering mattered invisibly; cursors had to be special-cased as the one option a later `init()` could re-apply; the same function meant two different things depending on the caller.

## Change

Separate the two intents. Keep `init(options)` working exactly as today (no breaking change), and add an authoritative, connection-free way to declare config.

- **`playhtml.configure(options)`** — declares config; does **not** connect. Idempotent and framework-agnostic: call it once, up front, from wherever owns the config (a `<head>` script, `PlayProvider`, an island). Connection happens later via `init()` / component mount, which read the declared config.
- **One uniform rule for every option:** the first declaration wins; a later *genuinely conflicting* option warns and is ignored. Passing the same options again — or none — is silent. The conflict check is **lenient and directional** (only keys the caller actually specifies are compared; functions are excluded since closures never compare equal), so the common "pass identical options at every call site" pattern stays quiet.
- **No breaking change:** `init(options)` is unchanged for single-call-site users. `configure()` is purely additive — the tool you reach for when you can't put one init at the top.

This removes the per-option cursor special-case and keeps the [#198](https://github.com/spencerc99/playhtml/pull/198) guarantee that repeated `init()` never rebuilds providers or triggers a re-render loop.

### Supported ordering

`configure()` before `init()`. An option-less `init()` with no prior config connects immediately with defaults; a `configure()` after connection warns (config can't change once connected). On the docs site `configure()` runs synchronously in `<head>` before any island hydrates, so it always wins.

## Consumers

- **`@playhtml/react`**: `PlayProvider` declares config via `configure()` then ensures running (public contract unchanged). The `standalone` path is ensure-running only (no options) — its `init()` becomes a harmless no-op when playhtml is already started; the element is registered via `setupPlayElement` regardless.
- **Docs site**: `HeadOverride` declares config with `configure({ cursors: { enabled: true, room: "domain" } })`, then `init()`. (This supersedes the interim eager-init fix in #215.)
- **Docs**: `reference/init-options.md` documents `configure()` and the first-declaration-wins rule.

## Tests / verification

- Core: **211 tests pass**; both `playhtml` and `@playhtml/react` type-check clean.
- New `init-configure.test.ts` covers: configure-then-init enables config; connect-immediately-with-defaults + warn on post-connect configure; lenient no-warn on identical/empty options; warn on genuine conflict; and a regression guard that repeated `init()`s connect exactly once (no provider churn / #198 loop).
- Verified in a browser against a built docs site: cursors + presence HUD up on **every** load across 4 pages, two-peer presence works, **zero** false-conflict warnings.

## Relationship to #215

[#215](https://github.com/spencerc99/playhtml/pull/215) is the interim, docs-only fix (eager init, no library change) to unblock the docs immediately. This PR is the proper library-level fix. If #215 merges first, this branch rebases on top and the `HeadOverride.astro` change resolves to the `configure()` version here.