### PR TITLE
Scope can-play composition with built-ins

### DIFF
--- a/.changeset/composed-candle.md
+++ b/.changeset/composed-candle.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Keep `can-play` element properties scoped to `can-play` when an element also uses a built-in capability, so custom state can compose with built-in behavior such as `can-move`.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -488,6 +488,8 @@ Click "+" to append a new `<li>`. The child addition itself mirrors, so new read
 
 **Use it for:** anything the built-ins don't already cover. Custom counters, guestbooks, chat, games, reactions, per-user state, event-based broadcasts.
 
+You can combine `can-play` with a built-in on the same element. The custom `defaultData`, event handlers, and `updateElement` you assign on the DOM node belong to `can-play`; the built-in keeps its own data and behavior. For example, `<img can-play can-move id="candle">` can use `can-play` to swap the image between lit/unlit states while `can-move` stores and renders the drag position separately.
+
 This page is itself a `can-play` showcase. Four examples live in the margins:
 
 - [**Doodle strip**](#play-doodle): freehand canvas input encoded as a tiny PNG data URL. The shared array caps at 20 via `splice` inside the setData mutator.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -488,7 +488,7 @@ Click "+" to append a new `<li>`. The child addition itself mirrors, so new read
 
 **Use it for:** anything the built-ins don't already cover. Custom counters, guestbooks, chat, games, reactions, per-user state, event-based broadcasts.
 
-You can combine `can-play` with a built-in on the same element. The custom `defaultData`, event handlers, and `updateElement` you assign on the DOM node belong to `can-play`; the built-in keeps its own data and behavior. For example, `<img can-play can-move id="candle">` can use `can-play` to swap the image between lit/unlit states while `can-move` stores and renders the drag position separately.
+Most capability tags can share the same element. Each tag keeps its own data and behavior, so an element can be both custom and draggable with `<img can-play can-move id="candle">`. Watch out for style conflicts: two capabilities can still fight if they write the same CSS property. For example, `can-move` and `can-spin` both update `transform`, so the last update wins instead of combining translate and rotate automatically.
 
 This page is itself a `can-play` showcase. Four examples live in the margins:
 

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -38,6 +38,38 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-toggle"]["foo"]).toEqual({ on: false });
   });
 
