### PR TITLE
Improve repo performance hot paths

### DIFF
--- a/.changeset/lazy-dev-toolbar.md
+++ b/.changeset/lazy-dev-toolbar.md
@@ -1,0 +1,7 @@
+---
+"playhtml": patch
+"@playhtml/react": patch
+---
+
+Defer loading the development toolbar until development mode is enabled so production runtime bundles do not include that code path.
+Keep the React package test bootstrap aligned with the current playhtml configuration API.

--- a/.changeset/lazy-dev-toolbar.md
+++ b/.changeset/lazy-dev-toolbar.md
@@ -1,7 +1,5 @@
 ---
 "playhtml": patch
-"@playhtml/react": patch
 ---
 
 Defer loading the development toolbar until development mode is enabled so production runtime bundles do not include that code path.
-Keep the React package test bootstrap aligned with the current playhtml configuration API.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Firefox now keeps one reliable browser-session identity without adding warnings to webpage consoles.
+- Preserve pending typing sequences when an input loses focus (#262)
 - Restored history no longer uploads again, while offline history in imported files stays queued to sync.
 - Send bugs, ideas, and other feedback directly from the extension popup.
   ![Feedback button in the extension popup](/changelog/media/feedback-popup-button.png)

--- a/extension/src/__tests__/KeyboardCollector.test.ts
+++ b/extension/src/__tests__/KeyboardCollector.test.ts
@@ -12,35 +12,7 @@ describe("KeyboardCollector", () => {
     removeListener: ReturnType<typeof vi.fn>;
   };
 
-  beforeEach(() => {
-    vi.useFakeTimers();
-    storageChangeListener = {
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-    };
-    (browser.storage as any).onChanged = storageChangeListener;
-    document.body.innerHTML = "";
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    document.body.innerHTML = "";
-  });
-
-  it("emits typing data without posting it to the page window", async () => {
-    const collector = new KeyboardCollector();
-    const emitted: KeyboardEventData[] = [];
-    collector.setEmitCallback((event) => {
-      emitted.push(event);
-    });
-    const postMessageSpy = vi.spyOn(window, "postMessage");
-    vi.spyOn(window, "getComputedStyle").mockReturnValue({
-      backgroundColor: "rgb(255, 255, 255)",
-      borderStyle: "solid",
-      borderTopLeftRadius: "4px",
-    } as CSSStyleDeclaration);
-
+  function appendInput(): HTMLInputElement {
     const input = document.createElement("input");
     input.id = "message";
     input.getBoundingClientRect = () =>
@@ -56,22 +28,108 @@ describe("KeyboardCollector", () => {
         toJSON: () => ({}),
       }) as DOMRect;
     document.body.appendChild(input);
+    return input;
+  }
 
-    collector.enable();
-    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
-    input.value = "h";
+  function insertText(input: HTMLInputElement, value: string, data: string): void {
+    input.value = value;
     input.dispatchEvent(
       new InputEvent("input", {
         bubbles: true,
         inputType: "insertText",
-        data: "h",
+        data,
       }),
     );
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    storageChangeListener = {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    (browser.storage as any).onChanged = storageChangeListener;
+    document.body.innerHTML = "";
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      backgroundColor: "rgb(255, 255, 255)",
+      borderStyle: "solid",
+      borderTopLeftRadius: "4px",
+    } as CSSStyleDeclaration);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("emits typing data without posting it to the page window", async () => {
+    const collector = new KeyboardCollector();
+    const emitted: KeyboardEventData[] = [];
+    collector.setEmitCallback((event) => {
+      emitted.push(event);
+    });
+    const postMessageSpy = vi.spyOn(window, "postMessage");
+    const input = appendInput();
+
+    collector.enable();
+    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    insertText(input, "h", "h");
 
     await vi.advanceTimersByTimeAsync(5_000);
 
     expect(emitted).toHaveLength(1);
     expect(postMessageSpy).not.toHaveBeenCalled();
+
+    collector.disable();
+  });
+
+  it("emits a pending typing sequence after the input blurs", async () => {
+    const collector = new KeyboardCollector();
+    const emitted: KeyboardEventData[] = [];
+    collector.setEmitCallback((event) => {
+      emitted.push(event);
+    });
+    const input = appendInput();
+
+    collector.enable();
+    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    insertText(input, "h", "h");
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(emitted).toHaveLength(1);
+
+    collector.disable();
+  });
+
+  it("accumulates typing when the same input regains focus before debouncing", async () => {
+    const collector = new KeyboardCollector();
+    const emitted: KeyboardEventData[] = [];
+    collector.setEmitCallback((event) => {
+      emitted.push(event);
+    });
+    const input = appendInput();
+
+    collector.enable();
+    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    insertText(input, "h", "h");
+    input.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    input.dispatchEvent(new FocusEvent("focus", { bubbles: true }));
+    insertText(input, "hi", "i");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(emitted).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].sequence).toHaveLength(1);
+    expect(emitted[0].sequence?.[0].action).toBe("type");
+    expect(emitted[0].sequence?.[0].text).toHaveLength(2);
 
     collector.disable();
   });

--- a/extension/src/__tests__/KeyboardCollector.test.ts
+++ b/extension/src/__tests__/KeyboardCollector.test.ts
@@ -75,4 +75,23 @@ describe("KeyboardCollector", () => {
 
     collector.disable();
   });
+
+  it("removes storage change listeners when disabled", () => {
+    const collector = new KeyboardCollector();
+
+    collector.enable();
+    expect(storageChangeListener.addListener).toHaveBeenCalledTimes(1);
+    const firstHandler = storageChangeListener.addListener.mock.calls[0][0];
+
+    collector.disable();
+    expect(storageChangeListener.removeListener).toHaveBeenCalledWith(firstHandler);
+
+    collector.enable();
+    expect(storageChangeListener.addListener).toHaveBeenCalledTimes(2);
+    const secondHandler = storageChangeListener.addListener.mock.calls[1][0];
+
+    collector.disable();
+    expect(storageChangeListener.removeListener).toHaveBeenCalledWith(secondHandler);
+    expect(storageChangeListener.removeListener).toHaveBeenCalledTimes(2);
+  });
 });

