### PR TITLE
Fix extension release manifest resource validation

### DIFF
--- a/extension/scripts/validateExtensionBuild.mjs
+++ b/extension/scripts/validateExtensionBuild.mjs
@@ -19,13 +19,68 @@ function collectManifestResources(manifest) {
   return resources;
 }
 
+async function collectBuildFiles(buildDir, dir = buildDir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await collectBuildFiles(buildDir, entryPath)));
+    } else if (entry.isFile()) {
+      files.push(path.relative(buildDir, entryPath).split(path.sep).join("/"));
+    }
+  }
+
+  return files;
+}
+
+function hasResourcePattern(resource) {
+  return /[*?]/.test(resource);
+}
+
+function resourcePatternToRegExp(resource) {
+  let source = "^";
+
+  for (let index = 0; index < resource.length; index += 1) {
+    const char = resource[index];
+
+    if (char === "*") {
+      if (resource[index + 1] === "*") {
+        source += ".*";
+        index += 1;
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[\\^$+?.()|{}[\]]/g, "\\$&");
+    }
+  }
+
+  return new RegExp(`${source}$`);
+}
+
 export async function validateExtensionBuild(buildDir) {
   const manifestPath = path.join(buildDir, "manifest.json");
   const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8"));
   const resources = collectManifestResources(manifest);
   const missingResources = [];
+  let buildFiles;
 
   for (const resource of resources) {
+    if (hasResourcePattern(resource)) {
+      buildFiles ??= await collectBuildFiles(buildDir);
+      const resourcePattern = resourcePatternToRegExp(resource);
+
+      if (!buildFiles.some((file) => resourcePattern.test(file))) {
+        missingResources.push(resource);
+      }
+      continue;
+    }
+
     try {
       await fs.stat(path.join(buildDir, resource));
     } catch (error) {

--- a/extension/scripts/validateExtensionBuild.test.mjs
+++ b/extension/scripts/validateExtensionBuild.test.mjs
@@ -62,3 +62,19 @@ test("passes when manifest resources exist in the build directory", async () => 
 
   await expect(validateExtensionBuild(dir)).resolves.toBeUndefined();
 });
+
+test("passes when web accessible resource patterns match build files", async () => {
+  const dir = await makeBuildDir({
+    manifest_version: 3,
+    web_accessible_resources: [
+      {
+        resources: ["inventory/*"],
+        matches: ["<all_urls>"],
+      },
+    ],
+  });
+  await mkdir(path.join(dir, "inventory"), { recursive: true });
+  await writeFile(path.join(dir, "inventory/bottle.svg"), "");
+
+  await expect(validateExtensionBuild(dir)).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- Teach the extension build validator to treat manifest resource entries with `*` or `?` as patterns instead of literal files.
- Add a regression test for the `inventory/*` web-accessible resource pattern that broke the Chrome release zip validation.

## Root Cause
The extension build included `inventory/backpack.png`, `inventory/bottle.svg`, and `inventory/sparkle.svg`, but `validateExtensionBuild.mjs` checked `inventory/*` with `fs.stat` as if it were a literal path. The release job failed after WXT successfully built and zipped the extension.

## Validation
- `bun run test -- --run validateExtensionBuild`
- `bun run build-packages`
- `WXT_OUT_DIR=publish bun run zip`
- `node scripts/validateExtensionBuild.mjs publish/chrome-mv3`
- `bun run test -- --run`

After merging, rerun the Extension Release workflow on the fixed `main` SHA. Use `dry-run=false` for an actual store submission.