### PR TITLE
Coalesce can-mirror observer updates

### DIFF
--- a/.changeset/can-mirror-pacing.md
+++ b/.changeset/can-mirror-pacing.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Coalesce can-mirror DOM observer writes before syncing so many simultaneous element mutations send a single shared document update instead of one update per element.

--- a/packages/playhtml/src/__tests__/can-mirror-network-pacing.test.ts
+++ b/packages/playhtml/src/__tests__/can-mirror-network-pacing.test.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Covers can-mirror network pacing under many simultaneous DOM mutations.
+// ABOUTME: Verifies pixel-grid style changes coalesce before leaving the client.
+import { beforeEach, describe, expect, it } from "vitest";
+import { playhtml, resetPlayHTML } from "../index";
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+const flushFrame = () =>
+  new Promise<void>((resolve) => {
+    if (typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(() => setTimeout(resolve, 0));
+      return;
+    }
+    setTimeout(resolve, 0);
+  });
+
+function getMainProvider(): any {
+  const providers = (globalThis as any).PLAYHTML_TEST_PROVIDERS as any[];
+  const provider = providers?.[0];
+  if (!provider) throw new Error("Expected test provider");
+  return provider;
+}
+
+describe("can-mirror network pacing", () => {
+  beforeEach(async () => {
+    document.body.innerHTML = "";
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+  });
+
+  it("coalesces simultaneous element mutations into one document update", async () => {
+    await playhtml.init({
+      host: "http://localhost:1999",
+      room: "/can-mirror-network-pacing",
+      cursors: { enabled: false },
+    });
+
+    const pixels: HTMLElement[] = [];
+    for (let i = 0; i < 32; i++) {
+      const pixel = document.createElement("div");
+      pixel.id = `pixel-${i}`;
+      pixel.setAttribute("can-mirror", "");
+      document.body.appendChild(pixel);
+      pixels.push(pixel);
+      await playhtml.setupPlayElementForTag(pixel, "can-mirror");
+    }
+    await flush();
+
+    const provider = getMainProvider();
+    provider.ws.send.mockClear();
+
+    for (const pixel of pixels) {
+      pixel.classList.add("writing");
+      pixel.style.opacity = "0.5";
+    }
+
+    await flushFrame();
+    await flush();
+
+    expect(provider.ws.send).toHaveBeenCalledTimes(1);
+    for (const pixel of pixels) {
+      expect(playhtml.syncedStore["can-mirror"][pixel.id].attributes.class).toBe(
+        "writing",
+      );
+      expect(
+        playhtml.syncedStore["can-mirror"][pixel.id].attributes.style,
+      ).toContain("opacity: 0.5");
+    }
+  });
+});

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Covers ElementHandler state, awareness, event data, and setup behavior.
+// ABOUTME: Verifies handler-level write semantics used by playhtml capabilities.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ElementHandler } from "../elements";
 import type {
@@ -59,6 +61,38 @@ describe("ElementHandler", () => {
     expect(onChange).toHaveBeenCalledWith({ a: 2 });
     // Internal state only updates via __data setter (i.e., from sync layer)
     expect(handler.data).toEqual({ a: 1 });
+  });
+
+  it("can schedule setup setData writes without delaying public setData", () => {
+    const updateElement = vi.fn();
+    const onChange = vi.fn();
+    const onAwarenessChange = vi.fn();
+    const pendingWrites: Array<() => void> = [];
+
+    const handler = new ElementHandler({
+      element,
+      defaultData: { a: 1 },
+      updateElement,
+      onChange,
+      onAwarenessChange,
+      triggerAwarenessUpdate: () => {},
+      onMount: ({ setData }) => {
+        setData({ a: 2 });
+      },
+    } as unknown as ElementData, {
+      scheduleSetupDataWrite: (write) => {
+        pendingWrites.push(write);
+      },
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(pendingWrites).toHaveLength(1);
+
+    pendingWrites[0]();
+    expect(onChange).toHaveBeenCalledWith({ a: 2 });
+
+    handler.setData({ a: 3 });
+    expect(onChange).toHaveBeenLastCalledWith({ a: 3 });
   });
 
   it("notifies data update listeners when internal data changes", () => {

--- a/packages/playhtml/src/canMirrorDataQueue.ts
+++ b/packages/playhtml/src/canMirrorDataQueue.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Queues can-mirror observer data writes before they sync through Yjs.
+// ABOUTME: Keeps high-frequency DOM mutation bursts to one transaction per frame.
+import * as Y from "yjs";
+
+type PendingCanMirrorDataChange = {
+  targetDoc: Y.Doc;
+  apply: () => void;
+};
+
+export class CanMirrorDataQueue {
+  private pendingChanges: PendingCanMirrorDataChange[] = [];
+  private cancelFlush: (() => void) | null = null;
+  private readonly getDoc: () => Y.Doc;
+
+  constructor(getDoc: () => Y.Doc) {
+    this.getDoc = getDoc;
+  }
+
+  queue(apply: () => void): void {
+    this.pendingChanges.push({ targetDoc: this.getDoc(), apply });
+    this.requestFlush();
+  }
+
+  clear(): void {
+    if (this.cancelFlush) {
+      this.cancelFlush();
+      this.cancelFlush = null;
+    }
+    this.pendingChanges = [];
+  }
+
+  private flush(): void {
+    this.cancelFlush = null;
+    const changes = this.pendingChanges;
+    this.pendingChanges = [];
+    if (!changes.length) {
+      return;
+    }
+
+    const changesByDoc = new Map<Y.Doc, Array<() => void>>();
+    for (const change of changes) {
+      const docChanges = changesByDoc.get(change.targetDoc) ?? [];
+      docChanges.push(change.apply);
+      changesByDoc.set(change.targetDoc, docChanges);
+    }
+
+    for (const [targetDoc, docChanges] of changesByDoc) {
+      targetDoc.transact(() => {
+        for (const apply of docChanges) {
+          apply();
+        }
+      });
+    }
+  }
+
+  private requestFlush(): void {
+    if (this.cancelFlush) {
+      return;
+    }
+
+    const flush = () => this.flush();
+    if (typeof window.requestAnimationFrame === "function") {
+      const frame = window.requestAnimationFrame(flush);
+      this.cancelFlush = () => window.cancelAnimationFrame(frame);
+      return;
+    }
+
+    const timeout = window.setTimeout(flush, 0);
+    this.cancelFlush = () => window.clearTimeout(timeout);
+  }
+}

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Defines ElementHandler, the runtime controller for each playhtml element.
+// ABOUTME: Handles event wiring, rendering, local state, shared writes, and teardown.
 /// <reference lib="dom"/>
 import { render } from "lit-html";
 import {
@@ -17,6 +19,12 @@ const debounce = (fn: Function, ms = 300) => {
     timeoutId = setTimeout(() => fn.apply(this, args), ms);
   };
 };
+
+type ElementDataWrite<T> = T | ((draft: T) => void);
+
+interface ElementHandlerOptions {
+  scheduleSetupDataWrite?: (write: () => void) => void;
+}
 
 // TODO: turn this into just an extension of HTMLElement and initialize all the methods / do all the state tracking
 // on the element itself??
@@ -53,6 +61,7 @@ export class ElementHandler<T = any, U = any, V = any> {
   onAfterRender?: (element: HTMLElement) => void;
   private descendantObserver?: MutationObserver;
   private dataUpdateListeners = new Set<() => void>();
+  private scheduleSetupDataWrite?: (write: () => void) => void;
 
   // event handlers
   onClick?: (
@@ -68,7 +77,10 @@ export class ElementHandler<T = any, U = any, V = any> {
     eventData: ElementEventHandlerData<T, U, V>
   ) => void;
 
-  constructor(elementData: ElementData<T>) {
+  constructor(
+    elementData: ElementData<T>,
+    options: ElementHandlerOptions = {},
+  ) {
     const {
       element,
       onChange,
@@ -87,6 +99,7 @@ export class ElementHandler<T = any, U = any, V = any> {
       devMode,
     } = elementData;
     // console.log("🔨 constructing ", element.id);
+    this.scheduleSetupDataWrite = options.scheduleSetupDataWrite;
     this.element = element;
     this.view = view;
     this.devMode = devMode;
@@ -433,11 +446,22 @@ export class ElementHandler<T = any, U = any, V = any> {
       getData: () => this.data,
       getLocalData: () => this.localData,
       getAwareness: () => this.awareness,
-      setData: (newData) => this.setData(newData),
+      setData: (newData) => this.setSetupData(newData),
       setLocalData: (newData) => this.setLocalData(newData),
       setMyAwareness: (newData) => this.setMyAwareness(newData),
       requestUpdate: () => this.requestUpdate(),
     };
+  }
+
+  private setSetupData(data: ElementDataWrite<T>): void {
+    if (!this.scheduleSetupDataWrite) {
+      this.setData(data);
+      return;
+    }
+    if (this.rejectWriteDuringRender("setData")) return;
+    this.scheduleSetupDataWrite(() => {
+      this.onChange(data as unknown as T);
+    });
   }
 
   /**
@@ -463,7 +487,7 @@ export class ElementHandler<T = any, U = any, V = any> {
    * - Directly mutating eventData.data may work in SyncedStore mode, but the
    *   recommended portable pattern is setData(draft => { ... }).
    */
-  setData(data: T | ((draft: T) => void)): void {
+  setData(data: ElementDataWrite<T>): void {
     // Writing shared data from inside a view render is a re-render loop:
     // the write triggers another render, which writes again. Reject it.
     if (this.rejectWriteDuringRender("setData")) return;

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -56,6 +56,7 @@ import {
   canUseRealtimePresenceTransport,
   RealtimePresenceTransport,
 } from "./presence-transport";
+import { CanMirrorDataQueue } from "./canMirrorDataQueue";
 
 const DefaultPartykitHost = "playhtml.spencerc99.workers.dev";
 const StagingPartykitHost = "playhtml-staging.spencerc99.workers.dev";
@@ -332,6 +333,7 @@ let eventHandlers: Map<string, Array<RegisteredPlayEvent>> = new Map<
 // Tracks elements currently being updated due to remote SyncedStore/Yjs updates.
 // Allows us to distinguish programmatic remote-applied changes from local user writes.
 const remoteApplyingKeys: Set<string> = new Set();
+const canMirrorDataQueue = new CanMirrorDataQueue(() => doc);
 const selectorIdsToAvailableIdx = new Map<string, number>();
 let eventCount = 0;
 export type CursorRoom =
@@ -825,6 +827,7 @@ function teardownMainProvider(): void {
  * through their ensureProxy/attachObserver re-acquire path.
  */
 function recreateStore(): void {
+  canMirrorDataQueue.clear();
   const oldDoc = doc;
 
   store = syncedStore<StoreShape>({ play: {} });
@@ -1465,6 +1468,39 @@ function markAllElementsAsReady(): void {
   }
 }
 
+function applyElementDataChange<TData>(
+  elementId: string,
+  dataProxy: TData,
+  newData: TData | ((draft: TData) => void),
+): void {
+  if (typeof newData === "function") {
+    const returned = (newData as (draft: unknown) => unknown)(dataProxy);
+    // Only warn when the return looks like an intended *replacement*
+    // snapshot (an object/array). Terse arrows like `d => d.count++` or
+    // `d => (d.x = 1)` return a number/boolean as a side effect of a
+    // valid in-place mutation — warning on those is just noise.
+    if (
+      isDevelopmentMode &&
+      returned !== undefined &&
+      typeof returned === "object"
+    ) {
+      console.warn(
+        `[playhtml] A setData() mutator for "${elementId}" returned an object. ` +
+          `Mutators must mutate the draft in place (e.g. \`d => { d.count++ }\`); ` +
+          `the return value is ignored. To replace the whole snapshot, pass a value instead of a function.`,
+      );
+    }
+    return;
+  }
+
+  deepReplaceIntoProxy(dataProxy, newData);
+}
+
+function canWriteElementData(element: HTMLElement): boolean {
+  const elementIdFromAttr = getIdForElement(element);
+  return !isSharedReadOnly(element, elementIdFromAttr);
+}
+
 function createPlayElementData<T extends TagType, TData = any>(
   element: HTMLElement,
   tag: T,
@@ -1506,37 +1542,13 @@ function createPlayElementData<T extends TagType, TData = any>(
     element,
     onChange: (newData: TData) => {
       // Prevent writes for read-only shared consumer elements
-      const elementIdFromAttr = getIdForElement(element);
-      if (isSharedReadOnly(element, elementIdFromAttr)) {
+      if (!canWriteElementData(element)) {
         return;
       }
-      if (typeof newData === "function") {
-        // Mutator form support: onChange can accept function(draft)
-        // Batch all nested mutations into a single Yjs transaction to coalesce events
-        doc.transact(() => {
-          const returned = (newData as (draft: unknown) => unknown)(dataProxy);
-          // Only warn when the return looks like an intended *replacement*
-          // snapshot (an object/array). Terse arrows like `d => d.count++` or
-          // `d => (d.x = 1)` return a number/boolean as a side effect of a
-          // valid in-place mutation — warning on those is just noise.
-          if (
-            isDevelopmentMode &&
-            returned !== undefined &&
-            typeof returned === "object"
-          ) {
-            console.warn(
-              `[playhtml] A setData() mutator for "${elementId}" returned an object. ` +
-                `Mutators must mutate the draft in place (e.g. \`d => { d.count++ }\`); ` +
-                `the return value is ignored. To replace the whole snapshot, pass a value instead of a function.`,
-            );
-          }
-        });
-      } else {
-        // Value form: replace snapshot semantics
-        doc.transact(() => {
-          deepReplaceIntoProxy(dataProxy, newData);
-        });
-      }
+
+      doc.transact(() => {
+        applyElementDataChange(elementId, dataProxy, newData);
+      });
     },
     onAwarenessChange: (elementAwarenessData) => {
       const awarenessProvider = getElementAwarenessProvider();
@@ -1895,6 +1907,7 @@ export async function resetPlayHTML(): Promise<void> {
   if (firstSetup && !initStarted) return;
 
   try {
+    canMirrorDataQueue.clear();
     if (navigationController) {
       navigationController.destroy();
       navigationController = null;
@@ -2191,7 +2204,12 @@ async function setupPlayElementForTag<T extends TagType | string>(
     attachSyncedStoreObserver(tag as string, elementId);
     return;
   } else {
-    const handler = new ElementHandler(elementData);
+    const handler = new ElementHandler(
+      elementData,
+      tag === TagType.CanMirror
+        ? { scheduleSetupDataWrite: (write) => canMirrorDataQueue.queue(write) }
+        : undefined,
+    );
     tagElementHandlers.set(elementId, handler);
     // View handlers can emit capability descendants (mount points for
     // `define`d capabilities / `register`ed ids). Bind the current children and

--- a/packages/playhtml/vitest.setup.ts
+++ b/packages/playhtml/vitest.setup.ts
@@ -47,16 +47,25 @@ vi.mock("y-partyserver/provider", () => {
       awareness: any;
       private listeners: Record<string, Function[]> = {};
       private clientId: number = 1;
+      private doc: any;
+      private docUpdateListener?: (update: Uint8Array) => void;
       roomname: string;
-      constructor(_host: string, room: string) {
+      constructor(_host: string, room: string, doc?: any) {
         if ((globalThis as any).PLAYHTML_TEST_PROVIDER_THROW) {
           throw new Error("test provider init failure");
         }
         this.roomname = room;
+        this.doc = doc;
         this.ws = {
           send: vi.fn(),
           addEventListener: vi.fn(),
         } as any;
+        if (this.doc && typeof this.doc.on === "function") {
+          this.docUpdateListener = (update: Uint8Array) => {
+            this.ws?.send(update as any);
+          };
+          this.doc.on("update", this.docUpdateListener);
+        }
         const states = new Map<number, any>();
         const local = { state: {} as any };
         this.awareness = {
@@ -89,6 +98,13 @@ vi.mock("y-partyserver/provider", () => {
         (this.listeners[t] || []).forEach((cb) => cb(...args));
       }
       destroy() {
+        if (
+          this.doc &&
+          this.docUpdateListener &&
+          typeof this.doc.off === "function"
+        ) {
+          this.doc.off("update", this.docUpdateListener);
+        }
         this.listeners = {};
       }
     },


### PR DESCRIPTION
## Summary

- Coalesce `can-mirror` DOM observer writes before syncing so many simultaneous element mutations flush as one Yjs transaction per frame.
- Keep direct handler `setData` immediate so explicit programmatic updates still apply synchronously.
- Add a network-pacing regression that verifies many mirrored pixel mutations produce one outbound document update instead of one per element.

## Root Cause

The skywriting example has 2,000 `can-mirror` elements and a 100ms fade loop over `.writing` pixels. Each mirrored pixel owned its own observer, and each observer write became its own Yjs document update. That could exceed the server's per-connection websocket message rate before the server could do useful batching.

## Validation

- Fetched the live GitHub Pages example and confirmed it matches the pasted 40x50 pixel reproduction.
- `bun run test` in `packages/playhtml` (350 tests)
- `bun run build` in `packages/playhtml`

No docs or starter-template changes: this is runtime pacing only and does not change public API or usage.