### PR TITLE
docs: remove AI-writing patterns (em-dash overuse, poetic filler)

### DIFF
--- a/apps/docs/src/content/docs/advanced/development.mdx
+++ b/apps/docs/src/content/docs/advanced/development.mdx
@@ -7,15 +7,15 @@ sidebar:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-playhtml ships with a built-in **development mode** — an in-page devtools panel that makes it easy to debug your collaborative elements while you're building. Turn it on while developing, and remember to turn it off before you deploy.
+playhtml ships with a built-in **development mode**: an in-page devtools panel for debugging your collaborative elements while you're building. Turn it on while developing, and remember to turn it off before you deploy.
 
 The panel lets you:
 
-- **See the data stored** for every element — a live tree of synced state that updates as you and others interact.
-- **Find the active elements** on the page — each row maps to an element, and hovering it highlights where that element lives.
-- **Reset data** — restore one element (or all of them) to its defaults when you want a clean slate.
-- **Watch the console** — playhtml's logs, mirrored in a tab so you don't have to dig through the browser console.
-- **Check the connection** — the current room, host, and how many readers and elements are live.
+- **See the data stored** for every element: a live tree of synced state that updates as you and others interact.
+- **Find the active elements** on the page: each row maps to an element, and hovering it highlights where that element lives.
+- **Reset data**: restore one element (or all of them) to its defaults when you want a clean slate.
+- **Watch the console**: playhtml's logs, mirrored in a tab so you don't have to dig through the browser console.
+- **Check the connection**: the current room, host, and how many readers and elements are live.
 
 ## Development mode
 
@@ -48,14 +48,14 @@ Each row in the Data tab is one element. Expand it to see its live data tree, an
 
 State persists per room, so a value you set while testing stays until you reset it. The devtools panel gives you two ways to do that.
 
-**Reset one element.** Hover a row in the Data tab and click **reset** — it restores that element to its `defaultData` (a moved element snaps back to its origin, a toggle to off). The change syncs to everyone in the room, same as any other update.
+**Reset one element.** Hover a row in the Data tab and click **reset**. It restores that element to its `defaultData` (a moved element snaps back to its origin, a toggle to off). The change syncs to everyone in the room, same as any other update.
 
 ![Hovering an element row reveals a reset button; Reset All sits at the top of the panel](/docs/dev-toolbar-reset.png)
 
 **Reset everything.** **Reset All**, at the top of the panel, restores every element on the page to its defaults at once.
 
-Readers can also reset the built-in interactive capabilities themselves by [shift-clicking](/docs/capabilities/) an element — handy for "clear the board" affordances you want to expose in your own UI.
+Readers can also reset the built-in interactive capabilities themselves by [shift-clicking](/docs/capabilities/) an element, which is handy for "clear the board" affordances you want to expose in your own UI.
 
 ## Starting fresh
 
-To wipe state without resetting elements one by one, point your app at a **new room** — change the [`room` option](/docs/reference/init-options/) to a string you haven't used before. The new room starts empty; the old one is untouched, so you can switch back. This is the quickest way to get a clean slate while iterating on a layout.
+To wipe state without resetting elements one by one, point your app at a **new room**: change the [`room` option](/docs/reference/init-options/) to a string you haven't used before. The new room starts empty; the old one is untouched, so you can switch back. This is the quickest way to get a clean slate while iterating on a layout.

--- a/apps/docs/src/content/docs/advanced/dynamic-elements.md
+++ b/apps/docs/src/content/docs/advanced/dynamic-elements.md
@@ -7,7 +7,7 @@ sidebar:
 
 `playhtml.init()` walks the DOM once at startup and wires up every element it finds. Two situations fall outside that single pass:
 
-1. You **create new playhtml elements after init** — a new row in a list, a cloned template, a client-rendered component. The library doesn't know they exist yet.
+1. You **create new playhtml elements after init**: a new row in a list, a cloned template, a client-rendered component. The library doesn't know they exist yet.
 2. You have **many elements of the same kind** that can't each get a hand-written unique id but still need their own slot of synced state.
 
 This page covers both.
@@ -25,13 +25,13 @@ document.body.appendChild(el);
 playhtml.setupPlayElement(el);
 ```
 
-`setupPlayElement(element, options?)` is **idempotent** — pass `{ ignoreIfAlreadySetup: true }` to skip elements that are already wired, which is handy when the same code path can run over both fresh and existing nodes:
+`setupPlayElement(element, options?)` is **idempotent**. Pass `{ ignoreIfAlreadySetup: true }` to skip elements that are already wired, which is handy when the same code path can run over both fresh and existing nodes:
 
 ```js
 playhtml.setupPlayElement(el, { ignoreIfAlreadySetup: true });
 ```
 
-To re-walk the whole DOM (e.g. after injecting a chunk of server-rendered HTML), call `playhtml.setupPlayElements()` — the same pass `init()` runs.
+To re-walk the whole DOM (e.g. after injecting a chunk of server-rendered HTML), call `playhtml.setupPlayElements()`, the same pass `init()` runs.
 
 ### Cleaning up
 
@@ -42,7 +42,7 @@ playhtml.removePlayElement(el);
 el.remove();
 ```
 
-`removePlayElement` only detaches the live handlers — **the element's persisted shared data stays in the room**, so if you re-add an element with the same id it picks up where it left off. To also wipe the saved data, use `deleteElementData(tag, id)`:
+`removePlayElement` only detaches the live handlers. **The element's persisted shared data stays in the room**, so if you re-add an element with the same id it picks up where it left off. To also wipe the saved data, use `deleteElementData(tag, id)`:
 
 ```js
 playhtml.deleteElementData("can-move", "note-42");
@@ -52,13 +52,13 @@ See [Development & data cleanup](/docs/advanced/development/) for inspecting and
 
 ### React
 
-In React you rarely call these directly — mounting a `<CanMoveElement>` (or any capability component) registers the node, and unmounting it calls `removePlayElement` for you. The one place it surfaces is `can-duplicate`, where clones are created imperatively: `CanDuplicateElement` calls `setupPlayElement` on each new clone under the hood. See the [React API reference](/docs/reference/react-api/#other-capability-components).
+In React you rarely call these directly: mounting a `<CanMoveElement>` (or any capability component) registers the node, and unmounting it calls `removePlayElement` for you. The one place it surfaces is `can-duplicate`, where clones are created imperatively: `CanDuplicateElement` calls `setupPlayElement` on each new clone under the hood. See the [React API reference](/docs/reference/react-api/#other-capability-components).
 
 ## Many-of-a-kind elements with `selector-id`
 
-Every playhtml element needs a [stable id](/docs/capabilities/) so collaborators agree on which element owns which state. For a list of structurally identical elements — fridge magnets, reaction buttons, a grid of cells — inventing a unique id for each is tedious and error-prone.
+Every playhtml element needs a [stable id](/docs/capabilities/) so collaborators agree on which element owns which state. For a list of structurally identical elements (fridge magnets, reaction buttons, a grid of cells), inventing a unique id for each is tedious and error-prone.
 
-`selector-id` solves this. Give every element in the group the **same** `selector-id` value (a CSS selector that matches all of them), and playhtml assigns each one a stable id based on **its position among the selector's matches**. The 1st `.magnet` always gets the 1st slot of state, the 2nd gets the 2nd, and so on — consistently for every visitor.
+`selector-id` solves this. Give every element in the group the **same** `selector-id` value (a CSS selector that matches all of them), and playhtml assigns each one a stable id based on **its position among the selector's matches**. The 1st `.magnet` always gets the 1st slot of state, the 2nd gets the 2nd, and so on, consistently for every visitor.
 
 ```html
 <div id="fridge">
@@ -92,4 +92,4 @@ export const FridgeWord = withSharedState(
 );
 ```
 
-Render a `<FridgeWord>` for each word inside `#fridge` and every one gets its own draggable, synced position — no per-word id required.
+Render a `<FridgeWord>` for each word inside `#fridge` and every one gets its own draggable, synced position, with no per-word id required.

--- a/apps/docs/src/content/docs/advanced/mirror-playground.mdx
+++ b/apps/docs/src/content/docs/advanced/mirror-playground.mdx
@@ -223,7 +223,7 @@ li.textContent = "added via console";
 el.appendChild(li);
 ```
 
-Anything a MutationObserver would fire for (attribute additions and removals, childList inserts, characterData changes) can-mirror sends across. That's the whole capability.
+Anything a MutationObserver would fire for (attribute additions and removals, childList inserts, characterData changes) can-mirror sends across.
 
 ## What doesn't mirror (yet)
 

--- a/apps/docs/src/content/docs/advanced/mirror-playground.mdx
+++ b/apps/docs/src/content/docs/advanced/mirror-playground.mdx
@@ -5,15 +5,15 @@ sidebar:
   order: 5
 ---
 
-`can-mirror` is the "everything syncs" capability. Put it on any element and playhtml observes the DOM — input values, checked state, pseudo-class data attributes, attribute changes, child adds/removes — then replays those mutations on every other reader.
+`can-mirror` is the "everything syncs" capability. Put it on any element and playhtml observes the DOM (input values, checked state, pseudo-class data attributes, attribute changes, child adds/removes), then replays those mutations on every other reader.
 
-This page hosts **every edge case we've found useful**, one section each. Open it in two browser windows side by side and poke at each demo — everything should mirror.
+This page hosts **every edge case we've found useful**, one section each. Open it in two browser windows side by side and poke at each demo. Everything should mirror.
 
 Nothing on this page requires custom JavaScript. It's all plain HTML with `can-mirror` on a root element. The docs site's shared `playhtml.init()` picks each one up automatically.
 
 ## :hover
 
-The synced `data-playhtml-hover` attribute lets CSS target the hover state from across the network. Hover over the box in one tab — it turns green in every other tab.
+The synced `data-playhtml-hover` attribute lets CSS target the hover state from across the network. Hover over the box in one tab and it turns green in every other tab.
 
 <div className="ph-mirror-sample">
   <div can-mirror id="pg-mirror-hover" className="pg-hover-box">
@@ -34,7 +34,7 @@ The synced `data-playhtml-hover` attribute lets CSS target the hover state from 
 
 ## :focus
 
-Click the input — the blue outline shows for every client until you blur.
+Click the input and the blue outline shows for every client until you blur.
 
 <div className="ph-mirror-sample">
   <input
@@ -48,7 +48,7 @@ Click the input — the blue outline shows for every client until you blur.
 
 ## Text input
 
-Type — the value replicates.
+Type and the value replicates.
 
 <div className="ph-mirror-sample">
   <input can-mirror id="pg-mirror-text" type="text" placeholder="Type here..." />
@@ -132,7 +132,7 @@ Type — the value replicates.
 
 ## Details / summary
 
-Expand and collapse — the native `open` attribute mirrors automatically.
+Expand and collapse, and the native `open` attribute mirrors automatically.
 
 <div className="ph-mirror-sample">
   <details can-mirror id="pg-mirror-details">
@@ -147,7 +147,7 @@ Expand and collapse — the native `open` attribute mirrors automatically.
 
 ## contenteditable
 
-Type, paste, delete — every mutation lands on every client. Try pressing `Enter` inside the list to add items; delete them by selecting and pressing `Backspace`.
+Type, paste, and delete: every mutation lands on every client. Try pressing `Enter` inside the list to add items; delete them by selecting and pressing `Backspace`.
 
 <div className="ph-mirror-sample">
   <div
@@ -169,14 +169,14 @@ Type, paste, delete — every mutation lands on every client. Try pressing `Ente
     suppressContentEditableWarning
     className="pg-editable pg-editable--list"
   >
