### PR TITLE
docs: clarify can-hover presence behavior

### DIFF
--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -125,7 +125,7 @@ BUILT-IN CAPABILITIES (if they fit the use case):
 - can-spin: Rotatable element
 - can-grow: Click to scale up/down
 - can-duplicate: Click to clone element
-- can-hover: Hover to toggle on/off state
+- can-hover: Shares hover presence while someone is hovering
 - can-mirror: Syncs all element changes automatically
 - Use these instead of can-play when possible
 


### PR DESCRIPTION
## Summary
- correct the AI-building prompt text for `can-hover`
- describe it as shared hover presence instead of toggled on/off state

## Verification
- `git diff --check`
- initial `bun run build` in `apps/docs` failed in the fresh worktree because `packages/playhtml/dist/playhtml.es.js` had not been generated for the docs playground raw import
- `bun run build` in `packages/playhtml` to generate the local docs dependency artifact; output includes the existing API Extractor TypeScript-version warning
- `bun run build` in `apps/docs` passes; output includes existing Vite/Astro warnings for fire-hydrant asset resolution, React reexport chunking, chunk size, and missing sitemap site config