+  it("keeps can-play element props scoped when combined with can-move", async () => {
+    const el = document.createElement("img");
+    el.id = "composed-candle";
+    el.setAttribute("can-play", "");
+    el.setAttribute("can-move", "");
+    (el as any).defaultData = { on: true };
+    (el as any).onClick = (_event: MouseEvent, { data, setData }: any) => {
+      setData({ on: !data.on });
+    };
+    (el as any).updateElement = ({ element, data }: any) => {
+      element.setAttribute("data-lit", String(data.on));
+    };
+    document.body.appendChild(el);
+
+    playhtml.setupPlayElement(el);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const playHandler = playhtml
+      .elementHandlers!.get("can-play")!
+      .get("composed-candle");
+    const moveHandler = playhtml
+      .elementHandlers!.get("can-move")!
+      .get("composed-candle");
+
+    expect(playHandler).toBeTruthy();
+    expect(moveHandler).toBeTruthy();
+    expect(playHandler!.data).toEqual({ on: true });
+    expect(moveHandler!.data).toEqual({ x: 0, y: 0 });
+    expect(el.getAttribute("data-lit")).toBe("true");
+    expect(el.style.transform).toBe("translate(0px, 0px)");
+  });
+
   it("handles awareness changes per element (no updateElementAwareness)", async () => {
     const el = document.createElement("div");
     el.id = "bar";

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -306,7 +306,7 @@ function ensureElementProxy<TData = unknown>(
   const tagMap = proxyByTagAndId.get(tag)!;
   if (!tagMap.has(elementId)) {
     store.play[tag] ??= {};
-    const tagRecord = store.play[tag];
+    const tagRecord = store.play[tag]!;
     if (tagRecord[elementId] === undefined) {
       // Always clone to avoid reusing the same object reference across multiple elements,
       // which SyncedStore forbids ("reassigning object that already occurs in the tree").
@@ -1388,20 +1388,31 @@ function getCustomElementProps(element: HTMLElement) {
   return props;
 }
 
+function shouldReadElementPropsForTag(
+  tag: TagType | string,
+  element: HTMLElement,
+): boolean {
+  return tag === TagType.CanPlay || !element.hasAttribute(TagType.CanPlay);
+}
+
 function getElementInitializerInfoForElement(
   tag: TagType | string,
   element: HTMLElement,
 ) {
-  const customProps = getCustomElementProps(element);
-
   if (tag === TagType.CanPlay) {
     // For can-play, all properties come from the DOM element
+    const customProps = getCustomElementProps(element);
     return customProps as Required<Omit<ElementInitializer, "additionalSetup">>;
   }
 
   const builtIn = capabilitiesToInitializer[tag];
   if (!builtIn) return undefined;
 
+  if (!shouldReadElementPropsForTag(tag, element)) {
+    return builtIn;
+  }
+
+  const customProps = getCustomElementProps(element);
   // Merge: built-in defaults overridden by any custom properties on the element
   return { ...builtIn, ...customProps };
 }
@@ -1768,7 +1779,9 @@ function isElementValidForTag(
   element: HTMLElement,
   tag: TagType | string,
 ): boolean {
-  const customValidator = (element as any).isValidElementForTag;
+  const customValidator = shouldReadElementPropsForTag(tag, element)
+    ? (element as any).isValidElementForTag
+    : undefined;
   if (typeof customValidator === "function") {
     return customValidator(element);
   }
@@ -2113,10 +2126,11 @@ function deleteElementData(tag: string, elementId: string): void {
   }
 
   // 2. Remove from SyncedStore
-  if (store.play[tag] && elementId in store.play[tag]) {
+  const tagRecord = store.play[tag];
+  if (tagRecord && elementId in tagRecord) {
     try {
       doc.transact(() => {
-        delete store.play[tag]![elementId];
+        delete tagRecord[elementId];
       });
     } catch (error) {
       console.warn(

--- a/packages/playhtml/src/page-data.ts
+++ b/packages/playhtml/src/page-data.ts
@@ -131,18 +131,19 @@ export function createPageDataChannel<T>(
       // default into a fresh value and attachObserver re-attaches the deep
       // observer, wired to this channel's preserved listener set — so the
       // handle keeps both writing AND notifying after the reset.
-      let currentProxy = getProxy(PAGE_TAG, name) as T | undefined;
-      if (!currentProxy) {
+      let currentProxy = getProxy(PAGE_TAG, name) as T | null | undefined;
+      if (currentProxy == null) {
         currentProxy = ensureProxy<T>(PAGE_TAG, name, defaultValue) as T;
         attachObserver();
       }
+      const proxy = currentProxy;
       if (typeof data === "function") {
         doc().transact(() => {
-          (data as (draft: T) => void)(currentProxy);
+          (data as (draft: T) => void)(proxy);
         });
       } else {
         doc().transact(() => {
-          deepReplaceIntoProxy(currentProxy, data);
+          deepReplaceIntoProxy(proxy, data);
         });
       }
     },


### PR DESCRIPTION
## Summary
- Scope bare `can-play` DOM props away from built-in capabilities when an element uses both.
- Add regression coverage for `can-play` + `can-move` composition.
- Document the supported composition behavior and add a patch changeset.
- Fix TypeScript nullability around SyncedStore/page-data proxy access found during package build.
- Leave starter templates unchanged because their current examples do not demonstrate multi-tag composition and remain copy-pasteable.

## Root cause
The runtime read generic DOM element props for every capability tag on a node, so `can-play` props like `defaultData` and `updateElement` could override a built-in initializer such as `can-move`.

## Verification
- `./node_modules/.bin/vitest run --no-typecheck` in `packages/playhtml` (31 files, 284 tests passed; existing perf stdout and expected `can-duplicate` stderr)
- `bun run build` in `packages/playhtml` (passed with existing Sass legacy API warning)
- `/Users/spencerchang/Projects/playhtml/node_modules/.bin/astro build` in `apps/docs` (passed with existing Vite/Astro warnings)
- `git diff --check`