--- a/extension/src/collectors/KeyboardCollector.ts
+++ b/extension/src/collectors/KeyboardCollector.ts
@@ -52,6 +52,7 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
   private keydownHandler?: (e: KeyboardEvent) => void;
   private inputHandler?: (e: Event) => void;
   private beforeUnloadHandler?: (e: Event) => void;
+  private storageChangedHandler?: Parameters<typeof browser.storage.onChanged.addListener>[0];
 
   // Typing sequence tracking
   private sequence: TypingAction[] = [];
@@ -72,7 +73,7 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
     });
 
     // Listen for storage changes to update cache
-    browser.storage.onChanged.addListener((changes, areaName) => {
+    this.storageChangedHandler = (changes, areaName) => {
       if (areaName === 'local') {
         if (changes[PRIVACY_LEVEL_KEY]) {
           this.legibilityPct = parseLegibility(changes[PRIVACY_LEVEL_KEY].newValue);
@@ -84,7 +85,8 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
           }
         }
       }
-    });
+    };
+    browser.storage.onChanged.addListener(this.storageChangedHandler);
 
     // Set up focus handler
     this.focusHandler = (e: FocusEvent) => {
@@ -180,6 +182,11 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
     if (this.beforeUnloadHandler) {
       window.removeEventListener('beforeunload', this.beforeUnloadHandler);
       this.beforeUnloadHandler = undefined;
+    }
+
+    if (this.storageChangedHandler) {
+      browser.storage.onChanged.removeListener(this.storageChangedHandler);
+      this.storageChangedHandler = undefined;
     }
 
     // Clear debounce timer

--- a/extension/src/collectors/KeyboardCollector.ts
+++ b/extension/src/collectors/KeyboardCollector.ts
@@ -446,7 +446,7 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
     }
 
     this.debounceTimer = window.setTimeout(() => {
-      if (this.sequence.length > 0 && this.focusedInput) {
+      if (this.sequence.length > 0) {
         this.flushTypingEvent();
       }
       this.debounceTimer = null;
@@ -509,7 +509,7 @@ export class KeyboardCollector extends BaseCollector<KeyboardEventData> {
    * Flush pending typing event
    */
   private flushTypingEvent(): void {
-    if (!this.focusedInput || !this.cachedPosition || !this.cachedSelector) {
+    if (!this.cachedPosition || !this.cachedSelector) {
       return;
     }
 

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -46,6 +46,14 @@ const REMOVE_AFTER_DIM_MS = 20_000;
 // archive's eviction fade (EVICTION_FADE_MS).
 const KEEP_AFTER_DEPART_MS = EVICTION_FADE_MS;
 
+export function getDrawClockTime(
+  performanceNow: number,
+  pausedAccumMs: number,
+  pauseStartedAt: number | null,
+): number {
+  return (pauseStartedAt ?? performanceNow) - pausedAccumMs;
+}
+
 /** Tiny deterministic hash of a string to a small int, for per-trail variation. */
 function hashKey(key: string): number {
   let h = 0;
@@ -278,7 +286,12 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     // The draw clock: wall-clock minus time spent paused. Depart timestamps and
     // fades MUST use this (not raw performance.now()) so a depart-fade that's in
     // progress when the canvas pauses doesn't keep accruing during the pause.
-    const drawClock = () => performance.now() - pausedAccumMsRef.current;
+    const drawClock = () =>
+      getDrawClockTime(
+        performance.now(),
+        pausedAccumMsRef.current,
+        pauseStartedAtRef.current,
+      );
 
     useEffect(() => {
       const clearScheduled = () => {

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -19,8 +19,6 @@ import {
   type ImperativeTrailCursorHandle,
 } from "./trailPrimitives";
 
-const HIDDEN_TAB_TICK_MS = 100;
-
 // A trail that hasn't gained a point in this long (and has drawn up to its tip)
 // has finished tracing and settles from the live full opacity to the completed
 // dim (cursor hidden). Kept comfortably longer than the stream's ~1s batch gaps
@@ -94,7 +92,6 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const svgRef = useRef<SVGSVGElement>(null);
     const pathLayerRef = useRef<SVGGElement>(null);
     const animationRef = useRef<number | undefined>(undefined);
-    const timeoutRef = useRef<number | undefined>(undefined);
     const consecutiveErrorsRef = useRef(0);
 
     const renderer = getTrailRenderer(settings.trailVisualStyle ?? "color");
@@ -289,19 +286,25 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           cancelAnimationFrame(animationRef.current);
           animationRef.current = undefined;
         }
-        if (timeoutRef.current !== undefined) {
-          window.clearTimeout(timeoutRef.current);
-          timeoutRef.current = undefined;
+      };
+
+      const pauseDrawClock = (perfNow: number) => {
+        if (pauseStartedAtRef.current === null) {
+          pauseStartedAtRef.current = perfNow;
+        }
+      };
+
+      const resumeDrawClock = (perfNow: number) => {
+        if (pauseStartedAtRef.current !== null) {
+          pausedAccumMsRef.current += perfNow - pauseStartedAtRef.current;
+          pauseStartedAtRef.current = null;
         }
       };
 
       const scheduleNext = () => {
         clearScheduled();
         if (document.visibilityState === "hidden") {
-          timeoutRef.current = window.setTimeout(
-            () => tick(performance.now()),
-            HIDDEN_TAB_TICK_MS,
-          );
+          pauseDrawClock(performance.now());
           return;
         }
         animationRef.current = requestAnimationFrame(tick);
@@ -332,15 +335,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
 
       const runFrame = (perfNow: number) => {
         if (frozenRef.current) {
-          if (pauseStartedAtRef.current === null) {
-            pauseStartedAtRef.current = perfNow;
-          }
+          pauseDrawClock(perfNow);
           return;
         }
-        if (pauseStartedAtRef.current !== null) {
-          pausedAccumMsRef.current += perfNow - pauseStartedAtRef.current;
-          pauseStartedAtRef.current = null;
-        }
+        resumeDrawClock(perfNow);
 
         const entries = keptRef.current;
         const clockMs = perfNow - pausedAccumMsRef.current;

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -1,8 +1,9 @@
-// ABOUTME: Tests one-shot click spawning for the live cursor-trail renderer.
-// ABOUTME: Covers trail growth without replaying clicks already shown.
+// ABOUTME: Tests click spawning and lifecycle timing for the live cursor-trail renderer.
+// ABOUTME: Covers one-shot effects and clock pauses while the document is hidden.
 
 import { describe, expect, it, vi } from "vitest";
 import type { TrailState } from "../../types";
+import { getDrawClockTime } from "../LiveTrails";
 import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
@@ -112,5 +113,16 @@ describe("collectDueClickEffects", () => {
     ).toEqual([]);
 
     random.mockRestore();
+  });
+});
+
+describe("getDrawClockTime", () => {
+  it("freezes lifecycle time while a pause is active", () => {
+    expect(getDrawClockTime(15_000, 2_000, 10_000)).toBe(8_000);
+    expect(getDrawClockTime(30_000, 2_000, 10_000)).toBe(8_000);
+  });
+
+  it("resumes from the same lifecycle time after accounting for the pause", () => {
+    expect(getDrawClockTime(30_000, 22_000, null)).toBe(8_000);
   });
 });

--- a/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
+++ b/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Tests cursor-trail scheduling helpers used by movement visualizations.
+// ABOUTME: Verifies stagger playback can use constant-time schedule lookup.
+
+import { describe, expect, it } from "vitest";
+import { buildTrailSchedulePositionLookup } from "../useCursorTrails";
+
+describe("buildTrailSchedulePositionLookup", () => {
+  it("maps trail indexes to their ordered stagger positions", () => {
+    const orderedIndices = [2, 0, 3, 1];
+    const positions = buildTrailSchedulePositionLookup(orderedIndices, 4);
+
+    expect(Array.from(positions)).toEqual([1, 3, 0, 2]);
+  });
+});

--- a/extension/website/shared/hooks/useAccumulatedEvents.ts
+++ b/extension/website/shared/hooks/useAccumulatedEvents.ts
@@ -8,6 +8,7 @@ import type { CollectionEvent } from "../types";
 /** A participant+url group's accumulated events plus its last-active time. */
 export interface AccumulatedGroup {
   events: CollectionEvent[];
+  eventIds: Set<string>;
   lastTs: number;
 }
 
@@ -48,27 +49,54 @@ export function accumulateEvents(
     for (const id of evictIds) next.delete(id);
   }
 
-  // Fold incoming events into their groups.
-  const touched = new Map<string, Set<string>>();
+  // Fold incoming events into their groups. Each touched group is copied once,
+  // then appended to in-place for this accumulation pass.
+  const touched = new Map<
+    string,
+    {
+      events: CollectionEvent[];
+      eventIds: Set<string>;
+      lastTs: number;
+      changed: boolean;
+      needsSort: boolean;
+    }
+  >();
   for (const e of incoming) {
     const key = groupKey(e);
-    const existing = next.get(key);
-    const ids =
-      touched.get(key) ??
-      new Set(existing ? existing.events.map((ev) => ev.id) : []);
-    touched.set(key, ids);
-    if (ids.has(e.id)) continue;
-    ids.add(e.id);
-    const events = existing ? existing.events.concat(e) : [e];
-    next.set(key, { events, lastTs: Math.max(existing?.lastTs ?? 0, e.ts) });
+    let group = touched.get(key);
+    if (!group) {
+      const existing = next.get(key);
+      group = {
+        events: existing ? existing.events.slice() : [],
+        eventIds: new Set(
+          existing?.eventIds ?? existing?.events.map((ev) => ev.id) ?? [],
+        ),
+        lastTs: existing?.lastTs ?? 0,
+        changed: false,
+        needsSort: false,
+      };
+      touched.set(key, group);
+    }
+    if (group.eventIds.has(e.id)) continue;
+    const previous = group.events[group.events.length - 1];
+    if (previous && e.ts < previous.ts) group.needsSort = true;
+    group.eventIds.add(e.id);
+    group.events.push(e);
+    group.lastTs = Math.max(group.lastTs, e.ts);
+    group.changed = true;
   }
 
   // Re-sort only the groups we touched (incoming may arrive out of order).
-  for (const key of touched.keys()) {
-    const group = next.get(key);
-    if (!group) continue;
-    const sorted = group.events.slice().sort((a, b) => a.ts - b.ts);
-    next.set(key, { events: sorted, lastTs: group.lastTs });
+  for (const [key, group] of touched) {
+    if (!group.changed) continue;
+    if (group.needsSort) {
+      group.events.sort((a, b) => a.ts - b.ts);
+    }
+    next.set(key, {
+      events: group.events,
+      eventIds: group.eventIds,
+      lastTs: group.lastTs,
+    });
   }
 
   // Cap to the maxGroups most-recently-active groups, evicting the oldest, so
@@ -158,9 +186,9 @@ export function useAccumulatedEvents(
     // Flatten groups into a single ts-ordered array. The total-event budget is
     // enforced inside accumulateEvents by evicting whole oldest groups, so no
     // mid-trail truncation happens here.
-    let result: CollectionEvent[] = [];
+    const result: CollectionEvent[] = [];
     for (const group of groupsRef.current.values()) {
-      result = result.concat(group.events);
+      result.push(...group.events);
     }
     result.sort((a, b) => a.ts - b.ts);
     return result;

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -70,6 +70,18 @@ interface TrailScheduleItem {
   }>;
 }
 
+export function buildTrailSchedulePositionLookup(
+  orderedIndices: number[],
+  trailCount: number,
+): Int32Array {
+  const positions = new Int32Array(trailCount);
+  positions.fill(-1);
+  for (let position = 0; position < orderedIndices.length; position++) {
+    positions[orderedIndices[position]] = position;
+  }
+  return positions;
+}
+
 export interface UseCursorTrailsResult {
   trails: Trail[];
   trailStates: TrailState[];
@@ -410,6 +422,10 @@ export function useCursorTrails(
         }
       }
     }
+    const schedulePositions = buildTrailSchedulePositionLookup(
+      orderedIndices,
+      trails.length,
+    );
 
     // Create schedule for each trail
     const schedule = trails.map((trail, originalIndex) => {
@@ -424,7 +440,7 @@ export function useCursorTrails(
       } else {
         // Stagger mode - choreograph trail timing
         const trailDuration = trail.endTime - trail.startTime;
-        const scheduledPosition = orderedIndices.indexOf(originalIndex);
+        const scheduledPosition = schedulePositions[originalIndex];
         const startOffset = (scheduledPosition * actualSpacing) % cycleDuration;
         const timeOffset = min + startOffset - trail.startTime;
 

--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -1,7 +1,16 @@
 // ABOUTME: Homepage for wewere.online
 // ABOUTME: Single-page landing — hero with downloads, three pull-quote beats with living elements, guestbook
 
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import {
+  Suspense,
+  lazy,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  type ReactNode,
+} from "react";
 import { LiveTrails } from "@movement/components/LiveTrails";
 import { LiveIndicator } from "@movement/components/LiveIndicator";
 import { WordmarkClock } from "@movement/components/WordmarkClock";
@@ -11,7 +20,6 @@ import { summarizeActiveLocations } from "@movement/utils/eventUtils";
 import { useLiveEvents } from "@movement/hooks/useLiveEvents";
 import { useAccumulatedEvents } from "@movement/hooks/useAccumulatedEvents";
 import { PresenceIndicator } from "./components/PresenceIndicator";
-import { AuraGuestbook } from "./components/AuraGuestbook";
 import { Bench } from "./components/Bench";
 import { CoffeeMachine } from "./components/CoffeeMachine";
 import { DownloadGate } from "./components/DownloadGate";
@@ -21,6 +29,12 @@ import {
   LIVE_PORTRAIT_URL,
 } from "./navigation";
 import styles from "./App.module.scss";
+
+const LazyAuraGuestbook = lazy(() =>
+  import("./components/AuraGuestbook").then(({ AuraGuestbook }) => ({
+    default: AuraGuestbook,
+  })),
+);
 
 const ALIVE_INTERNET_ESSAY_URL =
   "https://news.spencer.place/p/alive-internet-theory";
@@ -82,6 +96,42 @@ function RisoTexture() {
       />
     </svg>
   );
+}
+
+function LazyOnVisible({
+  children,
+  fallback,
+  rootMargin = "600px",
+}: {
+  children: ReactNode;
+  fallback?: ReactNode;
+  rootMargin?: string;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    if (isVisible) return;
+    const root = rootRef.current;
+    if (!root) return;
+    if (!("IntersectionObserver" in window)) {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setIsVisible(true);
+        observer.disconnect();
+      },
+      { rootMargin },
+    );
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [isVisible, rootMargin]);
+
+  return <div ref={rootRef}>{isVisible ? children : fallback}</div>;
 }
 
 // Deep enough that trails stay on screen for minutes (don't age off the window
@@ -416,7 +466,15 @@ export default function App() {
 
         <section className={styles.section}>
           <h2 className={styles.sectionHeading}>leave a mark</h2>
-          <AuraGuestbook id="wewere-online-guestbook" />
+          <LazyOnVisible
+            fallback={<div style={{ minHeight: 720 }} aria-hidden="true" />}
+          >
+            <Suspense
+              fallback={<div style={{ minHeight: 720 }} aria-hidden="true" />}
+            >
+              <LazyAuraGuestbook id="wewere-online-guestbook" />
+            </Suspense>
+          </LazyOnVisible>
         </section>
 
         <section className={`${styles.section} ${styles.helpBuild}`}>

--- a/extension/website/src/components/Bench.tsx
+++ b/extension/website/src/components/Bench.tsx
@@ -69,6 +69,10 @@ export const Bench = withSharedState<BenchData, any, BenchProps>(
         <img
           src="/red-park-bench-face-right.png"
           alt="A red park bench"
+          width={386}
+          height={386}
+          loading="lazy"
+          decoding="async"
           className={styles.benchImg}
           draggable={false}
         />

--- a/extension/website/src/components/CoffeeMachine.tsx
+++ b/extension/website/src/components/CoffeeMachine.tsx
@@ -145,6 +145,10 @@ export const CoffeeMachine = withSharedState<CoffeeData, any, CoffeeMachineProps
           <img
             src="/la-marzocco.png"
             alt="Espresso machine"
+            width={943}
+            height={942}
+            loading="lazy"
+            decoding="async"
             className={`${styles.machineImg} ${
               visualState === "ready" || visualState === "drinking"
                 ? styles.machineBackground
@@ -160,6 +164,10 @@ export const CoffeeMachine = withSharedState<CoffeeData, any, CoffeeMachineProps
                 ? "/cortado.png"
                 : "/cortado-empty.png"
             }
+            width={956}
+            height={958}
+            loading="lazy"
+            decoding="async"
             alt={
               visualState === "ready"
                 ? "A cortado ready to drink"

--- a/packages/playhtml/src/development.ts
+++ b/packages/playhtml/src/development.ts
@@ -10,7 +10,9 @@ import {
   type EditableStateLeafValue,
   type StatePathSegment,
 } from "./leafEditor";
-import { normalizePath } from "@playhtml/common";
+import { listSharedElements } from "./shared-elements";
+
+export { listSharedElements } from "./shared-elements";
 
 let activeElementObserver: MutationObserver | null = null;
 let activeDevRoot: HTMLElement | null = null;
@@ -713,71 +715,6 @@ const DEV_STYLES = `
   font-size: 12px;
 }
 `;
-
-// ─── Shared Elements Listing ───────────────────────────────────────────
-export function listSharedElements() {
-  const out: Array<{
-    type: "source" | "consumer";
-    elementId: string;
-    dataSource: string;
-    normalized: string;
-    permissions?: "read-only" | "read-write";
-    element: HTMLElement;
-  }> = [];
-
-  document.querySelectorAll("[shared]").forEach((el) => {
-    const element = el as HTMLElement;
-    const id = element.id;
-    if (!id) return;
-    const ds = `${window.location.host}${normalizePath(
-      window.location.pathname
-    )}#${id}`;
-    out.push({
-      type: "source",
-      elementId: id,
-      dataSource: ds,
-      normalized: ds,
-      permissions: element.getAttribute("shared")?.includes("read-only")
-        ? "read-only"
-        : "read-write",
-      element,
-    });
-  });
-
-  document.querySelectorAll("[data-source]").forEach((el) => {
-    const element = el as HTMLElement;
-    const raw = element.getAttribute("data-source") || "";
-    const [domainAndPath, elementId] = raw.split("#");
-    if (!domainAndPath || !elementId) return;
-    const firstSlash = domainAndPath.indexOf("/");
-    const domain =
-      firstSlash === -1 ? domainAndPath : domainAndPath.slice(0, firstSlash);
-    const path = firstSlash === -1 ? "/" : domainAndPath.slice(firstSlash);
-    const normalized = `${domain}${normalizePath(path)}#${elementId}`;
-    out.push({
-      type: "consumer",
-      elementId,
-      dataSource: raw,
-      normalized,
-      element,
-    });
-  });
-
-  if (out.length > 0) {
-    try {
-      console.table(
-        out.map((e) => ({
-          type: e.type,
-          elementId: e.elementId,
-          dataSource: e.dataSource,
-          normalized: e.normalized,
-          permissions: e.permissions || "",
-        }))
-      );
-    } catch {}
-  }
-  return out;
-}
 
 export interface DuplicatePlayElement {
   tagType: string;

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -18,11 +18,7 @@ import {
   deepReplaceIntoProxy,
   clonePlain,
 } from "@playhtml/common";
-import {
-  listSharedElements as devListSharedElements,
-  teardownDevUI,
-  setupDevUI,
-} from "./development";
+import { listSharedElements as devListSharedElements } from "./shared-elements";
 import {
   createNavigationController,
   attachNavigationListeners,
@@ -114,6 +110,7 @@ type PlayStore = {
 let store: PlayStore = syncedStore<StoreShape>({ play: {} });
 let doc = getYjsDoc(store);
 let publicSyncedStore = createReadOnlyStore(store.play);
+let developmentModule: typeof import("./development") | null = null;
 
 function getDefaultRoom({ includeSearch }: DefaultRoomOptions): string {
   // TODO: Strip filename extension
@@ -1352,7 +1349,8 @@ async function initPlayHTMLOnce() {
   document.head.appendChild(playStyles);
 
   if (isDevelopmentMode) {
-    setupDevUI(playhtml);
+    developmentModule = await import("./development");
+    developmentModule.setupDevUI(playhtml);
   }
   // TODO: expose a way to activate the dev tools UI on any page at runtime
   // (e.g. window.playhtml.showDevTools()) so it can be triggered from the
@@ -1977,7 +1975,7 @@ export async function resetPlayHTML(): Promise<void> {
     teardownMainProvider();
 
     try {
-      teardownDevUI();
+      developmentModule?.teardownDevUI();
     } catch {}
 
     document.head

--- a/packages/playhtml/src/shared-elements.ts
+++ b/packages/playhtml/src/shared-elements.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Finds shared playhtml sources and consumers in the current document.
+// ABOUTME: Supports runtime diagnostics without loading the full development toolbar.
+
+import { normalizePath } from "@playhtml/common";
+
+export function listSharedElements() {
+  const out: Array<{
+    type: "source" | "consumer";
+    elementId: string;
+    dataSource: string;
+    normalized: string;
+    permissions?: "read-only" | "read-write";
+    element: HTMLElement;
+  }> = [];
+
+  document.querySelectorAll("[shared]").forEach((el) => {
+    const element = el as HTMLElement;
+    const id = element.id;
+    if (!id) return;
+    const ds = `${window.location.host}${normalizePath(
+      window.location.pathname,
+    )}#${id}`;
+    out.push({
+      type: "source",
+      elementId: id,
+      dataSource: ds,
+      normalized: ds,
+      permissions: element.getAttribute("shared")?.includes("read-only")
+        ? "read-only"
+        : "read-write",
+      element,
+    });
+  });
+
+  document.querySelectorAll("[data-source]").forEach((el) => {
+    const element = el as HTMLElement;
+    const raw = element.getAttribute("data-source") || "";
+    const [domainAndPath, elementId] = raw.split("#");
+    if (!domainAndPath || !elementId) return;
+    const firstSlash = domainAndPath.indexOf("/");
+    const domain =
+      firstSlash === -1 ? domainAndPath : domainAndPath.slice(0, firstSlash);
+    const path = firstSlash === -1 ? "/" : domainAndPath.slice(firstSlash);
+    const normalized = `${domain}${normalizePath(path)}#${elementId}`;
+    out.push({
+      type: "consumer",
+      elementId,
+      dataSource: raw,
+      normalized,
+      element,
+    });
+  });
+
+  if (out.length > 0) {
+    try {
+      console.table(
+        out.map((e) => ({
+          type: e.type,
+          elementId: e.elementId,
+          dataSource: e.dataSource,
+          normalized: e.normalized,
+          permissions: e.permissions || "",
+        })),
+      );
+    } catch {}
+  }
+  return out;
+}

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -57,7 +57,6 @@ const mockedPlayhtml = {
     mockReadyResolve();
     return mockReady;
   }),
-  configure: vi.fn(),
   setupPlayElements: vi.fn(),
   setupPlayElement: vi.fn(),
   removePlayElement: vi.fn(),

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -57,6 +57,7 @@ const mockedPlayhtml = {
     mockReadyResolve();
     return mockReady;
   }),
+  configure: vi.fn(),
   setupPlayElements: vi.fn(),
   setupPlayElement: vi.fn(),
   removePlayElement: vi.fn(),


### PR DESCRIPTION
## Summary

- Split the core development toolbar into a lazy-loaded development chunk while keeping `playhtml.listSharedElements()` synchronous.
- Reduce hot-path work in keyboard collector teardown, live movement accumulation, and cursor trail scheduling.
- Defer the below-fold homepage guestbook and lazy-decode supporting images so first render avoids unnecessary work.
- Preserve a pending keyboard typing sequence after blur, while retaining same-input blur/refocus aggregation.

## Rationale

This PR keeps the highest-confidence improvements from the performance loop across the core package, extension collector, movement-derived experiments, and the extension homepage. The keyboard fix closes a data-loss path uncovered in the July audit. Changes remain local: no public API behavior changes, no persisted data-shape changes, and no starter-template updates are needed.

## Validation

- `git diff --check origin/main...HEAD`
- `bun run build` in `packages/common` and `packages/extension-types`
- `bun run build` and `bun run test` in `packages/playhtml`
- `bun run build` and `bun run test` in `packages/react`
- `bun run test -- --run` and `bun run build` in `extension`
- `bun run build` and `../../node_modules/.bin/tsc --noEmit` in `extension/website`
- Browser smoke at `http://127.0.0.1:5175/`: the first render shows `we were online`, keeps the guestbook unloaded, and lazy-loads it after scrolling.