### PR TITLE
partykit: recover shared bridges after reset

### DIFF
--- a/partykit/__tests__/bridgeEpochPolicy.test.ts
+++ b/partykit/__tests__/bridgeEpochPolicy.test.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Verifies reset-epoch selection for shared-element bridge applies.
+// ABOUTME: Keeps source-to-consumer and consumer-to-source reset guards aligned.
+import { describe, expect, it } from "bun:test";
+
+async function loadBridgeEpochPolicy(): Promise<{
+  getBridgeApplyTargetResetEpoch: (input: {
+    originKind: "source" | "consumer";
+    consumerResetEpoch?: number | null;
+    sourceResetEpoch?: number | null;
+  }) => number | null;
+}> {
+  const module = await import("../bridgeEpochPolicy").catch(() => null);
+  expect(module).not.toBeNull();
+  return module as NonNullable<typeof module>;
+}
+
+describe("getBridgeApplyTargetResetEpoch", () => {
+  it("uses the consumer reset epoch for source-to-consumer applies", async () => {
+    const { getBridgeApplyTargetResetEpoch } = await loadBridgeEpochPolicy();
+
+    expect(
+      getBridgeApplyTargetResetEpoch({
+        originKind: "source",
+        consumerResetEpoch: 123,
+        sourceResetEpoch: null,
+      })
+    ).toBe(123);
+  });
+
+  it("uses the source reset epoch for consumer-to-source applies", async () => {
+    const { getBridgeApplyTargetResetEpoch } = await loadBridgeEpochPolicy();
+
+    expect(
+      getBridgeApplyTargetResetEpoch({
+        originKind: "consumer",
+        consumerResetEpoch: 123,
+        sourceResetEpoch: 456,
+      })
+    ).toBe(456);
+  });
+
+  it("normalizes unknown target reset epochs to null", async () => {
+    const { getBridgeApplyTargetResetEpoch } = await loadBridgeEpochPolicy();
+
+    expect(
+      getBridgeApplyTargetResetEpoch({
+        originKind: "source",
+      })
+    ).toBeNull();
+  });
+});

--- a/partykit/__tests__/bridgeHealth.test.ts
+++ b/partykit/__tests__/bridgeHealth.test.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Tests the per-(peer,direction) bridge circuit breaker that stops
+// ABOUTME: storming a misconfigured bridge link after repeated rejected applies.
+import { describe, expect, it } from "bun:test";
+import {
+  BRIDGE_CIRCUIT_OPEN_THRESHOLD,
+  BridgeHealth,
+} from "../bridgeHealth";
+
+function tripLink(
+  health: BridgeHealth,
+  peer: string,
+  direction: "source" | "consumer"
+): void {
+  for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD; i++) {
+    health.recordResult(peer, direction, false);
+  }
+}
+
+describe("BridgeHealth circuit breaker", () => {
+  it("allows sends to a healthy peer", () => {
+    const health = new BridgeHealth();
+    expect(health.shouldSend("consumer-a", "source")).toBe(true);
+  });
+
+  it("opens the circuit after the threshold of consecutive rejects", () => {
+    const health = new BridgeHealth();
+    for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD; i++) {
+      expect(health.shouldSend("c", "source")).toBe(true);
+      health.recordResult("c", "source", false);
+    }
+    expect(health.shouldSend("c", "source")).toBe(false);
+  });
+
+  it("returns justOpened exactly on the threshold-crossing result", () => {
+    const health = new BridgeHealth();
+    for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD - 1; i++) {
+      expect(health.recordResult("c", "source", false)).toBe(false);
+    }
+    // The crossing result reports the open edge once.
+    expect(health.recordResult("c", "source", false)).toBe(true);
+    // Already-open further rejects do not re-report.
+    expect(health.recordResult("c", "source", false)).toBe(false);
+  });
+
+  it("keeps healthy peers unaffected when another peer trips", () => {
+    const health = new BridgeHealth();
+    tripLink(health, "bad", "source");
+    expect(health.shouldSend("bad", "source")).toBe(false);
+    expect(health.shouldSend("good", "source")).toBe(true);
+  });
+
+  it("tracks each direction to the same peer independently", () => {
+    const health = new BridgeHealth();
+    tripLink(health, "p", "source");
+    expect(health.shouldSend("p", "source")).toBe(false);
+    // The consumer direction to the same peer is untouched.
+    expect(health.shouldSend("p", "consumer")).toBe(true);
+  });
+
+  it("does not let a success in one direction clear the other direction's streak", () => {
+    const health = new BridgeHealth();
+    // Accumulate rejects on the consumer direction.
+    for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD - 1; i++) {
+      health.recordResult("p", "consumer", false);
+    }
+    // A success on the source direction must not reset the consumer streak.
+    health.recordResult("p", "source", true);
+    expect(health.recordResult("p", "consumer", false)).toBe(true); // crosses now
+    expect(health.shouldSend("p", "consumer")).toBe(false);
+  });
+
+  it("resets the counter on a successful apply", () => {
+    const health = new BridgeHealth();
+    for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD - 1; i++) {
+      health.recordResult("c", "source", false);
+    }
+    health.recordResult("c", "source", true);
+    expect(health.shouldSend("c", "source")).toBe(true);
+    for (let i = 0; i < BRIDGE_CIRCUIT_OPEN_THRESHOLD - 1; i++) {
+      health.recordResult("c", "source", false);
+    }
+    expect(health.shouldSend("c", "source")).toBe(true);
+  });
+
+  it("reopens both directions of a tripped peer on reset() (resubscribe)", () => {
+    const health = new BridgeHealth();
+    tripLink(health, "c", "source");
+    tripLink(health, "c", "consumer");
+    expect(health.shouldSend("c", "source")).toBe(false);
+    expect(health.shouldSend("c", "consumer")).toBe(false);
+    health.reset("c");
+    expect(health.shouldSend("c", "source")).toBe(true);
+    expect(health.shouldSend("c", "consumer")).toBe(true);
+  });
+
+  it("treats absence (never-seen peer) as healthy", () => {
+    const health = new BridgeHealth();
+    expect(health.shouldSend("never-seen", "source")).toBe(true);
+  });
+});

