### PR TITLE
Fix Firefox session coordination and packaging compatibility

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - The inventory shortcut moved to Ctrl+Shift+B on Windows/Linux (Cmd+Shift+I on Mac is unchanged), freeing Ctrl+Shift+E for an in-progress emote wheel.
+- Firefox now keeps one reliable browser-session identity without adding warnings to webpage consoles.
 
 <!--
 Add a bullet here in any PR that changes the extension itself (extension/src/**

--- a/extension/scripts/validateExtensionBuild.mjs
+++ b/extension/scripts/validateExtensionBuild.mjs
@@ -70,6 +70,10 @@ export async function validateExtensionBuild(buildDir) {
   const missingResources = [];
   let buildFiles;
 
+  if (manifest.options_ui?.open_in_tab !== true) {
+    throw new Error("Extension manifest options_ui.open_in_tab must be true");
+  }
+
   for (const resource of resources) {
     if (hasResourcePattern(resource)) {
       buildFiles ??= await collectBuildFiles(buildDir);

--- a/extension/scripts/validateExtensionBuild.test.mjs
+++ b/extension/scripts/validateExtensionBuild.test.mjs
@@ -21,7 +21,16 @@ async function makeBuildDir(manifest) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "extension-build-"));
   tempDirs.push(dir);
   await mkdir(path.join(dir, "content-scripts"), { recursive: true });
-  await writeFile(path.join(dir, "manifest.json"), JSON.stringify(manifest));
+  await writeFile(
+    path.join(dir, "manifest.json"),
+    JSON.stringify({
+      options_ui: {
+        page: "options.html",
+        open_in_tab: true,
+      },
+      ...manifest,
+    }),
+  );
   return dir;
 }
 
@@ -77,4 +86,28 @@ test("passes when web accessible resource patterns match build files", async () 
   await writeFile(path.join(dir, "inventory/bottle.svg"), "");
 
   await expect(validateExtensionBuild(dir)).resolves.toBeUndefined();
+});
+
+test("throws when the options page is not configured to open in a tab", async () => {
+  const dir = await makeBuildDir({
+    manifest_version: 2,
+    options_ui: {
+      page: "options.html",
+    },
+  });
+
+  await expect(validateExtensionBuild(dir)).rejects.toThrow(
+    /options_ui\.open_in_tab must be true/,
+  );
+});
+
+test("throws when the options page is missing from the manifest", async () => {
+  const dir = await makeBuildDir({
+    manifest_version: 2,
+    options_ui: undefined,
+  });
+
+  await expect(validateExtensionBuild(dir)).rejects.toThrow(
+    /options_ui\.open_in_tab must be true/,
+  );
 });

--- a/extension/src/__tests__/EventBuffer.test.ts
+++ b/extension/src/__tests__/EventBuffer.test.ts
@@ -4,12 +4,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import browser from "webextension-polyfill";
 import { EventBuffer } from "../storage/EventBuffer";
-import { getParticipantId, getSessionId } from "../storage/participant";
+import { getParticipantId, requestSessionId } from "../storage/participant";
 import type { CollectionEvent } from "../collectors/types";
 
 const participantMocks = vi.hoisted(() => ({
   getParticipantId: vi.fn().mockResolvedValue("test-participant-id"),
-  getSessionId: vi.fn().mockResolvedValue("test-session-id"),
+  requestSessionId: vi.fn().mockResolvedValue("test-session-id"),
   getTimezone: vi.fn().mockReturnValue("America/New_York"),
 }));
 
@@ -44,7 +44,7 @@ describe("EventBuffer", () => {
     vi.useFakeTimers();
     vi.mocked(browser.runtime.sendMessage).mockResolvedValue({});
     vi.mocked(getParticipantId).mockResolvedValue("test-participant-id");
-    vi.mocked(getSessionId).mockResolvedValue("test-session-id");
+    vi.mocked(requestSessionId).mockResolvedValue("test-session-id");
   });
 
   afterEach(() => {
@@ -142,7 +142,7 @@ describe("EventBuffer", () => {
     await buffer.createEvent("viewport", { event: "scroll", scrollY: 0.3 });
 
     expect(getParticipantId).toHaveBeenCalledTimes(1);
-    expect(getSessionId).toHaveBeenCalledTimes(1);
+    expect(requestSessionId).toHaveBeenCalledTimes(1);
   });
 
   it("does not cache temporary participant IDs", async () => {

--- a/extension/src/__tests__/background-retention.test.ts
+++ b/extension/src/__tests__/background-retention.test.ts
@@ -11,7 +11,8 @@ const browserMock = vi.hoisted(() => ({
         getBytesInUse: vi.fn().mockResolvedValue(1024),
       },
     session: {
-      setAccessLevel: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue({ collection_session_id: "sid_background" }),
+      set: vi.fn().mockResolvedValue(undefined),
     },
   },
   runtime: {
@@ -131,5 +132,22 @@ describe("background local retention", () => {
         countsByType: { cursor: 1, keyboard: 1 },
       },
     });
+  });
+
+  it("returns the background-owned browser session id", async () => {
+    const background = await import("../entrypoints/background");
+
+    const startBackground = background.default as unknown as () => void;
+    startBackground();
+
+    const messageListener =
+      browserMock.runtime.onMessage.addListener.mock.calls[0]?.[0];
+    const reply = vi.fn();
+
+    const keepAlive = messageListener?.({ type: "GET_SESSION_ID" }, {}, reply);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(keepAlive).toBe(true);
+    expect(reply).toHaveBeenCalledWith("sid_background");
   });
 });

--- a/extension/src/__tests__/background-upload.test.ts
+++ b/extension/src/__tests__/background-upload.test.ts
@@ -68,9 +68,6 @@ describe("background upload flushing", () => {
             set: vi.fn().mockResolvedValue(undefined),
             remove: vi.fn().mockResolvedValue(undefined),
           },
-          session: {
-            setAccessLevel: vi.fn().mockResolvedValue(undefined),
-          },
         },
         runtime: {
           onInstalled: { addListener: vi.fn() },

--- a/extension/src/__tests__/collectors.integration.test.ts
+++ b/extension/src/__tests__/collectors.integration.test.ts
@@ -23,7 +23,7 @@ vi.mock("../storage/sync", () => ({
 
 vi.mock("../storage/participant", () => ({
   getParticipantId: vi.fn().mockResolvedValue("test-pid"),
-  getSessionId: vi.fn().mockResolvedValue("test-sid"),
+  requestSessionId: vi.fn().mockResolvedValue("test-sid"),
   getTimezone: vi.fn().mockReturnValue("America/New_York"),
 }));
 

--- a/extension/src/__tests__/participant.test.ts
+++ b/extension/src/__tests__/participant.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Verifies participant/session identity fallbacks for Firefox API gaps.
-// ABOUTME: Covers missing crypto.randomUUID and missing browser.storage.session.
+// ABOUTME: Verifies participant identity fallbacks and browser-session coordination.
+// ABOUTME: Covers shared session IDs, background requests, and Web Crypto gaps.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,6 +19,52 @@ function installCryptoWithoutRandomUuid(): void {
   });
 }
 
+function installSequentialCrypto(): void {
+  let nextId = 0;
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: {
+      randomUUID: () => `00000000-0000-4000-8000-${String(++nextId).padStart(12, "0")}`,
+    } as Pick<Crypto, "randomUUID">,
+  });
+}
+
+function installBrowser(options: {
+  sessionStorage?: Record<string, unknown> | null;
+  sendMessage?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const sessionStorage = options.sessionStorage === undefined ? {} : options.sessionStorage;
+  const get = vi.fn(async (keys: string[]) => {
+    const result: Record<string, unknown> = {};
+    for (const key of keys) {
+      if (sessionStorage && key in sessionStorage) {
+        result[key] = sessionStorage[key];
+      }
+    }
+    return result;
+  });
+  const set = vi.fn(async (items: Record<string, unknown>) => {
+    if (sessionStorage) Object.assign(sessionStorage, items);
+  });
+  const sendMessage = options.sendMessage ?? vi.fn().mockResolvedValue("sid_background");
+
+  vi.doMock("webextension-polyfill", () => ({
+    default: {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({}),
+        },
+        ...(sessionStorage ? { session: { get, set } } : {}),
+      },
+      runtime: {
+        sendMessage,
+      },
+    },
+  }));
+
+  return { get, set, sendMessage };
+}
+
 describe("participant storage fallbacks", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -32,18 +78,44 @@ describe("participant storage fallbacks", () => {
     });
   });
 
-  it("uses a stable in-memory sid when browser.storage.session is unavailable", async () => {
+  it("returns the stored browser session id", async () => {
+    const storage = { collection_session_id: "sid_existing" };
+    const { set } = installBrowser({ sessionStorage: storage });
+
+    const { getSessionId } = await import("../storage/participant");
+
+    expect(await getSessionId()).toBe("sid_existing");
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it("shares one created id across concurrent requests", async () => {
+    installSequentialCrypto();
+    const storage: Record<string, unknown> = {};
+    const { get, set } = installBrowser({ sessionStorage: storage });
+
+    const { getSessionId } = await import("../storage/participant");
+    const [first, second] = await Promise.all([getSessionId(), getSessionId()]);
+
+    expect(first).toBe(second);
+    expect(storage.collection_session_id).toBe(first);
+    expect(get).toHaveBeenCalledOnce();
+    expect(set).toHaveBeenCalledOnce();
+  });
+
+  it("requests the coordinated session id from the background", async () => {
+    const sendMessage = vi.fn().mockResolvedValue("sid_background");
+    installBrowser({ sendMessage });
+
+    const { requestSessionId } = await import("../storage/participant");
+
+    expect(await requestSessionId()).toBe("sid_background");
+    expect(sendMessage).toHaveBeenCalledWith({ type: "GET_SESSION_ID" });
+  });
+
+  it("keeps one background fallback when privileged session storage fails", async () => {
     installCryptoWithoutRandomUuid();
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    vi.doMock("webextension-polyfill", () => ({
-      default: {
-        storage: {
-          local: {
-            get: vi.fn().mockResolvedValue({}),
-          },
-        },
-      },
-    }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    installBrowser({ sessionStorage: null });
 
     const { getSessionId } = await import("../storage/participant");
     const first = await getSessionId();
@@ -51,9 +123,10 @@ describe("participant storage fallbacks", () => {
 
     expect(first.startsWith("sid_")).toBe(true);
     expect(first).toBe(second);
-    expect(warn).toHaveBeenCalledOnce();
-    expect(warn).toHaveBeenCalledWith(
-      "[Participant] browser.storage.session unavailable; using in-memory session id",
+    expect(error).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith(
+      "[Participant] Failed to access browser session storage:",
+      expect.any(Error),
     );
   });
 

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -25,6 +25,8 @@ export function ProfilePage({ playerIdentity, onBack, onIdentityUpdated }: Props
   const [copied, setCopied] = useState(false);
   const [saving, setSaving] = useState(false);
   const colorInputRef = useRef<HTMLInputElement>(null);
+  // Firefox closes extension toolbar panels when an OS-level color picker opens.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1378527
   const opensNativePickerInPopup = !import.meta.env.FIREFOX;
 
   const hasColorChanged = color !== savedColor;

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -32,6 +32,8 @@ const LOCAL_RETENTION_LAST_RUN_KEY = 'localRetentionLastRun'
 let localRetentionRunning = false
 
 async function getBrowserStorageUsageBytes(): Promise<number | null> {
+  // Firefox ESR 140 omits storage.local.getBytesInUse, so this remains optional.
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/getBytesInUse
   const storageArea = browser.storage.local as typeof browser.storage.local & {
     getBytesInUse?: (keys?: string | string[] | null) => Promise<number>
   }

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -18,6 +18,7 @@ import {
   recordToastShown,
 } from '../milestones/state'
 import { checkAllMilestones, pxToMiles } from '../milestones/milestones'
+import { getSessionId } from '../storage/participant'
 
 const store = new LocalEventStore()
 const LOCAL_RAW_EVENT_RETENTION_ENABLED = false
@@ -126,11 +127,6 @@ async function runLocalRetention(options: { force?: boolean } = {}): Promise<voi
 }
 
 export default defineBackground(() => {
-  // Allow content scripts to access storage.session (needed for session IDs)
-  (browser.storage.session as any).setAccessLevel?.({
-    accessLevel: 'TRUSTED_AND_UNTRUSTED_CONTEXTS',
-  }).catch(() => {});
-
   // Storage durability is provided by the `unlimitedStorage` permission
   // declared in wxt.config.ts — Chromium's quota manager exempts extensions
   // with this permission from both quota caps and automatic eviction.
@@ -313,6 +309,11 @@ export default defineBackground(() => {
   // Cross-site messaging coordination
   browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const reply = sendResponse as (response?: any) => void;
+    if (message.type === 'GET_SESSION_ID') {
+      getSessionId().then(reply)
+      return true
+    }
+
     if (message.type === 'GET_PLAYER_IDENTITY') {
       getPlayerIdentity().then(reply)
       return true // Will respond asynchronously

--- a/extension/src/entrypoints/options/index.html
+++ b/extension/src/entrypoints/options/index.html
@@ -1,8 +1,11 @@
+<!-- ABOUTME: Defines the extension options page document and React mount point. -->
+<!-- ABOUTME: Configures setup to open in a dedicated browser tab. -->
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="manifest.open_in_tab" content="true" />
     <title>we were online — Setup</title>
   </head>
   <body>

--- a/extension/src/storage/EventBuffer.ts
+++ b/extension/src/storage/EventBuffer.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Collects browser events, buffers them in memory, and delegates storage and
 // ABOUTME: upload to the background service worker via browser.runtime.sendMessage
 import type { CollectionEvent, CollectionEventType } from '../collectors/types';
-import { getParticipantId, getSessionId, getTimezone } from './participant';
+import { getParticipantId, requestSessionId, getTimezone } from './participant';
 import { VERBOSE } from '../config';
 import browser from 'webextension-polyfill';
 
@@ -133,7 +133,7 @@ export class EventBuffer {
     if (!this.metadataBasePromise) {
       this.metadataBasePromise = Promise.all([
         getParticipantId(),
-        getSessionId(),
+        requestSessionId(),
       ]).then(([pid, sid]) => ({
         pid,
         sid,

--- a/extension/src/storage/participant.ts
+++ b/extension/src/storage/participant.ts
@@ -4,7 +4,7 @@
 import browser from 'webextension-polyfill';
 
 let fallbackSessionId: string | null = null;
-let warnedAboutMissingSessionStorage = false;
+let sessionIdPromise: Promise<string> | null = null;
 
 function createUuidLikeId(): string {
   if (typeof crypto?.randomUUID === 'function') {
@@ -51,32 +51,17 @@ export async function getParticipantId(): Promise<string> {
 
 const SESSION_ID_KEY = 'collection_session_id';
 
-/**
- * Get or create session ID.
- * Uses browser.storage.session so it resets when the browser closes.
- */
-export async function getSessionId(): Promise<string> {
+async function readOrCreateSessionId(): Promise<string> {
   const sessionStorage = (browser.storage as { session?: typeof browser.storage.local }).session;
-  const supportsSessionStorage =
-    typeof sessionStorage?.get === 'function' && typeof sessionStorage?.set === 'function';
-
-  if (!supportsSessionStorage) {
-    // Firefox can omit storage.session in content scripts. Keep one in-memory
-    // fallback ID so event creation keeps working instead of failing per emit.
-    if (!fallbackSessionId) {
-      fallbackSessionId = createPrefixedId('sid_');
-    }
-    if (!warnedAboutMissingSessionStorage) {
-      warnedAboutMissingSessionStorage = true;
-      console.warn('[Participant] browser.storage.session unavailable; using in-memory session id');
-    }
-    return fallbackSessionId;
-  }
 
   try {
+    if (!sessionStorage) {
+      throw new Error('browser.storage.session unavailable');
+    }
+
     const result = await sessionStorage.get([SESSION_ID_KEY]);
 
-    if (result[SESSION_ID_KEY]) {
+    if (typeof result[SESSION_ID_KEY] === 'string') {
       return result[SESSION_ID_KEY];
     }
 
@@ -84,12 +69,34 @@ export async function getSessionId(): Promise<string> {
     await sessionStorage.set({ [SESSION_ID_KEY]: sessionId });
     return sessionId;
   } catch (error) {
-    console.error('Failed to get session ID:', error);
+    console.error('[Participant] Failed to access browser session storage:', error);
     if (!fallbackSessionId) {
       fallbackSessionId = createPrefixedId('sid_');
     }
     return fallbackSessionId;
   }
+}
+
+/**
+ * Get or create the background-owned browser session ID.
+ * Uses browser.storage.session so it resets when the browser closes.
+ */
+export function getSessionId(): Promise<string> {
+  if (!sessionIdPromise) {
+    sessionIdPromise = readOrCreateSessionId();
+  }
+  return sessionIdPromise;
+}
+
+/**
+ * Request the browser session ID from the background context.
+ */
+export async function requestSessionId(): Promise<string> {
+  const sessionId = await browser.runtime.sendMessage({ type: 'GET_SESSION_ID' });
+  if (typeof sessionId !== 'string' || !sessionId.startsWith('sid_')) {
+    throw new Error('Background returned an invalid session ID');
+  }
+  return sessionId;
 }
 
 /**

--- a/extension/src/storage/participant.ts
+++ b/extension/src/storage/participant.ts
@@ -52,7 +52,9 @@ export async function getParticipantId(): Promise<string> {
 const SESSION_ID_KEY = 'collection_session_id';
 
 async function readOrCreateSessionId(): Promise<string> {
-  const sessionStorage = (browser.storage as { session?: typeof browser.storage.local }).session;
+  const sessionStorage = (browser.storage as unknown as {
+    session?: Pick<typeof browser.storage.local, 'get' | 'set'>;
+  }).session;
 
   try {
     if (!sessionStorage) {

--- a/extension/vitest.setup.ts
+++ b/extension/vitest.setup.ts
@@ -103,5 +103,6 @@ vi.mock("../config", () => ({
 vi.mock("../storage/participant", () => ({
   getParticipantId: vi.fn().mockResolvedValue("test-participant-id"),
   getSessionId: vi.fn().mockResolvedValue("test-session-id"),
+  requestSessionId: vi.fn().mockResolvedValue("test-session-id"),
   getTimezone: vi.fn().mockReturnValue("America/New_York"),
 }));

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -29,11 +29,6 @@ export default defineConfig({
         matches: ["<all_urls>"],
       },
     ],
-    // Add options page to host first-time setup
-    options_ui: {
-      page: "options.html",
-      open_in_tab: true,
-    },
     browser_specific_settings: {
       gecko: {
         id: "we-were-online@spencerchang.com",


### PR DESCRIPTION
## Summary

- coordinate one browser-session ID in the background and serve it to content scripts over runtime messaging
- remove the Chromium-only `storage.session.setAccessLevel` dependency and the Firefox webpage-console warning
- declare `options_ui.open_in_tab` through WXT entrypoint metadata and validate it in generated manifests
- document retained Firefox compatibility branches with direct Mozilla/MDN links

## Root cause

Firefox does not implement `StorageArea.setAccessLevel`, so content scripts could not access `browser.storage.session`. Each document fell back to its own in-memory session ID and logged a warning into the inspected page's console.

The compatibility audit also found that WXT reconstructs `options_ui` from the HTML entrypoint, which caused the value in `wxt.config.ts` to be dropped from generated manifests.

## User impact

Firefox now uses one stable session identity across tabs and navigations without adding warnings to webpage developer consoles. The setup page is also consistently opened in a dedicated tab in both generated browser manifests.

## Validation

- `bun run test -- --run`: 50 files, 334 tests passed
- Chrome MV3 production build passed
- Firefox MV2 production build and zip passed
- Chrome and Firefox generated-manifest validation passed
- `web-ext lint`: 0 errors, 17 pre-existing generated-bundle warnings
- Firefox 152.0.1 live smoke: temporary add-on installed, content page initialized, and the page console contained no `ConsoleAPI` or `PageError` messages
- `git diff --check cd1ebf95..HEAD` passed

The repository-wide type-check still reports unrelated existing errors in extension visualization/worker files and the WXT schema; no changed-code type error remains.