### PR TITLE
templates: add html starter metadata

### DIFF
--- a/templates/html-starter/package.json
+++ b/templates/html-starter/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "playhtml-html-starter",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- replace the empty HTML starter `package.json` with valid package metadata
- keep the starter static by avoiding scripts or dependencies

## Verification
- `bun -e "const pkg = await import('./templates/html-starter/package.json', { with: { type: 'json' } }); if (pkg.default.name !== 'playhtml-html-starter') throw new Error('unexpected name');"`
- `git diff --check`

## Notes
No changeset needed because this only touches `templates/`. No package install/build is needed for the HTML starter; `templates/README.md` documents opening `index.html` directly.