--- a/partykit/__tests__/bridgePermissionPolicy.test.ts
+++ b/partykit/__tests__/bridgePermissionPolicy.test.ts
@@ -1,0 +1,38 @@
+// ABOUTME: Verifies shared-element permission filtering for bridge payloads.
+// ABOUTME: Prevents consumers from hydrating source elements that were not exported.
+import { describe, expect, it } from "bun:test";
+
+async function loadBridgePermissionPolicy(): Promise<{
+  getPermittedSharedElementIds: (
+    requestedIds: string[],
+    permissions: Record<string, "read-only" | "read-write">
+  ) => string[];
+}> {
+  const module = await import("../bridgePermissionPolicy").catch(() => null);
+  expect(module).not.toBeNull();
+  return module as NonNullable<typeof module>;
+}
+
+describe("getPermittedSharedElementIds", () => {
+  it("keeps only element ids that the source exported", async () => {
+    const { getPermittedSharedElementIds } =
+      await loadBridgePermissionPolicy();
+
+    expect(
+      getPermittedSharedElementIds(["shared", "private"], {
+        shared: "read-write",
+      })
+    ).toEqual(["shared"]);
+  });
+
+  it("treats read-only exports as hydratable", async () => {
+    const { getPermittedSharedElementIds } =
+      await loadBridgePermissionPolicy();
+
+    expect(
+      getPermittedSharedElementIds(["readonly"], {
+        readonly: "read-only",
+      })
+    ).toEqual(["readonly"]);
+  });
+});

--- a/partykit/bridgeEpochPolicy.ts
+++ b/partykit/bridgeEpochPolicy.ts
@@ -1,0 +1,26 @@
+// ABOUTME: Selects reset epochs for cross-room shared-element bridge requests.
+// ABOUTME: Ensures each receiver validates bridge data against its own epoch.
+
+export type BridgeApplyOriginKind = "source" | "consumer";
+
+type BridgeApplyTargetResetEpochInput = {
+  originKind: BridgeApplyOriginKind;
+  consumerResetEpoch?: number | null;
+  sourceResetEpoch?: number | null;
+};
+
+function normalizeResetEpoch(resetEpoch: number | null | undefined): number | null {
+  return typeof resetEpoch === "number" && Number.isFinite(resetEpoch)
+    ? resetEpoch
+    : null;
+}
+
+export function getBridgeApplyTargetResetEpoch({
+  originKind,
+  consumerResetEpoch,
+  sourceResetEpoch,
+}: BridgeApplyTargetResetEpochInput): number | null {
+  return originKind === "source"
+    ? normalizeResetEpoch(consumerResetEpoch)
+    : normalizeResetEpoch(sourceResetEpoch);
+}

