### PR TITLE
Firm up can-move bounds

### DIFF
--- a/.changeset/firm-move-bounds.md
+++ b/.changeset/firm-move-bounds.md
@@ -4,4 +4,4 @@
 "@playhtml/react": patch
 ---
 
-Make `can-move-bounds` clamp the full element inside its bounds by default, account for the element's starting position within the bounds container, and normalize persisted out-of-bounds positions on mount. Explicit `min-visible` settings can still allow partial overhang when that behavior is wanted.
+Make `can-move-bounds` clamp the full element inside its bounds by default, account for the element's starting position within the bounds container, normalize persisted out-of-bounds positions on mount, and keep fast edge drags pinned while synced position updates catch up. Explicit `min-visible` settings can still allow partial overhang when that behavior is wanted.

--- a/.changeset/firm-move-bounds.md
+++ b/.changeset/firm-move-bounds.md
@@ -1,0 +1,7 @@
+---
+"@playhtml/common": patch
+"playhtml": patch
+"@playhtml/react": patch
+---
+
+Make `can-move-bounds` clamp the full element inside its bounds by default and account for the element's starting position within the bounds container. Explicit `min-visible` settings can still allow partial overhang when that behavior is wanted.

--- a/.changeset/firm-move-bounds.md
+++ b/.changeset/firm-move-bounds.md
@@ -4,4 +4,4 @@
 "@playhtml/react": patch
 ---
 
-Make `can-move-bounds` clamp the full element inside its bounds by default and account for the element's starting position within the bounds container. Explicit `min-visible` settings can still allow partial overhang when that behavior is wanted.
+Make `can-move-bounds` clamp the full element inside its bounds by default, account for the element's starting position within the bounds container, and normalize persisted out-of-bounds positions on mount. Explicit `min-visible` settings can still allow partial overhang when that behavior is wanted.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -95,10 +95,10 @@ import { CanMoveElement } from "@playhtml/react";
   </TabItem>
 </Tabs>
 
-The **cursor** can go past the container edge; only the element's position is clamped. By default, the keep-visible slice is `max(25% of element size, 60px)` on every edge, so readers always have something to grab. Two knobs let you tune that:
+The **cursor** can go past the container edge; only the element's position is clamped. By default, the whole element stays inside the container. Two knobs let you opt into partial overhang while keeping a visible slice inside:
 
-- `can-move-bounds-min-visible` / `boundsMinVisible`: fraction `(0–1)` of the element to keep inside. `1` pins fully inside (strict clamp); `0` drops the fraction constraint entirely.
-- `can-move-bounds-min-visible-px` / `boundsMinVisiblePx`: absolute pixel floor. Useful when an image has transparent padding around its paint; a pure fraction of the layout bbox can let the visible pixels clip into invisible border.
+- `can-move-bounds-min-visible` / `boundsMinVisible`: fraction `(0–1)` of the element to keep inside. Default `1` pins fully inside; lower values allow part of the element to hang over the edge. `0` drops the fraction constraint entirely.
+- `can-move-bounds-min-visible-px` / `boundsMinVisiblePx`: absolute pixel floor. Default `60`; it applies when `min-visible` allows partial overhang.
 
 The effective slice on each axis is `max(fraction × size, pxFloor)`. Set both to `0` to opt fully out of the keep-visible guarantee and let the element slip entirely out of view.
 
@@ -113,8 +113,7 @@ The effective slice on each axis is `max(fraction × size, pxFloor)`. Set both t
   🧲
 </div>
 
