### PR TITLE
worker: paginate admin event exports

### DIFF
--- a/extension/worker/src/__tests__/export.test.ts
+++ b/extension/worker/src/__tests__/export.test.ts
@@ -1,0 +1,125 @@
+// ABOUTME: Tests for the admin event export route.
+// ABOUTME: Verifies auth, pagination, and JSON export shape for collected events.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../lib/supabase';
+
+const queryBuilder = {
+  select: vi.fn(),
+  eq: vi.fn(),
+  gte: vi.fn(),
+  lt: vi.fn(),
+  order: vi.fn(),
+  range: vi.fn(),
+  then: vi.fn(),
+};
+
+const from = vi.fn();
+let pageResults: Array<{
+  data: Array<Record<string, unknown>>;
+  error: null;
+  count: number;
+}>;
+
+vi.mock('../lib/supabase', () => ({
+  createSupabaseClient: vi.fn(() => ({
+    from,
+  })),
+}));
+
+import { handleExport } from '../routes/export';
+
+const ENV: Env = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SECRET_KEY: 'k',
+  ADMIN_KEY: 'admin',
+  RESEND_API_KEY: 'r',
+  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
+};
+
+function makeExportRequest(): Request {
+  return new Request('https://example.com/events/export', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer admin',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      type: 'keyboard',
+      startDate: '2026-01-01T00:00:00.000Z',
+      endDate: '2026-01-02T00:00:00.000Z',
+      name: 'Keyboard Export',
+    }),
+  });
+}
+
+function makeRow(index: number): Record<string, unknown> {
+  return {
+    id: `event-${index}`,
+    type: 'keyboard',
+    ts: new Date(index).toISOString(),
+    data: { event: 'type', index },
+    participant_id: `participant-${index % 2}`,
+    session_id: `session-${index}`,
+    url: `https://example.com/${index}`,
+    viewport_width: 1024,
+    viewport_height: 768,
+    timezone: 'America/Los_Angeles',
+  };
+}
+
+describe('handleExport', () => {
+  beforeEach(() => {
+    queryBuilder.select.mockReset();
+    queryBuilder.eq.mockReset();
+    queryBuilder.gte.mockReset();
+    queryBuilder.lt.mockReset();
+    queryBuilder.order.mockReset();
+    queryBuilder.range.mockReset();
+    queryBuilder.then.mockReset();
+    from.mockReset();
+
+    pageResults = [
+      {
+        data: Array.from({ length: 1000 }, (_, index) => makeRow(index)),
+        error: null,
+        count: 1001,
+      },
+      {
+        data: [makeRow(1000)],
+        error: null,
+        count: 1001,
+      },
+    ];
+
+    from.mockReturnValue(queryBuilder);
+    queryBuilder.select.mockReturnValue(queryBuilder);
+    queryBuilder.eq.mockReturnValue(queryBuilder);
+    queryBuilder.gte.mockReturnValue(queryBuilder);
+    queryBuilder.lt.mockReturnValue(queryBuilder);
+    queryBuilder.order.mockReturnValue(queryBuilder);
+    queryBuilder.range.mockImplementation(() => Promise.resolve(pageResults.shift()));
+    queryBuilder.then.mockImplementation((resolve, reject) =>
+      Promise.resolve(pageResults[0]).then(resolve, reject),
+    );
+  });
+
+  it('exports every matching event across Supabase result pages', async () => {
+    const res = await handleExport(makeExportRequest(), ENV);
+
+    expect(res.status).toBe(200);
+    expect(queryBuilder.range).toHaveBeenCalledWith(0, 999);
+    expect(queryBuilder.range).toHaveBeenCalledWith(1000, 1999);
+
+    const body = await res.json() as {
+      edition: { eventCount: number; participantCount: number };
+      events: Array<{ id: string; ts: number }>;
+    };
+
+    expect(body.edition.eventCount).toBe(1001);
+    expect(body.edition.participantCount).toBe(2);
+    expect(body.events).toHaveLength(1001);
+    expect(body.events[0]).toMatchObject({ id: 'event-0', ts: 0 });
+    expect(body.events[1000]).toMatchObject({ id: 'event-1000', ts: 1000 });
+  });
+});

--- a/extension/worker/src/routes/export.ts
+++ b/extension/worker/src/routes/export.ts
@@ -4,6 +4,15 @@
 import { createSupabaseClient, type Env } from '../lib/supabase';
 import type { CollectionEvent, EventMeta } from '@playhtml/extension-types';
 
+const EXPORT_PAGE_SIZE = 1000;
+
+interface ExportRequestBody {
+  type?: string;
+  startDate?: string;
+  endDate?: string;
+  name?: string;
+}
+
 /**
  * POST /events/export
  * Export edition data to JSON format
@@ -29,7 +38,7 @@ export async function handleExport(
   }
   
   try {
-    const body = await request.json();
+    const body = await request.json() as ExportRequestBody;
     const { type, startDate, endDate, name } = body;
     
     if (!type || !startDate || !endDate) {
@@ -41,21 +50,40 @@ export async function handleExport(
     
     const supabase = createSupabaseClient(env);
     
-    // Query events in date range
-    const { data, error, count } = await supabase
-      .from('collection_events')
-      .select('*', { count: 'exact' })
-      .eq('type', type)
-      .gte('ts', startDate)
-      .lt('ts', endDate)
-      .order('ts', { ascending: true });
+    const data = [];
+    let count = 0;
+    let offset = 0;
     
-    if (error) {
-      console.error('Supabase export error:', error);
-      return new Response(
-        JSON.stringify({ error: 'Failed to export events', details: error.message }),
-        { status: 500, headers: { 'Content-Type': 'application/json' } }
-      );
+    while (true) {
+      const { data: pageData, error, count: pageCount } = await supabase
+        .from('collection_events')
+        .select('*', { count: 'exact' })
+        .eq('type', type)
+        .gte('ts', startDate)
+        .lt('ts', endDate)
+        .order('ts', { ascending: true })
+        .range(offset, offset + EXPORT_PAGE_SIZE - 1);
+      
+      if (error) {
+        console.error('Supabase export error:', error);
+        return new Response(
+          JSON.stringify({ error: 'Failed to export events', details: error.message }),
+          { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      
+      const rows = pageData || [];
+      data.push(...rows);
+      
+      if (typeof pageCount === 'number') {
+        count = pageCount;
+      }
+      
+      if (rows.length < EXPORT_PAGE_SIZE || (count > 0 && data.length >= count)) {
+        break;
+      }
+      
+      offset += EXPORT_PAGE_SIZE;
     }
     
     // Get unique participants


### PR DESCRIPTION
## Summary
- page admin event exports in 1,000-row windows so exports are not capped by Supabase's default response size
- preserve the exact matching event count from Supabase
- add a route-level regression test for a 1,001-event export
- type the export request body so the worker route passes package typecheck

## Rationale
The previous export query requested the exact count but only read one response page. For exports larger than Supabase's default page size, the JSON contained fewer events than `edition.eventCount` reported.

## Tests
- Red: `bun run test -- src/__tests__/export.test.ts` failed because the old handler never called `.range()`
- Green: `bun run test -- src/__tests__/export.test.ts`
- Green: `bun run test` from `extension/worker/`
- Green: `bunx tsc -p extension/worker/tsconfig.json --noEmit`

## Notes
- No package code changed, so no changeset is needed.
- Root `bun run lint` still fails on existing repo-wide type errors outside this PR's scope; I used the worker-specific typecheck for this branch.