--- a/partykit/bridgeHealth.ts
+++ b/partykit/bridgeHealth.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Per-peer circuit breaker for shared-element bridge fan-out.
+// ABOUTME: Stops re-sending to a peer that keeps rejecting applies (e.g. a
+// ABOUTME: misconfigured source stuck on a stale reset epoch) until it recovers.
+
+// A misconfigured bridge pair (most commonly a source stuck on a stale reset
+// epoch) gets every apply rejected. Without a breaker the sender re-fans-out on
+// every document update, producing a retry storm against every peer. After this
+// many consecutive rejected applies to the same (peer, direction), the sender
+// stops sending on that link until the streak is reset.
+export const BRIDGE_CIRCUIT_OPEN_THRESHOLD = 5;
+
+// A room can be both a source and a consumer to the same peer (bidirectional
+// share), so health is tracked per direction as well as per peer — otherwise a
+// success in one direction would clear the other direction's reject streak.
+export type BridgeDirection = "source" | "consumer";
+
+function linkKey(peerRoomId: string, direction: BridgeDirection): string {
+  return `${direction} ${peerRoomId}`;
+}
+
+// Tracks consecutive rejected applies per (peer room, direction). In-memory
+// only: a Durable Object reload (which produces a fresh, correct reset epoch)
+// naturally drops this state and re-enables every bridge. reset() additionally
+// reopens a peer early when it resubscribes (a new page load on the consumer
+// side).
+export class BridgeHealth {
+  private consecutiveRejectsByLink = new Map<string, number>();
+
+  // Whether the sender should attempt a send on this link right now.
+  shouldSend(peerRoomId: string, direction: BridgeDirection): boolean {
+    const key = linkKey(peerRoomId, direction);
+    const rejects = this.consecutiveRejectsByLink.get(key) ?? 0;
+    return rejects < BRIDGE_CIRCUIT_OPEN_THRESHOLD;
+  }
+
+  // Record the outcome of an apply on this link. `applied === true` clears the
+  // reject streak; a rejected apply increments it toward the circuit threshold.
+  // Returns true only on the result that crosses the threshold (the open edge),
+  // so the caller can log the trip exactly once.
+  recordResult(
+    peerRoomId: string,
+    direction: BridgeDirection,
+    applied: boolean
+  ): boolean {
+    const key = linkKey(peerRoomId, direction);
+    if (applied) {
+      this.consecutiveRejectsByLink.delete(key);
+      return false;
+    }
+    const before = this.consecutiveRejectsByLink.get(key) ?? 0;
+    const after = before + 1;
+    this.consecutiveRejectsByLink.set(key, after);
+    return (
+      before < BRIDGE_CIRCUIT_OPEN_THRESHOLD &&
+      after >= BRIDGE_CIRCUIT_OPEN_THRESHOLD
+    );
+  }
+
+  // Reopen a peer's circuit in both directions. Called when a consumer
+  // resubscribes (a fresh page load), so a genuine new client always gets a
+  // clean attempt even if the link had previously tripped.
+  reset(peerRoomId: string): void {
+    this.consecutiveRejectsByLink.delete(linkKey(peerRoomId, "source"));
+    this.consecutiveRejectsByLink.delete(linkKey(peerRoomId, "consumer"));
+  }
+}

