### PR TITLE
Route extension release Discord announcements

### DIFF
--- a/.github/scripts/announce-extension-release.test.mjs
+++ b/.github/scripts/announce-extension-release.test.mjs
@@ -74,4 +74,18 @@ describe("extension release workflow", () => {
     assert.ok(releaseStepIndex < announceStepIndex);
     assert.ok(releaseCommandIndex < announceStepIndex);
   });
+
+  it("uses the extension release Discord webhook", () => {
+    const workflowPath = fileURLToPath(
+      new URL("../workflows/extension-release.yml", import.meta.url),
+    );
+    const workflow = readFileSync(workflowPath, "utf8");
+    const announceStepIndex = workflow.indexOf("- name: Announce release on Discord");
+    const nextStepIndex = workflow.indexOf("\n      - name:", announceStepIndex + 1);
+    const announceStep = workflow.slice(announceStepIndex, nextStepIndex);
+
+    assert.notEqual(announceStepIndex, -1);
+    assert.match(announceStep, /secrets\.DISCORD_EXTENSION_RELEASE_WEBHOOK/);
+    assert.doesNotMatch(announceStep, /secrets\.DISCORD_RELEASE_WEBHOOK/);
+  });
 });

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Announce release on Discord
         if: env.DRY_RUN != 'true' && steps.tag.outputs.tag_created == 'true'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_EXTENSION_RELEASE_WEBHOOK }}
           VERSION: ${{ env.VERSION }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           CHANGELOG_URL: https://wewere.online/changelog/


### PR DESCRIPTION
## Summary

- Route extension release Discord announcements through a dedicated GitHub Actions secret: `DISCORD_EXTENSION_RELEASE_WEBHOOK`.
- Add a workflow regression test so the extension release job cannot silently fall back to the package-release webhook secret.

## Root cause

Extension releases and package releases both used `DISCORD_RELEASE_WEBHOOK`, so extension release announcements were sent to the general release channel instead of the extension release channel.

## Validation

- `node --test .github/scripts/*.test.mjs`

## Follow-up before the next release

Add repo secret `DISCORD_EXTENSION_RELEASE_WEBHOOK` with the Discord webhook URL for the extension release channel (`1516563778538442864`).