### PR TITLE
website: decode scroll viewport title entities

### DIFF
--- a/extension/website/shared/components/AnimatedScrollViewports.tsx
+++ b/extension/website/shared/components/AnimatedScrollViewports.tsx
@@ -10,6 +10,7 @@ import React, {
 } from "react";
 import { ScrollAnimation, ActiveViewport, ViewportPhase } from "../types";
 import { RISO_COLORS, extractDomain } from "../utils/eventUtils";
+import { getViewportTitleText } from "../utils/titleText";
 import { PagePreview } from "./PagePreview";
 import { useDebugHover } from "./DebugHover";
 
@@ -539,29 +540,6 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
       </svg>
     );
   });
-
-// Best-effort title derivation purely from the URL — used as a fallback when
-// no captured page title is available. Currently handles Wikipedia articles
-// since the article slug IS the title; everything else returns null so the
-// caller can fall through to the domain.
-function deriveTitleFromUrl(url: string): string | null {
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname.endsWith("wikipedia.org")) {
-      const m = parsed.pathname.match(/^\/wiki\/(.+)$/);
-      if (m) {
-        const slug = decodeURIComponent(m[1]).replace(/_/g, " ");
-        // Skip namespace pages (Special:, Talk:, User:, Category:, etc.) and
-        // the Main Page — neither is useful as a title-bar label.
-        if (/^[A-Za-z_]+:/.test(slug) || slug === "Main Page") return null;
-        return slug;
-      }
-    }
-  } catch {
-    // ignore malformed URLs
-  }
-  return null;
-}
 
 type ScrollKeyframe = ScrollAnimation["scrollEvents"][number];
 type ResizeKeyframe = NonNullable<ScrollAnimation["resizeEvents"]>[number];