--- a/partykit/bridgePermissionPolicy.ts
+++ b/partykit/bridgePermissionPolicy.ts
@@ -1,0 +1,16 @@
+// ABOUTME: Filters bridge element ids by source-declared sharing permissions.
+// ABOUTME: Keeps hydration and live fan-out from exposing unexported elements.
+
+export type SharedElementPermissionMap = Record<
+  string,
+  "read-only" | "read-write"
+>;
+
+export function getPermittedSharedElementIds(
+  requestedIds: string[],
+  permissions: SharedElementPermissionMap
+): string[] {
+  return requestedIds.filter((elementId) => {
+    return Boolean(permissions[elementId]);
+  });
+}

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -58,6 +58,7 @@ export const ORIGIN_C2S = "__bridge_c2s__";
 export type Subscriber = {
   consumerRoomId: string;
   elementIds?: string[];
+  consumerResetEpoch?: number | null;
   createdAt?: string;
   lastSeen?: string;
   leaseMs?: number;
@@ -66,6 +67,7 @@ export type Subscriber = {
 export type SharedRefEntry = {
   sourceRoomId: string;
   elementIds: string[];
+  sourceResetEpoch?: number | null;
   lastSeen?: string;
 };
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -78,6 +78,7 @@ import {
   isResetEpochStale,
   parseClientResetEpoch,
 } from "./resetEpochPolicy";
+import { BridgeHealth } from "./bridgeHealth";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
@@ -169,6 +170,11 @@ export class PartyServer extends YServer {
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly BRIDGE_DEBOUNCE_MS = 500;
+
+  // Per-peer circuit breaker: stops re-sending bridge applies to a peer that
+  // keeps rejecting them (e.g. a misconfigured peer stuck on a stale reset
+  // epoch). In-memory, so a DO reload re-enables every bridge.
+  private bridgeHealth = new BridgeHealth();
 
   // Preserve the same debounce timing as the old y-partykit callback config
   static callbackOptions = {
@@ -1133,17 +1139,13 @@ export class PartyServer extends YServer {
       await Promise.all(
         subscribers.map(async ({ consumerRoomId, elementIds }) => {
           if (!elementIds || !elementIds.includes(element.elementId)) return;
-          const consumerRoom = await getServerByName(env.Main, consumerRoomId);
-          try {
-            const applyRequest: ApplySubtreesImmediateRequest = {
-              action: "apply-subtrees-immediate",
-              subtrees: ensureExists(subtreesForNew),
-              sender: this.name,
-              originKind: "source",
-              resetEpoch: currentEpoch ?? null,
-            };
-            await consumerRoom.fetch(internalRequest("/apply", applyRequest));
-          } catch {}
+          await this.sendBridgeApply(consumerRoomId, {
+            action: "apply-subtrees-immediate",
+            subtrees: ensureExists(subtreesForNew),
+            sender: this.name,
+            originKind: "source",
+            resetEpoch: currentEpoch ?? null,
+          });
         })
       );
     } catch {}
@@ -1629,6 +1631,10 @@ export class PartyServer extends YServer {
           found.lastSeen = nowIso;
         }
         await this.setSubscribers(existing);
+        // A resubscribe means a fresh client load on the consumer side. Reopen
+        // its circuit so a genuine new visitor always gets a clean bridge attempt
+        // even if the pair had previously tripped from a stale-epoch storm.
+        this.bridgeHealth.reset(consumerRoomId);
         const response: SubscribeResponse = {
           ok: true,
           subscribed: true,
@@ -1658,7 +1664,7 @@ export class PartyServer extends YServer {
           console.warn(
             `[Bridge] Ignoring apply-subtrees for transient room ${this.name}: Supabase persistence unavailable.`
           );
-          const response: ApplySubtreesResponse = { ok: true };
+          const response: ApplySubtreesResponse = { ok: true, applied: false };
           return new Response(JSON.stringify(response), {
             headers: { "content-type": "application/json" },
           });
@@ -1678,7 +1684,7 @@ export class PartyServer extends YServer {
           console.warn(
             `[Bridge] Ignoring apply-subtrees from ${sender} (${originKind}) due to stale reset epoch (sender=${senderResetEpoch}, server=${serverResetEpoch})`
           );
-          const response: ApplySubtreesResponse = { ok: true };
+          const response: ApplySubtreesResponse = { ok: true, applied: false };
           return new Response(JSON.stringify(response), {
             headers: { "content-type": "application/json" },
           });
@@ -1741,7 +1747,9 @@ export class PartyServer extends YServer {
           }
         }
         if (!Object.keys(subtreesToApply).length) {
-          const response: ApplySubtreesResponse = { ok: true };
+          // Nothing to apply (filtered to empty). Not a failure — report applied
+          // so it does not count against the sender's circuit breaker.
+          const response: ApplySubtreesResponse = { ok: true, applied: true };
           return new Response(JSON.stringify(response), {
             headers: { "content-type": "application/json" },
           });
@@ -1778,24 +1786,17 @@ export class PartyServer extends YServer {
                 toSend = filteredSubtrees;
                 if (!Object.keys(toSend).length) return;
               }
-              const consumerRoom = await getServerByName(
-                env.Main,
-                consumerRoomId
-              );
-              try {
-                const applyRequest: ApplySubtreesImmediateRequest = {
-                  action: "apply-subtrees-immediate",
-                  subtrees: toSend,
-                  sender: this.name,
-                  originKind: "source",
-                  resetEpoch: currentEpoch ?? null,
-                };
-                await consumerRoom.fetch(internalRequest("/apply", applyRequest));
-              } catch {}
+              await this.sendBridgeApply(consumerRoomId, {
+                action: "apply-subtrees-immediate",
+                subtrees: toSend,
+                sender: this.name,
+                originKind: "source",
+                resetEpoch: currentEpoch ?? null,
+              });
             })
           );
         }
-        const response: ApplySubtreesResponse = { ok: true };
+        const response: ApplySubtreesResponse = { ok: true, applied: true };
         return new Response(JSON.stringify(response), {
           headers: { "content-type": "application/json" },
         });
@@ -2143,15 +2144,13 @@ export class PartyServer extends YServer {
             new Set(sharedElementIds)
           );
           if (!Object.keys(subtrees).length) return;
-          const consumerRoom = await getServerByName(env.Main, consumerRoomId);
-          const applyRequest: ApplySubtreesImmediateRequest = {
+          await this.sendBridgeApply(consumerRoomId, {
             action: "apply-subtrees-immediate",
             subtrees,
             sender: this.name,
             originKind: "source",
             resetEpoch: currentEpoch ?? null,
-          };
-          await consumerRoom.fetch(internalRequest("/apply", applyRequest));
+          });
         })
       );
     }
