### PR TITLE
website: append guestbook entries with mutator

### DIFF
--- a/extension/website/src/components/AuraGuestbook.tsx
+++ b/extension/website/src/components/AuraGuestbook.tsx
@@ -12,6 +12,7 @@ import {
 import { withSharedState, usePlayContext } from "@playhtml/react";
 import { containsProfanity } from "@movement/profanity";
 import {
+  appendGuestbookEntry,
   getGuestbookDotColors,
   getLoopedEntryIndex,
   getRenderedPileCardIndexes,
@@ -597,15 +598,14 @@ export const AuraGuestbook = withSharedState(
         return;
       }
       setError("");
-      setData([
-        ...data,
-        {
+      setData((draft) => {
+        appendGuestbookEntry(draft, {
           name: trimmedName || "someone",
           color: cursors.color || "#8a8279",
           message: trimmedMessage,
           timestamp: Date.now(),
-        },
-      ]);
+        });
+      });
       setMessage("");
       setName("");
       setComposing(false);

--- a/extension/website/src/components/__tests__/AuraGuestbook.test.ts
+++ b/extension/website/src/components/__tests__/AuraGuestbook.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  appendGuestbookEntry,
   getGuestbookDotColors,
   getLoopedEntryIndex,
   getRenderedPileCardIndexes,
@@ -107,5 +108,23 @@ describe("getLoopedEntryIndex", () => {
 
   it("keeps the current index when there are no entries", () => {
     expect(getLoopedEntryIndex(0, 0, 1)).toBe(0);
+  });
+});
+
+describe("appendGuestbookEntry", () => {
+  it("adds the new entry to the current draft without replacing existing entries", () => {
+    const draft = [
+      entry("#123456", 1),
+      entry("#abcdef", 2),
+    ];
+    const nextEntry = entry("#4a9a8a", 3);
+
+    appendGuestbookEntry(draft, nextEntry);
+
+    expect(draft).toEqual([
+      entry("#123456", 1),
+      entry("#abcdef", 2),
+      nextEntry,
+    ]);
   });
 });

--- a/extension/website/src/components/auraGuestbookData.ts
+++ b/extension/website/src/components/auraGuestbookData.ts
@@ -8,6 +8,13 @@ export interface GuestbookEntry {
   timestamp: number;
 }
 
+export function appendGuestbookEntry(
+  entries: GuestbookEntry[],
+  entry: GuestbookEntry,
+): void {
+  entries.push(entry);
+}
+
 export function getGuestbookDotColors(entries: GuestbookEntry[]): string[] {
   const sortedEntries = [...entries].sort((a, b) => a.timestamp - b.timestamp);
   const seen = new Set<string>();


### PR DESCRIPTION
## Summary
- submit Aura guestbook entries through `setData((draft) => ...)` instead of replacing shared data from a render snapshot
- add a small guestbook data helper and regression test for draft append behavior

## Rationale
The previous submit handler used `setData([...data, entry])`. If two clients submitted from the same stale render snapshot, the later write could drop the other entry. Using the mutator form appends to the current shared draft.

## Tests
- Red: `bunx vitest run src/components/__tests__/AuraGuestbook.test.ts` failed with `appendGuestbookEntry is not a function` before the helper/fix existed
- Green: `bunx vitest run src/components/__tests__/AuraGuestbook.test.ts`
- Green: `git diff --check`

## Notes
- No package code changed, so no changeset is needed.
- I attempted broader website verification. `bunx vitest run` fails in isolated worktrees because the website config aliases React to the worktree repo-root `node_modules`, which is absent. `bunx tsc --noEmit` also fails on existing package type errors outside this PR's scope.