### PR TITLE
sealing: textured outer roll, seal-band beat, fix finale/band alignment

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,3 +14,5 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
+
+- Sealing a message bottle got a nicer send-off: the rolled-up message keeps its text and your color on the outside, a color band snaps around it to seal it like an envelope, and it now drops exactly into the slot in the page.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,5 +14,3 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
-
-- Sealing a message bottle got a nicer send-off: the rolled-up message keeps its text and your color on the outside, a color band snaps around it to seal it like an envelope, and it now drops exactly into the slot in the page.

--- a/extension/src/components/sealing/SealingCeremony.tsx
+++ b/extension/src/components/sealing/SealingCeremony.tsx
@@ -65,13 +65,15 @@ export function SealingCeremony({
     scene.add(mesh);
     mesh.position.y = 0;
 
-    // Back face: same white as the paper/input so the curl's underside is
-    // the same color as the sheet (no visible strip). Vertex colors add a
-    // gentle depth shading based on how far each point curls away from the
-    // camera (computed each frame in the morph). Shares the morphing geometry
-    // and is a CHILD of the front mesh so it inherits every transform.
+    // Back face: carries the SAME message texture as the front so the wound-up
+    // outer wrap shows the faint message + the author-color stripe — matching
+    // the on-page capsule's "sticking out" look (text + color visible). A gentle
+    // grey tint keeps it reading as the paper's underside; per-frame vertex
+    // colors add depth shading as it curls. Shares the morphing geometry and is
+    // a CHILD of the front mesh so it inherits every transform.
     const backMaterial = new THREE.MeshBasicMaterial({
-      color: 0xffffff,
+      map: texture,
+      color: 0xdedad2,
       side: THREE.BackSide,
       transparent: true,
       vertexColors: true,
@@ -217,12 +219,72 @@ export function SealingCeremony({
         );
       }, 1200));
 
-      // 4. Then start the finale
-      pendingTimers.push(setTimeout(startFinale, 2000));
+      // 4. Envelope seal: an author-color band snaps around the middle of the
+      //    formed roll (like a wax-seal belt) — a distinct "sealing" beat before
+      //    it's tucked away. Fires once the card has formed (~1.9s).
+      pendingTimers.push(setTimeout(playSealBand, 1900));
+
+      // 5. Then start the finale (after the seal beat reads).
+      pendingTimers.push(setTimeout(startFinale, 2650));
+    }
+
+    // The seal band — a thin author-color belt that sweeps across the formed
+    // roll's middle. DOM overlay (fixed) aligned by projecting the coil's
+    // actual world bounding box to screen (the coil is NOT at the mesh origin —
+    // the roll winds around the paper's top edge). Holds while the seal reads,
+    // then fades as the finale lifts the bottle.
+    let sealBand: HTMLDivElement | null = null;
+    function playSealBand() {
+      const host = containerRef.current;
+      if (disposed || !host) return;
+      // Project the coil's world bbox center to screen: with the orthographic
+      // camera, screen = viewportCenter + world * camera.zoom (y flipped).
+      mesh.updateWorldMatrix(true, true);
+      const coilBox = new THREE.Box3().setFromObject(mesh);
+      const c = coilBox.getCenter(new THREE.Vector3());
+      const size = coilBox.getSize(new THREE.Vector3());
+      const z = camera.zoom;
+      const screenX = vw / 2 + c.x * z;
+      const screenY = vh / 2 - c.y * z;
+      const beltW = Math.max(size.x * z * 1.5, 26);
+      const beltH = Math.max(size.y * z * 0.2, 7);
+      const band = document.createElement("div");
+      band.style.cssText = [
+        "position:fixed",
+        `left:${screenX}px`,
+        `top:${screenY}px`,
+        `width:${beltW}px`,
+        `height:${beltH}px`,
+        `background:${authorColor}`,
+        "border-radius:1.5px",
+        "box-shadow:0 1px 3px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.25)",
+        // start collapsed at center, then sweep open across the card
+        "transform:translate(-50%,-50%) scaleX(0)",
+        "transform-origin:center center",
+        "opacity:0",
+        "pointer-events:none",
+        "z-index:6",
+        "transition:transform 280ms cubic-bezier(0.34,1.56,0.64,1), opacity 180ms ease-out",
+      ].join(";");
+      host.appendChild(band);
+      sealBand = band;
+      // next frame → animate the belt snapping into place
+      requestAnimationFrame(() => {
+        band.style.opacity = "1";
+        band.style.transform = "translate(-50%,-50%) scaleX(1)";
+      });
     }
 
     function startFinale() {
       if (disposed) return;
+      // The seal is set — let the band fade as the bottle lifts to travel.
+      if (sealBand) {
+        sealBand.style.transition = "opacity 300ms ease-out";
+        sealBand.style.opacity = "0";
+        const band = sealBand;
+        pendingTimers.push(setTimeout(() => band.remove(), 320));
+        sealBand = null;
+      }
       finaleHandle = playFinale({
         mesh,
         materialsToClip: [material, backMaterial],
@@ -277,6 +339,7 @@ export function SealingCeremony({
       material.dispose();
       backMaterial.dispose();
       if (hint.parentNode) hint.parentNode.removeChild(hint);
+      sealBand?.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/extension/src/components/sealing/common.ts
+++ b/extension/src/components/sealing/common.ts
@@ -341,8 +341,38 @@ export function playFinale(handles: FinaleHandles): { dispose: () => void } {
     handles;
   const { vw, vh, renderer, scene: threeScene, camera, clipPlane } = scene;
 
-  const slotSceneX = slotX - vw / 2;
-  const slotSceneY = vh / 2 - slotY;
+  // Slot position in WORLD units. The orthographic camera maps world → screen
+  // as screen = viewportCenter + world * camera.zoom, so converting the slot's
+  // CSS-pixel position into world space must divide by the CURRENT zoom (the
+  // camera has dollied out to ~0.65 by finale time — ignoring it made the card
+  // travel only 65% of the way to the fissure).
+  const zoom = camera.zoom;
+  const slotWorldX = (slotX - vw / 2) / zoom;
+  const slotWorldY = (vh / 2 - slotY) / zoom;
+
+  // The visible coil is NOT centered on the mesh origin (the roll winds around
+  // the paper's top edge, and the card-fit scale/rotation preserves that
+  // offset). Measure the coil's world bounding box and correct every target by
+  // the offset so the BOTTLE — not the mesh origin — lands on the slot.
+  mesh.updateWorldMatrix(true, true);
+  mesh.traverse((o) => {
+    (o as THREE.Mesh).geometry?.computeBoundingBox?.();
+  });
+  const coilBox = new THREE.Box3().setFromObject(mesh);
+  const coilCenter = coilBox.getCenter(new THREE.Vector3());
+  const coilH = Math.max(coilBox.max.y - coilBox.min.y, 1);
+  const corrX = coilCenter.x - mesh.position.x;
+  const corrY = coilCenter.y - mesh.position.y;
+
+  const targetX = slotWorldX - corrX;
+  // Travel ends with the coil's BOTTOM edge sitting at the slot line, so the
+  // whole bottle hovers visibly above the fissure right before plunge.
+  const travelEndY = slotWorldY + coilH / 2 - corrY;
+
+  // Keep the slot clipping plane on the zoom-corrected slot line (it was set
+  // at scene setup assuming zoom = 1).
+  clipPlane.constant = -slotWorldY;
+
   const startTime = performance.now();
   let phase: "travel" | "plunge" | "done" = "travel";
   let plungeStart = 0;
@@ -350,10 +380,6 @@ export function playFinale(handles: FinaleHandles): { dispose: () => void } {
   let fissureOpened = false;
   let completed = false;
   let completeTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Travel ends with the bottle's BOTTOM edge sitting at the slot line, so
-  // the whole bottle hovers visibly above the fissure right before plunge.
-  const travelEndY = slotSceneY + CARD_H_PX / 2;
 
   // Preserve the mesh's existing rotation (computeCardFit may have rotated it
   // to portrait). The travel wobble is ADDED to this base, never overwrites it.
@@ -364,12 +390,12 @@ export function playFinale(handles: FinaleHandles): { dispose: () => void } {
     if (phase === "travel") {
       const t = clamp((now - startTime) / T_TRAVEL, 0, 1);
       const e = easeInOutCubic(t);
-      const baseTx = THREE.MathUtils.lerp(0, slotSceneX, e);
+      const baseTx = THREE.MathUtils.lerp(0, targetX, e);
       const baseTy = THREE.MathUtils.lerp(0, travelEndY, e);
       const arc = Math.sin(e * Math.PI) * Math.min(160, vh * 0.18);
       mesh.position.set(baseTx, baseTy + arc, 0);
       // Gentle wobble added on top of the portrait base rotation
-      mesh.rotation.z = baseRotZ + Math.sin(e * Math.PI) * 0.1 * Math.sign(slotSceneX);
+      mesh.rotation.z = baseRotZ + Math.sin(e * Math.PI) * 0.1 * Math.sign(targetX);
       if (t >= 1) {
         phase = "plunge";
         plungeStart = now;
@@ -386,10 +412,10 @@ export function playFinale(handles: FinaleHandles): { dispose: () => void } {
     } else if (phase === "plunge") {
       const t = clamp((now - plungeStart) / T_PLUNGE, 0, 1);
       const e = easeInQuad(t);
-      // Descend so the bottle's bottom (currently at slot) sinks to
-      // CARD_H_PX + 20 below the slot — fully under the page.
-      const plungeDy = e * (CARD_H_PX + 20);
-      mesh.position.set(slotSceneX, travelEndY - plungeDy, 0);
+      // Descend so the bottle's bottom (currently at slot) sinks fully under
+      // the page (coil height + a screen-space margin, converted to world).
+      const plungeDy = e * (coilH + 24 / zoom);
+      mesh.position.set(targetX, travelEndY - plungeDy, 0);
       if (t >= 1) {
         phase = "done";
         fissure.close();


### PR DESCRIPTION
## Summary

Polish + fixes for the message-bottle sealing ceremony (follow-up to #189):

- **Textured outer roll** — the rolled-up message now shows the message texture and the author color stripe on its outer face (back material renders the shared canvas texture with a light grey tint), so the rolled card matches the on-page capsule instead of reading as blank white paper.
- **Seal-band beat** — a new animation beat: after the roll fits to card size, a band in the author's color snaps around the coil (spring `scaleX` sweep) like sealing an envelope, then fades as the bottle lifts into the finale.
- **Alignment fixes** — the finale's world↔screen mapping ignored `camera.zoom` (0.65 after the zoom-out), so the coil only traveled 65% of the way to the slot; and the coil winds around the paper's top edge, so it sits offset from the mesh origin. `playFinale` now converts slot coordinates through the zoom and corrects by the coil's bounding-box center, and `playSealBand` projects the coil bbox to screen the same way.

## Testing

- Verified with trusted-input Playwright runs on the social playground (`/social-playground/`): coil landing measured pixel-exact against the slot (`coil@screen {x:752, bottomY:432}` === slot `{752, 432}`), band rendered centered on the coil.
- Clean end-to-end ceremony run with zero console errors/warnings after removing debug instrumentation.
- `tsc` clean for the sealing files (remaining workspace errors are pre-existing and untouched).

No changeset: changes are under `extension/`, not `packages/`. No docs change: internal extension behavior, not library API. No `PENDING.md` bullet: bottles are behind a flag and not public yet.
