### PR TITLE
playhtml: rebind presence awareness listeners

### DIFF
--- a/.changeset/presence-awareness-rebind.md
+++ b/.changeset/presence-awareness-rebind.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Fix presence subscriptions so they continue receiving awareness updates after the underlying provider is rebuilt.

--- a/packages/playhtml/src/__tests__/presence-identity.test.ts
+++ b/packages/playhtml/src/__tests__/presence-identity.test.ts
@@ -10,25 +10,34 @@ const IDENTITY_FIELD = "__playhtml_identity__";
 interface MockAwareness {
   clientID: number;
   states: Map<number, Record<string, unknown>>;
+  listeners: Set<(...args: unknown[]) => void>;
   getStates(): Map<number, Record<string, unknown>>;
   getLocalState(): Record<string, unknown> | null;
   setLocalStateField(field: string, value: unknown): void;
   on(event: string, cb: (...args: unknown[]) => void): void;
+  emitChange(): void;
 }
 
 function makeAwareness(clientID: number): MockAwareness {
   const states = new Map<number, Record<string, unknown>>();
+  const listeners = new Set<(...args: unknown[]) => void>();
   states.set(clientID, {});
   return {
     clientID,
     states,
+    listeners,
     getStates: () => states,
     getLocalState: () => states.get(clientID) ?? null,
     setLocalStateField(field, value) {
       const cur = states.get(clientID) ?? {};
       states.set(clientID, { ...cur, [field]: value });
     },
-    on() {},
+    on(event, cb) {
+      if (event === "change") listeners.add(cb);
+    },
+    emitChange() {
+      for (const listener of listeners) listener();
+    },
   };
 }
 