-    <li>First item — type to edit, Enter for new line</li>
+    <li>First item: type to edit, Enter for new line</li>
     <li>Second item</li>
   </ul>
 </div>
 
 ## Mixed form inputs
 
-A single `can-mirror` wrapping a form with heterogeneous inputs — all of them sync together.
+A single `can-mirror` wrapping a form with heterogeneous inputs, all of them sync together.
 
 <div className="ph-mirror-sample">
   <div can-mirror id="pg-mirror-mixedform" className="pg-mixed-form">
@@ -212,7 +212,7 @@ el.classList.add("is-flag");
 el.setAttribute("data-you-changed-this", "yes");
 ```
 
-Then open this page in another tab and inspect the element — the class and the custom attribute will be there too.
+Then open this page in another tab and inspect the element. The class and the custom attribute will be there too.
 
 Same trick for programmatic child changes:
 
@@ -223,14 +223,14 @@ li.textContent = "added via console";
 el.appendChild(li);
 ```
 
-Anything a MutationObserver would fire for — attribute additions and removals, childList inserts, characterData changes — can-mirror sends across. That's the whole capability.
+Anything a MutationObserver would fire for (attribute additions and removals, childList inserts, characterData changes) can-mirror sends across. That's the whole capability.
 
 ## What doesn't mirror (yet)
 
-- **Scroll position** on nested containers — `scrollTop`/`scrollLeft` aren't DOM mutations, so the observer doesn't catch them.
-- **Media playback** — `<video>`/`<audio>` `currentTime` isn't attribute-driven.
-- **Canvas / WebGL** — pixel changes don't emit mutations.
-- **File inputs** — `<input type="file">`'s selected file isn't serializable across the wire.
+- **Scroll position** on nested containers: `scrollTop`/`scrollLeft` aren't DOM mutations, so the observer doesn't catch them.
+- **Media playback**: `<video>`/`<audio>` `currentTime` isn't attribute-driven.
+- **Canvas / WebGL**: pixel changes don't emit mutations.
+- **File inputs**: `<input type="file">`'s selected file isn't serializable across the wire.
 
 For these, use element data with `can-play` and explicitly sync the bit you care about.
 

--- a/apps/docs/src/content/docs/advanced/navigation.md
+++ b/apps/docs/src/content/docs/advanced/navigation.md
@@ -1,18 +1,18 @@
 ---
 title: "Navigation & SPAs"
-description: "How playhtml handles client-side navigation — React Router, Next.js, Astro ViewTransitions, htmx boost, Turbo."
+description: "How playhtml handles client-side navigation: React Router, Next.js, Astro ViewTransitions, htmx boost, Turbo."
 sidebar:
   order: 4
 ---
 
-playhtml works out of the box on full-page-reload sites. For single-page apps (SPAs) and frameworks with client-side navigation — React Router, Next.js, Astro ViewTransitions, htmx boost, Turbo — you'll want the patterns on this page so cursors, rooms, and element handlers stay consistent across navigation.
+playhtml works out of the box on full-page-reload sites. For single-page apps (SPAs) and frameworks with client-side navigation (React Router, Next.js, Astro ViewTransitions, htmx boost, Turbo), you'll want the patterns on this page so cursors, rooms, and element handlers stay consistent across navigation.
 
 ## How navigation detection works
 
 playhtml automatically listens for:
 
-- The browser's `navigation` API (`navigation.addEventListener("navigate")`) — fires on pushState, replaceState, and back/forward in Chromium 102+.
-- `popstate` events — fires on back/forward in all browsers.
+- The browser's `navigation` API (`navigation.addEventListener("navigate")`): fires on pushState, replaceState, and back/forward in Chromium 102+.
+- `popstate` events: fires on back/forward in all browsers.
 
 Whenever navigation is detected, playhtml recomputes the room. If it changed, playhtml reconnects to the new room, rescans the DOM for interactive elements, and refreshes cursors. **On a room change the document's data resets to the new room** (see [Room-scoped data](#room-scoped-data-on-navigation) below).
 
@@ -35,9 +35,9 @@ A static string stays fixed across navigation (good for a single shared room). A
 
 ## Room-scoped data on navigation
 
-Data in playhtml — both element data (`can-move`, `can-toggle`, …) and page data (`createPageData`) — is scoped to the room. When navigation **changes the room**, the document re-initializes so the new room starts from a clean state: the old room's data does not carry over, and your code re-creates / re-registers it for the new room exactly as on a fresh page load.
+Data in playhtml, both element data (`can-move`, `can-toggle`, …) and page data (`createPageData`), is scoped to the room. When navigation **changes the room**, the document re-initializes so the new room starts from a clean state: the old room's data does not carry over, and your code re-creates / re-registers it for the new room exactly as on a fresh page load.
 
-When navigation does **not** change the room — a hash change, a static explicit room, or a path that maps to the same room — nothing resets and data persists across the route change.
+When navigation does **not** change the room (a hash change, a static explicit room, or a path that maps to the same room), nothing resets and data persists across the route change.
 
 This reset discards the in-memory document and rebuilds it; it never deletes from the previous room, so a previous room's persisted data is never modified by navigating away and back.
 
@@ -141,8 +141,8 @@ The default auto-detection handles this because Astro fires `popstate`. You only
 
 ## Events
 
-- `playhtml:navigated` — fires on `document` after each successful navigation handling, with `event.detail.room` set to the current room ID.
+- `playhtml:navigated`: fires on `document` after each successful navigation handling, with `event.detail.room` set to the current room ID.
 
 ## Handles held across navigation
 
-A `createPageData` handle you keep across a room-changing navigation stays usable: it reads the new room's data (its default until re-seeded), its `setData` still writes, and its `onUpdate` keeps firing. You don't have to re-create channels on navigation, though doing so is also fine — a re-created channel and a surviving handle for the same name share one live channel in the new room.
+A `createPageData` handle you keep across a room-changing navigation stays usable: it reads the new room's data (its default until re-seeded), its `setData` still writes, and its `onUpdate` keeps firing. You don't have to re-create channels on navigation, though doing so is also fine: a re-created channel and a surviving handle for the same name share one live channel in the new room.

