### PR TITLE
Fix NamedNodeMap iteration to type-check under partykit's tsconfig

### DIFF
--- a/.changeset/mirror-attribute-iteration.md
+++ b/.changeset/mirror-attribute-iteration.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Iterate element attributes via `Array.from` in `canMirror` element-state capture so the code type-checks under TypeScript configs that lack `NamedNodeMap` iterator support (no `downlevelIteration`/`DOM.Iterable`). No runtime behavior change.

--- a/packages/common/src/canMirror.ts
+++ b/packages/common/src/canMirror.ts
@@ -591,7 +591,7 @@ function constructInitialState(element: HTMLElement | Text): ElementState {
 
   // @ts-ignore
   const context = getMirrorContextFromElement(element);
-  for (const attr of element.attributes) {
+  for (const attr of Array.from(element.attributes)) {
     const mirroredValue = getMirroredAttributeValue(
       attr.name,
       attr.value,


### PR DESCRIPTION
## Summary

`bun run lint` fails at its first step (`bunx tsc -p partykit`) on a clean tree because `packages/common/src/canMirror.ts` iterates `element.attributes` (a `NamedNodeMap`) with `for...of`, which requires `[Symbol.iterator]()` support. `packages/common`'s own tsconfig type-checks this fine, but partykit's tsconfig has different lib/downlevelIteration settings and rejects it.

- Changed the loop at `canMirror.ts:594` to `for (const attr of Array.from(element.attributes))`, matching the existing `Array.from(element.attributes)` pattern already used elsewhere in the same file (line 706).
- No runtime behavior change — this is a type-level fix only, and neither tsconfig was modified.
- Added a changeset (`@playhtml/common` patch) per repo convention for changes under `packages/`.

## Test plan

- [x] `bunx tsc -p partykit` passes
- [x] `bunx tsc` in `packages/common` still passes (unaffected)
- [x] Confirmed via diff against a clean checkout at the same commit that this was the only step blocking the lint script; all steps up through the four `packages/*` type-checks now pass. (The final `extension` step in `bun run lint` has pre-existing, unrelated type errors that predate this change and are out of scope here — CI already treats extension lint as non-blocking via `continue-on-error`.)