### PR TITLE
Prune stale PartyKit bridge leases

### DIFF
--- a/partykit/__tests__/compactionPolicy.test.ts
+++ b/partykit/__tests__/compactionPolicy.test.ts
@@ -4,8 +4,10 @@ import { describe, expect, it } from "bun:test";
 import { STORAGE_KEYS } from "../const";
 import {
   getNextAlarmTime,
+  getPrunedBridgeLeases,
   getCompactionCommitDecision,
   isCompactionAutosave,
+  shouldSetAlarm,
   shouldCheckEmergencyCompaction,
   shouldCommitCompactionSnapshot,
   shouldUseEmergencyCompactedDocument,
@@ -224,5 +226,117 @@ describe("getNextAlarmTime", () => {
         pruneIntervalMs: 10_000,
       })
     ).toBe(11_000);
+  });
+});
+
+describe("shouldSetAlarm", () => {
+  it("repairs missing and stale alarms", () => {
+    expect(
+      shouldSetAlarm({
+        previousAlarm: null,
+        nextAlarm: 20_000,
+        now: 10_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldSetAlarm({
+        previousAlarm: 9_000,
+        nextAlarm: 20_000,
+        now: 10_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldSetAlarm({
+        previousAlarm: 30_000,
+        nextAlarm: 20_000,
+        now: 10_000,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldSetAlarm({
+        previousAlarm: 15_000,
+        nextAlarm: 20_000,
+        now: 10_000,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("getPrunedBridgeLeases", () => {
+  it("removes expired leases", () => {
+    const subscribers = getPrunedBridgeLeases({
+      leases: [
+        {
+          consumerRoomId: "fresh-consumer",
+          elementIds: ["lamp"],
+          createdAt: "2026-07-03T09:00:00.000Z",
+          lastSeen: "2026-07-03T09:00:00.000Z",
+        },
+        {
+          consumerRoomId: "expired-consumer",
+          elementIds: ["lamp"],
+          createdAt: "2026-07-01T09:00:00.000Z",
+          lastSeen: "2026-07-01T09:00:00.000Z",
+        },
+      ],
+      now: Date.parse("2026-07-03T10:00:00.000Z"),
+      leaseMs: 12 * 60 * 60 * 1000,
+    });
+    const sharedReferences = getPrunedBridgeLeases({
+      leases: [
+        {
+          sourceRoomId: "fresh-source",
+          elementIds: ["lamp"],
+          lastSeen: "2026-07-03T09:00:00.000Z",
+        },
+        {
+          sourceRoomId: "expired-source",
+          elementIds: ["lamp"],
+          lastSeen: "2026-07-01T09:00:00.000Z",
+        },
+      ],
+      now: Date.parse("2026-07-03T10:00:00.000Z"),
+      leaseMs: 12 * 60 * 60 * 1000,
+    });
+
+    expect(subscribers.map((subscriber) => subscriber.consumerRoomId)).toEqual([
+      "fresh-consumer",
+    ]);
+    expect(sharedReferences.map((reference) => reference.sourceRoomId)).toEqual([
+      "fresh-source",
+    ]);
+  });
+
+  it("keeps timestamp-less bridge leases", () => {
+    const subscribers = getPrunedBridgeLeases({
+      leases: [
+        {
+          consumerRoomId: "timestampless-consumer",
+          elementIds: ["lamp"],
+        },
+      ],
+      now: Date.parse("2026-07-03T10:00:00.000Z"),
+      leaseMs: 12 * 60 * 60 * 1000,
+    });
+    const sharedReferences = getPrunedBridgeLeases({
+      leases: [
+        {
+          sourceRoomId: "timestampless-source",
+          elementIds: ["lamp"],
+        },
+      ],
+      now: Date.parse("2026-07-03T10:00:00.000Z"),
+      leaseMs: 12 * 60 * 60 * 1000,
+    });
+
+    expect(subscribers.map((subscriber) => subscriber.consumerRoomId)).toEqual([
+      "timestampless-consumer",
+    ]);
+    expect(sharedReferences.map((reference) => reference.sourceRoomId)).toEqual([
+      "timestampless-source",
+    ]);
   });
 });

--- a/partykit/compactionPolicy.ts
+++ b/partykit/compactionPolicy.ts
@@ -133,3 +133,50 @@ export function getNextAlarmTime({
 
   return Math.min(...candidates);
 }
+
+export function shouldSetAlarm({
+  previousAlarm,
+  nextAlarm,
+  now,
+}: {
+  previousAlarm: number | null | undefined;
+  nextAlarm: number;
+  now: number;
+}): boolean {
+  return (
+    previousAlarm === null ||
+    previousAlarm === undefined ||
+    previousAlarm <= now ||
+    nextAlarm < previousAlarm
+  );
+}
+
+type BridgeLease = {
+  createdAt?: string;
+  lastSeen?: string;
+};
+
+function isBridgeLeaseWithinWindow(
+  lease: BridgeLease,
+  now: number,
+  leaseMs: number
+): boolean {
+  const lastSeen = lease.lastSeen || lease.createdAt;
+  const timestamp = lastSeen ? Date.parse(lastSeen) : NaN;
+  if (!Number.isFinite(timestamp)) return true;
+  return now - timestamp <= leaseMs;
+}
+
+export function getPrunedBridgeLeases<Lease extends BridgeLease>({
+  leases,
+  now,
+  leaseMs,
+}: {
+  leases: Lease[];
+  now: number;
+  leaseMs: number;
+}): Lease[] {
+  return leases.filter((lease) =>
+    isBridgeLeaseWithinWindow(lease, now, leaseMs)
+  );
+}

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -69,7 +69,9 @@ import {
 import {
   getCompactionCommitDecision,
   getNextAlarmTime,
+  getPrunedBridgeLeases,
   isCompactionAutosave,
+  shouldSetAlarm,
   shouldCheckEmergencyCompaction,
   shouldUseEmergencyCompactedDocument,
   shouldStoreCompactedDocument,
@@ -202,6 +204,8 @@ export class PartyServer extends YServer {
   override async onStart(): Promise<void> {
     await super.onStart();
     await this.attachImmediateBridgeObservers();
+    await this.pruneBridgeLeases();
+    await this.ensureAlarmScheduled();
   }
 
   async getSubscribers(): Promise<Subscriber[]> {
@@ -906,12 +910,13 @@ export class PartyServer extends YServer {
   }
 
   private async scheduleNextAlarm(): Promise<void> {
+    const now = Date.now();
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
     const nextAlarm = getNextAlarmTime({
       compactAfter: await this.getEmptyRoomCompactAfter(),
       hasBridgeLeases: Boolean(subs.length || refs.length),
-      now: Date.now(),
+      now,
       pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS,
     });
 
@@ -921,11 +926,7 @@ export class PartyServer extends YServer {
     }
 
     const previousAlarm = await this.ctx.storage.getAlarm?.();
-    if (
-      previousAlarm === null ||
-      previousAlarm === undefined ||
-      nextAlarm < previousAlarm
-    ) {
+    if (shouldSetAlarm({ previousAlarm, nextAlarm, now })) {
       await this.ctx.storage.setAlarm?.(nextAlarm);
     }
   }
@@ -992,6 +993,7 @@ export class PartyServer extends YServer {
         }
       );
       await this.setSharedReferences(merged);
+      await this.ensureAlarmScheduled();
       return { entries: merged, changed: true };
     }
     return { entries: existing, changed: false };
@@ -1239,7 +1241,7 @@ export class PartyServer extends YServer {
       });
       if (subtreesForNew === null) return;
 
-      const subscribers = await this.getSubscribers();
+      const subscribers = await this.pruneBridgeLeases();
       if (!subscribers.length) return;
       await Promise.all(
         subscribers.map(
@@ -1870,6 +1872,7 @@ export class PartyServer extends YServer {
           found.lastSeen = nowIso;
         }
         await this.setSubscribers(existing);
+        await this.ensureAlarmScheduled();
         // A resubscribe means a fresh client load on the consumer side. Reopen
         // its circuit so a genuine new visitor always gets a clean bridge attempt
         // even if the pair had previously tripped from a stale-epoch storm.
@@ -2012,7 +2015,7 @@ export class PartyServer extends YServer {
 
         // If this is a SOURCE room receiving from a CONSUMER, immediately fanout to other consumers (excluding sender if provided)
         if (receivingFromConsumer) {
-          const subscribers = await this.getSubscribers();
+          const subscribers = await this.pruneBridgeLeases();
           await Promise.all(
             subscribers.map(
               async ({ consumerRoomId, elementIds, consumerResetEpoch }) => {
@@ -2325,6 +2328,32 @@ export class PartyServer extends YServer {
     }
   }
 
+  private async pruneBridgeLeases(): Promise<Subscriber[]> {
+    const subscribers = await this.getSubscribers();
+    const sharedReferences = await this.getSharedReferences();
+    const now = Date.now();
+    const prunedSubscribers = getPrunedBridgeLeases({
+      leases: subscribers,
+      now,
+      leaseMs: DEFAULT_SUBSCRIBER_LEASE_MS,
+    });
+    const prunedSharedReferences = getPrunedBridgeLeases({
+      leases: sharedReferences,
+      now,
+      leaseMs: DEFAULT_SUBSCRIBER_LEASE_MS,
+    });
+
+    if (prunedSubscribers.length !== subscribers.length) {
+      await this.setSubscribers(prunedSubscribers);
+    }
+
+    if (prunedSharedReferences.length !== sharedReferences.length) {
+      await this.setSharedReferences(prunedSharedReferences);
+    }
+
+    return prunedSubscribers;
+  }
+
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
     try {
@@ -2337,39 +2366,7 @@ export class PartyServer extends YServer {
         }
       }
 
-      const subscribers = await this.getSubscribers();
-
-      if (subscribers.length) {
-        const now = Date.now();
-        const withinLease = (s: any) => {
-          const leaseMs = DEFAULT_SUBSCRIBER_LEASE_MS;
-          const last = s?.lastSeen || s?.createdAt;
-          const t = last ? Date.parse(last) : NaN;
-          if (!Number.isFinite(t)) return true; // if no timestamp, be permissive but keep once
-          return now - t <= leaseMs;
-        };
-
-        const prunedForLease = subscribers.filter(withinLease);
-        if (prunedForLease.length !== subscribers.length) {
-          await this.setSubscribers(prunedForLease);
-        }
-      }
-
-      // Prune shared references by TTL on consumer rooms
-      const refsRaw = await this.getSharedReferences();
-      const refs: Array<SharedRefEntry> = Array.isArray(refsRaw) ? refsRaw : [];
-      if (refs.length) {
-        const now = Date.now();
-        const leaseMs = DEFAULT_SUBSCRIBER_LEASE_MS; // unified lease
-        const kept = refs.filter((r) => {
-          const t = r?.lastSeen ? Date.parse(r.lastSeen) : NaN;
-          if (!Number.isFinite(t)) return true;
-          return now - t <= leaseMs;
-        });
-        if (kept.length !== refs.length) {
-          await this.setSharedReferences(kept);
-        }
-      }
+      await this.pruneBridgeLeases();
     } finally {
       await this.scheduleNextAlarm();
     }
@@ -2384,8 +2381,9 @@ export class PartyServer extends YServer {
       return;
     }
 
+    const subscribers = await this.pruneBridgeLeases();
+
     // Push to subscribers (source -> consumer direction)
-    const subscribers = await this.getSubscribers();
     if (subscribers.length) {
       const permissions = await this.getSharedPermissions();
       await Promise.all(


### PR DESCRIPTION
## Summary

- prune expired bridge subscriber and shared-reference leases through a shared PartyKit policy helper
- repair missing or stale Durable Object alarms when rooms start and when bridge leases are written
- prune subscriber leases before every source-to-consumer fanout path, including immediate bridge sends

## Root cause

Production `spencer.place-%2F` had persisted subscriber leases far beyond the intended 12-hour window, many with no `consumerResetEpoch`. Those stale subscribers kept receiving source bridge applies and rejecting them against the room reset epoch, producing repeated stale reset-epoch warnings.

## Review finding addressed

The first patch pruned before the debounced bridge flush, but the immediate fanout paths still read `getSubscribers()` directly. This PR now prunes before startup scheduling and before each subscriber fanout path so stale persisted leases are not used for immediate bridge sends either.

## Verification

- `bun test partykit/__tests__/compactionPolicy.test.ts partykit/__tests__/bridgeHealth.test.ts partykit/__tests__/bridgeEpochPolicy.test.ts`
- `bun test partykit/__tests__`
- `bunx tsc -p partykit`
- `git diff --check`

No deploy was performed.