### PR TITLE
react: clean up cursor zone registrations

### DIFF
--- a/.changeset/cursor-zone-cleanup.md
+++ b/.changeset/cursor-zone-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Fix `useCursorZone` so cleanup unregisters the originally registered zone id and option changes re-register the zone.

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Bootstraps the playhtml singleton and exposes cursor/presence helpers.
 import {
   createContext,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -225,13 +226,13 @@ export function PlayProvider({
     return playhtml.cursorClient.triggerCursorAnimation(stableId, animationClass, durationMs);
   };
 
-  const registerCursorZone = (element: HTMLElement, options?: CursorZoneOptions) => {
+  const registerCursorZone = useCallback((element: HTMLElement, options?: CursorZoneOptions) => {
     playhtml.cursorClient?.registerZone(element, options);
-  };
+  }, []);
 
-  const unregisterCursorZone = (elementId: string) => {
+  const unregisterCursorZone = useCallback((elementId: string) => {
     playhtml.cursorClient?.unregisterZone(elementId);
-  };
+  }, []);
 
   const [cursorsState, setCursorsState] = useState<CursorEvents>({
     allColors: [] as string[],

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -12,6 +12,7 @@ import {
   usePageData,
   usePresenceRoom,
   usePlayerIdentity,
+  useCursorZone,
 } from "../index";
 import type { PlayerIdentity } from "@playhtml/common";
 
@@ -242,5 +243,98 @@ describe("usePlayerIdentity", () => {
     );
     expect(captured?.color.toLowerCase()).toBe("#ffae00");
     expect(captured?.pid).toBe("pk_injectedtestkey");
+  });
+});
+
+describe("useCursorZone", () => {
+  function makeContext({
+    registerCursorZone,
+    unregisterCursorZone,
+  }: {
+    registerCursorZone: React.ContextType<typeof PlayContext>["registerCursorZone"];
+    unregisterCursorZone: React.ContextType<typeof PlayContext>["unregisterCursorZone"];
+  }) {
+    return {
+      setupPlayElements: vi.fn(),
+      dispatchPlayEvent: vi.fn(),
+      registerPlayEventListener: vi.fn(),
+      removePlayEventListener: vi.fn(),
+      deleteElementData: vi.fn(),
+      hasSynced: true,
+      isLoading: false,
+      isProviderMissing: false,
+      configureCursors: vi.fn(),
+      getMyPlayerIdentity: vi.fn(() => null),
+      triggerCursorAnimation: vi.fn(() => false),
+      registerCursorZone,
+      unregisterCursorZone,
+      cursors: { allColors: [], color: "", name: undefined },
+      cursorPresences: new Map(),
+    } as unknown as React.ContextType<typeof PlayContext>;
+  }
+
+  function CursorZone({
+    options,
+  }: {
+    options?: Parameters<typeof useCursorZone>[1];
+  }) {
+    const ref = React.useRef<HTMLDivElement>(null);
+    useCursorZone(ref, options);
+    return <div id="zone-a" data-testid="zone" ref={ref} />;
+  }
+
+  it("unregisters the id that was registered even if the element id changes before cleanup", () => {
+    const registerCursorZone = vi.fn();
+    const unregisterCursorZone = vi.fn();
+    const ctx = makeContext({ registerCursorZone, unregisterCursorZone });
+
+    const { getByTestId, unmount } = render(
+      <PlayContext.Provider value={ctx}>
+        <CursorZone />
+      </PlayContext.Provider>,
+    );
+
+    const element = getByTestId("zone") as HTMLDivElement;
+    expect(registerCursorZone).toHaveBeenCalledWith(element, undefined);
+
+    element.id = "zone-b";
+    unmount();
+
+    expect(unregisterCursorZone).toHaveBeenCalledWith("zone-a");
+  });
+
+  it("re-registers the zone when options change", () => {
+    const registerCursorZone = vi.fn();
+    const unregisterCursorZone = vi.fn();
+    const ctx = makeContext({ registerCursorZone, unregisterCursorZone });
+    const firstOptions = { getCursorStyle: vi.fn(() => ({ opacity: "0.5" })) };
+    const secondOptions = { getCursorStyle: vi.fn(() => ({ opacity: "1" })) };
+
+    const { getByTestId, rerender } = render(
+      <PlayContext.Provider value={ctx}>
+        <CursorZone options={firstOptions} />
+      </PlayContext.Provider>,
+    );
+
+    const element = getByTestId("zone") as HTMLDivElement;
+    expect(registerCursorZone).toHaveBeenCalledWith(element, firstOptions);
+
+    rerender(
+      <PlayContext.Provider value={ctx}>
+        <CursorZone options={firstOptions} />
+      </PlayContext.Provider>,
+    );
+    registerCursorZone.mockClear();
+    unregisterCursorZone.mockClear();
+
+    rerender(
+      <PlayContext.Provider value={ctx}>
+        <CursorZone options={secondOptions} />
+      </PlayContext.Provider>,
+    );
+
+    expect(unregisterCursorZone).toHaveBeenCalledWith("zone-a");
+    expect(registerCursorZone).toHaveBeenCalledWith(element, secondOptions);
+    expect(registerCursorZone).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -41,13 +41,14 @@ export function useCursorZone(
   useEffect(() => {
     const element = ref.current;
     if (!element || !element.id) return;
+    const elementId = element.id;
 
     registerCursorZone(element, options);
 
     return () => {
-      unregisterCursorZone(element.id);
+      unregisterCursorZone(elementId);
     };
-  }, [ref.current, ref.current?.id]);
+  }, [ref, options, registerCursorZone, unregisterCursorZone]);
 }
 
 /**


### PR DESCRIPTION
## Summary
- make `useCursorZone` unregister the id that was originally registered, even if the DOM element id changes before cleanup
- re-register cursor zones when `options` changes
- stabilize the PlayProvider cursor-zone callbacks used by the hook dependency list
- add regression coverage for mutated-id cleanup and options changes
- add a patch changeset for `@playhtml/react`

## Rationale
The hook previously called `unregisterCursorZone(element.id)` during cleanup. If that element's id changed before unmount, the old zone id stayed registered. It also omitted `options` from the effect dependencies, so changed cursor-zone rendering/style options did not re-register the zone.

## Tests
- Red: `bun run test -- src/__tests__/hooks.test.tsx` failed on mutated-id cleanup and options-change regressions before the fix
- Green: `bun run test -- src/__tests__/hooks.test.tsx`
- Green: `bun run test` from `packages/react/` (passes with an existing Dart Sass legacy API deprecation warning)
- Green: `bunx tsc --noEmit` from `packages/react/`
- Green: `bun run build` from `packages/react/` (passes with the existing API Extractor bundled-TypeScript warning)
- Green: `git diff --check`

## Docs / changeset
- Added `.changeset/cursor-zone-cleanup.md` for `@playhtml/react` patch.
- Checked `apps/docs/src/content/docs/reference/react-api.md`; no docs update needed because the public API shape and usage are unchanged.