### PR TITLE
extension: keep keyboard events extension-only

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Bug fixes with the keyboard collector (#217)
+
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow
 watches this file: when there are bullets, it opens (or updates) a release PR

--- a/extension/src/__tests__/KeyboardCollector.test.ts
+++ b/extension/src/__tests__/KeyboardCollector.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Tests for KeyboardCollector privacy and emission behavior.
+// ABOUTME: Ensures captured typing stays inside the extension collector pipeline.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import { KeyboardCollector } from "../collectors/KeyboardCollector";
+import type { KeyboardEventData } from "../collectors/types";
+
+describe("KeyboardCollector", () => {
+  let storageChangeListener: {
+    addListener: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storageChangeListener = {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    (browser.storage as any).onChanged = storageChangeListener;
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("emits typing data without posting it to the page window", async () => {
+    const collector = new KeyboardCollector();
+    const emitted: KeyboardEventData[] = [];
+    collector.setEmitCallback((event) => {
+      emitted.push(event);
+    });
+    const postMessageSpy = vi.spyOn(window, "postMessage");
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      backgroundColor: "rgb(255, 255, 255)",
+      borderStyle: "solid",
+      borderTopLeftRadius: "4px",
+    } as CSSStyleDeclaration);
+
+    const input = document.createElement("input");
+    input.id = "message";
+    input.getBoundingClientRect = () =>
+      ({
+        left: 10,
+        top: 20,
+        width: 200,
+        height: 40,
+        right: 210,
+        bottom: 60,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    document.body.appendChild(input);
+
+    collector.enable();
+    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    input.value = "h";
+    input.dispatchEvent(
+      new InputEvent("input", {
+        bubbles: true,
+        inputType: "insertText",
+        data: "h",
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(emitted).toHaveLength(1);
+    expect(postMessageSpy).not.toHaveBeenCalled();
+
+    collector.disable();
+  });
+});

--- a/extension/src/collectors/KeyboardCollector.ts
+++ b/extension/src/collectors/KeyboardCollector.ts
@@ -566,9 +566,6 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
 
     this.emit(typeData);
 
-    // Expose event to page for testing
-    this.exposeEventToPage(typeData);
-
     if (VERBOSE) {
       console.log('[KeyboardCollector] Type event emitted:', typeData);
     }
@@ -614,20 +611,4 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
     }
   }
 
-  /**
-   * Expose event to page for testing (via window.postMessage)
-   */
-  private exposeEventToPage(data: KeyboardEventData): void {
-    try {
-      window.postMessage(
-        {
-          type: 'KEYBOARD_COLLECTOR_EVENT',
-          data: data,
-        },
-        window.location.origin
-      );
-    } catch (error) {
-      // Ignore errors (might fail in some contexts)
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- remove the KeyboardCollector `window.postMessage` exposure path for typing payloads
- add a focused collector test that verifies typing still emits through the extension pipeline without posting to the page window

## Rationale
The collector already emits captured typing data through the extension-owned collector pipeline. Posting the same payload onto `window` exposes it to page scripts, which is not needed for production behavior.

## Tests
- Red: `bun run test -- run src/__tests__/KeyboardCollector.test.ts` failed because `window.postMessage` received the typing payload
- Green: `bun run test -- run src/__tests__/KeyboardCollector.test.ts`
- Green: `bun run test -- run` from `extension/`

## Docs / changeset
- No package code changed, so no changeset is needed.
- No user-facing API or docs behavior changed.