@@ -1708,11 +1686,7 @@ const ViewportTitleBar = memo(
     const fontSize = Math.max(8, Math.round(barHeight * 0.55));
 
     const domain = extractDomain(pageUrl);
-    const displayTitle =
-      (pageTitle && pageTitle.trim()) ||
-      deriveTitleFromUrl(pageUrl) ||
-      domain ||
-      pageUrl;
+    const displayTitle = getViewportTitleText(pageUrl, pageTitle);
     const resolvedFavicon =
       faviconUrl ||
       (domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=32` : undefined);

--- a/extension/website/shared/components/__tests__/AnimatedScrollViewports.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedScrollViewports.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies interpolation behavior used by the animated viewport renderer.
 import { describe, expect, it } from "vitest";
 import type { ScrollAnimation } from "../../types";
+import { getViewportTitleText } from "../../utils/titleText";
 import {
   buildViewportAnimationTimeline,
   getResizeDimensionsAtTime,
@@ -82,5 +83,51 @@ describe("AnimatedScrollViewports timeline helpers", () => {
 
   it("interpolates zoom levels at a specific time", () => {
     expect(getZoomLevelAtTime(makeAnimation().zoomEvents ?? [], 500)).toBe(1.25);
+  });
+});
+
+describe("AnimatedScrollViewports title text", () => {
+  it("decodes HTML entities before rendering metadata titles", () => {
+    expect(
+      getViewportTitleText(
+        "https://example.com/post",
+        "Spencer&#39;s &amp; Codex &quot;notes&quot;",
+      ),
+    ).toBe("Spencer's & Codex \"notes\"");
+
+    expect(
+      getViewportTitleText(
+        "https://example.com/post",
+        "Spencer&amp;#39;s &amp;amp; Codex",
+      ),
+    ).toBe("Spencer's & Codex");
+
+    expect(
+      getViewportTitleText(
+        "https://example.com/post",
+        "Spencer&apos;s &rsquo;note&rsquo;",
+      ),
+    ).toBe("Spencer's \u2019note\u2019");
+  });
+
+  it("normalizes title whitespace and falls back for blank titles", () => {
+    expect(
+      getViewportTitleText(
+        "https://example.com/post",
+        "\n\t  Spencer&#39;s\u0000   notes  ",
+      ),
+    ).toBe("Spencer's notes");
+
+    expect(getViewportTitleText("https://example.com/post", "&nbsp;")).toBe(
+      "example.com",
+    );
+  });
+
+  it("keeps URL-derived Wikipedia titles readable", () => {
+    expect(
+      getViewportTitleText(
+        "https://en.wikipedia.org/wiki/Spencer%27s_Online_Notes",
+      ),
+    ).toBe("Spencer's Online Notes");
   });
 });

--- a/extension/website/shared/utils/titleText.ts
+++ b/extension/website/shared/utils/titleText.ts
@@ -1,0 +1,113 @@
+// ABOUTME: Formats captured page titles for compact viewport title-bar rendering.
+// ABOUTME: Decodes HTML title entities and falls back to readable URL labels.
+import { extractDomain } from "./eventUtils";
+
+const TITLE_ENTITY_DECODE_PASSES = 3;
+const TITLE_NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  hellip: "...",
+  ldquo: "\u201c",
+  lsquo: "\u2018",
+  lt: "<",
+  mdash: "\u2014",
+  nbsp: " ",
+  ndash: "\u2013",
+  quot: "\"",
+  rdquo: "\u201d",
+  rsquo: "\u2019",
+};
+
+// Best-effort title derivation purely from the URL. Currently handles
+// Wikipedia articles since the article slug is the title; everything else
+// returns null so callers can fall through to the domain.
+function deriveTitleFromUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.endsWith("wikipedia.org")) {
+      const m = parsed.pathname.match(/^\/wiki\/(.+)$/);
+      if (m) {
+        const slug = decodeURIComponent(m[1]).replace(/_/g, " ");
+        // Skip namespace pages (Special:, Talk:, User:, Category:, etc.) and
+        // the Main Page — neither is useful as a title-bar label.
+        if (/^[A-Za-z_]+:/.test(slug) || slug === "Main Page") return null;
+        return slug;
+      }
+    }
+  } catch {
+    // ignore malformed URLs
+  }
+  return null;
+}
+
+function decodeTitleEntities(title: string): string {
+  let decoded = title;
+  for (let pass = 0; pass < TITLE_ENTITY_DECODE_PASSES; pass++) {
+    const next = decoded.replace(
+      /&(?:#(\d+)|#x([\da-fA-F]+)|([a-zA-Z][\da-zA-Z]+));/g,
+      (
+        match,
+        decimal: string | undefined,
+        hex: string | undefined,
+        named: string | undefined,
+      ) => {
+        if (decimal || hex) {
+          const codePoint = Number.parseInt(
+            decimal ?? hex ?? "",
+            decimal ? 10 : 16,
+          );
+          if (
+            Number.isFinite(codePoint) &&
+            codePoint >= 0 &&
+            codePoint <= 0x10ffff
+          ) {
+            try {
+              return String.fromCodePoint(codePoint);
+            } catch {
+              return match;
+            }
+          }
+          return match;
+        }
+
+        const value = named
+          ? TITLE_NAMED_ENTITIES[named.toLowerCase()]
+          : undefined;
+        return value ?? match;
+      },
+    );
+    if (next === decoded) return decoded;
+    decoded = next;
+  }
+  return decoded;
+}
+
+function replaceControlCharacters(title: string): string {
+  let cleaned = "";
+  for (let index = 0; index < title.length; index++) {
+    const code = title.charCodeAt(index);
+    cleaned += code <= 0x1f || code === 0x7f ? " " : title[index];
+  }
+  return cleaned;
+}
+
+function cleanTitleText(title: string): string {
+  return replaceControlCharacters(decodeTitleEntities(title))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function getViewportTitleText(
+  pageUrl: string,
+  pageTitle?: string,
+): string {
+  const cleanedPageTitle = pageTitle ? cleanTitleText(pageTitle) : "";
+  if (cleanedPageTitle) return cleanedPageTitle;
+
+  const derivedTitle = deriveTitleFromUrl(pageUrl);
+  const cleanedDerivedTitle = derivedTitle ? cleanTitleText(derivedTitle) : "";
+  if (cleanedDerivedTitle) return cleanedDerivedTitle;
+
+  return extractDomain(pageUrl) || pageUrl;
+}


### PR DESCRIPTION
## Summary
- route scroll viewport title-bar labels through a shared title formatter
- decode named, numeric, and double-encoded HTML entities before SVG text rendering
- normalize title whitespace/control characters and preserve the Wikipedia slug fallback

## Root cause
Captured page titles can arrive already HTML-entity encoded. The title bar rendered the metadata string as safe SVG text, which kept strings like `Spencer&#39;s` visible instead of displaying the apostrophe.

## Verification
- `./node_modules/.bin/vitest run extension/website/shared/components/__tests__/AnimatedScrollViewports.test.ts`
- `../../node_modules/.bin/tsc --noEmit` from `extension/website`
- `ESLINT_USE_FLAT_CONFIG=false ../../node_modules/.bin/eslint shared/utils/titleText.ts shared/components/__tests__/AnimatedScrollViewports.test.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`

Full `bun run lint` in `extension/website` is still blocked by the repo's ESLint 9 flat-config mismatch and existing project-wide lint errors; the changed files lint cleanly under the existing eslintrc config.