@@ -2162,15 +2161,56 @@ export class PartyServer extends YServer {
       if (!elementIds?.length) continue;
       const subtrees = this.extractPlaySubtrees(yDoc, new Set(elementIds));
       if (!Object.keys(subtrees).length) continue;
-      const sourceRoom = await getServerByName(env.Main, sourceRoomId);
-      const applyRequest: ApplySubtreesImmediateRequest = {
+      await this.sendBridgeApply(sourceRoomId, {
         action: "apply-subtrees-immediate",
         subtrees,
         sender: this.name,
         originKind: "consumer",
         resetEpoch: currentEpoch ?? null,
-      };
-      await sourceRoom.fetch(internalRequest("/apply", applyRequest));
+      });
+    }
+  }
+
+  // The single outbound chokepoint for bridge applies. Every fan-out path must
+  // route through here so the per-(peer, direction) circuit breaker sees it:
+  // it skips the send when the link's circuit is open (the peer keeps rejecting
+  // us), records the apply result so a recovered peer reopens and a misconfigured
+  // one stops being stormed, and logs once on the open edge. The direction is the
+  // request's originKind, so the two directions to a bidirectional peer are
+  // tracked independently.
+  private async sendBridgeApply(
+    peerRoomId: string,
+    applyRequest: ApplySubtreesImmediateRequest
+  ): Promise<void> {
+    const direction = applyRequest.originKind;
+    if (!this.bridgeHealth.shouldSend(peerRoomId, direction)) {
+      return;
+    }
+    let applied: boolean;
+    try {
+      const peerRoom = await getServerByName(env.Main, peerRoomId);
+      const res = await peerRoom.fetch(internalRequest("/apply", applyRequest));
+      if (!res.ok) {
+        // A non-2xx response is a failed apply regardless of body.
+        applied = false;
+      } else {
+        try {
+          const parsed = (await res.json()) as ApplySubtreesResponse;
+          // Absent `applied` means an older peer that always applies — treat as true.
+          applied = parsed?.applied !== false;
+        } catch {
+          // Unparseable 2xx body — treat as a failed apply so a broken peer backs off.
+          applied = false;
+        }
+      }
+    } catch {
+      // Network/dispatch failure also counts against the link's health.
+      applied = false;
+    }
+    if (this.bridgeHealth.recordResult(peerRoomId, direction, applied)) {
+      console.warn(
+        `[Bridge] Circuit opened for ${this.name} -> ${peerRoomId} (${direction}): peer keeps rejecting applies; pausing sends until it recovers or resubscribes`
+      );
     }
   }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -80,6 +80,7 @@ import {
 } from "./resetEpochPolicy";
 import { BridgeHealth } from "./bridgeHealth";
 import { getBridgeApplyTargetResetEpoch } from "./bridgeEpochPolicy";