-<!-- Small magnet: fraction of 0.25 × 40px = 10px is too small to grab.
-     The 60px default floor keeps the whole magnet visible regardless. -->
+<!-- Default bounds keep the whole magnet visible. -->
 <div can-move can-move-bounds="fridge" id="tiny-magnet" style="width: 40px;">
   🌶️
 </div>

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -147,8 +147,8 @@ interface CanMoveElementProps {
 ```
 
 - **`bounds`**: id or CSS selector of the container to keep the element inside. `"arena"`, `"#arena"`, and `".grid"` all work.
-- **`boundsMinVisible`**: fraction (`0–1`) of the element that must stay inside `bounds` on every edge. Default `0.25`. Use `1` to pin the element fully inside, `0` to drop the fraction constraint entirely.
-- **`boundsMinVisiblePx`**: absolute pixel floor on the keep-visible slice. Default `60`. Useful when an image has transparent padding around its paint, where a pure fraction of the layout bbox might otherwise let the visible pixels clip into invisible border.
+- **`boundsMinVisible`**: fraction (`0–1`) of the element that must stay inside `bounds` on every edge. Default `1`, which keeps the full element inside. Lower values allow part of the element to hang over the edge; `0` drops the fraction constraint entirely.
+- **`boundsMinVisiblePx`**: absolute pixel floor on the keep-visible slice. Default `60`; it applies when `boundsMinVisible` allows partial overhang.
 
 The effective keep-visible slice on each axis is `max(boundsMinVisible × size, boundsMinVisiblePx)`. Set both knobs to `0` to opt fully out of the keep-visible guarantee. See [`can-move` in the capabilities reference](/docs/capabilities/#can-move) for the interaction details.
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -244,16 +244,12 @@ function getMoveBoundsClamp(
   boundsRoot: HTMLElement,
   currentData: MoveData,
   nextData: MoveData,
+  basePosition = getMoveBoundsBasePosition(element, boundsRoot, currentData),
 ): MoveData {
   const minVisible = getMinVisibleFraction(element);
   const minVisiblePx = getMinVisiblePx(element);
   const w = element.offsetWidth;
   const h = element.offsetHeight;
-  const basePosition = getMoveBoundsBasePosition(
-    element,
-    boundsRoot,
-    currentData,
-  );
   const keepX = keepVisibleSlice(w, minVisible, minVisiblePx);
   const keepY = keepVisibleSlice(h, minVisible, minVisiblePx);
   const minX = keepX - w - basePosition.x;
@@ -465,7 +461,14 @@ function getClientCoordinates(e: MouseEvent | TouchEvent): {
 }
 
 // @ts-ignore
-type MoveLocalData = { startMouseX: number; startMouseY: number };
+type MoveLocalData = {
+  startMouseX: number;
+  startMouseY: number;
+  dragX?: number;
+  dragY?: number;
+  boundsBaseX?: number;
+  boundsBaseY?: number;
+};
 type SpinLocalData = { startMouseX: number };
 type GrowLocalData = { maxScale: number; isHovering: boolean };
 
@@ -503,11 +506,22 @@ export const TagTypeToElement: DefaultTagInitializers = {
         setData(clampedData);
       }
     },
-    onDragStart: (e: MouseEvent | TouchEvent, { setLocalData }) => {
+    onDragStart: (
+      e: MouseEvent | TouchEvent,
+      { data, element, setLocalData },
+    ) => {
       const { clientX, clientY } = getClientCoordinates(e);
+      const boundsRoot = getMoveBoundsRoot(element);
+      const boundsBasePosition = boundsRoot
+        ? getMoveBoundsBasePosition(element, boundsRoot, data)
+        : undefined;
       setLocalData({
         startMouseX: clientX,
         startMouseY: clientY,
+        dragX: data.x,
+        dragY: data.y,
+        boundsBaseX: boundsBasePosition?.x,
+        boundsBaseY: boundsBasePosition?.y,
       });
     },
     onDrag: (
@@ -520,14 +534,32 @@ export const TagTypeToElement: DefaultTagInitializers = {
 
       const boundsRoot = getMoveBoundsRoot(element);
       if (boundsRoot) {
+        const dragData = {
+          x: localData.dragX ?? data.x,
+          y: localData.dragY ?? data.y,
+        };
+        const dragX = dragData.x + clientX - localData.startMouseX;
+        const dragY = dragData.y + clientY - localData.startMouseY;
+        const boundsBasePosition =
+          localData.boundsBaseX !== undefined &&
+          localData.boundsBaseY !== undefined
+            ? { x: localData.boundsBaseX, y: localData.boundsBaseY }
+            : getMoveBoundsBasePosition(element, boundsRoot, dragData);
         // The cursor itself is not clamped; only the element's persisted
         // translate is. Lower min-visible values can opt into partial
         // overhang while keeping a visible slice inside the bounds.
-        const clampedData = getMoveBoundsClamp(element, boundsRoot, data, {
-          x: newX,
-          y: newY,
-        });
-        setData(roundMoveData(clampedData));
+        const clampedData = getMoveBoundsClamp(
+          element,
+          boundsRoot,
+          dragData,
+          {
+            x: dragX,
+            y: dragY,
+          },
+          boundsBasePosition,
+        );
+        const roundedData = roundMoveData(clampedData);
+        setData(roundedData);
         // Only advance the cursor anchor by the portion of the delta that
         // actually translated the element. If the clamp ate some of the
         // delta (cursor went past the bound), hold that "debt" in the
@@ -535,11 +567,15 @@ export const TagTypeToElement: DefaultTagInitializers = {
         // before the element starts moving again. Without this, a fast
         // drag past one edge lets the return drag fling the element to
         // the opposite edge (apparent dt vs. clamped dt mismatch).
-        const usedDx = clampedData.x - data.x;
-        const usedDy = clampedData.y - data.y;
+        const usedDx = clampedData.x - dragData.x;
+        const usedDy = clampedData.y - dragData.y;
         setLocalData({
           startMouseX: localData.startMouseX + usedDx,
           startMouseY: localData.startMouseY + usedDy,
+          dragX: roundedData.x,
+          dragY: roundedData.y,
+          boundsBaseX: boundsBasePosition.x,
+          boundsBaseY: boundsBasePosition.y,
         });
         return;
       }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -188,11 +188,10 @@ function getMoveBoundsRoot(element: HTMLElement): HTMLElement | null {
 }
 
 /**
- * Fraction of the element that must stay inside the bounds container so a
- * reader can still grab it. Clamped to [0, 1]. Default 0.25 = a quarter of
- * the element remains visible / draggable on every edge.
+ * Fraction of the element that must stay inside the bounds container.
+ * Clamped to [0, 1]. Default 1 = the whole element remains inside.
  */
-const DEFAULT_MIN_VISIBLE_FRACTION = 0.25;
+const DEFAULT_MIN_VISIBLE_FRACTION = 1;
 
 /**
  * Absolute pixel floor on the keep-visible slice. This handles the case
@@ -227,6 +226,19 @@ function keepVisibleSlice(
   return Math.min(size, Math.max(size * fraction, pxFloor));
 }
 
+function getMoveBoundsBasePosition(
+  element: HTMLElement,
+  boundsRoot: HTMLElement,
+  data: MoveData,
+): { x: number; y: number } {
+  const elementRect = element.getBoundingClientRect();
+  const boundsRect = boundsRoot.getBoundingClientRect();
+  return {
+    x: elementRect.left - boundsRect.left - boundsRoot.clientLeft - data.x,
+    y: elementRect.top - boundsRect.top - boundsRoot.clientTop - data.y,
+  };
+}
+
 /**
  * Custom Capabilities data types
  */
@@ -249,23 +261,22 @@ export type GrowData = {
 export const CanDuplicateTo = "can-duplicate-to";
 /**
  * Optional id (`my-arena`, `#my-arena`) or selector (`.arena`) of a container;
- * `can-move` clamps the element's position so at least some of it stays inside.
- * The cursor itself is unconstrained — you can drag past the edge — the
- * element just stops when it would slip too far out to be grabbable.
+ * `can-move` clamps the element's position inside it. The cursor itself is
+ * unconstrained — you can drag past the edge — the element just stops at the
+ * bounds.
  */
 export const CanMoveBounds = "can-move-bounds";
 /**
  * Fraction (0–1) of the element that must remain inside `can-move-bounds`.
- * Defaults to 0.25 (quarter of the element stays visible on every edge).
- * Use 0 to let the element slip fully out of view, 1 to keep it entirely
- * inside the container (the original clamp behavior).
+ * Defaults to 1 (the whole element stays inside on every edge). Lower values
+ * allow explicit partial overhang; use 0 to let the element slip fully out of
+ * view when the pixel floor is also 0.
  */
 export const CanMoveBoundsMinVisible = "can-move-bounds-min-visible";
 /**
- * Absolute pixel floor on the keep-visible slice. Defaults to 60px. Useful
- * when an image has transparent padding around its paint — a pure fraction
- * of the layout bbox would let the visible pixels slip out of bounds. The
- * effective slice is `max(minVisible × size, minVisiblePx)`.
+ * Absolute pixel floor on the keep-visible slice. Defaults to 60px and applies
+ * when `can-move-bounds-min-visible` allows partial overhang. The effective
+ * slice is `max(minVisible × size, minVisiblePx)`, capped at the element size.
  */
 export const CanMoveBoundsMinVisiblePx = "can-move-bounds-min-visible-px";
 
@@ -463,23 +474,20 @@ export const TagTypeToElement: DefaultTagInitializers = {
 
       const boundsRoot = getMoveBoundsRoot(element);
       if (boundsRoot) {
-        // Allow the element to hang off the container's edges as long as
-        // enough of it is still inside — a reader needs something to grab
-        // to drag it back. The keep-visible slice is
-        // max(minVisible × size, minVisiblePx) so an image with
-        // transparent padding doesn't end up with its visible paint
-        // outside the bounds. The cursor itself is not clamped; only the
-        // element's persisted translate is.
+        // The cursor itself is not clamped; only the element's persisted
+        // translate is. Lower min-visible values can opt into partial
+        // overhang while keeping a visible slice inside the bounds.
         const minVisible = getMinVisibleFraction(element);
         const minVisiblePx = getMinVisiblePx(element);
         const w = element.offsetWidth;
         const h = element.offsetHeight;
+        const basePosition = getMoveBoundsBasePosition(element, boundsRoot, data);
         const keepX = keepVisibleSlice(w, minVisible, minVisiblePx);
         const keepY = keepVisibleSlice(h, minVisible, minVisiblePx);
-        const minX = -(w - keepX);
-        const maxX = boundsRoot.clientWidth - keepX;
-        const minY = -(h - keepY);
-        const maxY = boundsRoot.clientHeight - keepY;
+        const minX = keepX - w - basePosition.x;
+        const maxX = boundsRoot.clientWidth - keepX - basePosition.x;
+        const minY = keepY - h - basePosition.y;
+        const maxY = boundsRoot.clientHeight - keepY - basePosition.y;
         // If the container is narrower than the keep-visible slice, the
         // min/max can invert. Fall back to pinning at 0 in that case so the
         // element doesn't shoot off into negative space.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -239,6 +239,40 @@ function getMoveBoundsBasePosition(
   };
 }
 
+function getMoveBoundsClamp(
+  element: HTMLElement,
+  boundsRoot: HTMLElement,
+  currentData: MoveData,
+  nextData: MoveData,
+): MoveData {
+  const minVisible = getMinVisibleFraction(element);
+  const minVisiblePx = getMinVisiblePx(element);
+  const w = element.offsetWidth;
+  const h = element.offsetHeight;
+  const basePosition = getMoveBoundsBasePosition(
+    element,
+    boundsRoot,
+    currentData,
+  );
+  const keepX = keepVisibleSlice(w, minVisible, minVisiblePx);
+  const keepY = keepVisibleSlice(h, minVisible, minVisiblePx);
+  const minX = keepX - w - basePosition.x;
+  const maxX = boundsRoot.clientWidth - keepX - basePosition.x;
+  const minY = keepY - h - basePosition.y;
+  const maxY = boundsRoot.clientHeight - keepY - basePosition.y;
+  return {
+    x: maxX < minX ? 0 : Math.min(maxX, Math.max(minX, nextData.x)),
+    y: maxY < minY ? 0 : Math.min(maxY, Math.max(minY, nextData.y)),
+  };
+}
+
+function roundMoveData(data: MoveData): MoveData {
+  return {
+    x: roundToFirstDecimal(data.x),
+    y: roundToFirstDecimal(data.y),
+  };
+}
+
 /**
  * Custom Capabilities data types
  */
@@ -457,6 +491,18 @@ export const TagTypeToElement: DefaultTagInitializers = {
     updateElement: ({ element, data }) => {
       element.style.transform = `translate(${data.x}px, ${data.y}px)`;
     },
+    onMount: ({ getData, getElement, setData }) => {
+      const element = getElement();
+      const boundsRoot = getMoveBoundsRoot(element);
+      if (!boundsRoot) return;
+      const data = getData();
+      const clampedData = roundMoveData(
+        getMoveBoundsClamp(element, boundsRoot, data, data),
+      );
+      if (clampedData.x !== data.x || clampedData.y !== data.y) {
+        setData(clampedData);
+      }
+    },
     onDragStart: (e: MouseEvent | TouchEvent, { setLocalData }) => {
       const { clientX, clientY } = getClientCoordinates(e);
       setLocalData({
@@ -477,26 +523,11 @@ export const TagTypeToElement: DefaultTagInitializers = {
         // The cursor itself is not clamped; only the element's persisted
         // translate is. Lower min-visible values can opt into partial
         // overhang while keeping a visible slice inside the bounds.
-        const minVisible = getMinVisibleFraction(element);
-        const minVisiblePx = getMinVisiblePx(element);
-        const w = element.offsetWidth;
-        const h = element.offsetHeight;
-        const basePosition = getMoveBoundsBasePosition(element, boundsRoot, data);
-        const keepX = keepVisibleSlice(w, minVisible, minVisiblePx);
-        const keepY = keepVisibleSlice(h, minVisible, minVisiblePx);
-        const minX = keepX - w - basePosition.x;
-        const maxX = boundsRoot.clientWidth - keepX - basePosition.x;
-        const minY = keepY - h - basePosition.y;
-        const maxY = boundsRoot.clientHeight - keepY - basePosition.y;
-        // If the container is narrower than the keep-visible slice, the
-        // min/max can invert. Fall back to pinning at 0 in that case so the
-        // element doesn't shoot off into negative space.
-        const clampedX = maxX < minX ? 0 : Math.min(maxX, Math.max(minX, newX));
-        const clampedY = maxY < minY ? 0 : Math.min(maxY, Math.max(minY, newY));
-        setData({
-          x: roundToFirstDecimal(clampedX),
-          y: roundToFirstDecimal(clampedY),
+        const clampedData = getMoveBoundsClamp(element, boundsRoot, data, {
+          x: newX,
+          y: newY,
         });
+        setData(roundMoveData(clampedData));
         // Only advance the cursor anchor by the portion of the delta that
         // actually translated the element. If the clamp ate some of the
         // delta (cursor went past the bound), hold that "debt" in the
@@ -504,8 +535,8 @@ export const TagTypeToElement: DefaultTagInitializers = {
         // before the element starts moving again. Without this, a fast
         // drag past one edge lets the return drag fling the element to
         // the opposite edge (apparent dt vs. clamped dt mismatch).
-        const usedDx = clampedX - data.x;
-        const usedDy = clampedY - data.y;
+        const usedDx = clampedData.x - data.x;
+        const usedDy = clampedData.y - data.y;
         setLocalData({
           startMouseX: localData.startMouseX + usedDx,
           startMouseY: localData.startMouseY + usedDy,

--- a/packages/playhtml/src/__tests__/can-move-bounds.test.ts
+++ b/packages/playhtml/src/__tests__/can-move-bounds.test.ts
@@ -175,6 +175,29 @@ describe("can-move bounds clamp", () => {
     expect(state.data.y).toBe(-30);
   });
 
+  it("normalizes persisted out-of-bounds data on mount", () => {
+    const { element, state, setData } = makeDragHarness({
+      elementWidth: 400,
+      elementHeight: 400,
+      containerWidth: 1000,
+      containerHeight: 1000,
+      startX: 900,
+      startY: 0,
+    });
+    TagTypeToElement[TagType.CanMove].updateElement!({
+      element,
+      data: state.data,
+    } as any);
+
+    TagTypeToElement[TagType.CanMove].onMount?.({
+      getData: () => state.data,
+      getElement: () => element,
+      setData,
+    } as any);
+
+    expect(setData).toHaveBeenCalledWith({ x: 600, y: 0 });
+  });
+
   it("respects a custom min-visible fraction (floor disabled)", () => {
     // minVisible = 0.5, floor explicitly 0 so fraction always wins.
     // Slice = 50, max x = 300 - 50 = 250, min y = -50.

--- a/packages/playhtml/src/__tests__/can-move-bounds.test.ts
+++ b/packages/playhtml/src/__tests__/can-move-bounds.test.ts
@@ -26,6 +26,7 @@ function makeDragHarness({
   startY = 0,
   elementLeft = 0,
   elementTop = 0,
+  syncData = true,
 }: {
   elementWidth: number;
   elementHeight: number;
@@ -37,6 +38,7 @@ function makeDragHarness({
   startY?: number;
   elementLeft?: number;
   elementTop?: number;
+  syncData?: boolean;
 }) {
   const container = document.createElement("div");
   container.id = "arena";
@@ -100,7 +102,9 @@ function makeDragHarness({
     }) as DOMRect;
 
   const setData = vi.fn((next: { x: number; y: number }) => {
-    state.data = next;
+    if (syncData) {
+      state.data = next;
+    }
   });
   const setLocalData = vi.fn(
     (next: { startMouseX: number; startMouseY: number }) => {
@@ -122,7 +126,20 @@ function makeDragHarness({
     );
   };
 
-  return { container, element, state, setData, setLocalData, drag };
+  const start = (mouseX: number, mouseY: number) => {
+    const onDragStart = TagTypeToElement[TagType.CanMove].onDragStart!;
+    onDragStart(
+      { clientX: mouseX, clientY: mouseY } as MouseEvent,
+      {
+        data: state.data,
+        localData: state.localData,
+        setLocalData,
+        element,
+      } as any,
+    );
+  };
+
+  return { container, element, state, setData, setLocalData, drag, start };
 }
 
 describe("can-move bounds clamp", () => {
@@ -285,6 +302,23 @@ describe("can-move bounds clamp", () => {
     // Cursor back to 160. newX = 200 + (160 - 200) = 160. Inside → moves.
     drag(160, 0);
     expect(state.data.x).toBe(160);
+  });
+
+  it("does not advance cursor debt again while clamped data is still syncing", () => {
+    const { drag, start, state } = makeDragHarness({
+      elementWidth: 100,
+      elementHeight: 100,
+      containerWidth: 300,
+      containerHeight: 300,
+      syncData: false,
+    });
+
+    start(0, 0);
+    drag(10_000, 0);
+    expect(state.localData.startMouseX).toBe(200);
+
+    drag(10_000, 0);
+    expect(state.localData.startMouseX).toBe(200);
   });
 
   it("falls back to 0 when the keep-visible slice is larger than the container (inverted clamp)", () => {

--- a/packages/playhtml/src/__tests__/can-move-bounds.test.ts
+++ b/packages/playhtml/src/__tests__/can-move-bounds.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Drag-clamp tests for the `can-move-bounds` attribute — verifies the
-// ABOUTME: "at least some of the element stays grabbable" semantics.
+// ABOUTME: Drag-clamp tests for the `can-move-bounds` attribute.
+// ABOUTME: Verifies strict default bounds and explicit partial-overhang options.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
@@ -24,6 +24,8 @@ function makeDragHarness({
   minVisiblePx,
   startX = 0,
   startY = 0,
+  elementLeft = 0,
+  elementTop = 0,
 }: {
   elementWidth: number;
   elementHeight: number;
@@ -33,6 +35,8 @@ function makeDragHarness({
   minVisiblePx?: number;
   startX?: number;
   startY?: number;
+  elementLeft?: number;
+  elementTop?: number;
 }) {
   const container = document.createElement("div");
   container.id = "arena";
@@ -46,6 +50,18 @@ function makeDragHarness({
     configurable: true,
     value: containerHeight,
   });
+  container.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: containerWidth,
+      bottom: containerHeight,
+      width: containerWidth,
+      height: containerHeight,
+      toJSON: () => ({}),
+    }) as DOMRect;
   document.body.appendChild(container);
 
   const element = document.createElement("div");
@@ -70,6 +86,18 @@ function makeDragHarness({
     data: { x: startX, y: startY },
     localData: { startMouseX: 0, startMouseY: 0 },
   };
+  element.getBoundingClientRect = () =>
+    ({
+      x: elementLeft + state.data.x,
+      y: elementTop + state.data.y,
+      top: elementTop + state.data.y,
+      left: elementLeft + state.data.x,
+      right: elementLeft + state.data.x + elementWidth,
+      bottom: elementTop + state.data.y + elementHeight,
+      width: elementWidth,
+      height: elementHeight,
+      toJSON: () => ({}),
+    }) as DOMRect;
 
   const setData = vi.fn((next: { x: number; y: number }) => {
     state.data = next;
@@ -102,11 +130,9 @@ describe("can-move bounds clamp", () => {
     document.body.innerHTML = "";
   });
 
-  it("keeps the default fraction (25%) of the element visible when dragging past the right edge", () => {
-    // 200x200 element in a 500x500 container. Default minVisible = 0.25,
-    // floor = 60px. Slice = max(50, 60) = 60. Max x = 500 - 60 = 440.
-    // Use 200x200 so the fraction (50) is larger than the floor (60)? No:
-    // 50 < 60 still. Use 400x400 so fraction (100) dominates floor.
+  it("keeps the whole element inside by default when dragging past the right edge", () => {
+    // 400px element in a 1000px container. Default minVisible = 1, so
+    // max x = 1000 - 400 = 600.
     const { drag, state } = makeDragHarness({
       elementWidth: 400,
       elementHeight: 400,
@@ -114,13 +140,11 @@ describe("can-move bounds clamp", () => {
       containerHeight: 1000,
     });
     drag(10_000, 0);
-    // Slice = max(400 * 0.25, 60) = max(100, 60) = 100. Max x = 1000 - 100 = 900.
-    expect(state.data.x).toBe(900);
+    expect(state.data.x).toBe(600);
     expect(state.data.y).toBe(0);
   });
 
-  it("keeps the default fraction visible when dragging past the left edge", () => {
-    // Slice = 100, min x = -(400 - 100) = -300.
+  it("keeps the whole element inside by default when dragging past the left edge", () => {
     const { drag, state } = makeDragHarness({
       elementWidth: 400,
       elementHeight: 400,
@@ -128,23 +152,27 @@ describe("can-move bounds clamp", () => {
       containerHeight: 1000,
     });
     drag(-10_000, 0);
-    expect(state.data.x).toBe(-300);
+    expect(state.data.x).toBe(0);
   });
 
-  it("60px absolute floor kicks in when fraction × size is smaller than 60", () => {
-    // 100x100 element, default fraction 0.25 → fraction slice = 25, but
-    // 25 < 60, so floor wins: slice = 60.
-    // max x = 300 - 60 = 240, min x = -(100 - 60) = -40.
+  it("accounts for the element's starting position inside the bounds", () => {
+    // Element starts 80px from the left and 30px from the top. A strict
+    // clamp must translate relative to that starting layout position.
     const { drag, state } = makeDragHarness({
       elementWidth: 100,
       elementHeight: 100,
       containerWidth: 300,
-      containerHeight: 300,
+      containerHeight: 250,
+      minVisible: 1,
+      elementLeft: 80,
+      elementTop: 30,
     });
-    drag(10_000, 0);
-    expect(state.data.x).toBe(240);
-    drag(-20_000, 0);
-    expect(state.data.x).toBe(-40);
+    drag(10_000, 10_000);
+    expect(state.data.x).toBe(120);
+    expect(state.data.y).toBe(120);
+    drag(-10_000, -10_000);
+    expect(state.data.x).toBe(-80);
+    expect(state.data.y).toBe(-30);
   });
 
   it("respects a custom min-visible fraction (floor disabled)", () => {
@@ -172,13 +200,14 @@ describe("can-move bounds clamp", () => {
       elementHeight: 400,
       containerWidth: 1000,
       containerHeight: 1000,
+      minVisible: 0.25,
       minVisiblePx: 200,
     });
     drag(10_000, 0);
     expect(state.data.x).toBe(800);
   });
 
-  it("min-visible of 1 pins the element fully inside (legacy behavior)", () => {
+  it("min-visible of 1 pins the element fully inside", () => {
     // Slice = max(100, 60) = 100 (the whole element). max x = 300 - 100 = 200.
     const { drag, state } = makeDragHarness({
       elementWidth: 100,
@@ -210,14 +239,13 @@ describe("can-move bounds clamp", () => {
 
   it("cursor debt: fast drag past an edge does not fling the element to the opposite edge on return", () => {
     // Regression guard for the bug where clientX-startMouseX tracked the
-    // raw cursor. 100x100 element, default fraction 0.25, default floor
-    // 60px. Slice = 60, so max x = 300 - 60 = 240.
+    // raw cursor. 100x100 element in a 300px container has max x = 200.
     // Sequence:
     //   1. Cursor from 0 → 10_000 in one tick (past right edge). Element
-    //      clamps to 240. startMouseX advances only by 240 (the amount
+    //      clamps to 200. startMouseX advances only by 200 (the amount
     //      actually translated), not all the way to 10_000 — debt holds
     //      the unused cursor distance.
-    //   2. Cursor back to 5_000. Still clamped at 240.
+    //   2. Cursor back to 5_000. Still clamped at 200.
     //   3. Only when the cursor comes all the way back inside does the
     //      element start moving again.
     const { drag, state } = makeDragHarness({
@@ -227,13 +255,13 @@ describe("can-move bounds clamp", () => {
       containerHeight: 300,
     });
     drag(10_000, 0);
-    expect(state.data.x).toBe(240);
-    expect(state.localData.startMouseX).toBe(240);
-    drag(5_000, 0);
-    expect(state.data.x).toBe(240);
-    // Cursor back to 200. newX = 240 + (200 - 240) = 200. Inside → moves.
-    drag(200, 0);
     expect(state.data.x).toBe(200);
+    expect(state.localData.startMouseX).toBe(200);
+    drag(5_000, 0);
+    expect(state.data.x).toBe(200);
+    // Cursor back to 160. newX = 200 + (160 - 200) = 160. Inside → moves.
+    drag(160, 0);
+    expect(state.data.x).toBe(160);
   });
 
   it("falls back to 0 when the keep-visible slice is larger than the container (inverted clamp)", () => {
@@ -278,9 +306,7 @@ describe("can-move bounds clamp", () => {
         element,
       } as any,
     );
-    // 80px element, fraction 0.25 → fraction slice = 20. Floor = 60.
-    // Slice = max(20, 60) = 60. max x = 200 - 60 = 140.
-    expect(setData).toHaveBeenCalledWith({ x: 140, y: 0 });
+    expect(setData).toHaveBeenCalledWith({ x: 120, y: 0 });
   });
 
   it("clamps to one decimal place (rounds for wire compactness)", () => {

--- a/packages/react/src/elements.tsx
+++ b/packages/react/src/elements.tsx
@@ -24,14 +24,15 @@ export interface CanMoveBoundsProps {
   bounds?: string;
   /**
    * Fraction (0–1) of the element that must stay inside `bounds`. Default
-   * 0.25. `1` pins fully inside, `0` drops the fraction constraint (pixel
-   * floor still applies unless also zeroed).
+   * 1 keeps the full element inside; lower values allow explicit partial
+   * overhang. `0` drops the fraction constraint (pixel floor still applies
+   * unless also zeroed).
    */
   boundsMinVisible?: number;
   /**
-   * Absolute pixel floor on the keep-visible slice (default 60). The
-   * effective slice is `max(boundsMinVisible × size, boundsMinVisiblePx)`.
-   * Useful when an image has transparent padding around its paint.
+   * Absolute pixel floor on the keep-visible slice (default 60). Applies when
+   * `boundsMinVisible` allows partial overhang. The effective slice is
+   * `max(boundsMinVisible × size, boundsMinVisiblePx)`.
    */
   boundsMinVisiblePx?: number;
 }


### PR DESCRIPTION
## Summary

- Make `can-move-bounds` keep the full element inside its bounds by default.
- Clamp relative to the element's starting position inside the bounds container, so elements that do not start at the container origin behave consistently.
- Normalize persisted out-of-bounds `can-move` positions on mount, and keep explicit `min-visible` settings available for partial overhang.
- Update docs, React prop comments, regression coverage, and changeset release notes.

## Root Cause

The previous bounds math intentionally allowed partial overhang by default, and it assumed the draggable started at the bounds container origin. That made edge behavior inconsistent for elements with a non-zero starting layout position. After tightening the drag clamp, persisted positions from old rooms could still render outside the bounds because initial render applied stored `{ x, y }` directly before any drag happened.

## Docs And Starters

Docs were updated in the capabilities page and React API reference. Starter templates are unchanged because they do not demonstrate `can-move-bounds`, so their current examples remain copy-pasteable.

## Validation

- `bun run test src/__tests__/can-move-bounds.test.ts` in `packages/playhtml`
- `bun run test` in `packages/playhtml`
- `bun run build` in `packages/common`
- `bun run build` in `packages/playhtml`
- `bun run build` in `packages/react`
- `bun run build` in `apps/docs`
- `git diff --check HEAD`

`packages/playhtml` tests still print existing Lit dev-mode warnings and perf output.
