### PR TITLE
partykit: dedupe moderation delete targets

### DIFF
--- a/partykit/__tests__/moderation.test.ts
+++ b/partykit/__tests__/moderation.test.ts
@@ -178,6 +178,16 @@ describe("removeRecordsByTargets", () => {
     expect(words).toEqual(["remove-me"]);
   });
 
+  it("does not delete a neighboring record when the same target is repeated", () => {
+    const play = makePlay();
+    const key = "can-play.newWords#1";
+    const target = { key, contentHash: hashFor(play, key) };
+    const result = removeRecordsByTargets(play, [target, target]);
+    expect(result.removed).toBe(1);
+    const words = (result.play["can-play"] as any).newWords.map((r: any) => r.word);
+    expect(words).toEqual(["keep", "also-keep"]);
+  });
+
   it("skips a target whose hash no longer matches", () => {
     const play = makePlay();
     const key = "can-play.newWords#1";

--- a/partykit/moderation.ts
+++ b/partykit/moderation.ts
@@ -221,7 +221,9 @@ export function removeRecordsByTargets(
       continue;
     }
     const indices = deletionsByPath.get(record.path) ?? [];
-    indices.push(record.index);
+    if (!indices.includes(record.index)) {
+      indices.push(record.index);
+    }
     deletionsByPath.set(record.path, indices);
   }
 


### PR DESCRIPTION
## Summary
- make moderation removals idempotent when the same validated target is repeated
- add a regression test proving duplicate targets do not delete neighboring records after array indices shift

## Rationale
`removeRecordsByTargets` validates targets against the pre-delete snapshot, then splices array indices in descending order. If the same target appeared twice, the same index was added twice; the second splice could remove whatever shifted into that position.

## Tests
- Red: `bun test partykit/__tests__/moderation.test.ts` failed with `Expected: 1 / Received: 2` for the repeated-target regression
- Green: `bun test partykit/__tests__/moderation.test.ts`
- Green: `bun test partykit/__tests__/moderationPersistence.test.ts`
- Green: `bunx tsc -p partykit --noEmit`

## Docs / changeset
- No package code changed, so no changeset is needed.
- No public user-facing API changed.