### PR TITLE
Fix can-mirror registration for mirrored dynamic elements

### DIFF
--- a/.changeset/mirrored-chair-setup.md
+++ b/.changeset/mirrored-chair-setup.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Set up playhtml capability descendants created by can-mirror state so mirrored dynamic elements become interactive without an extra DOM setup pass.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -458,6 +458,8 @@ Click "+" to append a new `<li>`. The child addition itself mirrors, so new read
 ">add entry</button>
 ```
 
+If a mirrored child also has its own playhtml capability, keep giving it a stable `id`. The element that creates it locally can still call `playhtml.setupPlayElement(child)` right after insertion; copies that arrive through `can-mirror` are wired automatically.
+
 :::note[Experimental]
 `can-mirror` is the newest capability and still evolving. If you need full control over the shape of shared state (e.g. to enforce limits, migrate schemas, or derive values from mutations), reach for `can-play` instead.
 :::

--- a/packages/playhtml/src/__tests__/duplicate-element-ref.test.ts
+++ b/packages/playhtml/src/__tests__/duplicate-element-ref.test.ts
@@ -74,12 +74,18 @@ describe("can-duplicate element reference resolution", () => {
 
   it("does not push clone data when the template is missing", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const button = await setupDuplicateButton("does-not-exist", "");
 
     button.click();
     await new Promise((r) => queueMicrotask(r));
 
     expect(document.querySelectorAll("[id^='does-not-exist-']").length).toBe(0);
-    errorSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'can-duplicate element (clone-btn) duplicate element ("does-not-exist") not found.',
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Element does-not-exist not found. Cannot duplicate.",
+    );
   });
 });

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -210,6 +210,7 @@ describe("playhtml basic setup with SyncedStore", () => {
         },
       ],
     });
+
     await waitForCondition(
       () =>
         document.getElementById("chair-example") !== null &&
@@ -232,5 +233,60 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(
       playhtml.elementHandlers!.get("can-spin")!.get("chair-example")!.element,
     ).toBe(mirroredChair);
+
+    handler.setData({
+      nodeType: "HTMLElement",
+      tagName: "div",
+      attributes: {
+        id: "musicalChairs4",
+        "can-mirror": "",
+      },
+      children: [],
+    });
+    await waitForCondition(
+      () =>
+        document.getElementById("chair-example") === null &&
+        !playhtml.elementHandlers!.get("can-toggle")!.has("chair-example") &&
+        !playhtml.elementHandlers!.get("can-spin")!.has("chair-example"),
+      "Expected can-mirror to unregister the removed chair",
+    );
+
+    handler.setData({
+      nodeType: "HTMLElement",
+      tagName: "div",
+      attributes: {
+        id: "musicalChairs4",
+        "can-mirror": "",
+      },
+      children: [
+        {
+          nodeType: "HTMLElement",
+          tagName: "div",
+          attributes: {
+            id: "chair-example",
+            class: "chair",
+            "can-toggle": "",
+            "can-spin": "",
+          },
+          children: [],
+        },
+      ],
+    });
+    await waitForCondition(
+      () =>
+        document.getElementById("chair-example") !== null &&
+        playhtml.elementHandlers!.get("can-toggle")!.has("chair-example") &&
+        playhtml.elementHandlers!.get("can-spin")!.has("chair-example"),
+      "Expected can-mirror to register the re-added chair",
+    );
+
+    const readdedChair = document.getElementById("chair-example")!;
+    expect(
+      playhtml.elementHandlers!.get("can-toggle")!.get("chair-example")!
+        .element,
+    ).toBe(readdedChair);
+    expect(
+      playhtml.elementHandlers!.get("can-spin")!.get("chair-example")!.element,
+    ).toBe(readdedChair);
   });
 });

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -154,4 +154,49 @@ describe("playhtml basic setup with SyncedStore", () => {
     // Verify data is removed from SyncedStore
     expect(playhtml.syncedStore["can-move"]["cleanup-test"]).toBeUndefined();
   });
+
+  it("sets up mirrored descendants with playhtml capabilities", async () => {
+    const mirror = document.createElement("div");
+    mirror.id = "runtime-mirror";
+    mirror.setAttribute("can-mirror", "");
+    document.body.appendChild(mirror);
+    await playhtml.setupPlayElementForTag(mirror, "can-mirror");
+
+    const handler = playhtml.elementHandlers!
+      .get("can-mirror")!
+      .get("runtime-mirror")!;
+    handler.setData({
+      nodeType: "HTMLElement",
+      tagName: "div",
+      attributes: {
+        id: "runtime-mirror",
+        "can-mirror": "",
+      },
+      children: [
+        {
+          nodeType: "HTMLElement",
+          tagName: "div",
+          attributes: {
+            id: "mirrored-chair",
+            "can-toggle": "",
+            "can-spin": "",
+          },
+          children: [],
+        },
+      ],
+    });
+    await new Promise((resolve) => queueMicrotask(resolve));
+    await new Promise((resolve) => queueMicrotask(resolve));
+
+    const chair = document.getElementById("mirrored-chair")!;
+    expect(chair).toBeTruthy();
+    expect(
+      playhtml.elementHandlers!.get("can-toggle")!.get("mirrored-chair")!
+        .element,
+    ).toBe(chair);
+    expect(
+      playhtml.elementHandlers!.get("can-spin")!.get("mirrored-chair")!
+        .element,
+    ).toBe(chair);
+  });
 });

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -3,6 +3,19 @@
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
 import { playhtml } from "../index";
 
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(message);
+}
+
 beforeAll(async () => {
   // Initialize playhtml with SyncedStore as primary storage
   await playhtml.init({});
@@ -155,21 +168,22 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-move"]["cleanup-test"]).toBeUndefined();
   });
 
-  it("sets up mirrored descendants with playhtml capabilities", async () => {
+  it("sets up mirrored chair descendants with playhtml capabilities", async () => {
     const mirror = document.createElement("div");
-    mirror.id = "runtime-mirror";
+    mirror.id = "musicalChairs4";
     mirror.setAttribute("can-mirror", "");
     document.body.appendChild(mirror);
     await playhtml.setupPlayElementForTag(mirror, "can-mirror");
 
     const handler = playhtml.elementHandlers!
       .get("can-mirror")!
-      .get("runtime-mirror")!;
+      .get("musicalChairs4")!;
+
     handler.setData({
       nodeType: "HTMLElement",
       tagName: "div",
       attributes: {
-        id: "runtime-mirror",
+        id: "musicalChairs4",
         "can-mirror": "",
       },
       children: [
@@ -177,26 +191,46 @@ describe("playhtml basic setup with SyncedStore", () => {
           nodeType: "HTMLElement",
           tagName: "div",
           attributes: {
-            id: "mirrored-chair",
+            id: "chair-example",
+            class: "chair",
             "can-toggle": "",
             "can-spin": "",
           },
-          children: [],
+          children: [
+            {
+              nodeType: "HTMLElement",
+              tagName: "img",
+              attributes: {
+                src: "/red-stool.png",
+                alt: "chair",
+              },
+              children: [],
+            },
+          ],
         },
       ],
     });
-    await new Promise((resolve) => queueMicrotask(resolve));
-    await new Promise((resolve) => queueMicrotask(resolve));
+    await waitForCondition(
+      () =>
+        document.getElementById("chair-example") !== null &&
+        playhtml.elementHandlers!.get("can-toggle")!.has("chair-example") &&
+        playhtml.elementHandlers!.get("can-spin")!.has("chair-example"),
+      "Expected can-mirror to register the mirrored chair",
+    );
 
-    const chair = document.getElementById("mirrored-chair")!;
-    expect(chair).toBeTruthy();
+    const mirroredChair = document.getElementById("chair-example")!;
+    expect(mirroredChair).toBeTruthy();
+    expect(mirroredChair.classList.contains("chair")).toBe(true);
+    expect(mirroredChair.querySelector("img")?.getAttribute("src")).toBe(
+      "/red-stool.png",
+    );
+    expect(mirroredChair.querySelector("img")?.alt).toBe("chair");
     expect(
-      playhtml.elementHandlers!.get("can-toggle")!.get("mirrored-chair")!
+      playhtml.elementHandlers!.get("can-toggle")!.get("chair-example")!
         .element,
-    ).toBe(chair);
+    ).toBe(mirroredChair);
     expect(
-      playhtml.elementHandlers!.get("can-spin")!.get("mirrored-chair")!
-        .element,
-    ).toBe(chair);
+      playhtml.elementHandlers!.get("can-spin")!.get("chair-example")!.element,
+    ).toBe(mirroredChair);
   });
 });

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -321,6 +321,10 @@ let elementHandlers: Map<string, Map<string, ElementHandler>> = new Map<
   string,
   Map<string, ElementHandler>
 >();
+const mirrorDescendantElementsByRoot = new WeakMap<
+  HTMLElement,
+  Map<string, HTMLElement>
+>();
 let eventHandlers: Map<string, Array<RegisteredPlayEvent>> = new Map<
   string,
   Array<RegisteredPlayEvent>
@@ -2036,17 +2040,30 @@ function setupPlayElement(
 
 function setupPlayElementDescendants(element: HTMLElement): void {
   const descendants = new Set<HTMLElement>();
+  const currentDescendants = new Map<string, HTMLElement>();
   for (const tag of getTagTypes()) {
     element.querySelectorAll(`[${tag}]`).forEach((descendant) => {
       if (isHTMLElement(descendant)) {
         descendants.add(descendant);
+        const descendantId = getIdForElement(descendant);
+        if (descendantId) {
+          currentDescendants.set(`${tag}:${descendantId}`, descendant);
+        }
       }
     });
   }
 
+  const previousDescendants = mirrorDescendantElementsByRoot.get(element);
+  previousDescendants?.forEach((previousElement, key) => {
+    if (currentDescendants.get(key) !== previousElement) {
+      removePlayElement(previousElement);
+    }
+  });
+
   descendants.forEach((descendant) => {
     setupPlayElement(descendant);
   });
+  mirrorDescendantElementsByRoot.set(element, currentDescendants);
 }
 
 /**

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1878,6 +1878,9 @@ async function setupPlayElementForTag<T extends TagType | string>(
     return;
   } else {
     tagElementHandlers.set(elementId, new ElementHandler(elementData));
+    if (tag === TagType.CanMirror) {
+      setupPlayElementDescendants(element);
+    }
   }
 
   // redo this now that we have set it in the mapping.
@@ -1905,6 +1908,9 @@ function applySharedElementDataToHandler(
   try {
     // @ts-ignore private usage intended
     handler.__data = clonePlain(proxy);
+    if (tag === TagType.CanMirror) {
+      setupPlayElementDescendants(handler.element);
+    }
   } finally {
     remoteApplyingKeys.delete(applyKey);
   }
@@ -2026,6 +2032,21 @@ function setupPlayElement(
       .filter((tag) => element.hasAttribute(tag))
       .map((tag) => setupPlayElementForTag(element, tag)),
   );
+}
+
+function setupPlayElementDescendants(element: HTMLElement): void {
+  const descendants = new Set<HTMLElement>();
+  for (const tag of getTagTypes()) {
+    element.querySelectorAll(`[${tag}]`).forEach((descendant) => {
+      if (isHTMLElement(descendant)) {
+        descendants.add(descendant);
+      }
+    });
+  }
+
+  descendants.forEach((descendant) => {
+    setupPlayElement(descendant);
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- Register PlayHTML capability descendants after `can-mirror` applies shared DOM state, so dynamically mirrored children become interactive without a delayed `setupPlayElement` re-walk.
- Add a regression test shaped like the musical chairs example: a `can-mirror` container receives a `.chair` child with `can-spin`, `can-toggle`, and a `/red-stool.png` image, then verifies the mirrored chair gets live handlers.
- Add a patch changeset and a short docs note for nested capability children inside `can-mirror`.
- Capture expected `can-duplicate` missing-template logs in the existing test so package test output stays clean.

## Root Cause

`can-mirror` correctly applied the child DOM from shared state, but runtime element setup only happened during the top-level discovery pass or an explicit `playhtml.setupPlayElement(...)` call. Descendants created by `can-mirror` during load were inserted as plain DOM nodes, so their own `can-spin`, `can-toggle`, or other capability attributes were not registered.

## Validation

- `bun run test -- src/__tests__/main.basic.test.ts`
- `bun run test -- src/__tests__/can-mirror.test.ts`
- `bun run test` in `packages/playhtml`
- `bun run build` in `packages/common`
- `bun run build` in `packages/playhtml`
- `bun run build` in `apps/docs` (passes with existing Vite/Astro warnings)
- `bun run lint` still fails in unrelated extension/worker TypeScript surfaces after building `@playhtml/extension-types`: trail settings props, browser storage/data transfer types, worker runtime globals, page metadata `cf` fetch typing, and WXT manifest typing.