### PR TITLE
Pin PlayHTML Vitest to 3.2.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
         "typescript": "^5.0.2",
         "vite": "^7.1.2",
         "vite-plugin-dts": "^4.5.4",
-        "vitest": "^3.1.1",
+        "vitest": "3.2.4",
       },
     },
     "packages/react": {

--- a/packages/playhtml/package.json
+++ b/packages/playhtml/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.0.2",
     "vite": "^7.1.2",
     "vite-plugin-dts": "^4.5.4",
-    "vitest": "^3.1.1",
+    "vitest": "3.2.4",
     "jsdom": "^26.1.0",
     "happy-dom": "^15.11.6"
   },


### PR DESCRIPTION
## Summary

- Pin `packages/playhtml`'s Vitest dev dependency to `3.2.4`.
- Update the matching `bun.lock` workspace dependency metadata.

## Root cause

The cursor network pacing failures reproduced when a local checkout resolved an older Vitest 2.x binary. Clean CI already resolves the PlayHTML package to Vitest 3.2.4, where the tests pass. Pinning the package dependency makes that intended local test version explicit instead of relying on the `^3.1.1` range.

## Validation

- `bun install --frozen-lockfile`
- `cd packages/playhtml && bun run test src/cursors/__tests__/cursor-network-pacing.test.ts`
- `cd packages/playhtml && bun run test`