### PR TITLE
Fix element awareness not broadcasting updates to peers

### DIFF
--- a/.changeset/broadcast-element-awareness-updates.md
+++ b/.changeset/broadcast-element-awareness-updates.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Fix element awareness (`updateElementAwareness` / `setMyAwareness`) not syncing updates to other clients. The awareness write mutated the current local state object in place, which defeated the y-protocols deep-equality check that decides whether to emit the `change` event — so after the initial value, subsequent updates were applied locally but never broadcast. Element awareness now writes a fresh state object on each update so peers receive every change.

--- a/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
@@ -101,6 +101,43 @@ describe("element awareness sync", () => {
     expect(cursorProvider.awareness.getLocalState()?.["can-play"]).toBeUndefined();
   });
 
+  it("does not mutate the previous awareness state object when updating", async () => {
+    const provider = getCurrentProvider();
+
+    const el = document.createElement("div");
+    el.id = "toggle-presence";
+    el.setAttribute("can-play", "");
+    (el as any).defaultData = {};
+    (el as any).myDefaultAwareness = { hovering: false };
+    (el as any).updateElement = vi.fn();
+    document.body.appendChild(el);
+    await playhtml.setupPlayElementForTag(el, "can-play");
+
+    const handler = playhtml
+      .elementHandlers.get("can-play")!
+      .get("toggle-presence")!;
+
+    // The provider only broadcasts an awareness update when y-protocols'
+    // setLocalState sees a change via deep equality against the PREVIOUS state.
+    // If the update mutates the previous state object in place, that comparison
+    // sees no change and the broadcast is dropped — peers never see the update.
+    // Capture the sub-object the handler will read, then update, and assert the
+    // captured snapshot was left untouched (i.e. a fresh object was written).
+    const beforeSub = provider.awareness.getLocalState()?.["can-play"] as Record<
+      string,
+      unknown
+    >;
+    const beforeSnapshot = JSON.stringify(beforeSub);
+
+    handler.setMyAwareness({ hovering: true } as any);
+
+    expect(JSON.stringify(beforeSub)).toBe(beforeSnapshot);
+    expect(
+      provider.awareness.getLocalState()?.["can-play"]?.["toggle-presence"],
+    ).toEqual({ hovering: true });
+    expect(provider.awareness.getLocalState()?.["can-play"]).not.toBe(beforeSub);
+  });
+
   it("keeps existing local awareness when a handler is created", async () => {
     const provider = getCurrentProvider();
     provider.awareness.setLocalStateField("can-play", {

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -484,8 +484,10 @@ export class ElementHandler<T = any, U = any, V = any> {
 
     this.selfAwareness = data;
     this.onAwarenessChange(data);
-    // For some reason unless it's the first time, the localState changing is not called in the `change` observer callback for awareness. So we have to manually update
-    // the element's awareness rendering here.
+    // Render our own awareness change locally right away. The awareness "change"
+    // observer also fires (onAwarenessChange writes a fresh state object, so
+    // y-protocols detects the change and broadcasts it), but that path reflects
+    // the write back asynchronously; updating here keeps the local view immediate.
     this.triggerAwarenessUpdate?.();
   }
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1544,15 +1544,20 @@ function createPlayElementData<T extends TagType, TData = any>(
         awarenessProvider.awareness,
         cursorClient?.getMyPlayerIdentity() ?? generatePersistentPlayerIdentity(),
       );
-      const localAwareness =
+      const existingAwareness =
         awarenessProvider.awareness.getLocalState()?.[tag] || {};
 
-      if (localAwareness[elementId] === elementAwarenessData) {
+      if (existingAwareness[elementId] === elementAwarenessData) {
         return;
       }
 
-      localAwareness[elementId] = elementAwarenessData;
-      awarenessProvider.awareness.setLocalStateField(tag, localAwareness);
+      // Build a fresh object rather than mutating the existing one in place.
+      // y-protocols' setLocalState detects changes via deep equality against the
+      // previous state; mutating the current state object in place makes that
+      // comparison see no change, which suppresses the "change" event the
+      // provider listens on to broadcast awareness — so peers never receive it.
+      const nextAwareness = { ...existingAwareness, [elementId]: elementAwarenessData };
+      awarenessProvider.awareness.setLocalStateField(tag, nextAwareness);
     },
     triggerAwarenessUpdate: () => {
       onChangeAwareness();


### PR DESCRIPTION
## Problem

Element awareness (`updateElementAwareness` / `setMyAwareness` on `can-play`) applied updates locally but **never sent them to other clients** after the initial value. The initial `myDefaultAwareness` propagated, so presence counts looked right at first — but any subsequent change (a hover toggle, a typing indicator, an emoji pick) updated only the local view and was silently dropped for everyone else.

Reproduced live on both playhtml.fun and a consumer app, with two browser tabs: a mutation in one tab never reached the other.

## Root cause

`onAwarenessChange` read the current local awareness sub-object and **mutated it in place** before writing it back:

```js
const localAwareness = awareness.getLocalState()?.[tag] || {};
localAwareness[elementId] = elementAwarenessData;   // mutates the live object
awareness.setLocalStateField(tag, localAwareness);
```

y-protocols' `setLocalState` decides whether to emit the `change` event via `equalityDeep(prevState, newState)`. Because the sub-object was mutated in place, `prevState` already reflected the new value, so `equalityDeep` returned `true`, `change` never fired, and the provider's `change`-bound handler never broadcast the update over the socket. (`update` still fired, which is why the local view updated — but the provider broadcasts on `change`.)

This only affected the default config (cursor room == page room, awareness on the shared provider), which is why the `room: "domain"` regression test in #272 didn't catch it, and why the homepage smoke test — which only reads the initial `.length` — stayed green.

## Fix

Write a fresh object on each update so change detection sees the difference:

```js
const nextAwareness = { ...existingAwareness, [elementId]: elementAwarenessData };
awareness.setLocalStateField(tag, nextAwareness);
```

## Tests

Added a regression test to `element-awareness-sync.test.ts` asserting the previous awareness state object is not mutated on update (and a fresh object is written). Verified it **fails on the old in-place code** and passes with the fix. Full suite: 349 passing.

## Follow-up (not in this PR)

Stale awareness states from dead client ids accumulate on the server and are not pruned, which can inflate/confuse `awareness` array counts (dedup via `awarenessByStableId` helps but a stale entry sharing a stable id can still win last-write). That's a separate issue (server-side pruning was removed in #206; see also #273 to move element awareness onto the presence transport).

https://claude.ai/code/session_01SYoz69wU9c8acdC24pX7aw