### PR TITLE
Standardize element-reference resolution (fix can-duplicate with #/selector)

### DIFF
--- a/.changeset/duplicate-element-ref-resolution.md
+++ b/.changeset/duplicate-element-ref-resolution.md
@@ -1,0 +1,6 @@
+---
+"@playhtml/common": patch
+"playhtml": patch
+---
+
+`can-duplicate` and `can-duplicate-to` now accept an element id, an id with a leading `#`, or any CSS selector — the same resolution `can-move-bounds` already used. Previously `can-duplicate="#my-template"` silently failed because the value was passed straight to `getElementById`. Clone ids are now derived from the resolved template element's own id, so a selector or `#`-prefixed value still produces valid clone ids.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -340,12 +340,13 @@ import { TagType } from "@playhtml/common";
   <TabItem label="Vanilla HTML">
 ```html
 <img id="bunny-template" src="/pixel-bunny.png" alt="" />
-<button can-duplicate="#bunny-template" id="clone-btn">clone a bunny</button>
+<button can-duplicate="bunny-template" id="clone-btn">clone a bunny</button>
 
 <script>
   // The "reset" button sweeps every spawned rabbit from shared state.
+  // Clones get an id of the form "bunny-template-<random>", so match on that prefix.
   document.getElementById("reset-btn").addEventListener("click", () => {
-    document.querySelectorAll("[data-duplicate-source='#bunny-template']").forEach((el) => {
+    document.querySelectorAll("[id^='bunny-template-']").forEach((el) => {
       playhtml.deleteElementData("can-duplicate", el.id);
       el.remove();
     });
@@ -358,7 +359,7 @@ By default, clones are inserted right after the template (or the previous clone)
 
 ```html
 <button
-  can-duplicate="#bunny-template"
+  can-duplicate="bunny-template"
   can-duplicate-to="#bunny-pen"
   id="clone-btn"
 >clone a bunny</button>

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -25,15 +25,15 @@ The fastest path — no `import`, no `playhtml.init()` call. Add the script tag 
 <body>
   <button id="my-lamp" can-toggle>lamp</button>
 
-  <script type="module" src="https://unpkg.com/playhtml/init.js"></script>
+  <script type="module" src="https://unpkg.com/playhtml/dist/init.es.js"></script>
 </body>
 ```
 
 Give every interactive element a unique `id`. That's how state is keyed and synced across everyone on the page.
 
-> Why end-of-body? `init.js` runs `playhtml.init()` immediately, and `init()` scans the DOM for capability attributes (`can-toggle`, `can-move`, etc.) when it runs. Place it after the elements it should find.
+> Why end-of-body? The drop-in script runs `playhtml.init()` immediately, and `init()` scans the DOM for capability attributes (`can-toggle`, `can-move`, etc.) when it runs. Place it after the elements it should find.
 
-> Want options like cursors? Use Path B — the drop-in `init.js` calls `playhtml.init({})` with no options.
+> Want options like cursors? Use Path B — the drop-in script calls `playhtml.init({})` with no options.
 
 ### Path B: import + manual init (when you need options or a bundler)
 

--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -57,13 +57,14 @@ CRITICAL REQUIREMENTS:
 SETUP — Vanilla HTML (can-play with custom logic):
 The ordering rule is strict: assign all the custom properties BEFORE you call playhtml.init().
 
+  import { playhtml } from "https://unpkg.com/playhtml";
+
   const element = document.getElementById("myElement");
 
   element.defaultData = { /* ... */ };
   element.onClick = (e, { data, setData }) => { /* ... */ };
   element.updateElement = ({ data }) => { /* ... */ };
 
-  import { playhtml } from "https://unpkg.com/playhtml";
   playhtml.init();
 
 SETUP — React:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -123,11 +123,23 @@ function roundToFirstDecimal(n: number): number {
   return Math.round(n * 10) / 10 + 0;
 }
 
+/**
+ * Resolves an attribute value that names another element to that element.
+ * Accepts a bare id (`arena`), an id with leading `#` (`#arena`), or any CSS
+ * selector (`.container`): an id lookup is tried first, then a selector match.
+ */
+function resolveElementRef(raw: string | null | undefined): HTMLElement | null {
+  const value = raw?.trim();
+  if (!value) return null;
+  const forId = value.startsWith("#") ? value.slice(1) : value;
+  return (
+    document.getElementById(forId) ??
+    (document.querySelector(value) as HTMLElement | null)
+  );
+}
+
 function getMoveBoundsRoot(element: HTMLElement): HTMLElement | null {
-  const raw = element.getAttribute(CanMoveBounds)?.trim();
-  if (!raw) return null;
-  const forId = raw.startsWith("#") ? raw.slice(1) : raw;
-  return document.getElementById(forId) ?? document.querySelector(raw);
+  return resolveElementRef(element.getAttribute(CanMoveBounds));
 }
 
 /**
@@ -185,6 +197,10 @@ export type GrowData = {
   maxScale: number;
   isHovering: boolean;
 };
+/**
+ * Optional container for clones: an element id (with or without leading `#`)
+ * or any CSS selector. Defaults to inserting clones after the template.
+ */
 export const CanDuplicateTo = "can-duplicate-to";
 /**
  * Optional id (`my-arena`, `#my-arena`) or selector (`.arena`) of a container;
@@ -562,27 +578,24 @@ export const TagTypeToElement: DefaultTagInitializers = {
     defaultData: [],
     defaultLocalData: [],
     updateElement: ({ data, localData, setLocalData, element }) => {
-      const duplicateElementId = element.getAttribute(TagType.CanDuplicate)!;
-      const elementToDuplicate = document.getElementById(duplicateElementId);
+      const duplicateRef = element.getAttribute(TagType.CanDuplicate)!;
+      const elementToDuplicate = resolveElementRef(duplicateRef);
       let lastElement: HTMLElement | null =
         document.getElementById(localData.slice(-1)?.[0]) ?? null;
       if (!elementToDuplicate) {
         console.error(
-          `Element with id ${duplicateElementId} not found. Cannot duplicate.`,
+          `Element ${duplicateRef} not found. Cannot duplicate.`,
         );
         return;
       }
 
-      const canDuplicateTo = element.getAttribute(CanDuplicateTo);
+      const duplicateToElement = resolveElementRef(
+        element.getAttribute(CanDuplicateTo),
+      );
       function insertDuplicatedElement(newElement: Node) {
-        if (canDuplicateTo) {
-          const duplicateToElement =
-            document.getElementById(canDuplicateTo) ||
-            document.querySelector(canDuplicateTo);
-          if (duplicateToElement) {
-            duplicateToElement.appendChild(newElement);
-            return;
-          }
+        if (duplicateToElement) {
+          duplicateToElement.appendChild(newElement);
+          return;
         }
 
         // By default insert after the latest element inserted (or the element to duplicate if none yet)
@@ -610,9 +623,14 @@ export const TagTypeToElement: DefaultTagInitializers = {
       setLocalData(localData);
     },
     onClick: (_e: MouseEvent, { data, element, setData }) => {
-      const duplicateElementId = element.getAttribute(TagType.CanDuplicate)!;
+      const elementToDuplicate = resolveElementRef(
+        element.getAttribute(TagType.CanDuplicate),
+      );
+      if (!elementToDuplicate) return;
+      // Clone ids are prefixed with the template's own id (not the raw
+      // attribute) so a `#id` or selector value still yields a valid id.
       const newElementId =
-        duplicateElementId + "-" + Math.random().toString(36).substr(2, 9);
+        elementToDuplicate.id + "-" + Math.random().toString(36).substr(2, 9);
 
       setData((draft) => {
         draft.push(newElementId);
@@ -624,7 +642,7 @@ export const TagTypeToElement: DefaultTagInitializers = {
         return false;
       }
 
-      if (!document.getElementById(tagAttribute)) {
+      if (!resolveElementRef(tagAttribute)) {
         console.warn(
           `${TagType.CanDuplicate} element (${element.id}) duplicate element ("${tagAttribute}") not found.`,
         );

--- a/packages/playhtml/src/__tests__/duplicate-element-ref.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-element-ref.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Verifies can-duplicate resolves its template by bare id, #id, or selector.
+// ABOUTME: Locks in that clone ids derive from the resolved template's own id.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playhtml, resetPlayHTML } from "../index";
+
+async function setupDuplicateButton(duplicateAttr: string, templateMarkup: string) {
+  document.body.innerHTML = `
+    ${templateMarkup}
+    <button id="clone-btn" can-duplicate="${duplicateAttr}">clone</button>
+  `;
+  const button = document.getElementById("clone-btn")!;
+  await playhtml.setupPlayElementForTag(button, "can-duplicate");
+  return button;
+}
+
+describe("can-duplicate element reference resolution", () => {
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+    await playhtml.init({});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+  });
+
+  it("resolves a bare id and clones it on click", async () => {
+    const button = await setupDuplicateButton(
+      "bunny-template",
+      `<div id="bunny-template">bunny</div>`,
+    );
+
+    button.click();
+    await new Promise((r) => queueMicrotask(r));
+
+    const clones = document.querySelectorAll("[id^='bunny-template-']");
+    expect(clones.length).toBe(1);
+  });
+
+  it("resolves an id with a leading #", async () => {
+    const button = await setupDuplicateButton(
+      "#bunny-template",
+      `<div id="bunny-template">bunny</div>`,
+    );
+
+    button.click();
+    await new Promise((r) => queueMicrotask(r));
+
+    // Clone id is prefixed with the resolved element's own id, not the raw "#..." value.
+    const clones = document.querySelectorAll("[id^='bunny-template-']");
+    expect(clones.length).toBe(1);
+    expect(document.querySelector("[id^='#']")).toBeNull();
+  });
+
+  it("resolves a CSS selector to the template element", async () => {
+    const button = await setupDuplicateButton(
+      ".bunny-template",
+      `<div id="bunny-template" class="bunny-template">bunny</div>`,
+    );
+
+    button.click();
+    await new Promise((r) => queueMicrotask(r));
+
+    const clones = document.querySelectorAll("[id^='bunny-template-']");
+    expect(clones.length).toBe(1);
+  });
+
+  it("does not push clone data when the template is missing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const button = await setupDuplicateButton("does-not-exist", "");
+
+    button.click();
+    await new Promise((r) => queueMicrotask(r));
+
+    expect(document.querySelectorAll("[id^='does-not-exist-']").length).toBe(0);
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Element-reference attributes resolved their values inconsistently. `can-move-bounds` already accepted a bare id, a `#id`, or a CSS selector; `can-duplicate-to` accepted id-or-selector but didn't strip a leading `#`; and `can-duplicate` used `getElementById` **only**, so `can-duplicate="#bunny-template"` silently failed.

This extracts the resolution into a shared `resolveElementRef` helper and uses it for all three attributes. They now behave identically: id lookup first, selector fallback, leading `#` stripped.

Clone ids now derive from the **resolved template element's own `id`** rather than the raw attribute value, so a `#id` or selector value still produces valid clone ids (e.g. `bunny-template-abc123`, not `#bunny-template-abc123`).

## Docs fixes surfaced while auditing

Audited every vanilla HTML/JS snippet across the docs against the real library API. Three were broken if copy-pasted:

1. **`capabilities.mdx`** — the `can-duplicate` reset snippet queried `[data-duplicate-source='#bunny-template']`, an attribute the library never sets. Clones actually get an id of the form `<templateId>-<random>`, so it now matches `[id^='bunny-template-']`. Also switched the example values from `#bunny-template` to the bare-id form.
2. **`getting-started.mdx`** — the drop-in script tag pointed at `https://unpkg.com/playhtml/init.js`, which has never been published (the built file is `dist/init.es.js`). Corrected. *(Follow-up: add an `init.js` alias to the package so the short URL works — see issue.)*
3. **`building-with-ai.md`** — the vanilla `can-play` setup snippet placed `import` after executable statements (a `SyntaxError`). Moved the import to the top.

## Behavior change

`can-duplicate`'s `onClick` now early-returns when the template element is missing, instead of pushing an unrealizable clone id into shared state. This prevents orphan ids accumulating in synced state for a non-existent template.

## Tests

New `packages/playhtml/src/__tests__/duplicate-element-ref.test.ts` covers bare id, `#id`, selector resolution, and the missing-template no-op. Full suite: **211 passing**. Independent code review found no high-confidence issues.

## Changeset

`@playhtml/common` + `playhtml` patch. `@playhtml/react` is intentionally omitted — `CanDuplicateElement` resolves its template ref to a bare id before passing it through, so its behavior is unchanged.