+import { getPermittedSharedElementIds } from "./bridgePermissionPolicy";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
@@ -1709,8 +1710,13 @@ export class PartyServer extends YServer {
         // even if the pair had previously tripped from a stale-epoch storm.
         this.bridgeHealth.reset(consumerRoomId);
         const sourceResetEpoch = await this.getResetEpoch();
-        const subtrees = requestedIds.length
-          ? this.extractPlaySubtrees(this.document, new Set(requestedIds))
+        const permissions = await this.getSharedPermissions();
+        const permittedIds = getPermittedSharedElementIds(
+          requestedIds,
+          permissions
+        );
+        const subtrees = permittedIds.length
+          ? this.extractPlaySubtrees(this.document, new Set(permittedIds))
           : {};
         const response: SubscribeResponse = {
           ok: true,
@@ -2221,9 +2227,10 @@ export class PartyServer extends YServer {
         subscribers.map(
           async ({ consumerRoomId, elementIds, consumerResetEpoch }) => {
             if (!elementIds || !elementIds.length) return;
-            const sharedElementIds = elementIds.filter((id) => {
-              return Boolean(permissions[id]);
-            });
+            const sharedElementIds = getPermittedSharedElementIds(
+              elementIds,
+              permissions
+            );
             const subtrees = this.extractPlaySubtrees(
               yDoc,
               new Set(sharedElementIds)

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -79,6 +79,7 @@ import {
   parseClientResetEpoch,
 } from "./resetEpochPolicy";
 import { BridgeHealth } from "./bridgeHealth";
+import { getBridgeApplyTargetResetEpoch } from "./bridgeEpochPolicy";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
@@ -952,6 +953,9 @@ export class PartyServer extends YServer {
   private async subscribeAndHydrate(
     entries: Array<{ sourceRoomId: string; elementIds: string[] }>
   ): Promise<void> {
+    const consumerResetEpoch = await this.getResetEpoch();
+    const sourceResetEpochByRoom = new Map<string, number | null>();
+
     // Subscribe and cache allowedIds per source in sharedReferences
     await Promise.all(
       entries.map(async ({ sourceRoomId, elementIds }) => {
@@ -962,11 +966,65 @@ export class PartyServer extends YServer {
             action: "subscribe",
             consumerRoomId: this.name,
             elementIds,
+            consumerResetEpoch,
           };
-          await sourceRoom.fetch(internalRequest("/subscribe", subscribeRequest));
+          const response = await sourceRoom.fetch(
+            internalRequest("/subscribe", subscribeRequest)
+          );
+          if (!response.ok) return;
+
+          const subscribeResponse =
+            (await response.json()) as SubscribeResponse;
+          sourceResetEpochByRoom.set(
+            sourceRoomId,
+            typeof subscribeResponse.sourceResetEpoch === "number"
+              ? subscribeResponse.sourceResetEpoch
+              : null
+          );
+
+          if (
+            subscribeResponse.subtrees &&
+            Object.keys(subscribeResponse.subtrees).length
+          ) {
+            this.document.transact(
+              () =>
+                this.assignPlaySubtrees(
+                  this.document,
+                  ensureExists(subscribeResponse.subtrees)
+                ),
+              ORIGIN_S2C
+            );
+          }
         } catch {}
       })
     );
+
+    if (!sourceResetEpochByRoom.size) return;
+
+    const sharedReferences = await this.getSharedReferences();
+    let changed = false;
+    const updated = sharedReferences.map((reference) => {
+      if (!sourceResetEpochByRoom.has(reference.sourceRoomId)) {
+        return reference;
+      }
+
+      const sourceResetEpoch = sourceResetEpochByRoom.get(
+        reference.sourceRoomId
+      );
+      if (reference.sourceResetEpoch === sourceResetEpoch) {
+        return reference;
+      }
+
+      changed = true;
+      return {
+        ...reference,
+        sourceResetEpoch,
+      };
+    });
+
+    if (changed) {
+      await this.setSharedReferences(updated);
+    }
   }
 
   // --- Helper: extract subtrees for a set of elementIds from the play map
@@ -1135,18 +1193,22 @@ export class PartyServer extends YServer {
 
       const subscribers = await this.getSubscribers();
       if (!subscribers.length) return;
-      const currentEpoch = await this.getResetEpoch();
       await Promise.all(
-        subscribers.map(async ({ consumerRoomId, elementIds }) => {
-          if (!elementIds || !elementIds.includes(element.elementId)) return;
-          await this.sendBridgeApply(consumerRoomId, {
-            action: "apply-subtrees-immediate",
-            subtrees: ensureExists(subtreesForNew),
-            sender: this.name,
-            originKind: "source",
-            resetEpoch: currentEpoch ?? null,
-          });
-        })
+        subscribers.map(
+          async ({ consumerRoomId, elementIds, consumerResetEpoch }) => {
+            if (!elementIds || !elementIds.includes(element.elementId)) return;
+            await this.sendBridgeApply(consumerRoomId, {
+              action: "apply-subtrees-immediate",
+              subtrees: ensureExists(subtreesForNew),
+              sender: this.name,
+              originKind: "source",
+              resetEpoch: getBridgeApplyTargetResetEpoch({
+                originKind: "source",
+                consumerResetEpoch,
+              }),
+            });
+          }
+        )
       );
     } catch {}
   }
@@ -1603,12 +1665,21 @@ export class PartyServer extends YServer {
 
       if (isSubscribeRequest(body)) {
         // Called on SOURCE room; registers a consumer room id
-        const { consumerRoomId, elementIds: elementIdsRaw } = body;
+        const {
+          consumerRoomId,
+          elementIds: elementIdsRaw,
+          consumerResetEpoch: consumerResetEpochRaw,
+        } = body;
         const elementIds = Array.isArray(elementIdsRaw)
           ? Array.from(
               new Set(elementIdsRaw.filter((x) => typeof x === "string"))
             )
           : undefined;
+        const consumerResetEpoch =
+          typeof consumerResetEpochRaw === "number" &&
+          Number.isFinite(consumerResetEpochRaw)
+            ? consumerResetEpochRaw
+            : null;
         // IMPORTANT: Do NOT filter out unknown/not-yet-shared ids at subscribe time.
         // Keep the requested ids so that when the source registers those elements later,
         // existing subscribers will start receiving data automatically.
@@ -1621,6 +1692,7 @@ export class PartyServer extends YServer {
           existing.push({
             consumerRoomId,
             elementIds: requestedIds,
+            consumerResetEpoch,
             createdAt: nowIso,
             lastSeen: nowIso,
             leaseMs,
@@ -1628,6 +1700,7 @@ export class PartyServer extends YServer {
         } else {
           // Update elementIds (filtered) and lastSeen
           found.elementIds = requestedIds;
+          found.consumerResetEpoch = consumerResetEpoch;
           found.lastSeen = nowIso;
         }
         await this.setSubscribers(existing);
@@ -1635,10 +1708,16 @@ export class PartyServer extends YServer {
         // its circuit so a genuine new visitor always gets a clean bridge attempt
         // even if the pair had previously tripped from a stale-epoch storm.
         this.bridgeHealth.reset(consumerRoomId);
+        const sourceResetEpoch = await this.getResetEpoch();
+        const subtrees = requestedIds.length
+          ? this.extractPlaySubtrees(this.document, new Set(requestedIds))
+          : {};
         const response: SubscribeResponse = {
           ok: true,
           subscribed: true,
           elementIds: requestedIds,
+          sourceResetEpoch,
+          subtrees,
         };
         return new Response(JSON.stringify(response), {
           headers: { "content-type": "application/json" },
@@ -1763,37 +1842,44 @@ export class PartyServer extends YServer {
         // If this is a SOURCE room receiving from a CONSUMER, immediately fanout to other consumers (excluding sender if provided)
         if (receivingFromConsumer) {
           const subscribers = await this.getSubscribers();
-          const currentEpoch = await this.getResetEpoch();
           await Promise.all(
-            subscribers.map(async ({ consumerRoomId, elementIds }) => {
-              if (sender && consumerRoomId === sender) return;
-              // Per-subscriber filtering by their subscribed elementIds
-              let toSend = subtreesToApply;
-              if (elementIds && elementIds.length) {
-                const allowedElementIds = new Set(elementIds);
-                const filteredSubtrees: Record<
-                  string,
-                  Record<string, any>
-                > = {};
-                Object.entries(subtreesToApply).forEach(([tag, elements]) => {
-                  const kept: Record<string, any> = {};
-                  Object.entries(elements).forEach(([elementId, data]) => {
-                    if (allowedElementIds.has(elementId))
-                      kept[elementId] = data;
+            subscribers.map(
+              async ({ consumerRoomId, elementIds, consumerResetEpoch }) => {
+                if (sender && consumerRoomId === sender) return;
+                // Per-subscriber filtering by their subscribed elementIds
+                let toSend = subtreesToApply;
+                if (elementIds && elementIds.length) {
+                  const allowedElementIds = new Set(elementIds);
+                  const filteredSubtrees: Record<
+                    string,
+                    Record<string, any>
+                  > = {};
+                  Object.entries(subtreesToApply).forEach(([tag, elements]) => {
+                    const kept: Record<string, any> = {};
+                    Object.entries(elements).forEach(([elementId, data]) => {
+                      if (allowedElementIds.has(elementId)) {
+                        kept[elementId] = data;
+                      }
+                    });
+                    if (Object.keys(kept).length) {
+                      filteredSubtrees[tag] = kept;
+                    }
                   });
-                  if (Object.keys(kept).length) filteredSubtrees[tag] = kept;
+                  toSend = filteredSubtrees;
+                  if (!Object.keys(toSend).length) return;
+                }
+                await this.sendBridgeApply(consumerRoomId, {
+                  action: "apply-subtrees-immediate",
+                  subtrees: toSend,
+                  sender: this.name,
+                  originKind: "source",
+                  resetEpoch: getBridgeApplyTargetResetEpoch({
+                    originKind: "source",
+                    consumerResetEpoch,
+                  }),
                 });
-                toSend = filteredSubtrees;
-                if (!Object.keys(toSend).length) return;
               }
-              await this.sendBridgeApply(consumerRoomId, {
-                action: "apply-subtrees-immediate",
-                subtrees: toSend,
-                sender: this.name,
-                originKind: "source",
-                resetEpoch: currentEpoch ?? null,
-              });
-            })
+            )
           );
         }
         const response: ApplySubtreesResponse = { ok: true, applied: true };
@@ -2127,37 +2213,40 @@ export class PartyServer extends YServer {
       return;
     }
 
-    const currentEpoch = await this.getResetEpoch();
-
     // Push to subscribers (source -> consumer direction)
     const subscribers = await this.getSubscribers();
     if (subscribers.length) {
       const permissions = await this.getSharedPermissions();
       await Promise.all(
-        subscribers.map(async ({ consumerRoomId, elementIds }) => {
-          if (!elementIds || !elementIds.length) return;
-          const sharedElementIds = elementIds.filter((id) => {
-            return Boolean(permissions[id]);
-          });
-          const subtrees = this.extractPlaySubtrees(
-            yDoc,
-            new Set(sharedElementIds)
-          );
-          if (!Object.keys(subtrees).length) return;
-          await this.sendBridgeApply(consumerRoomId, {
-            action: "apply-subtrees-immediate",
-            subtrees,
-            sender: this.name,
-            originKind: "source",
-            resetEpoch: currentEpoch ?? null,
-          });
-        })
+        subscribers.map(
+          async ({ consumerRoomId, elementIds, consumerResetEpoch }) => {
+            if (!elementIds || !elementIds.length) return;
+            const sharedElementIds = elementIds.filter((id) => {
+              return Boolean(permissions[id]);
+            });
+            const subtrees = this.extractPlaySubtrees(
+              yDoc,
+              new Set(sharedElementIds)
+            );
+            if (!Object.keys(subtrees).length) return;
+            await this.sendBridgeApply(consumerRoomId, {
+              action: "apply-subtrees-immediate",
+              subtrees,
+              sender: this.name,
+              originKind: "source",
+              resetEpoch: getBridgeApplyTargetResetEpoch({
+                originKind: "source",
+                consumerResetEpoch,
+              }),
+            });
+          }
+        )
       );
     }
 
     // Push back to sources (consumer -> source direction)
     const refs = await this.getSharedReferences();
-    for (const { sourceRoomId, elementIds } of refs) {
+    for (const { sourceRoomId, elementIds, sourceResetEpoch } of refs) {
       if (!elementIds?.length) continue;
       const subtrees = this.extractPlaySubtrees(yDoc, new Set(elementIds));
       if (!Object.keys(subtrees).length) continue;
@@ -2166,7 +2255,10 @@ export class PartyServer extends YServer {
         subtrees,
         sender: this.name,
         originKind: "consumer",
-        resetEpoch: currentEpoch ?? null,
+        resetEpoch: getBridgeApplyTargetResetEpoch({
+          originKind: "consumer",
+          sourceResetEpoch,
+        }),
       });
     }
   }

--- a/partykit/request.ts
+++ b/partykit/request.ts
@@ -2,6 +2,7 @@ export interface SubscribeRequest {
   action: "subscribe";
   consumerRoomId: string;
   elementIds?: string[];
+  consumerResetEpoch?: number | null;
 }
 
 export interface ExportPermissionsRequest {
@@ -26,6 +27,8 @@ export interface SubscribeResponse {
   ok: true;
   subscribed: true;
   elementIds: string[];
+  sourceResetEpoch?: number | null;
+  subtrees?: Record<string, Record<string, any>>;
 }
 
 export interface ExportPermissionsResponse {

--- a/partykit/request.ts
+++ b/partykit/request.ts
@@ -34,6 +34,12 @@ export interface ExportPermissionsResponse {
 
 export interface ApplySubtreesResponse {
   ok: true;
+  // Whether the receiving room actually applied the subtrees. False when the
+  // apply was rejected (e.g. stale reset epoch) or skipped (transient mode).
+  // The sender uses this to back off a misconfigured bridge pair instead of
+  // re-sending on every flush. Optional so older callers reading only `ok`
+  // keep working; absence is treated as applied.
+  applied?: boolean;
 }
 
 export interface GenericErrorResponse {

--- a/partykit/request.ts
+++ b/partykit/request.ts
@@ -1,3 +1,6 @@
+// ABOUTME: Defines typed internal HTTP request and response payloads for PartyServer.
+// ABOUTME: Keeps bridge, subscription, and permission request guards in one place.
+
 export interface SubscribeRequest {
   action: "subscribe";
   consumerRoomId: string;


### PR DESCRIPTION
## Summary

Reintroduces the bridge circuit breaker from #214 and fixes the reset recovery path for shared elements.

- add per-peer bridge health so repeated rejected bridge applies stop after the threshold
- exchange reset epochs during source/consumer subscribe so each bridge apply carries the receiving room epoch
- hydrate the consumer from the subscribe response after reset/reconnect without reentrant source-to-consumer DO fetches
- filter subscribe hydration through source-declared shared permissions so unexported elements are not exposed

## Root Cause

The breaker stopped retry storms, but source-to-consumer bridge applies still carried the source room reset epoch. Consumers validate bridge applies against their own room reset epoch, so a consumer that had been hard-reset would reject healthy source applies forever until the source sent the consumer epoch.

## Validation

- `bun test partykit/__tests__` -> 96 pass
- `bunx tsc -p partykit`
- `git diff --check origin/main...HEAD`
- staged Worker deploy: `playhtml-staging` version `eab11f68-cd00-46f4-bef4-855b177c1c89`
- live staging smoke against `staging-bridge-circuit-break.playhtml.pages.dev`: consumer hard reset, stale source writes, fresh reconnect hydrated `shared.x=6`, source update reached `shared.x=7`, consumer write reached source at `shared.x=8`, and requested unexported `private` element stayed hidden before and after reconnect

## Docs

No public docs change: this is internal PartyServer bridge/reset behavior and does not change the user-facing API.