--- a/apps/docs/src/content/docs/advanced/shared-elements.md
+++ b/apps/docs/src/content/docs/advanced/shared-elements.md
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-Shared elements are a way to share data between different pages on the same site and even across different domains. Effectively, this allows for cross-origin data sharing that can be rendered with custom markup and styles. These are defined by a source page and can be referenced on the consumer page by their domain and path (the playhtml room that they are assigned to).
+Shared elements let you share data between different pages on the same site, and even across different domains. The same state can be rendered with different markup and styles on each page. You define a shared element on a source page, then reference it on a consumer page by its domain and path (the playhtml room it's assigned to).
 
 ```html
 <!-- Source page (thissite.com) -->

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -19,22 +19,22 @@ import { SmileyRow } from '@/components/react/capability-demos/SmileyRow';
 Every capability in playhtml is a single HTML attribute. Slap it on an element, give the element an `id`, and the library handles sync, persistence, and event wiring. This page catalogs the eight built-ins plus `can-play`, in order from most-commonly used to most-specialized.
 
 :::tip[Every playhtml element needs a stable id]
-The `id` is the key an element's synced data is stored under, so it must be **stable across reloads and browsers** — that's how two visitors agree on which element is which. A hand-written `id="my-lamp"` is ideal. If you omit it, playhtml falls back to hashing the element's HTML, which can differ across browsers and break sync.
+The `id` is the key an element's synced data is stored under, so it must be **stable across reloads and browsers**. That's how two visitors agree on which element is which. A hand-written `id="my-lamp"` is ideal. If you omit it, playhtml falls back to hashing the element's HTML, which can differ across browsers and break sync.
 
-For **many elements that share a selector** — a row of magnets, a list of reactions — give each the same markup and add a single `selector-id` attribute instead of inventing unique ids. playhtml indexes the matches by position, so the N-th `.magnet` always gets the N-th slot of state. See [Dynamic elements](/docs/advanced/dynamic-elements/#many-of-a-kind-elements-with-selector-id).
+For **many elements that share a selector** (a row of magnets, a list of reactions), give each the same markup and add a single `selector-id` attribute instead of inventing unique ids. playhtml indexes the matches by position, so the N-th `.magnet` always gets the N-th slot of state. See [Dynamic elements](/docs/advanced/dynamic-elements/#many-of-a-kind-elements-with-selector-id).
 :::
 
 :::tip[Shift-click to reset]
-The built-in interactive capabilities — `can-move`, `can-spin`, `can-toggle`, and `can-grow` — support **shift-clicking** an element to reset it to its default state. Because the state is shared, this resets it for everyone in the room (a moved element snaps back to its origin, a spun one to 0°, a toggle to off, a grown one to scale 1). Custom `can-play` elements can opt into this with the [`resetShortcut`](#resetting-custom-elements) option.
+The built-in interactive capabilities (`can-move`, `can-spin`, `can-toggle`, and `can-grow`) support **shift-clicking** an element to reset it to its default state. Because the state is shared, this resets it for everyone in the room (a moved element snaps back to its origin, a spun one to 0°, a toggle to off, a grown one to scale 1). Custom `can-play` elements can opt into this with the [`resetShortcut`](#resetting-custom-elements) option.
 :::
 
 Every section below has the same shape:
 
 - A short description of what the capability does and the kind of state it owns.
-- A live demo you can interact with — open the page in a second tab and watch both update.
+- A live demo you can interact with. Open the page in a second tab and watch both update.
 - The **vanilla HTML** form, and the **React** form. Pick the framework you're shipping in; the reader's choice syncs across every snippet on the page.
 
-This page also runs a few `can-play` demos directly in its margins — a [doodle strip](#play-doodle) below, a [guestbook](#play-guestbook) further down, a [prize wheel](#play-spinner) at the bottom, and a shared [tally on every code block](#play-copy) you copy from. They're discussed properly in the [`can-play`](#can-play) section.
+This page also runs a few `can-play` demos directly in its margins: a [doodle strip](#play-doodle) below, a [guestbook](#play-guestbook) further down, a [prize wheel](#play-spinner) at the bottom, and a shared [tally on every code block](#play-copy) you copy from. They're discussed properly in the [`can-play`](#can-play) section.
 
 <div id="play-doodle" class="ph-canplay-inline" data-label="can-play · doodle strip">
   <div class="ph-canplay-inline__head">
@@ -50,7 +50,7 @@ This page also runs a few `can-play` demos directly in its margins — a [doodle
 
 **What it does.** Drag anywhere. Position persists and syncs.
 
-**Use it for:** drag-and-drop affordances — fridge magnets, game pieces, arrangeable stickers, a puzzle.
+**Use it for:** drag-and-drop affordances such as fridge magnets, game pieces, arrangeable stickers, a puzzle.
 
 <div class="ph-demo-slot" data-label="LIVE DEMO — can-move">
   <MoveHatCatDemo client:only="react" />
@@ -110,10 +110,10 @@ import { CanMoveElement } from "@playhtml/react";
   </TabItem>
 </Tabs>
 
-The **cursor** can go past the container edge — only the element's position is clamped. By default, the keep-visible slice is `max(25% of element size, 60px)` on every edge, so readers always have something to grab. Two knobs let you tune that:
+The **cursor** can go past the container edge; only the element's position is clamped. By default, the keep-visible slice is `max(25% of element size, 60px)` on every edge, so readers always have something to grab. Two knobs let you tune that:
 
-- `can-move-bounds-min-visible` / `boundsMinVisible` — fraction `(0–1)` of the element to keep inside. `1` pins fully inside (strict clamp); `0` drops the fraction constraint entirely.
-- `can-move-bounds-min-visible-px` / `boundsMinVisiblePx` — absolute pixel floor. Useful when an image has transparent padding around its paint; a pure fraction of the layout bbox can let the visible pixels clip into invisible border.
+- `can-move-bounds-min-visible` / `boundsMinVisible`: fraction `(0–1)` of the element to keep inside. `1` pins fully inside (strict clamp); `0` drops the fraction constraint entirely.
+- `can-move-bounds-min-visible-px` / `boundsMinVisiblePx`: absolute pixel floor. Useful when an image has transparent padding around its paint; a pure fraction of the layout bbox can let the visible pixels clip into invisible border.
 
 The effective slice on each axis is `max(fraction × size, pxFloor)`. Set both to `0` to opt fully out of the keep-visible guarantee and let the element slip entirely out of view.
 
@@ -156,7 +156,7 @@ import { CanMoveElement } from "@playhtml/react";
 
 **What it does.** Click to flip an on/off boolean. Persists and syncs.
 
-**Use it for:** shared switches, lamps, "is-this-thing-open" signs, per-element read/unread state. The [playhtml homepage](https://playhtml.fun) uses this on the wordmark letters and the hanging lamp — click either to flip it for everyone.
+**Use it for:** shared switches, lamps, "is-this-thing-open" signs, per-element read/unread state. The [playhtml homepage](https://playhtml.fun) uses this on the wordmark letters and the hanging lamp; click either to flip it for everyone.
 
 <div class="ph-demo-slot" data-label="LIVE DEMO — can-toggle">
   <InteractiveToggleDemo client:only="react" />
@@ -196,7 +196,7 @@ import { CanToggleElement } from "@playhtml/react";
 </CanToggleElement>
 ```
 
-`CanToggleElement` already wires up the click handler — don't add your own `onClick`, or you'll toggle twice per click. Render declaratively from `data`.
+`CanToggleElement` already wires up the click handler. Don't add your own `onClick`, or you'll toggle twice per click. Render declaratively from `data`.
   </TabItem>
 </Tabs>
 
@@ -258,7 +258,7 @@ import { TagType } from "@playhtml/common";
 
 ## can-hover
 
-**What it does.** Shares hover state across everyone on the page. Presence-based, _not_ persistent — when a user leaves, their hover clears.
+**What it does.** Shares hover state across everyone on the page. Presence-based, _not_ persistent: when a user leaves, their hover clears.
 
 **Use it for:** "who's looking at this right now" affordances, social read-receipts, zero-latency shared hover effects.
 
@@ -266,7 +266,7 @@ import { TagType } from "@playhtml/common";
   <HoverCursorColorsDemo client:only="react" />
 </div>
 
-**How it works.** While *anyone* (you or another reader) is hovering the element, playhtml sets a `data-playhtml-hover` attribute on it; when nobody is hovering, the attribute is removed. Style the effect by targeting `[data-playhtml-hover]` instead of the `:hover` pseudo-class — that's the only change from a normal hover style, and it's the same attribute whether you use the vanilla capability or the React component.
+**How it works.** While *anyone* (you or another reader) is hovering the element, playhtml sets a `data-playhtml-hover` attribute on it; when nobody is hovering, the attribute is removed. Style the effect by targeting `[data-playhtml-hover]` instead of the `:hover` pseudo-class. That's the only change from a normal hover style, and it's the same attribute whether you use the vanilla capability or the React component.
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
@@ -355,7 +355,7 @@ import { TagType } from "@playhtml/common";
 <button id="reset-btn">reset</button>
 ```
 
-By default, clones are inserted right after the template (or the previous clone). Add **`can-duplicate-to`** — an element id or CSS selector — to drop every clone into a specific container instead:
+By default, clones are inserted right after the template (or the previous clone). Add **`can-duplicate-to`** (an element id or CSS selector) to drop every clone into a specific container instead:
 
 ```html
 <button
@@ -394,11 +394,11 @@ function BunnyField() {
 
 ## can-mirror
 
-**What it does.** A meta-capability: `can-mirror` auto-syncs **every attribute, child-node change, and form-state change** on the element. You don't write `defaultData`, `setData`, or an `updateElement` callback — the library observes the DOM for you.
+**What it does.** A meta-capability: `can-mirror` auto-syncs **every attribute, child-node change, and form-state change** on the element. You don't write `defaultData`, `setData`, or an `updateElement` callback; the library observes the DOM for you.
 
 **Use it for:** when the state you want to share _is_ the DOM: a shared textarea, a form, a growing list of children.
 
-### Vignette A — an emoji-only textarea
+### Vignette A: an emoji-only textarea
 
 A textarea that filters to emoji characters on input. The filtered value mirrors to everyone.
 
@@ -430,9 +430,9 @@ A textarea that filters to emoji characters on input. The filtered value mirrors
 </script>
 ```
 
-### Vignette B — a list you can add children to
+### Vignette B: a list you can add children to
 
-Click "+" to append a new `<li>`. The child addition itself mirrors — new readers see the whole list, not just the latest.
+Click "+" to append a new `<li>`. The child addition itself mirrors, so new readers see the whole list, not just the latest.
 
 <div class="ph-demo-slot" data-label="LIVE DEMO — can-mirror: growing list">
   <div class="ph-canmirror-vignette ph-canmirror-vignette--guestbook" data-can-mirror-vignette="guestbook">
@@ -467,7 +467,7 @@ Click "+" to append a new `<li>`. The child addition itself mirrors — new read
   <span className="ph-composed-card__title">See every can-mirror edge case →</span>
   <span className="ph-composed-card__body">
     Hover, focus, every form input, contenteditable, programmatic attribute
-    changes — one page with a live demo for each. Open in two tabs to watch it
+    changes: one page with a live demo for each. Open in two tabs to watch it
     sync.
   </span>
 </a>
@@ -484,18 +484,18 @@ Click "+" to append a new `<li>`. The child addition itself mirrors — new read
 
 ## can-play
 
-**What it does.** The "build your own capability" escape hatch. You define `defaultData`, `onClick` / `onDrag` / `onMount` handlers, and an `updateElement` callback — playhtml syncs the data and fires your handlers.
+**What it does.** The "build your own capability" escape hatch. You define `defaultData`, `onClick` / `onDrag` / `onMount` handlers, and an `updateElement` callback. playhtml syncs the data and fires your handlers.
 
 **Use it for:** anything the built-ins don't already cover. Custom counters, guestbooks, chat, games, reactions, per-user state, event-based broadcasts.
 
 This page is itself a `can-play` showcase. Four examples live in the margins:
 
-- [**Doodle strip**](#play-doodle) — freehand canvas input encoded as a tiny PNG data URL. The shared array caps at 20 via `splice` inside the setData mutator.
-- [**Guestbook**](#play-guestbook) — a growing list of short text entries. Same "cap the array" pattern, different payload.
-- [**Prize wheel**](#play-spinner) — one shared piece of data (the spin seed + target) animates identically on every tab. Every visitor sees the wheel land on the same label.
-- <a href="#play-copy" id="play-copy">**Tally on every code block**</a> — every `<pre>` on this page is a vanilla `can-play` element. Click <code>copy</code> on any snippet and watch a tally tick appear next to the button — readers all over the site share that counter, so popular snippets accumulate marks like a well-loved library book.
+- [**Doodle strip**](#play-doodle): freehand canvas input encoded as a tiny PNG data URL. The shared array caps at 20 via `splice` inside the setData mutator.
+- [**Guestbook**](#play-guestbook): a growing list of short text entries. Same "cap the array" pattern, different payload.
+- [**Prize wheel**](#play-spinner): one shared piece of data (the spin seed + target) animates identically on every tab. Every visitor sees the wheel land on the same label.
+- <a href="#play-copy" id="play-copy">**Tally on every code block**</a>: every `<pre>` on this page is a vanilla `can-play` element. Click <code>copy</code> on any snippet and watch a tally tick appear next to the button. Readers all over the site share that counter, so popular snippets accumulate more marks.
 
-That's four wildly different shapes — short array, blob payload, animation seed, single integer — built on the same primitive. The minimum viable shape is much smaller, though:
+That's four different shapes (short array, blob payload, animation seed, single integer) built on the same primitive. The minimum viable shape is much smaller, though:
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
@@ -544,7 +544,7 @@ Deeper material on custom capabilities lives in [Data essentials](/docs/data/dat
 
 ### Resetting custom elements
 
-The built-in interactive capabilities support shift-click to reset (see the tip at the top of this page). Opt your own `can-play` element into the same gesture with `resetShortcut` — a modifier key that, when held while clicking, restores the element's `defaultData` for everyone:
+The built-in interactive capabilities support shift-click to reset (see the tip at the top of this page). Opt your own `can-play` element into the same gesture with `resetShortcut`, a modifier key that, when held while clicking, restores the element's `defaultData` for everyone:
 
 ```js
 el.defaultData = { count: 0 };
@@ -586,7 +586,7 @@ These capabilities are the building blocks. The best way to see them in concert 
   </a>
 </div>
 
-These three are highlighted in the homepage experiments index — the fastest way to feel playhtml at room-scale.
+These three are highlighted in the homepage experiments index, the fastest way to see playhtml at room-scale.
 
 <div id="play-spinner" class="ph-canplay-inline ph-canplay-inline--final" data-label="can-play · prize wheel">
   <div class="ph-canplay-inline__head">

--- a/apps/docs/src/content/docs/concepts.md
+++ b/apps/docs/src/content/docs/concepts.md
@@ -7,9 +7,9 @@ sidebar:
 
 playhtml gives you four primitives for moving state between readers. Once you can reach for the right one, everything else is just attribute names.
 
-- **Element data** (`defaultData` / [`can-play`](/docs/capabilities/)) — persistent state scoped to a single DOM element. A toggle's on/off, a draggable's position, a shared count. Survives reload. See [data essentials](/docs/data/data-essentials/) for shape, updates, and cleanup.
-- **Page data** (`playhtml.createPageData`) — persistent state keyed by a name, not tied to any element. A page-level counter, a shared prompt, an open vote. See [page-level data](/docs/data/page-data/).
-- **Presence** (`playhtml.presence` / cursor awareness) — ephemeral per-user state: "who's online", "who's typing", "where's my cursor". Disappears when users disconnect. See [presence](/docs/data/presence/) and [cursors](/docs/data/presence/cursors/).
-- **Events** (`playhtml.dispatchPlayEvent`) — one-off broadcasts with no persisted state. Confetti, chimes, notifications. See [events](/docs/data/events/).
+- **Element data** (`defaultData` / [`can-play`](/docs/capabilities/)): persistent state scoped to a single DOM element. A toggle's on/off, a draggable's position, a shared count. Survives reload. See [data essentials](/docs/data/data-essentials/) for shape, updates, and cleanup.
+- **Page data** (`playhtml.createPageData`): persistent state keyed by a name, not tied to any element. A page-level counter, a shared prompt, an open vote. See [page-level data](/docs/data/page-data/).
+- **Presence** (`playhtml.presence` / cursor awareness): ephemeral per-user state: "who's online", "who's typing", "where's my cursor". Disappears when users disconnect. See [presence](/docs/data/presence/) and [cursors](/docs/data/presence/cursors/).
+- **Events** (`playhtml.dispatchPlayEvent`): one-off broadcasts with no persisted state. Confetti, chimes, notifications. See [events](/docs/data/events/).
 
 Not sure which one you want? The [decision table on data essentials](/docs/data/data-essentials/#when-to-use-which-primitive) lays out the tradeoffs side by side.

--- a/apps/docs/src/content/docs/data/data-essentials.md
+++ b/apps/docs/src/content/docs/data/data-essentials.md
@@ -24,7 +24,7 @@ playhtml has four primitives for moving state between readers. Pick by **lifetim
 Two rules that catch most mistakes:
 
 - **If a new reader opening the page should see the state, it's persistent data.** If they shouldn't, it's presence or an event.
-- **If you're reaching for `localStorage` to make state survive a reload, you wanted persistent data.** Use `localStorage` for _per-user_ preferences that should _not_ sync — see [rule 8 below](#8-use-localstorage-for-per-user-preferences).
+- **If you're reaching for `localStorage` to make state survive a reload, you wanted persistent data.** Use `localStorage` for _per-user_ preferences that should _not_ sync; see [rule 8 below](#8-use-localstorage-for-per-user-preferences).
 
 ## Updating data: mutator vs replacement
 
@@ -142,7 +142,7 @@ If someone refreshes the page and expects the state to still be there, it's pers
 
 Syncing on every `mousemove` or `scroll` will flood the socket and eat your PartyKit bill. Three options, in order of preference:
 
-**Use built-in handlers** — `onDrag`, `onMount` already debounce:
+**Use built-in handlers.** `onDrag`, `onMount` already debounce:
 
 ```js
 element.onDrag = (e, { setData }) => {
@@ -160,7 +160,7 @@ element.addEventListener("mousemove", (e) => {
 });
 ```
 
-**Local-state-then-commit** — keep ephemeral state local, sync only on the commit event (mouseup, blur, submit):
+**Local-state-then-commit.** Keep ephemeral state local, sync only on the commit event (mouseup, blur, submit):
 
 ```js
 let localX = data.x;
@@ -198,7 +198,7 @@ For moderated sites with long histories, store only recent items in shared state
 
 ### 6. Store only what needs to sync
 
-UI-only state, loading flags, animation state — none of that belongs in shared data. Use component state (React) or plain variables (vanilla).
+UI-only state, loading flags, animation state: none of that belongs in shared data. Use component state (React) or plain variables (vanilla).
 
 ```js
 // Bad — every reader sees every other reader's hover
@@ -208,11 +208,11 @@ defaultData: { isHovering: false }
 element.addEventListener("mouseenter", () => element.classList.add("hover"));
 ```
 
-If you _do_ want collaborative hover, use [`can-hover`](/docs/capabilities/) — that's literally its reason to exist, and it uses presence (not persistent data) under the hood.
+If you _do_ want collaborative hover, use [`can-hover`](/docs/capabilities/). That's its reason to exist, and it uses presence (not persistent data) internally.
 
 ### 7. Never write shared data from code that re-runs when that data changes
 
-This is the most dangerous mistake on this page, because it doesn't fail on your machine — it fails in production once a few readers connect, and it can grow the shared document until the sync server falls over.
+This is the most dangerous mistake on this page, because it doesn't fail on your machine. It fails in production once a few readers connect, and it can grow the shared document until the sync server falls over.
 
 The trap: a React effect (or any reactive subscription) that **both depends on the shared data and writes to it**.
 
@@ -226,7 +226,7 @@ const Roster = withSharedState({ defaultData: { entries: [] } }, ({ data, setDat
 });
 ```
 
-Each write changes `data.entries`, which re-runs the effect, which writes again. Worse, because the data is a CRDT, **two readers writing concurrently both land** — and with the **replacement form** (`setData({ entries: [...] })`) over an **array**, concurrent writes append rather than overwrite, so the loop never converges to a stable value the guard can catch. A single buggy element like this grew one production room to 1.2 million CRDT operations / 23 MB and took the room offline.
+Each write changes `data.entries`, which re-runs the effect, which writes again. Worse, because the data is a CRDT, **two readers writing concurrently both land**. With the **replacement form** (`setData({ entries: [...] })`) over an **array**, concurrent writes append rather than overwrite, so the loop never converges to a stable value the guard can catch. A single buggy element like this grew one production room to 1.2 million CRDT operations / 23 MB and took the room offline.
 
 **The strongest fix is the data model: store collections that must stay unique as a keyed map, and upsert in place with the mutator form.**
 
@@ -255,7 +255,7 @@ Two reinforcing rules at work here:
 1. **Prefer a keyed map + mutator-form upsert over an array + replacement-form rewrite.** The keyed write is idempotent and merge-safe; the array rewrite is neither. This alone defuses the runaway.
 2. **Still don't depend on the data you write.** Read it through a ref so the effect fires only on the inputs that should trigger a write (the local user's identity), not on every change to the shared collection. Belt-and-suspenders on top of the keyed model.
 
-If you genuinely need an array (order matters and there's no natural key), then you must both (a) read via a ref as above and (b) make the write converge — dedupe by id into a `Map` and write the deduped result — but a keyed map is almost always the better shape.
+If you genuinely need an array (order matters and there's no natural key), then you must both (a) read via a ref as above and (b) make the write converge (dedupe by id into a `Map` and write the deduped result), but a keyed map is almost always the better shape.
 
 The same rule applies to vanilla `updateElement`: never call `setData` from inside `updateElement` (which runs on every data change) without a guard that provably converges. When in doubt, write only from explicit user events, not from reactive callbacks.
 
@@ -283,9 +283,9 @@ onClick: (_e, { setData }) => {
 
 Three mistakes that show up often enough to call out explicitly.
 
-**Syncing UI state** — hover, focus, loading, animation progress. These should be local.
+**Syncing UI state.** Hover, focus, loading, animation progress. These should be local.
 
-**Over-normalizing** — playhtml data is a document, not a relational database. A flat array of message objects beats a `users: {…}` + `messages: {…}` split every time.
+**Over-normalizing.** playhtml data is a document, not a relational database. A flat array of message objects beats a `users: {…}` + `messages: {…}` split every time.
 
 ```js
 // Too normalized for playhtml
@@ -295,9 +295,9 @@ Three mistakes that show up often enough to call out explicitly.
 { messages: [{ id: "m1", author: "Alice", text: "Hi" }] }
 ```
 
-**Unbounded arrays with no cleanup** — any `push` without a matching size check will eventually bite you.
+**Unbounded arrays with no cleanup.** Any `push` without a matching size check will eventually bite you.
 
-**Self-triggering writes** — writing shared data from a reactive callback that depends on that same data. The most damaging anti-pattern here: it survives local testing and only blows up under concurrency in production. See [rule 7](#7-never-write-shared-data-from-code-that-re-runs-when-that-data-changes).
+**Self-triggering writes.** Writing shared data from a reactive callback that depends on that same data. The most damaging anti-pattern here: it survives local testing and only blows up under concurrency in production. See [rule 7](#7-never-write-shared-data-from-code-that-re-runs-when-that-data-changes).
 
 ## Cleaning up
 
@@ -311,7 +311,7 @@ playhtml.deleteElementData("can-move", elementId);
 
 This removes the SyncedStore entry, observer subscriptions, element handlers, and any legacy globalData entries.
 
-Example — a fridge magnet app deleting words:
+Example, a fridge magnet app deleting words:
 
 ```tsx
 function handleDeleteWord(id: string) {
@@ -371,7 +371,7 @@ When reviewing a new element's data shape:
 - Is this actually shared, or should it be local?
 - Could it be derived from other data instead of stored?
 - Will the arrays grow unbounded?
-- Does any effect/callback write shared data **and** depend on that data? (write loop — see rule 7)
+- Does any effect/callback write shared data **and** depend on that data? (write loop; see rule 7)
 - Am I about to update on a high-frequency DOM event?
 - Is there a built-in `can-*` capability that already does this?
 - Should this live in presence / events instead of persistent data?

--- a/apps/docs/src/content/docs/data/data-essentials.md
+++ b/apps/docs/src/content/docs/data/data-essentials.md
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-Every playhtml element owns a piece of shared data. Getting the shape right, writing to it correctly, and cleaning it up when elements go away are the three skills that separate a toy demo from a real feature. This page covers all three.
+Every playhtml element owns a piece of shared data. This page covers how to shape it, write to it correctly, and clean it up when elements go away.
 
 ## When to use which primitive
 
@@ -212,7 +212,7 @@ If you _do_ want collaborative hover, use [`can-hover`](/docs/capabilities/). Th
 
 ### 7. Never write shared data from code that re-runs when that data changes
 
-This is the most dangerous mistake on this page, because it doesn't fail on your machine. It fails in production once a few readers connect, and it can grow the shared document until the sync server falls over.
+This one doesn't fail on your machine. It fails in production once a few readers connect, and it can grow the shared document until the sync server falls over.
 
 The trap: a React effect (or any reactive subscription) that **both depends on the shared data and writes to it**.
 
@@ -297,7 +297,7 @@ Three mistakes that show up often enough to call out explicitly.
 
 **Unbounded arrays with no cleanup.** Any `push` without a matching size check will eventually bite you.
 
-**Self-triggering writes.** Writing shared data from a reactive callback that depends on that same data. The most damaging anti-pattern here: it survives local testing and only blows up under concurrency in production. See [rule 7](#7-never-write-shared-data-from-code-that-re-runs-when-that-data-changes).
+**Self-triggering writes.** Writing shared data from a reactive callback that depends on that same data. It survives local testing and only breaks under concurrency in production. See [rule 7](#7-never-write-shared-data-from-code-that-re-runs-when-that-data-changes).
 
 ## Cleaning up
 

--- a/apps/docs/src/content/docs/data/events.mdx
+++ b/apps/docs/src/content/docs/data/events.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Events"
-description: "Broadcast one-off signals with dispatchPlayEvent — no persisted data."
+description: "Broadcast one-off signals with dispatchPlayEvent, no persisted data."
 sidebar:
   order: 4
 ---
@@ -48,7 +48,7 @@ document.querySelector("#celebrate").addEventListener("click", () => {
 });
 ```
 
-`events` in the init options is an object keyed by a local name (the key) — `type` is the wire identifier every client must agree on.
+`events` in the init options is an object keyed by a local name (the key). `type` is the wire identifier every client must agree on.
   </TabItem>
   <TabItem label="React">
 Events live on the `PlayContext`. Register a listener inside an effect; dispatch whenever:
@@ -76,7 +76,7 @@ function ConfettiButton() {
 }
 ```
 
-Always return the cleanup in the effect — if the component unmounts and you don't remove the listener, you'll accumulate duplicates on every remount.
+Always return the cleanup in the effect. If the component unmounts and you don't remove the listener, you'll accumulate duplicates on every remount.
   </TabItem>
 </Tabs>
 
@@ -109,13 +109,13 @@ Keep the payload small and JSON-serializable. Events aren't a replacement for sh
 
 ## Try it live
 
-Click the hydrant. It dispatches a `"rain"` event — clouds drift across the top of the page for anyone reading this page right now. Try it in two tabs.
+Click the hydrant. It dispatches a `"rain"` event, and clouds drift across the top of the page for anyone reading this page right now. Try it in two tabs.
 
 <div className="ph-demo-slot" data-label="EVENTS — rain">
   <RainSprinklerDemo client:only="react" />
 </div>
 
-Same primitive, different shape: each click below sends a short-lived emoji burst. No state, no persistence — exactly the "live reactions" pattern from video calls.
+Same primitive, different shape: each click below sends a short-lived emoji burst. No state, no persistence: exactly the "live reactions" pattern from video calls.
 
 <div className="ph-demo-slot" data-label="EVENTS — live reactions">
   <LiveReactionsDemo client:only="react" />
@@ -126,10 +126,10 @@ Same primitive, different shape: each click below sends a short-lived emoji burs
 - **Not for state.** If you find yourself dispatching the same event every time a reader connects so they "catch up," that's shared data, not an event. Move it to element or page data.
 - **No ordering guarantees.** If two readers dispatch at the same moment, clients can observe them in either order. Design the listener so order doesn't matter.
 - **Keep listeners idempotent where possible.** In dev mode, React 18's strict-mode double-invoke can register + remove listeners twice. Idempotent handlers (they can run twice without harm) are easier to reason about.
-- **Side effects only.** The `onEvent` callback should do something visible — animate, play a sound, nudge the DOM. If you want to update shared state in response, use element/page data and let its observer fire a side effect on change.
+- **Side effects only.** The `onEvent` callback should do something visible: animate, play a sound, nudge the DOM. If you want to update shared state in response, use element/page data and let its observer fire a side effect on change.
 
 ## Related
 
-- [Data essentials](/docs/data/data-essentials/) — the three data types, and when events are the wrong tool
-- [Presence](/docs/data/presence/) — for "who's here" instead of "someone just did this"
-- [`playhtml.init()` options](/docs/reference/init-options/#events) — the full `events` config reference
+- [Data essentials](/docs/data/data-essentials/): the three data types, and when events are the wrong tool
+- [Presence](/docs/data/presence/): for "who's here" instead of "someone just did this"
+- [`playhtml.init()` options](/docs/reference/init-options/#events): the full `events` config reference

--- a/apps/docs/src/content/docs/data/page-data.mdx
+++ b/apps/docs/src/content/docs/data/page-data.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Page data is a persistent data channel keyed by a name — no DOM element required. Good for counters, vote tallies, link trackers — anything page-shaped instead of element-shaped.
+Page data is a persistent data channel keyed by a name, with no DOM element required. Good for counters, vote tallies, link trackers, anything page-shaped instead of element-shaped.
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
@@ -39,13 +39,13 @@ function VisitCounter() {
 
 The vanilla channel handle exposes four methods (`usePageData` wraps these for you):
 
-- **`getData()`** — read the current value synchronously.
-- **`setData(value | (draft) => void)`** — write. Accepts a replacement value or a mutator function, with the same merge semantics as element `setData`; see [data essentials](/docs/data/data-essentials/).
-- **`onUpdate(cb)`** — subscribe to changes. Returns an unsubscribe function.
-- **`destroy()`** — detach the channel and its observers. Call this when the channel is no longer needed (e.g. on teardown) to avoid leaking the subscription.
+- **`getData()`**: read the current value synchronously.
+- **`setData(value | (draft) => void)`**: write. Accepts a replacement value or a mutator function, with the same merge semantics as element `setData`; see [data essentials](/docs/data/data-essentials/).
+- **`onUpdate(cb)`**: subscribe to changes. Returns an unsubscribe function.
+- **`destroy()`**: detach the channel and its observers. Call this when the channel is no longer needed (e.g. on teardown) to avoid leaking the subscription.
 
 When you should reach for `createPageData` vs. element data, presence, or events: see the [decision table on data essentials](/docs/data/data-essentials/#when-to-use-which-primitive).
 
 ## Navigation
 
-Page data is room-scoped, like element data. On a single-page app, when navigation changes the room the channel resets to the new room — it reads its default until re-seeded. A channel handle you hold across the navigation stays usable (it keeps writing and notifying). Navigation that doesn't change the room leaves the data untouched. See [Navigation & SPAs](/docs/advanced/navigation/).
+Page data is room-scoped, like element data. On a single-page app, when navigation changes the room the channel resets to the new room: it reads its default until re-seeded. A channel handle you hold across the navigation stays usable (it keeps writing and notifying). Navigation that doesn't change the room leaves the data untouched. See [Navigation & SPAs](/docs/advanced/navigation/).

--- a/apps/docs/src/content/docs/data/presence/cursors.mdx
+++ b/apps/docs/src/content/docs/data/presence/cursors.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-Playhtml includes built-in cursor tracking and presence awareness. When enabled, users can see each other's cursors in real-time, along with their colors and names.
+playhtml can track cursors out of the box. When enabled, visitors see each other's cursors live, along with their colors and names.
 
 ## Basic Setup
 

--- a/apps/docs/src/content/docs/data/presence/cursors.mdx
+++ b/apps/docs/src/content/docs/data/presence/cursors.mdx
@@ -186,21 +186,21 @@ cursors: {
 }
 ```
 
-**`coordinateMode`** — how cursor positions are stored and shared:
+**`coordinateMode`**: how cursor positions are stored and shared:
 
-- `"relative"` (default) — positions are viewport percentages, so a cursor lands on the same _relative_ spot for every viewer regardless of window size. Best for documents and most pages.
-- `"absolute"` — positions are document pixels. Use this when collaborators share an identical fixed-size layout and you want pixel-for-pixel agreement.
+- `"relative"` (default): positions are viewport percentages, so a cursor lands on the same _relative_ spot for every viewer regardless of window size. Best for documents and most pages.
+- `"absolute"`: positions are document pixels. Use this when collaborators share an identical fixed-size layout and you want pixel-for-pixel agreement.
 
-For a pannable / zoomable canvas, you usually don't set `coordinateMode` directly — pass a transformed [`container`](#container) instead, which stores cursors in that container's local space.
+For a pannable / zoomable canvas, you usually don't set `coordinateMode` directly. Pass a transformed [`container`](#container) instead, which stores cursors in that container's local space.
 
-**`cursorStyle`** — a CSS `cursor` value applied to the page while cursors are enabled (e.g. `"none"` to hide the native pointer in favor of the rendered one).
+**`cursorStyle`**: a CSS `cursor` value applied to the page while cursors are enabled (e.g. `"none"` to hide the native pointer in favor of the rendered one).
 
 ### `container`
 
 Where playhtml mounts cursor DOM (and the cursor stylesheet). Defaults to `document.body`. Two reasons to set it:
 
-1. **Surviving SPA navigation.** If your framework swaps `document.body` on route changes (Astro ViewTransitions, htmx boost, Turbo), pass a container you mark as persistent so cursors don't get blown away. See [navigation](/docs/advanced/navigation/).
-2. **Anchoring cursors to a pannable / zoomable canvas.** If the container has its own CSS `transform` (e.g. you implement pinch-zoom and pan by setting `transform: translate(...) scale(...)` on a wrapper), playhtml stores cursor coordinates in that container's local space — so two viewers with different pan/zoom agree on which content a cursor is hovering. See the next section.
+1. **Surviving SPA navigation.** If your framework swaps `document.body` on route changes (Astro ViewTransitions, htmx boost, Turbo), pass a container you mark as persistent so cursors aren't destroyed. See [navigation](/docs/advanced/navigation/).
+2. **Anchoring cursors to a pannable / zoomable canvas.** If the container has its own CSS `transform` (e.g. you implement pinch-zoom and pan by setting `transform: translate(...) scale(...)` on a wrapper), playhtml stores cursor coordinates in that container's local space, so two viewers with different pan/zoom agree on which content a cursor is hovering. See the next section.
 
 **Type:** `HTMLElement | string | (() => HTMLElement | null) | React.RefObject<HTMLElement>`
 
@@ -220,7 +220,7 @@ playhtml.init({
 When `container` resolves to a non-`document.body` element, playhtml reads its live transform matrix from `getComputedStyle()` on every pointer event:
 
 - **Storage** is the container's local (pre-transform) coordinate space. Two clients with different pan/zoom now agree on cursor positions.
-- **Rendering** mounts cursors inside the container with `position: absolute`. The container's own CSS transform composes them into each viewer's viewport pixels for free — no JavaScript per-frame repositioning, no resize-event nudging.
+- **Rendering** mounts cursors inside the container with `position: absolute`. The container's own CSS transform composes them into each viewer's viewport pixels for free: no JavaScript per-frame repositioning, no resize-event nudging.
 
 ### Requirements
 
@@ -249,7 +249,7 @@ The [`website/fridge.tsx`](https://github.com/spencerc99/playhtml/blob/main/webs
 </PlayProvider>
 ```
 
-The transform itself (e.g. `translate(panX, panY) scale(scale)`) is applied however you like — inline `style.transform`, a CSS class, or a CSS variable. playhtml just reads it.
+The transform itself (e.g. `translate(panX, panY) scale(scale)`) is applied however you like: inline `style.transform`, a CSS class, or a CSS variable. playhtml just reads it.
 
 ## Global Cursor API
 

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import { OnlineIndicatorDemo } from "@/components/react/data-demos/OnlineIndicatorDemo";
 
-Presence is playhtml's "who's here right now" layer. Every connected user has an identity, an optional cursor position, and any number of custom named channels you define. None of it persists — when the user disconnects, their presence clears.
+Presence is playhtml's "who's here right now" layer. Every connected user has an identity, an optional cursor position, and any number of custom named channels you define. None of it persists. When the user disconnects, their presence clears.
 
 Reach for presence when the lifetime you want is "while this person is on the page". Reach for [persistent data](/docs/data/data-essentials/) when you want state to survive a reload, and [events](/docs/data/events/) for one-shot signals.
 
@@ -71,18 +71,18 @@ const unsub = playhtml.presence.onPresenceChange("cursor", (presences) => {
 });
 ```
 
-For pixel-accurate cursor rendering (including coordinate conversion across scrolled/zoomed pages), use the cursor system directly — see the [Cursors](/docs/data/presence/cursors/) page.
+For pixel-accurate cursor rendering (including coordinate conversion across scrolled/zoomed pages), use the cursor system directly. See the [Cursors](/docs/data/presence/cursors/) page.
 
 ## Custom channels
 
-Channel names flatten into the top-level `PresenceView`. Pick names that don't collide with the system fields (`playerIdentity`, `cursor`, `isMe`) — collisions are silently dropped.
+Channel names flatten into the top-level `PresenceView`. Pick names that don't collide with the system fields (`playerIdentity`, `cursor`, `isMe`): collisions are silently dropped.
 
 **Common shapes:**
 
-- `status` — `{ text, emoji }` or a tag string for "focused / typing / afk"
-- `focus` — `{ elementId }` to highlight which part of the page someone is looking at
-- `selection` — `{ start, end }` for collaborative text editing
-- `cursor-chat` — a short message shown beside the user's cursor
+- `status`: `{ text, emoji }` or a tag string for "focused / typing / afk"
+- `focus`: `{ elementId }` to highlight which part of the page someone is looking at
+- `selection`: `{ start, end }` for collaborative text editing
+- `cursor-chat`: a short message shown beside the user's cursor
 
 **Setting vs clearing:**
 
@@ -109,11 +109,11 @@ setMyPresence(null);
   </TabItem>
 </Tabs>
 
-There's no partial/merge update for a channel — when you call `setMyPresence`, you overwrite that channel's value for your user.
+There's no partial/merge update for a channel. When you call `setMyPresence`, you overwrite that channel's value for your user.
 
 ## Isolated presence rooms
 
-The main presence layer tracks everyone in the page's room. When you want a presence channel **scoped to something other than the page** — a lobby, a document, a game table that several pages share — create a separate presence room.
+The main presence layer tracks everyone in the page's room. When you want a presence channel **scoped to something other than the page** (a lobby, a document, a game table that several pages share), create a separate presence room.
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
@@ -127,7 +127,7 @@ const unsub = room.presence.onPresenceChange("status", renderLobby);
 room.destroy();
 ```
 
-`createPresenceRoom(name)` returns a `PresenceRoom` — `{ presence, destroy }` — where `presence` is the same API as `playhtml.presence`, backed by its own connection. Always call `destroy()` when the room is no longer needed; it closes the connection and clears your presence for everyone else.
+`createPresenceRoom(name)` returns a `PresenceRoom` (`{ presence, destroy }`), where `presence` is the same API as `playhtml.presence`, backed by its own connection. Always call `destroy()` when the room is no longer needed; it closes the connection and clears your presence for everyone else.
   </TabItem>
   <TabItem label="React">
 ```tsx
@@ -151,12 +151,12 @@ function Lobby() {
   <OnlineIndicatorDemo client:only="react" />
 </div>
 
-Each dot is one reader; the yellow-glowing dot is **you**. Pick a color and watch yours change for everyone else. Open this page in a second tab and you'll see two dots. Close a tab — the dot disappears. This is presence: no persistence, no replay.
+Each dot is one reader; the yellow-glowing dot is **you**. Pick a color and watch yours change for everyone else. Open this page in a second tab and you'll see two dots. Close a tab and the dot disappears. This is presence: no persistence, no replay.
 
 > Looking for a "live reactions" bursting button? That's an [event](/docs/data/events/), not presence. The docs for events have a live demo.
 
 ## Is presence really what you want?
 
-Presence shines for _ambient awareness_ — the quiet hum of other people existing on the page. If you find yourself reaching for `localStorage` or a refresh-survivor, you want data, not presence.
+Presence is for _ambient awareness_ of other people on the page. If you find yourself reaching for `localStorage` or a refresh-survivor, you want data, not presence.
 
-Not sure which primitive fits? The full decision table — covering element data, page data, presence, cursors, and events — is on [data essentials](/docs/data/data-essentials/#when-to-use-which-primitive).
+Not sure which primitive fits? The full decision table, covering element data, page data, presence, cursors, and events, is on [data essentials](/docs/data/data-essentials/#when-to-use-which-primitive).

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -155,7 +155,7 @@ Each dot is one reader; the yellow-glowing dot is **you**. Pick a color and watc
 
 > Looking for a "live reactions" bursting button? That's an [event](/docs/data/events/), not presence. The docs for events have a live demo.
 
-## Is presence really what you want?
+## When to use data instead
 
 Presence is for _ambient awareness_ of other people on the page. If you find yourself reaching for `localStorage` or a refresh-survivor, you want data, not presence.
 

--- a/apps/docs/src/content/docs/getting-started.mdx
+++ b/apps/docs/src/content/docs/getting-started.mdx
@@ -19,7 +19,7 @@ There are two paths. Pick the one that matches your project.
 
 ### Path A: drop-in script (no build, no module syntax)
 
-The fastest path — no `import`, no `playhtml.init()` call. Add the script tag at the end of your `<body>`, after your interactive elements:
+The fastest path, with no `import` and no `playhtml.init()` call. Add the script tag at the end of your `<body>`, after your interactive elements:
 
 ```html
 <body>
@@ -33,7 +33,7 @@ Give every interactive element a unique `id`. That's how state is keyed and sync
 
 > Why end-of-body? The drop-in script runs `playhtml.init()` immediately, and `init()` scans the DOM for capability attributes (`can-toggle`, `can-move`, etc.) when it runs. Place it after the elements it should find.
 
-> Want options like cursors? Use Path B — the drop-in script calls `playhtml.init({})` with no options.
+> Want options like cursors? Use Path B. The drop-in script calls `playhtml.init({})` with no options.
 
 ### Path B: import + manual init (when you need options or a bundler)
 
@@ -65,7 +65,7 @@ playhtml.init({ cursors: { enabled: true } });
 
 Bundlers usually handle script placement for you; just make sure `init()` runs after your interactive elements are in the DOM (e.g. on `DOMContentLoaded` or after your framework mounts).
 
-Either way, give every interactive element a unique `id` — that's how state is keyed and synced across everyone on the page.
+Either way, give every interactive element a unique `id`. That's how state is keyed and synced across everyone on the page.
 
   </TabItem>
   <TabItem label="React">
@@ -118,17 +118,17 @@ import { TagType } from "@playhtml/common";
 
 ## Try it live
 
-This toggle is shared with everyone reading this page right now. Click it and watch.
+This toggle is shared with everyone reading this page right now. Click it to see it update for all readers.
 
 <InteractiveToggleDemo client:only="react" />
 
 ## Where to next
 
-- [Core concepts](/docs/concepts/) — the four kinds of shared state (element data, page data, presence, events) and when to use each.
-- [Using React](/docs/using-react/) — if your app is a React app, start here; concept pages show React inline.
-- [Capabilities](/docs/capabilities/) — every built-in `can-*` attribute with live demos.
-- [Data essentials](/docs/data/data-essentials/) — shape, update, and clean up `defaultData`.
-- [Presence & cursors](/docs/data/presence/) — multiplayer cursors and ephemeral per-user state.
-- [Shared elements](/docs/advanced/shared-elements/) — cross-page and cross-domain state.
-- [Building with AI](/docs/integrations/building-with-ai/) — Claude Code plugin + a prompt template for any LLM.
-- [API reference](/docs/reference/init-options/) — the full `playhtml.init()` options table and React API types.
+- [Core concepts](/docs/concepts/): the four kinds of shared state (element data, page data, presence, events) and when to use each.
+- [Using React](/docs/using-react/): if your app is a React app, start here; concept pages show React inline.
+- [Capabilities](/docs/capabilities/): every built-in `can-*` attribute with live demos.
+- [Data essentials](/docs/data/data-essentials/): shape, update, and clean up `defaultData`.
+- [Presence & cursors](/docs/data/presence/): multiplayer cursors and ephemeral per-user state.
+- [Shared elements](/docs/advanced/shared-elements/): cross-page and cross-domain state.
+- [Building with AI](/docs/integrations/building-with-ai/): Claude Code plugin + a prompt template for any LLM.
+- [API reference](/docs/reference/init-options/): the full `playhtml.init()` options table and React API types.

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: "playhtml docs"
 template: splash
 hero:
   title: "make the web feel alive"
-  tagline: "Turn any element into a live, shared one with a single attribute — no backend required."
+  tagline: "Turn any element into a live, shared one with a single attribute, no backend required."
   actions:
     - text: "Get started"
       link: /docs/getting-started/
@@ -83,7 +83,7 @@ import { PlayProvider, CanToggleElement } from "@playhtml/react";
       &rarr;](/docs/getting-started/)
     </Card>
     <Card title="Core concepts" icon="open-book">
-      Element data, page data, presence, events — when to use each. [Read
+      Element data, page data, presence, events: when to use each. [Read
       &rarr;](/docs/concepts/)
     </Card>
     <Card title="Capabilities" icon="puzzle">

--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -164,10 +164,10 @@ DOCUMENTATION:
 The LLM should push back before writing code if:
 
 - It's unclear whether state should persist or be temporary.
-- Whether it's per-user data or shared across everyone is ambiguous.
+- It's ambiguous whether data is per-user or shared across everyone.
 - Key details are missing (what triggers the change, what gets stored).
 - The requirements contradict each other.
 
-Don't let the assistant guess. playhtml has different patterns for different use cases, and using the right one matters.
+Don't let the assistant guess.
 
 For the canonical setup walkthrough, see [getting started](/docs/getting-started/).

--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -9,7 +9,7 @@ playhtml plays well with AI coding assistants. There are two supported paths, de
 
 ## Claude Code plugin (recommended)
 
-If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), install the `playhtml` plugin. It ships a skill that activates automatically when you ask Claude to build playhtml elements — no manual context required. The plugin covers the APIs, data types, and the most common mistakes (mutator vs replacement, stable ids, presence vs data, and so on).
+If you use [Claude Code](https://docs.anthropic.com/en/docs/claude-code), install the `playhtml` plugin. It ships a skill that activates automatically when you ask Claude to build playhtml elements, with no manual context required. The plugin covers the APIs, data types, and the most common mistakes (mutator vs replacement, stable ids, presence vs data, and so on).
 
 ```bash
 claude plugin marketplace add spencerc99/playhtml

--- a/apps/docs/src/content/docs/reference/init-options.md
+++ b/apps/docs/src/content/docs/reference/init-options.md
@@ -21,11 +21,11 @@ playhtml.init({
 
 **Type:** `string | (() => string)` &nbsp; **Default:** `window.location.pathname + window.location.search`
 
-The room to connect users to — users sharing a room share state. Every room is automatically prefixed with `window.location.hostname` so your rooms can never collide with another site's rooms.
+The room to connect users to. Users sharing a room share state. Every room is automatically prefixed with `window.location.hostname` so your rooms can never collide with another site's rooms.
 
 If you leave this blank, playhtml derives the room from the URL. Two readers on `/docs/capabilities` share state; a reader on `/docs/concepts` is in a different room.
 
-Override it when you want to decouple state from the URL — for example, a site-wide guestbook that should behave the same no matter which page it's embedded on:
+Override it when you want to decouple state from the URL, for example a site-wide guestbook that should behave the same no matter which page it's embedded on:
 
 ```js
 playhtml.init({ room: "global-guestbook" });
@@ -37,7 +37,7 @@ A **string** stays fixed across [client-side navigation](/docs/advanced/navigati
 playhtml.init({ room: () => `notes${window.location.pathname}` });
 ```
 
-When navigation changes the room, the document resets to the new room (page and element data alike) — see [Navigation & SPAs](/docs/advanced/navigation/).
+When navigation changes the room, the document resets to the new room (page and element data alike). See [Navigation & SPAs](/docs/advanced/navigation/).
 
 ## `host`
 
@@ -51,7 +51,7 @@ playhtml.init({
 });
 ```
 
-You're responsible for deploying a compatible PartyKit worker — see the [playhtml repo](https://github.com/spencerc99/playhtml) for the current worker implementation.
+You're responsible for deploying a compatible PartyKit worker. See the [playhtml repo](https://github.com/spencerc99/playhtml) for the current worker implementation.
 
 ## `events`
 
@@ -76,7 +76,7 @@ You can also register events imperatively later with `playhtml.registerPlayEvent
 
 **Type:** `Record<string, ElementInitializer>` &nbsp; **Default:** `undefined`
 
-Ship your own `can-*` capability alongside the built-ins. Most authors never need this — use `can-play` on individual elements first. Reach for `extraCapabilities` when you're packaging a capability you want to reuse across many elements and want the shorter `can-mything` attribute form.
+Ship your own `can-*` capability alongside the built-ins. Most authors never need this; use `can-play` on individual elements first. Reach for `extraCapabilities` when you're packaging a capability you want to reuse across many elements and want the shorter `can-mything` attribute form.
 
 ```js
 playhtml.init({
@@ -117,7 +117,7 @@ playhtml.init({
 
 **Type:** `boolean` &nbsp; **Default:** `false`
 
-Enable the in-page devtools panel. Shows element inspector, live data tree, connection status, and tag-type badges — modeled after RollerCoaster Tycoon's inspect UI. Useful while debugging.
+Enable the in-page devtools panel. Shows element inspector, live data tree, connection status, and tag-type badges, modeled after RollerCoaster Tycoon's inspect UI. Useful while debugging.
 
 ```js
 playhtml.init({ developmentMode: true });
@@ -197,4 +197,4 @@ import { PlayProvider } from "@playhtml/react";
 </PlayProvider>;
 ```
 
-No React-specific options on the provider itself — all config flows through the shared `InitOptions` shape.
+No React-specific options on the provider itself; all config flows through the shared `InitOptions` shape.

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -1,6 +1,6 @@
 ---
 title: "React API"
-description: "Types and signatures for @playhtml/react — PlayProvider, withSharedState, capability components, hooks, and usePlayContext."
+description: "Types and signatures for @playhtml/react: PlayProvider, withSharedState, capability components, hooks, and usePlayContext."
 sidebar:
   order: 2
 ---
@@ -19,7 +19,7 @@ interface PlayProviderProps {
 }
 ```
 
-Everything in `initOptions` maps one-to-one onto the vanilla `playhtml.init()` argument — see the [init options reference](/docs/reference/init-options/).
+Everything in `initOptions` maps one-to-one onto the vanilla `playhtml.init()` argument. See the [init options reference](/docs/reference/init-options/).
 
 `pathname` is optional and only needed for client-side-navigation frameworks (React Router, Next.js, etc.) where the browser Navigation API isn't available. Pass it from your router and playhtml will rebuild rooms + rescan the DOM on pathname changes. See [navigation](/docs/advanced/navigation/) for details.
 
@@ -58,10 +58,10 @@ interface WithSharedStateConfig<T, V> {
 }
 ```
 
-- **`defaultData`** — required. The initial value of `data`. Survives reload.
-- **`myDefaultAwareness`** — optional. Initial value for this user's ephemeral per-user field. Does _not_ persist.
-- **`id`** — optional. Stable id for the element. If omitted, playhtml derives one from the rendered DOM; see [Dynamic elements](/docs/advanced/dynamic-elements/) for why stable ids matter.
-- **`tagInfo`** — optional. Marks the element as one of the built-in capabilities (e.g. `[TagType.CanToggle]`). See [Capabilities](/docs/capabilities/).
+- **`defaultData`**: required. The initial value of `data`. Survives reload.
+- **`myDefaultAwareness`**: optional. Initial value for this user's ephemeral per-user field. Does _not_ persist.
+- **`id`**: optional. Stable id for the element. If omitted, playhtml derives one from the rendered DOM; see [Dynamic elements](/docs/advanced/dynamic-elements/) for why stable ids matter.
+- **`tagInfo`**: optional. Marks the element as one of the built-in capabilities (e.g. `[TagType.CanToggle]`). See [Capabilities](/docs/capabilities/).
 
 ### Render-function props
 
@@ -108,10 +108,10 @@ interface CanPlayElementProps<T, V> {
 }
 ```
 
-- **`id`** — required if the top-level child is a React Fragment. Otherwise defaults to the child's id, or a hash of the child's content. A stable id matters for cross-browser sync; see [Dynamic elements](/docs/advanced/dynamic-elements/).
-- **`standalone`** — when `true`, the element initializes playhtml itself if no `PlayProvider` is present. Use it for one-off components mounted outside your provider tree (e.g. an Astro island). A no-op when a provider already exists.
-- **`loading`** — controls the loading affordance shown before the element's first sync. See [Loading options](#loading-options).
-- **`dataSource`**, **`shared`**, **`dataSourceReadOnly`** — wire the element to a shared source across pages or sites. See [Shared data props](#shared-data-props) and the [Shared elements](/docs/advanced/shared-elements/) guide.
+- **`id`**: required if the top-level child is a React Fragment. Otherwise defaults to the child's id, or a hash of the child's content. A stable id matters for cross-browser sync; see [Dynamic elements](/docs/advanced/dynamic-elements/).
+- **`standalone`**: when `true`, the element initializes playhtml itself if no `PlayProvider` is present. Use it for one-off components mounted outside your provider tree (e.g. an Astro island). A no-op when a provider already exists.
+- **`loading`**: controls the loading affordance shown before the element's first sync. See [Loading options](#loading-options).
+- **`dataSource`**, **`shared`**, **`dataSourceReadOnly`**: wire the element to a shared source across pages or sites. See [Shared data props](#shared-data-props) and the [Shared elements](/docs/advanced/shared-elements/) guide.
 
 ```tsx
 <CanPlayElement
@@ -143,9 +143,9 @@ interface CanMoveElementProps {
 }
 ```
 
-- **`bounds`** — id or CSS selector of the container to keep the element inside. `"arena"`, `"#arena"`, and `".grid"` all work.
-- **`boundsMinVisible`** — fraction (`0–1`) of the element that must stay inside `bounds` on every edge. Default `0.25`. Use `1` to pin the element fully inside, `0` to drop the fraction constraint entirely.
-- **`boundsMinVisiblePx`** — absolute pixel floor on the keep-visible slice. Default `60`. Useful when an image has transparent padding around its paint — a pure fraction of the layout bbox might otherwise let the visible pixels clip into invisible border.
+- **`bounds`**: id or CSS selector of the container to keep the element inside. `"arena"`, `"#arena"`, and `".grid"` all work.
+- **`boundsMinVisible`**: fraction (`0–1`) of the element that must stay inside `bounds` on every edge. Default `0.25`. Use `1` to pin the element fully inside, `0` to drop the fraction constraint entirely.
+- **`boundsMinVisiblePx`**: absolute pixel floor on the keep-visible slice. Default `60`. Useful when an image has transparent padding around its paint, where a pure fraction of the layout bbox might otherwise let the visible pixels clip into invisible border.
 
 The effective keep-visible slice on each axis is `max(boundsMinVisible × size, boundsMinVisiblePx)`. Set both knobs to `0` to opt fully out of the keep-visible guarantee. See [`can-move` in the capabilities reference](/docs/capabilities/#can-move) for the interaction details.
 
@@ -164,14 +164,14 @@ import { CanMoveElement } from "@playhtml/react";
 
 ## Other capability components
 
-Each built-in capability has a typed wrapper. All of them accept the shared `dataSource`, `shared`, and `standalone` props (see [Shared data props](#shared-data-props)); the table lists what's unique to each. For the full set of options including `loading` and `dataSourceReadOnly`, use `<CanPlayElement>` or `withSharedState` — the capability wrappers only forward the three props above.
+Each built-in capability has a typed wrapper. All of them accept the shared `dataSource`, `shared`, and `standalone` props (see [Shared data props](#shared-data-props)); the table lists what's unique to each. For the full set of options including `loading` and `dataSourceReadOnly`, use `<CanPlayElement>` or `withSharedState`; the capability wrappers only forward the three props above.
 
 | Component | Capability | Extra props |
 | --- | --- | --- |
-| `<CanToggleElement>` | `can-toggle` | `readOnly?: boolean` — render the toggle read-only (sets `data-source-read-only`). |
-| `<CanSpinElement>` | `can-spin` | — |
-| `<CanGrowElement>` | `can-grow` | — |
-| `<CanHoverElement>` | `can-hover` | — (sets `[data-playhtml-hover]` on its child while any user hovers; style that attribute instead of `:hover`). |
+| `<CanToggleElement>` | `can-toggle` | `readOnly?: boolean`: render the toggle read-only (sets `data-source-read-only`). |
+| `<CanSpinElement>` | `can-spin` | none |
+| `<CanGrowElement>` | `can-grow` | none |
+| `<CanHoverElement>` | `can-hover` | sets `[data-playhtml-hover]` on its child while any user hovers; style that attribute instead of `:hover`. |
 | `<CanDuplicateElement>` | `can-duplicate` | `elementToDuplicate: RefObject<HTMLElement>` (required), `canDuplicateTo?: RefObject<HTMLElement>`. |
 
 `CanDuplicateElement` takes refs rather than selector strings, since React owns the DOM:
@@ -191,7 +191,7 @@ const bin = useRef<HTMLDivElement>(null);
 </>;
 ```
 
-For the live demos of each capability, see the [Capabilities](/docs/capabilities/) page — every section has a React tab.
+For the live demos of each capability, see the [Capabilities](/docs/capabilities/) page. Every section has a React tab.
 
 ## Shared data props
 
@@ -199,7 +199,7 @@ These props let an element participate in [cross-page / cross-site sharing](/doc
 
 | Prop | HTML attribute | Where it works |
 | --- | --- | --- |
-| `shared` | `shared` | `CanPlayElement` and every capability wrapper. Mark this element as a **source** others can subscribe to. `true` → read-write; pass `"read-only"` to publish read-only. |
+| `shared` | `shared` | `CanPlayElement` and every capability wrapper. Mark this element as a **source** others can subscribe to. `true` is read-write; pass `"read-only"` to publish read-only. |
 | `dataSource` | `data-source` | `CanPlayElement` and every capability wrapper. Subscribe to a source as a **consumer**. Format: `"domain[/path]#elementId"`. |
 | `dataSourceReadOnly` | `data-source-read-only` | `CanPlayElement` / `withSharedState` only. Force a consumer to read-only even if the source is read-write. (On `CanToggleElement`, use its `readOnly` prop, which sets the same attribute.) |
 
@@ -217,7 +217,7 @@ These props let an element participate in [cross-page / cross-site sharing](/doc
 
 ## Loading options
 
-`CanPlayElement` and `withSharedState` accept a `loading` prop controlling the affordance shown before the element's first sync from the server (it's hidden or animated so readers don't see a flash of default state). The vanilla equivalents — the `loading-behavior` / `loading-class` / `loading-style` HTML attributes — work on any playhtml element.
+`CanPlayElement` and `withSharedState` accept a `loading` prop controlling the affordance shown before the element's first sync from the server (it's hidden or animated so readers don't see a flash of default state). The vanilla equivalents are the `loading-behavior` / `loading-class` / `loading-style` HTML attributes, which work on any playhtml element.
 
 ```tsx
 interface LoadingOptions {
@@ -227,9 +227,9 @@ interface LoadingOptions {
 }
 ```
 
-- **`behavior`** — `"auto"` (default) picks a reasonable affordance, `"hidden"` keeps the element invisible until synced, `"animate"` shows the loading animation, `"none"` disables the affordance entirely (element renders its default state immediately).
-- **`customClass`** — a CSS class applied while loading, so you can style the placeholder yourself.
-- **`style`** — the built-in loading animation: `"breathing"`, `"pulse"`, `"fade"`, or `"none"`.
+- **`behavior`**: `"auto"` (default) picks a reasonable affordance, `"hidden"` keeps the element invisible until synced, `"animate"` shows the loading animation, `"none"` disables the affordance entirely (element renders its default state immediately).
+- **`customClass`**: a CSS class applied while loading, so you can style the placeholder yourself.
+- **`style`**: the built-in loading animation: `"breathing"`, `"pulse"`, `"fade"`, or `"none"`.
 
 ```tsx
 <CanPlayElement
@@ -262,7 +262,7 @@ interface PlayContextValue {
 }
 ```
 
-Most consumers don't read the raw context — prefer the dedicated hooks ([`usePresence`](#usepresence), [`usePageData`](#usepagedata), [`useCursorPresences`](#usecursorpresences), [`usePlayerIdentity`](/docs/reference/use-player-identity/)) which subscribe and re-render for you.
+Most consumers don't read the raw context. Prefer the dedicated hooks ([`usePresence`](#usepresence), [`usePageData`](#usepagedata), [`useCursorPresences`](#usecursorpresences), [`usePlayerIdentity`](/docs/reference/use-player-identity/)) which subscribe and re-render for you.
 
 ### `isLoading`
 
@@ -284,7 +284,7 @@ useEffect(() => {
 
 Use a ref guard plus the mutator form for this kind of write, and don't include the field you write in the dependency list.
 
-`hasSynced` is a deprecated alias for `!isLoading` — prefer `isLoading` in new code.
+`hasSynced` is a deprecated alias for `!isLoading`. Prefer `isLoading` in new code.
 
 ### `cursors`
 
@@ -309,7 +309,7 @@ const {
 } = usePlayContext();
 ```
 
-Usually you'll wrap these in a hook to bind a listener to the component's lifecycle — see [Events](/docs/data/events/) for the `useConfetti` pattern.
+Usually you'll wrap these in a hook to bind a listener to the component's lifecycle. See [Events](/docs/data/events/) for the `useConfetti` pattern.
 
 ## Hooks
 
@@ -338,11 +338,11 @@ for (const [, p] of presences) {
 }
 ```
 
-The type parameter is an assertion about your channel's shape — no runtime validation is performed. Note your data lives under the channel key (`p.status`), not flattened onto the view.
+The type parameter is an assertion about your channel's shape; no runtime validation is performed. Note your data lives under the channel key (`p.status`), not flattened onto the view.
 
 ### `usePageData`
 
-Subscribe to a [page-level data channel](/docs/data/page-data/) — persistent state not tied to any element. The shape mirrors `useState`.
+Subscribe to a [page-level data channel](/docs/data/page-data/), persistent state not tied to any element. The shape mirrors `useState`.
 
 ```tsx
 function usePageData<T>(
@@ -383,7 +383,7 @@ function useCursorPresences(): Map<string, CursorPresenceView>;
 
 ### `useCursorZone`
 
-Register an element as a cursor zone. When the local user's cursor is inside it, other clients render the cursor positioned relative to their own copy of the same element (matched by element id) — useful for anchoring cursors to a shared widget rather than absolute page coordinates.
+Register an element as a cursor zone. When the local user's cursor is inside it, other clients render the cursor positioned relative to their own copy of the same element (matched by element id). This anchors cursors to a shared widget rather than absolute page coordinates.
 
 ```tsx
 function useCursorZone(

--- a/apps/docs/src/content/docs/using-react.md
+++ b/apps/docs/src/content/docs/using-react.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-playhtml ships a first-class React package. This page is an orientation; the rest of the docs show you the React form of each concept inline, next to the vanilla HTML form, so you can pick the shape that fits your codebase.
+playhtml ships a React package. This page is an orientation; the rest of the docs show you the React form of each concept inline, next to the vanilla HTML form, so you can pick the shape that fits your codebase.
 
 ## Install
 
@@ -42,7 +42,7 @@ A new page / route in a multi-page app needs its own provider only if it's a sep
 
 Almost every React element in playhtml is built from one of these.
 
-### `withSharedState` — a hook-flavored HOC
+### `withSharedState`: a hook-flavored HOC
 
 Wrap a component to give it live, shared `data` plus a `setData` callback.
 
@@ -83,7 +83,7 @@ Use the mutator form for counters and other `+/-` updates so each interaction ed
 
 Add `myDefaultAwareness` to the config to get presence-style ephemeral per-user data alongside your persistent data.
 
-### `<CanPlayElement>` — for when you need JSX children, not a wrapper
+### `<CanPlayElement>`: for when you need JSX children, not a wrapper
 
 Same idea, different shape. Useful when the thing you're wrapping is a specific DOM element you want to keep named, or when you want access to `ref`.
 
@@ -108,11 +108,11 @@ import { TagType } from "@playhtml/common";
 
 Every concept page shows both the vanilla and React forms. Pick whichever matches your codebase:
 
-- [Core concepts](/docs/concepts/) — the four primitives
-- [Data essentials](/docs/data/data-essentials/) — `setData` semantics and data shape
-- [Presence](/docs/data/presence/) — ephemeral per-user state, including cursors
-- [Events](/docs/data/events/) — one-off broadcasts
-- [Capabilities](/docs/capabilities/) — every built-in `can-*` attribute
-- [Navigation & SPAs](/docs/advanced/navigation/) — client-side routing with React Router, Next.js, and more
+- [Core concepts](/docs/concepts/): the four primitives
+- [Data essentials](/docs/data/data-essentials/): `setData` semantics and data shape
+- [Presence](/docs/data/presence/): ephemeral per-user state, including cursors
+- [Events](/docs/data/events/): one-off broadcasts
+- [Capabilities](/docs/capabilities/): every built-in `can-*` attribute
+- [Navigation & SPAs](/docs/advanced/navigation/): client-side routing with React Router, Next.js, and more
 
 For the full React component/hook signatures and types, see [React API](/docs/reference/react-api/).


### PR DESCRIPTION
Cleans up AI-writing patterns across the Starlight docs (`apps/docs/`). Rebased on `main` (includes the duplicate-element-ref bugfix #220). Three commits:

**1. Tighten language in shared-elements and cursors**
- `shared-elements`: dropped filler "Effectively" and copula avoidance ("allows for" / "that can be"); rewrote the intro in active voice.
- `cursors`: cut "includes built-in" and "in real-time" filler; leads with "playhtml can track cursors out of the box."

**2. Remove em-dash overuse and poetic filler (14 files)**
**3. Same cleanup for capabilities, getting-started, building-with-ai (3 files)**

Em-dashes were heavily overused across the docs from AI-generated drafts. Reworked prose to use colons for definitions, periods for clause splits, and commas/parentheses for asides. The only remaining em-dashes are inside code blocks, code comments, the AI prompt template, and JSX demo-label attributes (`data-label="LIVE DEMO — can-move"`), which aren't prose.

Cut poetic filler in favor of plain phrasing, e.g.:
- "the quiet hum of other people existing on the page" → "ambient awareness of other people on the page"
- "Presence shines for" → "Presence is for"
- "cursors don't get blown away" → "cursors aren't destroyed"
- "popular snippets accumulate marks like a well-loved library book" → "popular snippets accumulate more marks"
- "That's four wildly different shapes" → "That's four different shapes"

No behavior, API, attribute, or code-sample changes, prose only. `astro build` passes (all 22 pages generated). All 17 docs pages are now covered.