@@ -140,6 +149,34 @@ describe("createPresenceAPI identity propagation", () => {
 
     api.getPresences();
     expect(awareness.getLocalState()?.[IDENTITY_FIELD]).toEqual(identity);
+  });
+
+  it("re-attaches channel listeners after the awareness provider is rebuilt", () => {
+    let awareness = makeAwareness(1);
+    const identity = makeIdentity("pk_local");
+    const remoteIdentity = makeIdentity("pk_remote");
+    const api = createPresenceAPI({
+      getAwareness: () => awareness,
+      getPlayerIdentity: () => identity,
+    });
+    const received: Array<Map<string, unknown>> = [];
+    const unsub = api.onPresenceChange("status", (presences) => {
+      received.push(presences as Map<string, unknown>);
+    });
+    received.length = 0;
+
+    awareness = makeAwareness(2);
+    api.getPresences();
+    awareness.states.set(3, {
+      [IDENTITY_FIELD]: remoteIdentity,
+      __presence__: { status: { text: "available" } },
+    });
+    awareness.emitChange();
+
+    expect(received).toHaveLength(1);
+    const remote = Array.from(received[0].values()).find((p: any) => !p.isMe) as any;
+    expect(remote.status).toEqual({ text: "available" });
+    unsub();
   });
 
   it("returns playerIdentity undefined for peers with no identity at all", () => {

--- a/packages/playhtml/src/presence.ts
+++ b/packages/playhtml/src/presence.ts
@@ -31,7 +31,8 @@ interface ChannelListener {
 
 export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
   const listeners = new Map<string, ChannelListener>();
-  let awarenessListenerAttached = false;
+  const attachedAwarenessObjects = new WeakSet<AwarenessLike>();
+  let currentAwareness: AwarenessLike | null = null;
   let nextListenerId = 0;
 
   function getAwareness(): AwarenessLike {
@@ -79,31 +80,39 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
     return parts.join("|");
   }
 
+  function handleAwarenessChange(): void {
+    if (listeners.size === 0) return;
+    const states = getAwareness().getStates();
+
+    // Cache buildPresences() so multiple listeners in the same event share the result
+    let cachedPresences: Map<string, PresenceView> | null = null;
+    const getPresencesOnce = () => {
+      if (!cachedPresences) cachedPresences = buildPresences();
+      return cachedPresences;
+    };
+
+    for (const listener of listeners.values()) {
+      const fingerprint = channelFingerprint(
+        states as Map<number, Record<string, unknown>>,
+        listener.channel,
+      );
+      if (fingerprint === listener.lastFingerprint) continue;
+      listener.lastFingerprint = fingerprint;
+      listener.callback(getPresencesOnce());
+    }
+  }
+
   function attachAwarenessListener(): void {
-    if (awarenessListenerAttached) return;
-    awarenessListenerAttached = true;
+    const awareness = getAwareness();
+    if (currentAwareness === awareness) return;
+    currentAwareness = awareness;
+    if (attachedAwarenessObjects.has(awareness)) return;
+    attachedAwarenessObjects.add(awareness);
+    awareness.on("change", handleAwarenessChange);
+  }
 
-    getAwareness().on("change", () => {
-      if (listeners.size === 0) return;
-      const states = getAwareness().getStates();
-
-      // Cache buildPresences() so multiple listeners in the same event share the result
-      let cachedPresences: Map<string, PresenceView> | null = null;
-      const getPresencesOnce = () => {
-        if (!cachedPresences) cachedPresences = buildPresences();
-        return cachedPresences;
-      };
-
-      for (const listener of listeners.values()) {
-        const fingerprint = channelFingerprint(
-          states as Map<number, Record<string, unknown>>,
-          listener.channel,
-        );
-        if (fingerprint === listener.lastFingerprint) continue;
-        listener.lastFingerprint = fingerprint;
-        listener.callback(getPresencesOnce());
-      }
-    });
+  function attachAwarenessListenerIfSubscribed(): void {
+    if (listeners.size > 0) attachAwarenessListener();
   }
 
   function buildViewFromState(state: Record<string, unknown>, isMe: boolean): PresenceView {
@@ -198,6 +207,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
   return {
     setMyPresence(channel: string, data: unknown): void {
       ensureIdentityWritten();
+      attachAwarenessListenerIfSubscribed();
       const awareness = getAwareness();
       const currentState = awareness.getLocalState() ?? {};
       const currentPresence = (currentState[PRESENCE_FIELD] as Record<string, unknown>) ?? {};
@@ -215,6 +225,7 @@ export function createPresenceAPI(deps: PresenceDeps): PresenceAPI {
 
     getPresences(): Map<string, PresenceView> {
       ensureIdentityWritten();
+      attachAwarenessListenerIfSubscribed();
       return buildPresences();
     },
 


### PR DESCRIPTION
## Summary
- reattach `playhtml.presence` channel listeners when the underlying awareness provider is rebuilt
- keep listener attachment one-per-awareness-instance to avoid duplicate callbacks on the same provider
- add a regression test that swaps the awareness provider and verifies the existing subscriber receives new provider changes
- add a patch changeset for `playhtml`

## Rationale
`createPresenceAPI` previously guarded listener attachment with a single boolean. After navigation or a room reset rebuilt the provider, the API kept active subscribers but did not attach its `change` listener to the new awareness object. The next provider change could therefore be missed until code resubscribed.

## Tests
- Red: `bun run test -- src/__tests__/presence-identity.test.ts` failed because the rebuilt awareness emitted no subscriber callback
- Green: `bun run test -- src/__tests__/presence-identity.test.ts`
- Green: `bun run test -- src/__tests__/presence-identity.test.ts src/__tests__/presence-multitab.test.ts src/__tests__/presence.test.ts src/__tests__/presence-room.test.ts` (passes with existing Dart Sass deprecation warning)
- Green: `bunx tsc --noEmit` from `packages/playhtml/`
- Green: `bun run test` from `packages/playhtml/` (passes; includes existing perf stdout, Sass deprecation warning, and expected duplicate-template warning from an existing test)
- Green: `bun run build` from `packages/playhtml/` (passes with existing API Extractor bundled-TypeScript warning)
- Green: `git diff --check`

## Docs / changeset
- Added `.changeset/presence-awareness-rebind.md` for `playhtml` patch.
- Checked presence docs; no public docs update needed because API shape and usage are unchanged.