### PR TITLE
Allow awareness-only can-play elements

### DIFF
--- a/.changeset/calm-awareness-pairs.md
+++ b/.changeset/calm-awareness-pairs.md
@@ -1,0 +1,7 @@
+---
+"playhtml": patch
+"@playhtml/common": patch
+"@playhtml/react": patch
+---
+
+Allow `can-play` elements to render from element awareness alone when `myDefaultAwareness` is paired with `updateElementAwareness`, and report incomplete initializer pairs with specific diagnostics.

--- a/apps/docs/src/content/docs/custom-elements.mdx
+++ b/apps/docs/src/content/docs/custom-elements.mdx
@@ -200,7 +200,6 @@ Most capability tags can share the same element. Each tag keeps its own data and
   import { playhtml } from "playhtml";
 
   const el = document.getElementById("online");
-  el.defaultData = {};
   el.myDefaultAwareness = "#2563eb";
   el.updateElementAwareness = ({ element, awareness }) => {
     element.replaceChildren(

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -126,9 +126,7 @@ In vanilla `can-play`, element awareness appears on the element handler data:
 
 <script>
   const element = document.getElementById("presence-count");
-  element.defaultData = {};
   element.myDefaultAwareness = { color: "#3b82f6" };
-  element.updateElement = () => {};
   element.onClick = (_event, { setMyAwareness }) => {
     setMyAwareness({ color: "#f97316" });
   };

--- a/apps/docs/src/content/docs/reference/element-api.md
+++ b/apps/docs/src/content/docs/reference/element-api.md
@@ -66,7 +66,7 @@ Everything you can set on `can-play` (same object for `register`, `define`, and 
 {
   // Starting shared state for elements that render from shared data. Must be
   // an object (or a function that returns one) — not a bare number or string.
-  // Synced across the room. Pair with updateElement or view.
+  // Synced across the room. Must be paired with updateElement or view.
   defaultData: { count: 0 },
   // defaultData: (element) => ({ color: element.dataset.color }),
 
@@ -304,7 +304,7 @@ When an element has both `can-play` and a built-in capability (e.g. `can-move`),
 
 At registration time, playhtml checks:
 
-- `defaultData`, when present, is an object or a function and is paired with `updateElement` **or** `view`
+- `defaultData` and `updateElement` / `view` are provided together
 - `myDefaultAwareness`, when present, is paired with `updateElementAwareness`
 - At least one update function exists: `updateElement`, `view`, or `updateElementAwareness`
 - `register` / `define` throw if both `view` and `updateElement` are set, or if `view` is combined with `onClick` / `onDrag` / `onDragStart`

--- a/apps/docs/src/content/docs/reference/element-api.md
+++ b/apps/docs/src/content/docs/reference/element-api.md
@@ -64,18 +64,20 @@ Everything you can set on `can-play` (same object for `register`, `define`, and 
 
 ```js
 {
-  // Required. Starting shared state. Must be an object (or a function that
-  // returns one) — not a bare number or string. Synced across the room.
+  // Starting shared state for elements that render from shared data. Must be
+  // an object (or a function that returns one) — not a bare number or string.
+  // Synced across the room. Pair with updateElement or view.
   defaultData: { count: 0 },
   // defaultData: (element) => ({ color: element.dataset.color }),
 
   // Per-user, per-tab state. Never synced. Drag anchors, drafts, UI flags.
   defaultLocalData: undefined,
 
-  // Your starting awareness value for this element. Ephemeral — clears on disconnect.
+  // Your starting awareness value for this element. Ephemeral — clears on
+  // disconnect. Pair with updateElementAwareness.
   myDefaultAwareness: undefined,
 
-  // --- update path: provide updateElement OR view, not both ---
+  // --- data update path: provide updateElement OR view, not both ---
 
   updateElement(ctx) {
     // ctx — see Callback context above. Write the DOM from ctx.data.
@@ -89,7 +91,7 @@ Everything you can set on `can-play` (same object for `register`, `define`, and 
   },
 
   updateElementAwareness(ctx) {
-    // ctx — Callback context + myAwareness
+    // ctx — Callback context + myAwareness. Pair with myDefaultAwareness.
   },
 
   // --- event handlers (ignored when using view) ---
@@ -302,8 +304,9 @@ When an element has both `can-play` and a built-in capability (e.g. `can-move`),
 
 At registration time, playhtml checks:
 
-- `defaultData` is present and is an object or a function
-- At least one update path exists: `updateElement` **or** `view`
+- `defaultData`, when present, is an object or a function and is paired with `updateElement` **or** `view`
+- `myDefaultAwareness`, when present, is paired with `updateElementAwareness`
+- At least one update function exists: `updateElement`, `view`, or `updateElementAwareness`
 - `register` / `define` throw if both `view` and `updateElement` are set, or if `view` is combined with `onClick` / `onDrag` / `onDragStart`
 
-If validation fails, the element is skipped and a console warning lists the missing fields.
+If validation fails, the element is skipped and a console error lists the missing or invalid pair.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -24,7 +24,8 @@ export interface ElementInitializer<T = any, U = any, V = any> {
   myDefaultAwareness?: V | ((element: HTMLElement) => V);
   /**
    * Imperative update path: receives the current state and mutates the DOM
-   * directly. Required with `defaultData` unless `view` is provided.
+   * directly. Pair with `defaultData`; use `view` instead for declarative
+   * rendering.
    * `view` and `updateElement` are mutually exclusive — providing both is a
    * registration-time error.
    */

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,13 +19,14 @@ export * from "./presence-protocol";
 export type ViewTemplate = unknown;
 
 export interface ElementInitializer<T = any, U = any, V = any> {
-  defaultData: T | ((element: HTMLElement) => T);
+  defaultData?: T | ((element: HTMLElement) => T);
   defaultLocalData?: U | ((element: HTMLElement) => U);
   myDefaultAwareness?: V | ((element: HTMLElement) => V);
   /**
    * Imperative update path: receives the current state and mutates the DOM
-   * directly. Required unless `view` is provided. `view` and `updateElement`
-   * are mutually exclusive — providing both is a registration-time error.
+   * directly. Required with `defaultData` unless `view` is provided.
+   * `view` and `updateElement` are mutually exclusive — providing both is a
+   * registration-time error.
    */
   updateElement?: (data: ElementEventHandlerData<T, U, V>) => void;
   /**
@@ -41,6 +42,9 @@ export interface ElementInitializer<T = any, U = any, V = any> {
    * @experimental New and subject to change in a future minor release.
    */
   view?: (data: ElementEventHandlerData<T, U, V>) => ViewTemplate;
+  /**
+   * Imperative awareness update path. Required with `myDefaultAwareness`.
+   */
   updateElementAwareness?: (
     data: ElementAwarenessEventHandlerData<T, U, V>,
   ) => void;

--- a/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
@@ -110,6 +110,7 @@ describe("element awareness sync", () => {
     (el as any).defaultData = {};
     (el as any).myDefaultAwareness = { hovering: false };
     (el as any).updateElement = vi.fn();
+    (el as any).updateElementAwareness = vi.fn();
     document.body.appendChild(el);
     await playhtml.setupPlayElementForTag(el, "can-play");
 
@@ -150,6 +151,7 @@ describe("element awareness sync", () => {
     (el as any).defaultData = {};
     (el as any).myDefaultAwareness = { active: false };
     (el as any).updateElement = vi.fn();
+    (el as any).updateElementAwareness = vi.fn();
     document.body.appendChild(el);
     await playhtml.setupPlayElementForTag(el, "can-play");
 

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -138,6 +138,11 @@ describe("playhtml basic setup with SyncedStore", () => {
         message: "defaultData requires updateElement or view",
       },
       {
+        id: "render-without-data",
+        props: { updateElement: vi.fn() },
+        message: "updateElement or view requires defaultData",
+      },
+      {
         id: "awareness-without-render",
         props: { myDefaultAwareness: { seated: false } },
         message: "myDefaultAwareness requires updateElementAwareness",

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -92,20 +92,72 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(el.style.transform).toBe("translate(0px, 0px)");
   });
 
-  it("reports missing can-play initializer properties", () => {
+  it("sets up can-play elements that only render awareness", async () => {
     const el = document.createElement("div");
-    el.id = "incomplete-widget";
+    el.id = "presence-only-widget";
     el.setAttribute("can-play", "");
+    (el as any).myDefaultAwareness = { seated: false };
+    (el as any).updateElementAwareness = vi.fn(({ element, myAwareness }) => {
+      element.setAttribute("data-seated", String(myAwareness?.seated));
+    });
     document.body.appendChild(el);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    playhtml.setupPlayElement(el);
+    await playhtml.setupPlayElementForTag(el, "can-play");
 
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "Missing or invalid initializer properties: defaultData, updateElement or view.",
-      ),
+    expect(errorSpy).not.toHaveBeenCalled();
+    const handler = playhtml
+      .elementHandlers!.get("can-play")!
+      .get("presence-only-widget");
+    expect(handler).toBeTruthy();
+
+    (el as any).updateElementAwareness.mockClear();
+    handler!.setMyAwareness({ seated: true });
+
+    expect((el as any).updateElementAwareness).toHaveBeenCalledWith(
+      expect.objectContaining({
+        myAwareness: { seated: true },
+      }),
     );
+  });
+
+  it("reports incomplete can-play initializer pairs", () => {
+    const cases: Array<{
+      id: string;
+      props: Record<string, unknown>;
+      message: string;
+    }> = [
+      {
+        id: "empty-widget",
+        props: {},
+        message: "updateElement, view, or updateElementAwareness",
+      },
+      {
+        id: "data-without-render",
+        props: { defaultData: {} },
+        message: "defaultData requires updateElement or view",
+      },
+      {
+        id: "awareness-without-render",
+        props: { myDefaultAwareness: { seated: false } },
+        message: "myDefaultAwareness requires updateElementAwareness",
+      },
+    ];
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    for (const { id, props, message } of cases) {
+      const el = document.createElement("div");
+      el.id = id;
+      el.setAttribute("can-play", "");
+      Object.assign(el, props);
+      document.body.appendChild(el);
+
+      playhtml.setupPlayElement(el);
+
+      expect(errorSpy).toHaveBeenLastCalledWith(
+        expect.stringContaining(message),
+      );
+    }
   });
 
   it("handles awareness changes per element (no updateElementAwareness)", async () => {

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -121,6 +121,31 @@ describe("playhtml basic setup with SyncedStore", () => {
     );
   });
 
+  it("sets up can-play elements with awareness updates and no default awareness", async () => {
+    const el = document.createElement("div");
+    el.id = "external-presence-widget";
+    el.setAttribute("can-play", "");
+    (el as any).updateElementAwareness = vi.fn();
+    document.body.appendChild(el);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await playhtml.setupPlayElementForTag(el, "can-play");
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    const handler = playhtml
+      .elementHandlers!.get("can-play")!
+      .get("external-presence-widget");
+    expect(handler).toBeTruthy();
+
+    handler!.setMyAwareness({ active: true });
+
+    expect((el as any).updateElementAwareness).toHaveBeenCalledWith(
+      expect.objectContaining({
+        myAwareness: { active: true },
+      }),
+    );
+  });
+
   it("reports incomplete can-play initializer pairs", () => {
     const cases: Array<{
       id: string;
@@ -138,8 +163,23 @@ describe("playhtml basic setup with SyncedStore", () => {
         message: "defaultData requires updateElement or view",
       },
       {
+        id: "data-with-awareness-render-only",
+        props: { defaultData: {}, updateElementAwareness: vi.fn() },
+        message: "defaultData requires updateElement or view",
+      },
+      {
         id: "render-without-data",
         props: { updateElement: vi.fn() },
+        message: "updateElement or view requires defaultData",
+      },
+      {
+        id: "view-without-data",
+        props: { view: vi.fn() },
+        message: "updateElement or view requires defaultData",
+      },
+      {
+        id: "render-with-awareness-render-without-data",
+        props: { updateElement: vi.fn(), updateElementAwareness: vi.fn() },
         message: "updateElement or view requires defaultData",
       },
       {
@@ -147,10 +187,30 @@ describe("playhtml basic setup with SyncedStore", () => {
         props: { myDefaultAwareness: { seated: false } },
         message: "myDefaultAwareness requires updateElementAwareness",
       },
+      {
+        id: "awareness-with-data-render-only",
+        props: {
+          defaultData: {},
+          updateElement: vi.fn(),
+          myDefaultAwareness: { seated: false },
+        },
+        message: "myDefaultAwareness requires updateElementAwareness",
+      },
+      {
+        id: "primitive-default-data",
+        props: { defaultData: 0, updateElement: vi.fn() },
+        message: "defaultData must be an object or function",
+      },
+      {
+        id: "null-default-data",
+        props: { defaultData: null, updateElement: vi.fn() },
+        message: "defaultData must be an object or function",
+      },
     ];
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     for (const { id, props, message } of cases) {
+      const callCount = errorSpy.mock.calls.length;
       const el = document.createElement("div");
       el.id = id;
       el.setAttribute("can-play", "");
@@ -159,6 +219,7 @@ describe("playhtml basic setup with SyncedStore", () => {
 
       playhtml.setupPlayElement(el);
 
+      expect(errorSpy).toHaveBeenCalledTimes(callCount + 1);
       expect(errorSpy).toHaveBeenLastCalledWith(
         expect.stringContaining(message),
       );

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Manages per-element playhtml handlers, state updates, rendering, and events.
+// ABOUTME: Bridges shared data, local data, awareness, and DOM capability callbacks.
 /// <reference lib="dom"/>
 import { render } from "lit-html";
 import {
@@ -21,7 +23,7 @@ const debounce = (fn: Function, ms = 300) => {
 // TODO: turn this into just an extension of HTMLElement and initialize all the methods / do all the state tracking
 // on the element itself??
 export class ElementHandler<T = any, U = any, V = any> {
-  defaultData: T;
+  defaultData: T | undefined;
   localData: U;
   awareness: V[] = [];
   awarenessByStableId: Map<string, V> = new Map();
@@ -115,8 +117,8 @@ export class ElementHandler<T = any, U = any, V = any> {
       this.setMyAwareness(myInitialAwareness);
     }
     // Needed to get around the typescript error even though it is assigned in __data.
-    this._data = initialData;
-    this.__data = initialData;
+    this._data = initialData as T;
+    this.__data = initialData as T;
 
     this.reinitializeElementData(elementData);
 
@@ -499,6 +501,7 @@ export class ElementHandler<T = any, U = any, V = any> {
    * Resets the element to its default state.
    */
   reset() {
+    if (this.defaultData === undefined) return;
     this.setData(this.defaultData);
   }
 }

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1605,6 +1605,8 @@ function getElementInitializerValidationIssues(
 
   if (hasDefaultData && !hasDataUpdate) {
     issues.push("defaultData requires updateElement or view");
+  } else if (!hasDefaultData && hasDataUpdate) {
+    issues.push("updateElement or view requires defaultData");
   }
 
   if (hasMyDefaultAwareness && !hasUpdateElementAwareness) {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1480,12 +1480,10 @@ function createPlayElementData<T extends TagType, TData = any>(
       ? tagInfo.defaultData(element)
       : tagInfo.defaultData;
 
-  // Always use SyncedStore proxy
-  const dataProxy = ensureElementProxy<TData>(
-    tag,
-    elementId,
-    initialData as TData,
-  );
+  const dataProxy =
+    tagInfo.defaultData === undefined
+      ? undefined
+      : ensureElementProxy<TData>(tag, elementId, initialData as TData);
   const initialAwareness = getElementAwareness(tag, elementId);
 
   const elementData: ElementData = {
@@ -1505,6 +1503,12 @@ function createPlayElementData<T extends TagType, TData = any>(
           : undefined,
     element,
     onChange: (newData: TData) => {
+      if (dataProxy === undefined) {
+        console.error(
+          `[playhtml] setData() was called for "${elementId}", but its initializer does not define \`defaultData\`.`,
+        );
+        return;
+      }
       // Prevent writes for read-only shared consumer elements
       const elementIdFromAttr = getIdForElement(element);
       if (isSharedReadOnly(element, elementIdFromAttr)) {
@@ -1581,21 +1585,34 @@ function getElementInitializerValidationIssues(
   }
 
   const issues: string[] = [];
-  if (
-    tagInfo.defaultData === undefined ||
-    (typeof tagInfo.defaultData !== "object" &&
-      typeof tagInfo.defaultData !== "function")
-  ) {
-    issues.push("defaultData");
+
+  const hasDefaultData = tagInfo.defaultData !== undefined;
+  const hasValidDefaultData =
+    hasDefaultData &&
+    (typeof tagInfo.defaultData === "object" ||
+      typeof tagInfo.defaultData === "function");
+  const hasUpdateElement = typeof tagInfo.updateElement === "function";
+  const hasView = typeof tagInfo.view === "function";
+  const hasDataUpdate = hasUpdateElement || hasView;
+  const hasMyDefaultAwareness = tagInfo.myDefaultAwareness !== undefined;
+  const hasUpdateElementAwareness =
+    typeof tagInfo.updateElementAwareness === "function";
+  const hasUpdateFunction = hasDataUpdate || hasUpdateElementAwareness;
+
+  if (hasDefaultData && !hasValidDefaultData) {
+    issues.push("defaultData must be an object or function");
   }
 
-  // A valid initializer needs an update path: the imperative `updateElement`
-  // or the declarative `view`.
-  if (
-    typeof tagInfo.updateElement !== "function" &&
-    typeof tagInfo.view !== "function"
-  ) {
-    issues.push("updateElement or view");
+  if (hasDefaultData && !hasDataUpdate) {
+    issues.push("defaultData requires updateElement or view");
+  }
+
+  if (hasMyDefaultAwareness && !hasUpdateElementAwareness) {
+    issues.push("myDefaultAwareness requires updateElementAwareness");
+  }
+
+  if (issues.length === 0 && !hasUpdateFunction) {
+    issues.push("updateElement, view, or updateElementAwareness");
   }
 
   return issues;
@@ -2470,11 +2487,12 @@ export interface PlayElementHandle<T = any, U = any, V = any> {
 const pendingRegistrations = new Map<string, ElementInitializer>();
 
 /**
- * Enforces the `view` invariants: a `view` cannot coexist with the imperative
- * `updateElement` or with element-level event handlers, and an initializer
- * must provide at least one update path.
+ * Enforces initializer invariants before register/define stores a capability.
  */
-function validateViewInitializer(name: string, init: ElementInitializer): void {
+function validateRegisteredInitializer(
+  name: string,
+  init: ElementInitializer,
+): void {
   if (init.view && init.updateElement) {
     throw new Error(
       `[playhtml] "${name}" defines both \`view\` and \`updateElement\`. They are mutually exclusive — pick one.`,
@@ -2484,11 +2502,6 @@ function validateViewInitializer(name: string, init: ElementInitializer): void {
     throw new Error(
       `[playhtml] "${name}" defines \`view\` alongside an element event handler (onClick/onDrag/onDragStart). ` +
         `In view mode, attach events inside the template (e.g. \`@click=\${...}\`) instead.`,
-    );
-  }
-  if (!init.view && !init.updateElement) {
-    throw new Error(
-      `[playhtml] "${name}" must define either \`view\` or \`updateElement\`.`,
     );
   }
   // Shared data must be an object (or a factory returning one), never a bare
@@ -2502,6 +2515,12 @@ function validateViewInitializer(name: string, init: ElementInitializer): void {
     throw new Error(
       `[playhtml] "${name}" has a non-object \`defaultData\`. Use an object ` +
         `(e.g. \`{ count: 0 }\`) so the shape can grow without a data migration.`,
+    );
+  }
+  const issues = getElementInitializerValidationIssues(init);
+  if (issues.length > 0) {
+    throw new Error(
+      `[playhtml] "${name}" has an invalid initializer: ${issues.join(", ")}.`,
     );
   }
 }
@@ -2611,7 +2630,7 @@ function registerPlayElement<T = any, U = any, V = any>(
   elementId: string,
   init: ElementInitializer<T, U, V>,
 ): PlayElementHandle<T, U, V> {
-  validateViewInitializer(elementId, init as ElementInitializer);
+  validateRegisteredInitializer(elementId, init as ElementInitializer);
   pendingRegistrations.set(elementId, init as ElementInitializer);
   applyPendingRegistration(elementId);
   if (isDevelopmentMode && hasSynced && !document.getElementById(elementId)) {
@@ -2654,7 +2673,7 @@ function definePlayCapability<T = any, U = any, V = any>(
       `[playhtml] "${capabilityName}" is a built-in capability and cannot be redefined.`,
     );
   }
-  validateViewInitializer(capabilityName, init as ElementInitializer);
+  validateRegisteredInitializer(capabilityName, init as ElementInitializer);
   capabilitiesToInitializer[capabilityName] = init as ElementInitializer;
   // Upgrade any elements already on the page (no-op before init()).
   if (hasSynced) {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1589,6 +1589,7 @@ function getElementInitializerValidationIssues(
   const hasDefaultData = tagInfo.defaultData !== undefined;
   const hasValidDefaultData =
     hasDefaultData &&
+    tagInfo.defaultData !== null &&
     (typeof tagInfo.defaultData === "object" ||
       typeof tagInfo.defaultData === "function");
   const hasUpdateElement = typeof tagInfo.updateElement === "function";

--- a/packages/react/src/elements.tsx
+++ b/packages/react/src/elements.tsx
@@ -101,7 +101,7 @@ export function CanToggleElement({
     readOnly?: boolean;
   }) {
   return (
-    <CanPlayElement
+    <CanPlayElement<any>
       // @ts-ignore
       tagInfo={[TagType.CanToggle]}
       {...TagTypeToElement[TagType.CanToggle]}


### PR DESCRIPTION
## Summary

- allow `can-play` initializers to be valid when they render only element awareness via `updateElementAwareness`
- make initializer diagnostics specific about incomplete `defaultData` and `myDefaultAwareness` pairs
- reject data render paths (`updateElement` / `view`) that omit `defaultData`
- reject `null` / primitive `defaultData` in setup-time validation
- update the public element API docs and awareness examples to avoid placeholder shared data for awareness-only elements
- add changesets for `playhtml`, `@playhtml/common`, and `@playhtml/react`

## Root Cause

The setup guard always required `defaultData` plus `updateElement` or `view`, so an element that only declared `myDefaultAwareness` and `updateElementAwareness` was rejected even though awareness rendering is a valid update path. The validation also needed to report both sides of the data pair: `defaultData` without a data render path, and a data render path without `defaultData`.

## Validation

- `packages/common`: `bun run build`
- `packages/playhtml`: focused initializer validation test
- `packages/playhtml`: `bun run test` (34 files / 351 tests)
- `packages/playhtml`: `bun run build`
- `packages/react`: `bun run test` (6 files / 43 tests)
- `packages/react`: `bun run build`
- `apps/docs`: `bun run build`
- `git diff --check`

## Review Follow-up

Addressed Spencer's review note that data update functions without `defaultData` were not being reported as invalid. Then expanded setup-time coverage across empty, data-only, render-only, awareness-only, mixed invalid-pair, primitive default, and null default cases.