### PR TITLE
Multi-screen installation mode (wewere.online cursor field + synced cinematic zooms)

### DIFF
--- a/extension/website/archive/archive.tsx
+++ b/extension/website/archive/archive.tsx
@@ -1,54 +1,20 @@
 // ABOUTME: Historical browsing-portrait page (the archive view) at wewere.online/archive
 // ABOUTME: Fetches events from /events/recent and passes them to MovementCanvas for rendering
 import "../shared/portrait-styles.scss";
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import ReactDOM from "react-dom/client";
-import { CollectionEvent, DayCounts } from "../shared/types";
 import { MovementCanvas } from "../shared/components/MovementCanvas";
+import { DEFAULT_ACTIVE_VISUALIZATIONS } from "../shared/components/registry";
 import {
-  deriveRequiredEventTypes,
-  DEFAULT_ACTIVE_VISUALIZATIONS,
-} from "../shared/components/registry";
-import {
-  RECENT_EVENTS_URL,
-  DAILY_COUNTS_URL,
   parseFiltersFromUrl,
   parseVizFromUrl,
   parseDayFromUrl,
   parseTimeOfDayFromUrl,
 } from "../shared/config";
+import { useArchiveEvents } from "../shared/hooks/useArchiveEvents";
 import type { FilterChip } from "../shared/utils/eventUtils";
 
-const EVENTS_URL = RECENT_EVENTS_URL;
-
-/** For a `day` (YYYY-MM-DD) and a recurring time-of-day window (minutes from
- * LOCAL midnight ± radius), return the absolute UTC `from`/`to` ISO bounds that
- * bracket that window. The Date(year, month, day, ...) constructor interprets
- * its args in the viewer's LOCAL timezone, so adding the center/radius minutes
- * and calling toISOString() yields the correct UTC instants — this is how we
- * source "local midnight" footage without the day fetch's recency cap clipping
- * the early-UTC-day midnight events. Pads the window by 1 minute on each side so
- * the client-side ±radius filter has full coverage at the edges. */
-function midnightWindowBounds(
-  day: string,
-  centerMinutes: number,
-  radiusMinutes: number,
-): { from: string; to: string } {
-  const [y, m, d] = day.split("-").map(Number);
-  const localMidnight = new Date(y, m - 1, d, 0, 0, 0, 0);
-  const pad = 1;
-  const startMin = centerMinutes - radiusMinutes - pad;
-  const endMin = centerMinutes + radiusMinutes + pad;
-  const from = new Date(localMidnight.getTime() + startMin * 60_000);
-  const to = new Date(localMidnight.getTime() + endMin * 60_000);
-  return { from: from.toISOString(), to: to.toISOString() };
-}
-
 const InternetMovement = () => {
-  const [events, setEvents] = useState<CollectionEvent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [dayCounts, setDayCounts] = useState<DayCounts>(new Map());
   const [selectedDay, setSelectedDay] = useState<string | null>(
     () => parseDayFromUrl() ?? null,
   );
@@ -99,175 +65,12 @@ const InternetMovement = () => {
     localStorage.setItem("movement_active_viz", JSON.stringify(activeVisualizations));
   }, [activeVisualizations]);
 
-  // Track which event types we've already fetched so we only fetch missing ones
-  const fetchedTypesRef = useRef<Set<string>>(new Set());
-  // Track the last domain+day combo we fetched for so we know when to force refresh
-  const lastFetchKeyRef = useRef<string>("");
-
-  // Fetch daily counts for the heatmap calendar
-  useEffect(() => {
-    fetch(DAILY_COUNTS_URL)
-      .then((r) => {
-        if (!r.ok) throw new Error(`Failed to fetch daily counts: ${r.status}`);
-        return r.json();
-      })
-      .then((rows: { day: string; count: number }[]) => {
-        const map = new Map<string, number>();
-        for (const row of rows) {
-          map.set(row.day, row.count);
-        }
-        setDayCounts(map);
-      })
-      .catch((err) => {
-        console.error("Error fetching daily counts:", err);
-      });
-  }, []);
-
-  const fetchEvents = useCallback(
-    async (
-      day: string | null | undefined,
-      vizIds: string[],
-      domain: string = "",
-      forceRefresh = false,
-      tod: ReturnType<typeof parseTimeOfDayFromUrl> | null = null,
-    ) => {
-      const requiredTypes = deriveRequiredEventTypes(vizIds);
-
-      if (requiredTypes.size === 0) {
-        setLoading(false);
-        return;
-      }
-
-      // Force refresh when the filter context (day+domain+time-of-day) changed
-      const todKey = tod ? `${tod.centerMinutes}:${tod.radiusMinutes}` : "none";
-      const fetchKey = `${day ?? "all"}|${domain}|${todKey}`;
-      if (fetchKey !== lastFetchKeyRef.current) {
-        forceRefresh = true;
-        fetchedTypesRef.current = new Set();
-        lastFetchKeyRef.current = fetchKey;
-      }
-
-      // Determine which types we actually need to fetch
-      const typesToFetch = forceRefresh
-        ? requiredTypes
-        : new Set([...requiredTypes].filter((t) => !fetchedTypesRef.current.has(t)));
-
-      if (typesToFetch.size === 0) {
-        setLoading(false);
-        return;
-      }
-
-      setLoading(true);
-      setError(null);
-
-      try {
-        const buildUrl = (extraParams: Record<string, string>, type: string) => {
-          const params = new URLSearchParams(extraParams);
-          if (domain) params.set("domain", domain);
-          params.set("type", type);
-          return `${EVENTS_URL}?${params}`;
-        };
-
-        const fetchOne = (
-          extraParams: Record<string, string>,
-          type: string,
-        ): Promise<CollectionEvent[]> =>
-          fetch(buildUrl(extraParams, type)).then((r) => {
-            if (!r.ok)
-              throw new Error(`Failed to fetch ${type} events: ${r.status}`);
-            return r.json();
-          });
-
-        let fetched: CollectionEvent[] = [];
-        if (day && tod) {
-          // Time-of-day capture (e.g. the "midnight moment"): fetch the tight
-          // local time-of-day window directly. A whole-day fetch is recency-
-          // capped and returns the END of the UTC day, never reaching early-
-          // UTC-day instants like local midnight — so we must bracket the
-          // window's exact UTC bounds instead.
-          const { from, to } = midnightWindowBounds(
-            day,
-            tod.centerMinutes,
-            tod.radiusMinutes,
-          );
-          const results = await Promise.all(
-            [...typesToFetch].map((type) =>
-              fetchOne({ limit: "20000", from, to }, type),
-            ),
-          );
-          fetched = results.flat();
-        } else if (day) {
-          // Single-day fetch: scope tightly with the original limit.
-          const results = await Promise.all(
-            [...typesToFetch].map((type) =>
-              fetchOne(
-                {
-                  limit: "5000",
-                  from: day,
-                  to: `${day}T23:59:59Z`,
-                },
-                type,
-              ),
-            ),
-          );
-          fetched = results.flat();
-        } else {
-          // No-day fetch: one broad request per type, no date range. The
-          // worker returns the 20000 most recent matching events (its hard
-          // ceiling), which for typical domains covers months. The earlier
-          // 14-day × 800-per-day fan-out introduced a hidden cliff that
-          // capped visible history regardless of how much data existed —
-          // see the activity strip showing months while the canvas only
-          // rendered the most recent two weeks. (The activity strip's
-          // per-day counts come from a separate /events/daily-counts
-          // endpoint and are not affected by this change.)
-          const results = await Promise.all(
-            [...typesToFetch].map((type) =>
-              fetchOne({ limit: "20000" }, type).catch((err) => {
-                console.warn(`Failed to fetch ${type} events:`, err);
-                return [] as CollectionEvent[];
-              }),
-            ),
-          );
-          fetched = results.flat();
-        }
-
-        // Track what we've fetched
-        for (const t of typesToFetch) {
-          fetchedTypesRef.current.add(t);
-        }
-
-        if (forceRefresh) {
-          setEvents(fetched);
-        } else {
-          setEvents((prev) => [...prev, ...fetched]);
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fetch events");
-        console.error("Error fetching events:", err);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [],
-  );
-
-  // Refetch when the day, server-side domain, time-of-day window, or active
-  // visualizations change. time-of-day must refetch because the midnight window
-  // is fetched server-side (a tight from/to bracket), not just filtered
-  // client-side; active-viz changes fetch any missing event types. A single
-  // effect (rather than one per dependency group) so mount fires ONE fetch —
-  // two effects both ran on the first render, and the duplicate fetch's late
-  // resolution rebuilt the trail set and restarted the animation mid-reveal.
-  useEffect(() => {
-    fetchEvents(selectedDay, activeVisualizations, serverDomain, false, timeOfDay);
-  }, [selectedDay, serverDomain, timeOfDay, activeVisualizations]);
-
-  const handleRefresh = useCallback(() => {
-    fetchedTypesRef.current = new Set();
-    lastFetchKeyRef.current = "";
-    fetchEvents(selectedDay, activeVisualizations, serverDomain, true, timeOfDay);
-  }, [selectedDay, serverDomain, activeVisualizations, timeOfDay, fetchEvents]);
+  const { events, loading, error, dayCounts, refresh } = useArchiveEvents({
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+  });
 
   return (
     <>
@@ -292,7 +95,7 @@ const InternetMovement = () => {
         events={events}
         loading={loading}
         error={error}
-        fetchEvents={handleRefresh}
+        fetchEvents={refresh}
         dayCounts={dayCounts}
         selectedDay={selectedDay}
         onSelectDay={setSelectedDay}

--- a/extension/website/archive/saved.tsx
+++ b/extension/website/archive/saved.tsx
@@ -134,13 +134,12 @@ const InstallationPanel: React.FC<{ sourceUrl: string }> = ({ sourceUrl }) => {
     );
   };
 
-  // Opening many windows at once is a popup-blocker magnet, so open followers
-  // one click at a time (each open() is its own user gesture).
+  // Opening many windows at once is a popup-blocker magnet — the browser may
+  // block all but the first. Each screen also has its own open button below for
+  // that case (each click is its own user gesture).
   const openWindow = (url: string) => {
     window.open(url, "_blank", "noopener");
   };
-
-  const followerUrls = screens.filter((s) => s.role === "follower");
 
   return (
     <div
@@ -206,16 +205,14 @@ const InstallationPanel: React.FC<{ sourceUrl: string }> = ({ sourceUrl }) => {
           1 master + {followerCount} zoomed{" "}
           {followerCount === 1 ? "follower" : "followers"}
         </span>
-        {followerUrls.length > 0 && (
-          <button
-            type="button"
-            onClick={() => followerUrls.forEach((s) => openWindow(s.url))}
-            style={{ ...pillBtnStyle, marginLeft: "auto" }}
-            title="Open every follower window (allow popups if blocked)"
-          >
-            open all followers
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => screens.forEach((s) => openWindow(s.url))}
+          style={{ ...pillBtnStyle, marginLeft: "auto" }}
+          title="Open the master + every follower window (allow popups if blocked)"
+        >
+          open all screens
+        </button>
       </div>
 
       <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>

--- a/extension/website/archive/saved.tsx
+++ b/extension/website/archive/saved.tsx
@@ -9,6 +9,7 @@ import {
   subscribeSavedConfigs,
   type SavedConfig,
 } from "../shared/utils/savedConfigs";
+import { buildInstallationScreens } from "../shared/utils/installationUrls";
 
 interface ParsedMetadata {
   viz: string[];
@@ -105,6 +106,207 @@ const VizPill: React.FC<{ id: string }> = ({ id }) => (
   </span>
 );
 
+/** Inline multi-screen installation builder for one saved config. Turns the
+ * config's share URL into a master + N follower URLs (all same-origin so the
+ * BroadcastChannel clock/claims connect), with copy + open-in-new-window
+ * actions. The screens coordinate at runtime — no per-cursor setup here. */
+const InstallationPanel: React.FC<{ sourceUrl: string }> = ({ sourceUrl }) => {
+  const [followerCount, setFollowerCount] = useState(2);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const screens = useMemo(
+    () =>
+      buildInstallationScreens(
+        sourceUrl,
+        followerCount,
+        typeof window !== "undefined" ? window.location.origin : undefined,
+      ),
+    [sourceUrl, followerCount],
+  );
+
+  const copy = (url: string) => {
+    navigator.clipboard?.writeText(url).then(
+      () => {
+        setCopied(url);
+        window.setTimeout(() => setCopied((c) => (c === url ? null : c)), 1500);
+      },
+      () => {},
+    );
+  };
+
+  // Opening many windows at once is a popup-blocker magnet, so open followers
+  // one click at a time (each open() is its own user gesture).
+  const openWindow = (url: string) => {
+    window.open(url, "_blank", "noopener");
+  };
+
+  const followerUrls = screens.filter((s) => s.role === "follower");
+
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1",
+        marginTop: 12,
+        padding: "14px 16px",
+        borderRadius: 6,
+        background: "#f5f0e8",
+        border: "1px solid rgba(61,56,51,0.1)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+          marginBottom: 12,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "'Martian Mono', monospace",
+            fontSize: 11,
+            letterSpacing: "0.5px",
+            textTransform: "uppercase",
+            color: "#8a8279",
+          }}
+        >
+          follower screens
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <button
+            type="button"
+            onClick={() => setFollowerCount((n) => Math.max(0, n - 1))}
+            style={stepperBtnStyle}
+            title="Fewer follower screens"
+          >
+            −
+          </button>
+          <span
+            style={{
+              minWidth: 20,
+              textAlign: "center",
+              fontFamily: "'Martian Mono', monospace",
+              fontSize: 14,
+              color: "#3d3833",
+            }}
+          >
+            {followerCount}
+          </span>
+          <button
+            type="button"
+            onClick={() => setFollowerCount((n) => Math.min(8, n + 1))}
+            style={stepperBtnStyle}
+            title="More follower screens"
+          >
+            +
+          </button>
+        </div>
+        <span style={{ fontSize: 11, color: "#8a8279" }}>
+          1 master + {followerCount} zoomed{" "}
+          {followerCount === 1 ? "follower" : "followers"}
+        </span>
+        {followerUrls.length > 0 && (
+          <button
+            type="button"
+            onClick={() => followerUrls.forEach((s) => openWindow(s.url))}
+            style={{ ...pillBtnStyle, marginLeft: "auto" }}
+            title="Open every follower window (allow popups if blocked)"
+          >
+            open all followers
+          </button>
+        )}
+      </div>
+
+      <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {screens.map((s) => (
+          <li
+            key={s.label}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "6px 0",
+            }}
+          >
+            <span
+              style={{
+                minWidth: 96,
+                fontFamily: "'Martian Mono', monospace",
+                fontSize: 11,
+                letterSpacing: "0.3px",
+                color: s.role === "master" ? "#c4724e" : "#4a9a8a",
+              }}
+            >
+              {s.label}
+            </span>
+            <code
+              style={{
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                fontSize: 11,
+                color: "#5b8db8",
+                background: "#fdfcf9",
+                border: "1px solid rgba(61,56,51,0.08)",
+                borderRadius: 4,
+                padding: "4px 8px",
+              }}
+              title={s.url}
+            >
+              {s.url}
+            </code>
+            <button
+              type="button"
+              onClick={() => copy(s.url)}
+              style={pillBtnStyle}
+              title="Copy URL"
+            >
+              {copied === s.url ? "copied" : "copy"}
+            </button>
+            <button
+              type="button"
+              onClick={() => openWindow(s.url)}
+              style={pillBtnStyle}
+              title="Open in a new window"
+            >
+              open
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const stepperBtnStyle: React.CSSProperties = {
+  width: 24,
+  height: 24,
+  border: "1px solid rgba(61,56,51,0.18)",
+  borderRadius: 4,
+  background: "#fdfcf9",
+  color: "#3d3833",
+  fontSize: 16,
+  lineHeight: 1,
+  cursor: "pointer",
+};
+
+const pillBtnStyle: React.CSSProperties = {
+  border: "1px solid rgba(61,56,51,0.18)",
+  borderRadius: 999,
+  background: "#fdfcf9",
+  color: "#3d3833",
+  fontFamily: "'Martian Mono', monospace",
+  fontSize: 10,
+  letterSpacing: "0.3px",
+  textTransform: "uppercase",
+  padding: "4px 10px",
+  cursor: "pointer",
+  whiteSpace: "nowrap",
+};
+
 const SavedConfigsPage: React.FC = () => {
   const [configs, setConfigs] = useState<SavedConfig[]>(() =>
     loadSavedConfigs(),
@@ -112,6 +314,8 @@ const SavedConfigsPage: React.FC = () => {
   const [query, setQuery] = useState("");
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const confirmTimerRef = useRef<number | null>(null);
+  // Which config's multi-screen installation builder panel is expanded.
+  const [installOpenId, setInstallOpenId] = useState<string | null>(null);
 
   // Cross-tab sync: when the dev panel saves/deletes in another tab, this
   // page reflects the change without a manual reload.
@@ -387,35 +591,67 @@ const SavedConfigsPage: React.FC = () => {
                   </div>
                 </div>
 
-                <button
-                  type="button"
-                  onClick={() => handleDeleteClick(cfg.id)}
-                  title={
-                    confirming
-                      ? "Click again to confirm delete"
-                      : "Delete this saved config"
-                  }
-                  style={{
-                    background: confirming ? "#c4724e" : "transparent",
-                    color: confirming ? "#faf7f2" : "#8a8279",
-                    border: confirming
-                      ? "1px solid #c4724e"
-                      : "1px solid rgba(61,56,51,0.18)",
-                    borderRadius: 4,
-                    padding: confirming ? "4px 10px" : "2px 8px",
-                    fontSize: confirming ? 11 : 16,
-                    lineHeight: 1,
-                    fontFamily: confirming
-                      ? "'Martian Mono', monospace"
-                      : "inherit",
-                    letterSpacing: confirming ? "0.5px" : undefined,
-                    textTransform: confirming ? "uppercase" : undefined,
-                    cursor: "pointer",
-                    minWidth: confirming ? 80 : 28,
-                  }}
-                >
-                  {confirming ? "Confirm" : "×"}
-                </button>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setInstallOpenId((cur) =>
+                        cur === cfg.id ? null : cfg.id,
+                      )
+                    }
+                    title="Set up a multi-screen installation from this config"
+                    style={{
+                      background:
+                        installOpenId === cfg.id ? "#4a9a8a" : "transparent",
+                      color: installOpenId === cfg.id ? "#faf7f2" : "#4a9a8a",
+                      border: "1px solid #4a9a8a",
+                      borderRadius: 999,
+                      padding: "4px 10px",
+                      fontSize: 10,
+                      lineHeight: 1,
+                      fontFamily: "'Martian Mono', monospace",
+                      letterSpacing: "0.3px",
+                      textTransform: "uppercase",
+                      cursor: "pointer",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    ⧉ install
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteClick(cfg.id)}
+                    title={
+                      confirming
+                        ? "Click again to confirm delete"
+                        : "Delete this saved config"
+                    }
+                    style={{
+                      background: confirming ? "#c4724e" : "transparent",
+                      color: confirming ? "#faf7f2" : "#8a8279",
+                      border: confirming
+                        ? "1px solid #c4724e"
+                        : "1px solid rgba(61,56,51,0.18)",
+                      borderRadius: 4,
+                      padding: confirming ? "4px 10px" : "2px 8px",
+                      fontSize: confirming ? 11 : 16,
+                      lineHeight: 1,
+                      fontFamily: confirming
+                        ? "'Martian Mono', monospace"
+                        : "inherit",
+                      letterSpacing: confirming ? "0.5px" : undefined,
+                      textTransform: confirming ? "uppercase" : undefined,
+                      cursor: "pointer",
+                      minWidth: confirming ? 80 : 28,
+                    }}
+                  >
+                    {confirming ? "Confirm" : "×"}
+                  </button>
+                </div>
+
+                {installOpenId === cfg.id && (
+                  <InstallationPanel sourceUrl={cfg.url} />
+                )}
               </li>
             );
           })}

--- a/extension/website/installation/index.html
+++ b/extension/website/installation/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="we were online — multi-screen installation view"
+    />
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,200..900;1,200..900&family=Martian+Mono:wght@100..800&family=Lora:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>installation — we were online</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #faf9f6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./installation.tsx"></script>
+  </body>
+</html>

--- a/extension/website/installation/installation.tsx
+++ b/extension/website/installation/installation.tsx
@@ -12,7 +12,7 @@ import {
   parseDayFromUrl,
   parseTimeOfDayFromUrl,
 } from "../shared/config";
-import { useArchiveEvents } from "../shared/hooks/useArchiveEvents";
+import { useInstallationEvents } from "../shared/hooks/useInstallationEvents";
 import { useInstallationClock } from "../shared/hooks/useInstallationClock";
 
 /** A single installation screen. Every screen loads this page with the SAME
@@ -30,7 +30,7 @@ const Installation = () => {
     () => parseVizFromUrl() ?? DEFAULT_ACTIVE_VISUALIZATIONS,
   );
 
-  const { events, loading, error, refresh } = useArchiveEvents({
+  const { events, loading, error, refresh } = useInstallationEvents({
     selectedDay,
     timeOfDay,
     serverDomain: "",

--- a/extension/website/installation/installation.tsx
+++ b/extension/website/installation/installation.tsx
@@ -1,0 +1,58 @@
+// ABOUTME: Multi-screen installation view — one master window drives the animation
+// ABOUTME: clock; follower windows render zoomed (?cinematic=follow&follow=N) in sync.
+import "../shared/portrait-styles.scss";
+import React, { useState } from "react";
+import ReactDOM from "react-dom/client";
+import { MovementCanvas } from "../shared/components/MovementCanvas";
+import {
+  DEFAULT_ACTIVE_VISUALIZATIONS,
+} from "../shared/components/registry";
+import {
+  parseVizFromUrl,
+  parseDayFromUrl,
+  parseTimeOfDayFromUrl,
+} from "../shared/config";
+import { useArchiveEvents } from "../shared/hooks/useArchiveEvents";
+import { useInstallationClock } from "../shared/hooks/useInstallationClock";
+
+/** A single installation screen. Every screen loads this page with the SAME
+ * archive params (day/tod/viz/settings) so they render identical trail data;
+ * they differ only by `?role=` (master drives the clock, followers render it)
+ * and, on follower zoom screens, `?cinematic=follow&follow=N` to lock onto a
+ * specific cursor. Fetch + viz components are shared with the archive page — no
+ * forked logic. */
+const Installation = () => {
+  // URL is the single source of truth for an installation screen — no in-page
+  // controls, so these never change after mount.
+  const selectedDay = parseDayFromUrl() ?? null;
+  const timeOfDay = parseTimeOfDayFromUrl() ?? null;
+  const [activeVisualizations] = useState<string[]>(
+    () => parseVizFromUrl() ?? DEFAULT_ACTIVE_VISUALIZATIONS,
+  );
+
+  const { events, loading, error, refresh } = useArchiveEvents({
+    selectedDay,
+    timeOfDay,
+    serverDomain: "",
+    activeVisualizations,
+  });
+
+  const { getOverrideElapsedMs, broadcastElapsed } = useInstallationClock();
+
+  return (
+    <MovementCanvas
+      events={events}
+      loading={loading}
+      error={error}
+      fetchEvents={refresh}
+      activeVisualizations={activeVisualizations}
+      onSetActiveVisualizations={() => {}}
+      getOverrideElapsedMs={getOverrideElapsedMs}
+      onBroadcastElapsed={broadcastElapsed}
+    />
+  );
+};
+
+ReactDOM.createRoot(
+  document.getElementById("reactContent") as HTMLElement,
+).render(<Installation />);

--- a/extension/website/installation/installation.tsx
+++ b/extension/website/installation/installation.tsx
@@ -1,5 +1,5 @@
-// ABOUTME: Multi-screen installation view — one master window drives the animation
-// ABOUTME: clock; follower windows render zoomed (?cinematic=follow&follow=N) in sync.
+// ABOUTME: Multi-screen installation view — every window computes animation time from a
+// ABOUTME: shared wall-clock epoch; follower windows render zoomed (?cinematic=follow&follow=N) in sync.
 import "../shared/portrait-styles.scss";
 import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
@@ -17,8 +17,8 @@ import { useInstallationClock } from "../shared/hooks/useInstallationClock";
 
 /** A single installation screen. Every screen loads this page with the SAME
  * archive params (day/tod/viz/settings) so they render identical trail data;
- * they differ only by `?role=` (master drives the clock, followers render it)
- * and, on follower zoom screens, `?cinematic=follow&follow=N` to lock onto a
+ * they differ only by `?role=` (marks follower windows for cinematic follow
+ * coordination) and, on follower zoom screens, `?cinematic=follow&follow=N` to lock onto a
  * specific cursor. Fetch + viz components are shared with the archive page — no
  * forked logic. */
 const Installation = () => {
@@ -37,7 +37,7 @@ const Installation = () => {
     activeVisualizations,
   });
 
-  const { getOverrideElapsedMs, broadcastElapsed } = useInstallationClock();
+  const { getScaledElapsedMs } = useInstallationClock();
 
   return (
     <MovementCanvas
@@ -47,8 +47,7 @@ const Installation = () => {
       fetchEvents={refresh}
       activeVisualizations={activeVisualizations}
       onSetActiveVisualizations={() => {}}
-      getOverrideElapsedMs={getOverrideElapsedMs}
-      onBroadcastElapsed={broadcastElapsed}
+      getInstallationElapsedMs={getScaledElapsedMs}
     />
   );
 };

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -50,13 +50,11 @@ interface AnimatedTrailsProps {
   cinematicNextSignal?: number;
   // Multi-screen installation clock. When provided and it returns a non-null
   // number, that value is used as the RAW scaled-elapsed for this frame and the
-  // local accumulation is skipped — so a follower window renders the master's
-  // pushed time. Read each frame through this accessor (never as a raw value)
-  // so incoming messages don't re-run the animation-loop effect.
-  getOverrideElapsedMs?: () => number | null;
-  // Called each frame with the RAW pre-modulo scaled-elapsed when this window
-  // is NOT following an override, so a master can broadcast it.
-  onBroadcastElapsed?: (scaledElapsed: number) => void;
+  // local accumulation is skipped — every window computes the same time from a
+  // shared wall-clock epoch, so no window depends on another's rAF. Read each
+  // frame through this accessor (never as a raw value) so the clock's internal
+  // state changes don't re-run the animation-loop effect.
+  getInstallationElapsedMs?: (animationSpeed: number) => number | null;
   soundEngine?: SoundEngine | null;
   settings: {
     strokeWidth: number;
@@ -87,8 +85,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     documentSpace = false,
     cinematic = null,
     cinematicNextSignal = 0,
-    getOverrideElapsedMs,
-    onBroadcastElapsed,
+    getInstallationElapsedMs,
     soundEngine = null,
     settings,
   }) => {
@@ -189,12 +186,10 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     // Installation-clock accessors read by the rAF loop. Kept current via a
     // separate effect so the loop reads xxxRef.current and its dep array does
     // NOT include per-frame-changing values (which would restart the clock).
-    const getOverrideElapsedMsRef = useRef(getOverrideElapsedMs);
-    const onBroadcastElapsedRef = useRef(onBroadcastElapsed);
+    const getInstallationElapsedMsRef = useRef(getInstallationElapsedMs);
     useEffect(() => {
-      getOverrideElapsedMsRef.current = getOverrideElapsedMs;
-      onBroadcastElapsedRef.current = onBroadcastElapsed;
-    }, [getOverrideElapsedMs, onBroadcastElapsed]);
+      getInstallationElapsedMsRef.current = getInstallationElapsedMs;
+    }, [getInstallationElapsedMs]);
 
     const cameraRef = useRef<CinematicCamera | null>(null);
     if (cinematic && cameraRef.current === null) {
@@ -396,18 +391,20 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         const frameDelta = Math.min(250, timestamp - lastTimestamp);
         lastTimestamp = timestamp;
 
-        // Multi-screen installation: a follower renders the RAW scaled-elapsed
-        // pushed by the master this frame instead of accumulating its own, so a
-        // stutter self-corrects rather than drifting. A master (or standalone
-        // window) accumulates locally and broadcasts its value for followers.
-        const override = getOverrideElapsedMsRef.current?.() ?? null;
+        // Multi-screen installation: every window computes its OWN scaled-
+        // elapsed from a shared wall-clock epoch, so a throttled/backgrounded
+        // window just renders fewer FRAMES rather than falling behind — it
+        // jumps to the correct current time when refocused. Standalone windows
+        // (and the brief moment before an epoch is known) accumulate locally.
+        const inst =
+          getInstallationElapsedMsRef.current?.(animationSpeedRef.current) ??
+          null;
         let scaledElapsed: number;
-        if (override !== null) {
-          scaledElapsed = override;
+        if (inst !== null) {
+          scaledElapsed = inst;
         } else {
           accumulatedScaled += frameDelta * animationSpeedRef.current;
           scaledElapsed = accumulatedScaled;
-          onBroadcastElapsedRef.current?.(scaledElapsed);
         }
         const loopedElapsed = scaledElapsed % timeRange.duration;
 
@@ -694,12 +691,6 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
                 `${vb.x} ${vb.y} ${vb.w} ${vb.h}`,
               );
             }
-            // Surface the camera's current subject for dev/test tooling (used to
-            // verify multi-window coordination picks distinct cursors). Harmless
-            // no-op read for normal usage — just a number on window.
-            (
-              window as unknown as { __cameraSubjectIndex?: number | null }
-            ).__cameraSubjectIndex = camera.getCurrentSubjectIndex();
           }
         }
 

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -48,6 +48,15 @@ interface AnimatedTrailsProps {
   cinematic?: CinematicConfig | null;
   // Increment to ask the cinematic camera to jump to a new subject now.
   cinematicNextSignal?: number;
+  // Multi-screen installation clock. When provided and it returns a non-null
+  // number, that value is used as the RAW scaled-elapsed for this frame and the
+  // local accumulation is skipped — so a follower window renders the master's
+  // pushed time. Read each frame through this accessor (never as a raw value)
+  // so incoming messages don't re-run the animation-loop effect.
+  getOverrideElapsedMs?: () => number | null;
+  // Called each frame with the RAW pre-modulo scaled-elapsed when this window
+  // is NOT following an override, so a master can broadcast it.
+  onBroadcastElapsed?: (scaledElapsed: number) => void;
   soundEngine?: SoundEngine | null;
   settings: {
     strokeWidth: number;
@@ -78,6 +87,8 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     documentSpace = false,
     cinematic = null,
     cinematicNextSignal = 0,
+    getOverrideElapsedMs,
+    onBroadcastElapsed,
     soundEngine = null,
     settings,
   }) => {
@@ -174,6 +185,16 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
     useEffect(() => {
       cinematicRef.current = cinematic;
     }, [cinematic]);
+
+    // Installation-clock accessors read by the rAF loop. Kept current via a
+    // separate effect so the loop reads xxxRef.current and its dep array does
+    // NOT include per-frame-changing values (which would restart the clock).
+    const getOverrideElapsedMsRef = useRef(getOverrideElapsedMs);
+    const onBroadcastElapsedRef = useRef(onBroadcastElapsed);
+    useEffect(() => {
+      getOverrideElapsedMsRef.current = getOverrideElapsedMs;
+      onBroadcastElapsedRef.current = onBroadcastElapsed;
+    }, [getOverrideElapsedMs, onBroadcastElapsed]);
 
     const cameraRef = useRef<CinematicCamera | null>(null);
     if (cinematic && cameraRef.current === null) {
@@ -374,8 +395,20 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         // pause) doesn't accumulate a huge jump when the loop resumes.
         const frameDelta = Math.min(250, timestamp - lastTimestamp);
         lastTimestamp = timestamp;
-        accumulatedScaled += frameDelta * animationSpeedRef.current;
-        const scaledElapsed = accumulatedScaled;
+
+        // Multi-screen installation: a follower renders the RAW scaled-elapsed
+        // pushed by the master this frame instead of accumulating its own, so a
+        // stutter self-corrects rather than drifting. A master (or standalone
+        // window) accumulates locally and broadcasts its value for followers.
+        const override = getOverrideElapsedMsRef.current?.() ?? null;
+        let scaledElapsed: number;
+        if (override !== null) {
+          scaledElapsed = override;
+        } else {
+          accumulatedScaled += frameDelta * animationSpeedRef.current;
+          scaledElapsed = accumulatedScaled;
+          onBroadcastElapsedRef.current?.(scaledElapsed);
+        }
         const loopedElapsed = scaledElapsed % timeRange.duration;
 
         // Detect loop wrap

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -694,6 +694,12 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
                 `${vb.x} ${vb.y} ${vb.w} ${vb.h}`,
               );
             }
+            // Surface the camera's current subject for dev/test tooling (used to
+            // verify multi-window coordination picks distinct cursors). Harmless
+            // no-op read for normal usage — just a number on window.
+            (
+              window as unknown as { __cameraSubjectIndex?: number | null }
+            ).__cameraSubjectIndex = camera.getCurrentSubjectIndex();
           }
         }
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -377,12 +377,11 @@ interface MovementCanvasProps {
   live?: boolean;
   /** Live-stream connection status, gates the people-count readout. */
   connected?: boolean;
-  /** Multi-screen installation clock. When provided, a follower reads the
-   * master's pushed animation time each frame via `getOverrideElapsedMs`, and a
-   * master broadcasts its time via `onBroadcastElapsed`. Both optional so pages
-   * that don't run the installation are completely unaffected. */
-  getOverrideElapsedMs?: () => number | null;
-  onBroadcastElapsed?: (scaledElapsed: number) => void;
+  /** Multi-screen installation clock. When provided and it returns a non-null
+   * number, that value is used as the scaled-elapsed for the frame — every
+   * window computes the same time from a shared wall-clock epoch. Optional so
+   * pages that don't run the installation are completely unaffected. */
+  getInstallationElapsedMs?: (animationSpeed: number) => number | null;
 }
 
 export const MovementCanvas: React.FC<MovementCanvasProps> = ({
@@ -402,8 +401,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   defaultSoundEnabled = false,
   live = false,
   connected = false,
-  getOverrideElapsedMs,
-  onBroadcastElapsed,
+  getInstallationElapsedMs,
 }) => {
   const [settings, setSettings] = useState(loadSettings());
   const [controlsVisible, setControlsVisible] = useState(false);
@@ -1569,8 +1567,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               frozen={paused}
               cinematic={cinematicConfig}
               cinematicNextSignal={cinematicNextSignal}
-              getOverrideElapsedMs={getOverrideElapsedMs}
-              onBroadcastElapsed={onBroadcastElapsed}
+              getInstallationElapsedMs={getInstallationElapsedMs}
             />
           ))}
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -376,6 +376,12 @@ interface MovementCanvasProps {
   live?: boolean;
   /** Live-stream connection status, gates the people-count readout. */
   connected?: boolean;
+  /** Multi-screen installation clock. When provided, a follower reads the
+   * master's pushed animation time each frame via `getOverrideElapsedMs`, and a
+   * master broadcasts its time via `onBroadcastElapsed`. Both optional so pages
+   * that don't run the installation are completely unaffected. */
+  getOverrideElapsedMs?: () => number | null;
+  onBroadcastElapsed?: (scaledElapsed: number) => void;
 }
 
 export const MovementCanvas: React.FC<MovementCanvasProps> = ({
@@ -395,6 +401,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   defaultSoundEnabled = false,
   live = false,
   connected = false,
+  getOverrideElapsedMs,
+  onBroadcastElapsed,
 }) => {
   const [settings, setSettings] = useState(loadSettings());
   const [controlsVisible, setControlsVisible] = useState(false);
@@ -1543,6 +1551,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               frozen={paused}
               cinematic={cinematic}
               cinematicNextSignal={cinematicNextSignal}
+              getOverrideElapsedMs={getOverrideElapsedMs}
+              onBroadcastElapsed={onBroadcastElapsed}
             />
           ))}
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -31,6 +31,7 @@ import { useViewportScroll } from "../hooks/useViewportScroll";
 import { usePageMetaFallback } from "../hooks/usePageMetaFallback";
 import { useNavigationTimeline } from "../hooks/useNavigationTimeline";
 import { useNavigationRadial } from "../hooks/useNavigationRadial";
+import { useFollowerCoordination } from "../hooks/useFollowerCoordination";
 import {
   extractDomain,
   formatFilterChip,
@@ -411,6 +412,23 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   );
   // Bumped by the N key to ask the cinematic camera to swap subjects now.
   const [cinematicNextSignal, setCinematicNextSignal] = useState(0);
+
+  // Multi-screen coordination: when this window is a follower, `pickSubject`
+  // filters out cursors other followers are riding so no two screens follow the
+  // same cursor. Inert (identity-stable lowest-progress selector, no channel)
+  // for every other window. Injected into the cinematic config below.
+  const { isFollower, pickSubject } = useFollowerCoordination();
+
+  // Merge the coordination selector into the cinematic config in FOLLOW mode
+  // only. The camera gives `forcedSubjectIndex` (the `?follow=N` escape hatch)
+  // precedence over `pickSubject`, so this stays inert when a cursor is pinned.
+  // Memoized on the stable `cinematic`/`pickSubject` identities so the camera's
+  // setConfig isn't called every render (which would restart the follow state).
+  const cinematicConfig = useMemo<CinematicConfig | null>(() => {
+    if (!cinematic) return null;
+    if (!isFollower || cinematic.mode !== "follow") return cinematic;
+    return { ...cinematic, pickSubject };
+  }, [cinematic, isFollower, pickSubject]);
 
   /** When set, only events whose timestamp falls in [start, end) are passed
    * downstream to the visualization hooks. Used by the Hotspots dev tool to
@@ -1549,7 +1567,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               soundEngine={paused || !soundEnabled ? null : soundEngineReady}
               settings={trailAnimationSettings}
               frozen={paused}
-              cinematic={cinematic}
+              cinematic={cinematicConfig}
               cinematicNextSignal={cinematicNextSignal}
               getOverrideElapsedMs={getOverrideElapsedMs}
               onBroadcastElapsed={onBroadcastElapsed}

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -207,6 +207,18 @@ export function parseTimeOfDayFromUrl(): TimeOfDayFilter | undefined {
   return { centerMinutes, radiusMinutes };
 }
 
+/** `?role=master`/`follower` selects this window's part in the multi-screen
+ * installation clock. `master` broadcasts its animation time each frame;
+ * `follower` renders the master's pushed time instead of its own. Returns
+ * null when the param is absent (a standalone window drives its own clock). */
+export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
+  if (typeof window === "undefined") return null;
+  const raw = new URLSearchParams(window.location.search).get("role");
+  if (raw === "master") return "master";
+  if (raw === "follower") return "follower";
+  return null;
+}
+
 /** `?cinematic=1`/`follow` enables cursor-follow; `?cinematic=reveal` runs the
  * one-shot scripted pull-back (tight close-up → full canvas). Optional tuning:
  *   ?cinemaZoom=0.25        follow: fraction of screen width visible

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -219,6 +219,19 @@ export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
   return null;
 }
 
+/** `?follower=<id>` is the stable id a follower window uses to claim cursors in
+ * the coordinated auto-follow protocol (so no two follower screens ride the same
+ * cursor). Any non-empty string works (e.g. `a`, `b`, `1`, `2`). Returns null
+ * when absent — the coordination hook then falls back to a per-window random id
+ * so it still participates without a URL-set id. */
+export function parseFollowerIdFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  const raw = new URLSearchParams(window.location.search).get("follower");
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
 /** `?cinematic=1`/`follow` enables cursor-follow; `?cinematic=reveal` runs the
  * one-shot scripted pull-back (tight close-up → full canvas). Optional tuning:
  *   ?cinemaZoom=0.25        follow: fraction of screen width visible

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -227,6 +227,8 @@ export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
  *   ?cinemaVelZoom=0        follow: velocity-aware zoom-out (0 = off)
  *   ?cinemaReveal=10        reveal: seconds to pull back to full canvas
  *   ?cinemaStartZoom=0.18   reveal: fraction of screen width at the tightest
+ *   ?follow=5               follow: lock onto trail index 5 (only takes effect
+ *                           in follow mode; ignored by reveal)
  * Returns null when cinematic mode is not requested. */
 export function parseCinematicFromUrl(): CinematicConfig | null {
   if (typeof window === "undefined") return null;
@@ -242,6 +244,11 @@ export function parseCinematicFromUrl(): CinematicConfig | null {
   const velZoom = parseNumber(params.get("cinemaVelZoom"));
   const revealS = parseNumber(params.get("cinemaReveal"));
   const startZoom = parseNumber(params.get("cinemaStartZoom"));
+  const followRaw = parseNumber(params.get("follow"));
+  const forcedSubjectIndex =
+    followRaw !== undefined && Number.isInteger(followRaw) && followRaw >= 0
+      ? followRaw
+      : null;
 
   return {
     ...DEFAULT_CINEMATIC_CONFIG,
@@ -267,5 +274,6 @@ export function parseCinematicFromUrl(): CinematicConfig | null {
       startZoom !== undefined && startZoom > 0
         ? startZoom
         : DEFAULT_CINEMATIC_CONFIG.revealStartZoom,
+    forcedSubjectIndex,
   };
 }

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -207,10 +207,11 @@ export function parseTimeOfDayFromUrl(): TimeOfDayFilter | undefined {
   return { centerMinutes, radiusMinutes };
 }
 
-/** `?role=master`/`follower` selects this window's part in the multi-screen
- * installation clock. `master` broadcasts its animation time each frame;
- * `follower` renders the master's pushed time instead of its own. Returns
- * null when the param is absent (a standalone window drives its own clock). */
+/** `?role=master`/`follower` marks this window as part of the multi-screen
+ * installation. Both roles compute animation time from a shared wall-clock
+ * epoch; `follower` additionally participates in cinematic follow coordination.
+ * Returns null when the param is absent (a standalone window drives its own
+ * clock). */
 export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
   if (typeof window === "undefined") return null;
   const raw = new URLSearchParams(window.location.search).get("role");

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -1,0 +1,236 @@
+// ABOUTME: Fetches archived browsing events from /events/recent for the archive
+// ABOUTME: and installation pages, keyed by day + time-of-day + active viz.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CollectionEvent, DayCounts } from "../types";
+import { deriveRequiredEventTypes } from "../components/registry";
+import {
+  RECENT_EVENTS_URL,
+  DAILY_COUNTS_URL,
+  parseTimeOfDayFromUrl,
+} from "../config";
+
+const EVENTS_URL = RECENT_EVENTS_URL;
+
+type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
+
+/** For a `day` (YYYY-MM-DD) and a recurring time-of-day window (minutes from
+ * LOCAL midnight ± radius), return the absolute UTC `from`/`to` ISO bounds that
+ * bracket that window. The Date(year, month, day, ...) constructor interprets
+ * its args in the viewer's LOCAL timezone, so adding the center/radius minutes
+ * and calling toISOString() yields the correct UTC instants — this is how we
+ * source "local midnight" footage without the day fetch's recency cap clipping
+ * the early-UTC-day midnight events. Pads the window by 1 minute on each side so
+ * the client-side ±radius filter has full coverage at the edges. */
+function midnightWindowBounds(
+  day: string,
+  centerMinutes: number,
+  radiusMinutes: number,
+): { from: string; to: string } {
+  const [y, m, d] = day.split("-").map(Number);
+  const localMidnight = new Date(y, m - 1, d, 0, 0, 0, 0);
+  const pad = 1;
+  const startMin = centerMinutes - radiusMinutes - pad;
+  const endMin = centerMinutes + radiusMinutes + pad;
+  const from = new Date(localMidnight.getTime() + startMin * 60_000);
+  const to = new Date(localMidnight.getTime() + endMin * 60_000);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+export interface ArchiveEventsState {
+  events: CollectionEvent[];
+  loading: boolean;
+  error: string | null;
+  dayCounts: DayCounts;
+  /** Force a full refetch of the current day/tod/viz context. */
+  refresh: () => void;
+}
+
+/** Owns the archive event fetch. Given the current day, time-of-day window,
+ * server-side domain, and active visualizations, keeps `events` populated and
+ * fetches only the event types that are missing. Extracted from the archive
+ * page so the installation page shares the exact same fetch behavior. */
+export function useArchiveEvents(params: {
+  selectedDay: string | null;
+  timeOfDay: TimeOfDay;
+  serverDomain: string;
+  activeVisualizations: string[];
+}): ArchiveEventsState {
+  const { selectedDay, timeOfDay, serverDomain, activeVisualizations } = params;
+
+  const [events, setEvents] = useState<CollectionEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dayCounts, setDayCounts] = useState<DayCounts>(new Map());
+
+  // Track which event types we've already fetched so we only fetch missing ones
+  const fetchedTypesRef = useRef<Set<string>>(new Set());
+  // Track the last domain+day combo we fetched for so we know when to force refresh
+  const lastFetchKeyRef = useRef<string>("");
+
+  // Fetch daily counts for the heatmap calendar
+  useEffect(() => {
+    fetch(DAILY_COUNTS_URL)
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to fetch daily counts: ${r.status}`);
+        return r.json();
+      })
+      .then((rows: { day: string; count: number }[]) => {
+        const map = new Map<string, number>();
+        for (const row of rows) {
+          map.set(row.day, row.count);
+        }
+        setDayCounts(map);
+      })
+      .catch((err) => {
+        console.error("Error fetching daily counts:", err);
+      });
+  }, []);
+
+  const fetchEvents = useCallback(
+    async (
+      day: string | null | undefined,
+      vizIds: string[],
+      domain: string = "",
+      forceRefresh = false,
+      tod: TimeOfDay = null,
+    ) => {
+      const requiredTypes = deriveRequiredEventTypes(vizIds);
+
+      if (requiredTypes.size === 0) {
+        setLoading(false);
+        return;
+      }
+
+      // Force refresh when the filter context (day+domain+time-of-day) changed
+      const todKey = tod ? `${tod.centerMinutes}:${tod.radiusMinutes}` : "none";
+      const fetchKey = `${day ?? "all"}|${domain}|${todKey}`;
+      if (fetchKey !== lastFetchKeyRef.current) {
+        forceRefresh = true;
+        fetchedTypesRef.current = new Set();
+        lastFetchKeyRef.current = fetchKey;
+      }
+
+      // Determine which types we actually need to fetch
+      const typesToFetch = forceRefresh
+        ? requiredTypes
+        : new Set([...requiredTypes].filter((t) => !fetchedTypesRef.current.has(t)));
+
+      if (typesToFetch.size === 0) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const buildUrl = (extraParams: Record<string, string>, type: string) => {
+          const params = new URLSearchParams(extraParams);
+          if (domain) params.set("domain", domain);
+          params.set("type", type);
+          return `${EVENTS_URL}?${params}`;
+        };
+
+        const fetchOne = (
+          extraParams: Record<string, string>,
+          type: string,
+        ): Promise<CollectionEvent[]> =>
+          fetch(buildUrl(extraParams, type)).then((r) => {
+            if (!r.ok)
+              throw new Error(`Failed to fetch ${type} events: ${r.status}`);
+            return r.json();
+          });
+
+        let fetched: CollectionEvent[] = [];
+        if (day && tod) {
+          // Time-of-day capture (e.g. the "midnight moment"): fetch the tight
+          // local time-of-day window directly. A whole-day fetch is recency-
+          // capped and returns the END of the UTC day, never reaching early-
+          // UTC-day instants like local midnight — so we must bracket the
+          // window's exact UTC bounds instead.
+          const { from, to } = midnightWindowBounds(
+            day,
+            tod.centerMinutes,
+            tod.radiusMinutes,
+          );
+          const results = await Promise.all(
+            [...typesToFetch].map((type) =>
+              fetchOne({ limit: "20000", from, to }, type),
+            ),
+          );
+          fetched = results.flat();
+        } else if (day) {
+          // Single-day fetch: scope tightly with the original limit.
+          const results = await Promise.all(
+            [...typesToFetch].map((type) =>
+              fetchOne(
+                {
+                  limit: "5000",
+                  from: day,
+                  to: `${day}T23:59:59Z`,
+                },
+                type,
+              ),
+            ),
+          );
+          fetched = results.flat();
+        } else {
+          // No-day fetch: one broad request per type, no date range. The
+          // worker returns the 20000 most recent matching events (its hard
+          // ceiling), which for typical domains covers months. The earlier
+          // 14-day × 800-per-day fan-out introduced a hidden cliff that
+          // capped visible history regardless of how much data existed —
+          // see the activity strip showing months while the canvas only
+          // rendered the most recent two weeks. (The activity strip's
+          // per-day counts come from a separate /events/daily-counts
+          // endpoint and are not affected by this change.)
+          const results = await Promise.all(
+            [...typesToFetch].map((type) =>
+              fetchOne({ limit: "20000" }, type).catch((err) => {
+                console.warn(`Failed to fetch ${type} events:`, err);
+                return [] as CollectionEvent[];
+              }),
+            ),
+          );
+          fetched = results.flat();
+        }
+
+        // Track what we've fetched
+        for (const t of typesToFetch) {
+          fetchedTypesRef.current.add(t);
+        }
+
+        if (forceRefresh) {
+          setEvents(fetched);
+        } else {
+          setEvents((prev) => [...prev, ...fetched]);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to fetch events");
+        console.error("Error fetching events:", err);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
+
+  // Refetch when the day, server-side domain, time-of-day window, or active
+  // visualizations change. time-of-day must refetch because the midnight window
+  // is fetched server-side (a tight from/to bracket), not just filtered
+  // client-side; active-viz changes fetch any missing event types. A single
+  // effect (rather than one per dependency group) so mount fires ONE fetch —
+  // two effects both ran on the first render, and the duplicate fetch's late
+  // resolution rebuilt the trail set and restarted the animation mid-reveal.
+  useEffect(() => {
+    fetchEvents(selectedDay, activeVisualizations, serverDomain, false, timeOfDay);
+  }, [selectedDay, serverDomain, timeOfDay, activeVisualizations, fetchEvents]);
+
+  const refresh = useCallback(() => {
+    fetchedTypesRef.current = new Set();
+    lastFetchKeyRef.current = "";
+    fetchEvents(selectedDay, activeVisualizations, serverDomain, true, timeOfDay);
+  }, [selectedDay, serverDomain, activeVisualizations, timeOfDay, fetchEvents]);
+
+  return { events, loading, error, dayCounts, refresh };
+}

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -131,15 +131,40 @@ export function useArchiveEvents(params: {
           return `${EVENTS_URL}?${params}`;
         };
 
-        const fetchOne = (
+        // Retry with exponential backoff so a transient network hiccup or a 5xx
+        // doesn't leave a window permanently blank. Only network errors and 5xx
+        // responses retry (a 4xx is a real request problem — fail fast); the
+        // error surfaces only after every attempt is exhausted.
+        const RETRY_BACKOFFS_MS = [400, 1200];
+        // A 4xx is a real request problem — throwing this tag skips the retry.
+        class NonRetryableFetchError extends Error {}
+        const fetchOne = async (
           extraParams: Record<string, string>,
           type: string,
-        ): Promise<CollectionEvent[]> =>
-          fetch(buildUrl(extraParams, type)).then((r) => {
-            if (!r.ok)
-              throw new Error(`Failed to fetch ${type} events: ${r.status}`);
-            return r.json();
-          });
+        ): Promise<CollectionEvent[]> => {
+          const url = buildUrl(extraParams, type);
+          let lastError: unknown;
+          for (let attempt = 0; attempt <= RETRY_BACKOFFS_MS.length; attempt++) {
+            if (attempt > 0) {
+              await new Promise((resolve) =>
+                setTimeout(resolve, RETRY_BACKOFFS_MS[attempt - 1]),
+              );
+            }
+            try {
+              const r = await fetch(url);
+              if (r.ok) return r.json();
+              const message = `Failed to fetch ${type} events: ${r.status}`;
+              // Retry only on server errors; a 4xx fails fast.
+              throw r.status >= 500
+                ? new Error(message)
+                : new NonRetryableFetchError(message);
+            } catch (err) {
+              if (err instanceof NonRetryableFetchError) throw err;
+              lastError = err;
+            }
+          }
+          throw lastError;
+        };
 
         let fetched: CollectionEvent[] = [];
         if (day && tod) {

--- a/extension/website/shared/hooks/useFollowerCoordination.ts
+++ b/extension/website/shared/hooks/useFollowerCoordination.ts
@@ -1,0 +1,222 @@
+// ABOUTME: Coordinates which cursor each follower window rides, over a same-origin BroadcastChannel.
+// ABOUTME: Owns the claims map + pruning + heartbeat + race resolution; exposes a stable pickSubject.
+
+import { useCallback, useEffect, useRef } from "react";
+import { parseInstallationRoleFromUrl, parseFollowerIdFromUrl } from "../config";
+
+/** Same-origin channel every follower window joins to publish/read cursor
+ * claims. Separate from the clock channel so claim traffic and time traffic
+ * don't interleave; all followers on one machine share it. */
+const CHANNEL_NAME = "wewe-installation-claims";
+
+/** A claim goes stale this long after its last heartbeat. A crashed/closed
+ * follower's claim then frees up so others can pick that cursor again. Must be
+ * comfortably larger than HEARTBEAT_MS so a live claim never lapses between
+ * beats. */
+const STALE_MS = 2500;
+
+/** How often a follower re-broadcasts a claim for the cursor it currently
+ * rides, so peers keep its entry fresh. */
+const HEARTBEAT_MS = 1000;
+
+/** One entry per claimed cursor: who claims it and when we last heard. */
+interface ClaimEntry {
+  by: string;
+  ts: number;
+}
+
+interface ClaimMessage {
+  type: "claim" | "release";
+  cursor: number;
+  by: string;
+  ts?: number;
+}
+
+type Candidate = { index: number; x: number; y: number; progress: number };
+
+/** The selector signature the cinematic camera calls in follow mode. */
+export type PickSubject = (
+  candidates: Candidate[],
+  currentIndex: number | null,
+) => number | null;
+
+export interface FollowerCoordination {
+  /** True when this window is a follower participating in coordination. */
+  isFollower: boolean;
+  /** A STABLE (identity-preserving) selector to hand the cinematic camera. When
+   * this window is a follower it filters out cursors claimed by OTHER followers
+   * and picks randomly among the rest; otherwise it just picks lowest-progress.
+   * Never changes identity across renders, so injecting it into the cinematic
+   * config doesn't thrash the camera's setConfig. */
+  pickSubject: PickSubject;
+}
+
+/** Lowest-progress pick — prefer a trail early in its draw so the camera rides
+ * most of it. Matches the camera's built-in default; used when this window
+ * isn't coordinating. */
+function pickLowestProgress(
+  candidates: Candidate[],
+  currentIndex: number | null,
+): number | null {
+  let best: number | null = null;
+  let bestProgress = Infinity;
+  for (const c of candidates) {
+    if (c.index === currentIndex) continue;
+    if (c.progress < bestProgress) {
+      bestProgress = c.progress;
+      best = c.index;
+    }
+  }
+  if (best === null && candidates.length > 0) best = candidates[0].index;
+  return best;
+}
+
+/** Wires the claims BroadcastChannel keyed off `?role=follower`. Inert for any
+ * other window: `pickSubject` just does lowest-progress and no channel opens, so
+ * the archive/portrait pages and a single-window auto-pick are unaffected. */
+export function useFollowerCoordination(): FollowerCoordination {
+  const roleRef = useRef(parseInstallationRoleFromUrl());
+  const isFollower = roleRef.current === "follower";
+
+  // Stable window id: the URL-set follower id, or a random one generated once
+  // so an id-less follower still participates (and two id-less windows diverge).
+  const idRef = useRef<string>(
+    parseFollowerIdFromUrl() ??
+      `f-${Math.random().toString(36).slice(2, 8)}`,
+  );
+
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  // Everyone's current claims (including our own), last-seen timestamp.
+  const claimsRef = useRef<Map<number, ClaimEntry>>(new Map());
+  // The cursor index this window currently rides (null = none yet).
+  const myClaimRef = useRef<number | null>(null);
+
+  const now = () =>
+    typeof performance !== "undefined" ? performance.now() : Date.now();
+
+  const broadcastClaim = useCallback((cursor: number) => {
+    const message: ClaimMessage = {
+      type: "claim",
+      cursor,
+      by: idRef.current,
+      ts: now(),
+    };
+    channelRef.current?.postMessage(message);
+    // Reflect our own claim locally too, so a fresh window's pickSubject sees it
+    // without waiting for the message to round-trip.
+    claimsRef.current.set(cursor, { by: idRef.current, ts: message.ts! });
+  }, []);
+
+  useEffect(() => {
+    if (!isFollower) return;
+    if (typeof BroadcastChannel === "undefined") return;
+
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+
+    channel.onmessage = (event: MessageEvent<ClaimMessage>) => {
+      const msg = event.data;
+      if (!msg || typeof msg.cursor !== "number" || typeof msg.by !== "string") {
+        return;
+      }
+      if (msg.by === idRef.current) return; // ignore our own echoes
+
+      if (msg.type === "release") {
+        const entry = claimsRef.current.get(msg.cursor);
+        if (entry && entry.by === msg.by) claimsRef.current.delete(msg.cursor);
+        return;
+      }
+
+      // type === "claim": record the peer's claim.
+      claimsRef.current.set(msg.cursor, {
+        by: msg.by,
+        ts: typeof msg.ts === "number" ? msg.ts : now(),
+      });
+
+      // Race resolution: if a peer claims the cursor WE currently ride, the
+      // lower id keeps it (string compare). If the peer's id is lower, we yield
+      // — drop our claim so pickSubject re-picks a fresh cursor next call.
+      if (
+        myClaimRef.current === msg.cursor &&
+        msg.by < idRef.current
+      ) {
+        myClaimRef.current = null;
+      }
+    };
+
+    // Heartbeat: keep our current claim fresh for peers, and prune stale claims
+    // from windows that went away.
+    const heartbeat = window.setInterval(() => {
+      const t = now();
+      for (const [cursor, entry] of claimsRef.current) {
+        if (t - entry.ts > STALE_MS) claimsRef.current.delete(cursor);
+      }
+      if (myClaimRef.current !== null) broadcastClaim(myClaimRef.current);
+    }, HEARTBEAT_MS);
+
+    return () => {
+      window.clearInterval(heartbeat);
+      if (myClaimRef.current !== null) {
+        const release: ClaimMessage = {
+          type: "release",
+          cursor: myClaimRef.current,
+          by: idRef.current,
+        };
+        channel.postMessage(release);
+      }
+      channel.onmessage = null;
+      channel.close();
+      channelRef.current = null;
+      claimsRef.current.clear();
+      myClaimRef.current = null;
+    };
+  }, [isFollower, broadcastClaim]);
+
+  // STABLE selector handed to the camera. Reads refs so its identity never
+  // changes — the camera reads config.pickSubject fresh each tick, so live
+  // claims are always current without re-running setConfig.
+  const pickSubject = useCallback<PickSubject>(
+    (candidates, currentIndex) => {
+      if (!isFollower) return pickLowestProgress(candidates, currentIndex);
+      if (candidates.length === 0) return null;
+
+      const t = now();
+      const me = idRef.current;
+      const claimedByOther = (index: number): boolean => {
+        const entry = claimsRef.current.get(index);
+        if (!entry) return false;
+        if (entry.by === me) return false;
+        if (t - entry.ts > STALE_MS) return false; // stale claims don't block
+        return true;
+      };
+
+      // Keep the current subject if it's still an active candidate and not
+      // claimed by another follower — don't hop unnecessarily.
+      if (
+        currentIndex !== null &&
+        candidates.some((c) => c.index === currentIndex) &&
+        !claimedByOther(currentIndex)
+      ) {
+        // Make sure our claim is recorded (e.g. after yielding then re-keeping).
+        if (myClaimRef.current !== currentIndex) {
+          myClaimRef.current = currentIndex;
+          broadcastClaim(currentIndex);
+        }
+        return currentIndex;
+      }
+
+      // Prefer cursors no other follower claims; fall back to all candidates so
+      // more-followers-than-cursors allows a temporary duplicate over freezing.
+      const free = candidates.filter((c) => !claimedByOther(c.index));
+      const pool = free.length > 0 ? free : candidates;
+      const chosen = pool[Math.floor(Math.random() * pool.length)].index;
+
+      myClaimRef.current = chosen;
+      broadcastClaim(chosen);
+      return chosen;
+    },
+    [isFollower, broadcastClaim],
+  );
+
+  return { isFollower, pickSubject };
+}

--- a/extension/website/shared/hooks/useInstallationClock.ts
+++ b/extension/website/shared/hooks/useInstallationClock.ts
@@ -1,78 +1,148 @@
-// ABOUTME: Shared animation clock for multi-screen installations, over BroadcastChannel.
-// ABOUTME: A master window broadcasts its scaled-elapsed each frame; follower windows render it.
+// ABOUTME: Shared wall-clock epoch for multi-screen installations, over localStorage + BroadcastChannel.
+// ABOUTME: Every window computes its own scaled-elapsed from an agreed epoch, so no window depends on another's rAF.
 
 import { useCallback, useEffect, useRef } from "react";
 import { parseInstallationRoleFromUrl } from "../config";
 
-/** Same-origin channel every installation window joins. Same for all windows
- * so the master's broadcasts reach all followers on the same machine. */
+/** Same-origin channel every installation window joins to announce/adopt the
+ * shared epoch. */
 const CHANNEL_NAME = "wewe-installation-clock";
 
-interface InstallationClockMessage {
-  elapsed: number;
+/** localStorage key holding the shared epoch (ms since Unix epoch). Survives
+ * reload and is shared across same-origin windows. */
+const EPOCH_STORAGE_KEY = "wewe-installation-epoch";
+
+interface EpochMessage {
+  type: "epoch";
+  epoch: number;
 }
+
+interface EpochRequestMessage {
+  type: "epoch-request";
+}
+
+type ClockMessage = EpochMessage | EpochRequestMessage;
 
 export interface InstallationClock {
   role: "master" | "follower" | null;
   isFollower: boolean;
-  /** Accessor a follower reads each animation frame to get the latest RAW
-   * scaled-elapsed pushed by the master, or null when there's nothing to
-   * follow (no message yet, or this window is master/standalone). Reading
-   * through this accessor avoids a React re-render per broadcast (60/sec). */
-  getOverrideElapsedMs: () => number | null;
-  /** A master posts its RAW pre-modulo scaled-elapsed each frame. No-op for
-   * follower/standalone windows. */
-  broadcastElapsed: (scaledElapsed: number) => void;
+  /** True when this window participates in the installation clock (any role). */
+  isInstallation: boolean;
+  /** Returns `(Date.now() - epoch) * animationSpeed` when this is an
+   * installation window and an epoch is known, else null. The animate loop
+   * falls back to local accumulation while null (before an epoch is adopted,
+   * or for standalone windows). Read through this accessor each frame so
+   * incoming messages don't re-run the animation-loop effect. */
+  getScaledElapsedMs: (animationSpeed: number) => number | null;
 }
 
-/** Wires a BroadcastChannel-backed shared clock keyed off `?role=`. Inert when
- * no role is present: `getOverrideElapsedMs` returns null and `broadcastElapsed`
- * is a no-op, so a standalone window drives its own clock exactly as before. */
+function readStoredEpoch(): number | null {
+  try {
+    const raw = localStorage.getItem(EPOCH_STORAGE_KEY);
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredEpoch(epoch: number): void {
+  try {
+    localStorage.setItem(EPOCH_STORAGE_KEY, String(epoch));
+  } catch {
+    /* localStorage may be unavailable (private mode); the in-memory ref still
+     * holds the epoch for this window's own frames. */
+  }
+}
+
+/** Wires a shared wall-clock epoch keyed off `?role=`. Any installation window
+ * (master OR follower) establishes an epoch if none exists and adopts the
+ * earliest epoch it sees (earliest-wins converges all windows). Inert when no
+ * role is present: `getScaledElapsedMs` returns null so a standalone window
+ * accumulates its own clock exactly as before. */
 export function useInstallationClock(): InstallationClock {
   const roleRef = useRef<"master" | "follower" | null>(
     parseInstallationRoleFromUrl(),
   );
   const role = roleRef.current;
   const isFollower = role === "follower";
+  const isInstallation = role !== null;
 
-  const channelRef = useRef<BroadcastChannel | null>(null);
-  const overrideElapsedRef = useRef<number | null>(null);
+  const epochRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (role === null) return;
-    if (typeof BroadcastChannel === "undefined") return;
 
-    const channel = new BroadcastChannel(CHANNEL_NAME);
-    channelRef.current = channel;
+    // On load, adopt any epoch already persisted for this origin.
+    epochRef.current = readStoredEpoch();
 
-    if (isFollower) {
-      channel.onmessage = (event: MessageEvent<InstallationClockMessage>) => {
-        const elapsed = event.data?.elapsed;
-        if (typeof elapsed === "number" && Number.isFinite(elapsed)) {
-          overrideElapsedRef.current = elapsed;
+    const channel =
+      typeof BroadcastChannel !== "undefined"
+        ? new BroadcastChannel(CHANNEL_NAME)
+        : null;
+
+    /** Adopt `epoch` when it's earlier than ours (or we have none). Earliest
+     * wins so two windows that establish simultaneously converge to one. */
+    const adopt = (epoch: number) => {
+      if (!Number.isFinite(epoch)) return;
+      if (epochRef.current === null || epoch < epochRef.current) {
+        epochRef.current = epoch;
+        writeStoredEpoch(epoch);
+      }
+    };
+
+    if (channel) {
+      channel.onmessage = (event: MessageEvent<ClockMessage>) => {
+        const msg = event.data;
+        if (!msg) return;
+        if (msg.type === "epoch") {
+          const before = epochRef.current;
+          adopt(msg.epoch);
+          // If our (earlier) epoch won, re-announce it so the sender adopts it.
+          if (before !== null && before < msg.epoch) {
+            channel.postMessage({ type: "epoch", epoch: before });
+          }
+        } else if (msg.type === "epoch-request") {
+          if (epochRef.current !== null) {
+            channel.postMessage({ type: "epoch", epoch: epochRef.current });
+          }
         }
       };
     }
 
+    if (epochRef.current === null) {
+      // No epoch anywhere we know of yet: establish one and announce it.
+      const epoch = Date.now();
+      epochRef.current = epoch;
+      writeStoredEpoch(epoch);
+      channel?.postMessage({ type: "epoch", epoch });
+    } else {
+      // We have a stored epoch: announce it so any other window converges down.
+      channel?.postMessage({ type: "epoch", epoch: epochRef.current });
+    }
+
+    // Ask anyone already running to reply with their epoch, covering the case
+    // where our localStorage was cleared but a peer window is live.
+    channel?.postMessage({ type: "epoch-request" });
+
     return () => {
-      channel.onmessage = null;
-      channel.close();
-      channelRef.current = null;
+      if (channel) {
+        channel.onmessage = null;
+        channel.close();
+      }
     };
-  }, [role, isFollower]);
+  }, [role]);
 
-  const getOverrideElapsedMs = useCallback(
-    () => (isFollower ? overrideElapsedRef.current : null),
-    [isFollower],
-  );
-
-  const broadcastElapsed = useCallback(
-    (scaledElapsed: number) => {
-      if (role !== "master") return;
-      channelRef.current?.postMessage({ elapsed: scaledElapsed });
+  const getScaledElapsedMs = useCallback(
+    (animationSpeed: number) => {
+      if (role === null) return null;
+      const epoch = epochRef.current;
+      if (epoch === null) return null;
+      return (Date.now() - epoch) * animationSpeed;
     },
     [role],
   );
 
-  return { role, isFollower, getOverrideElapsedMs, broadcastElapsed };
+  return { role, isFollower, isInstallation, getScaledElapsedMs };
 }

--- a/extension/website/shared/hooks/useInstallationClock.ts
+++ b/extension/website/shared/hooks/useInstallationClock.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Shared animation clock for multi-screen installations, over BroadcastChannel.
+// ABOUTME: A master window broadcasts its scaled-elapsed each frame; follower windows render it.
+
+import { useCallback, useEffect, useRef } from "react";
+import { parseInstallationRoleFromUrl } from "../config";
+
+/** Same-origin channel every installation window joins. Same for all windows
+ * so the master's broadcasts reach all followers on the same machine. */
+const CHANNEL_NAME = "wewe-installation-clock";
+
+interface InstallationClockMessage {
+  elapsed: number;
+}
+
+export interface InstallationClock {
+  role: "master" | "follower" | null;
+  isFollower: boolean;
+  /** Accessor a follower reads each animation frame to get the latest RAW
+   * scaled-elapsed pushed by the master, or null when there's nothing to
+   * follow (no message yet, or this window is master/standalone). Reading
+   * through this accessor avoids a React re-render per broadcast (60/sec). */
+  getOverrideElapsedMs: () => number | null;
+  /** A master posts its RAW pre-modulo scaled-elapsed each frame. No-op for
+   * follower/standalone windows. */
+  broadcastElapsed: (scaledElapsed: number) => void;
+}
+
+/** Wires a BroadcastChannel-backed shared clock keyed off `?role=`. Inert when
+ * no role is present: `getOverrideElapsedMs` returns null and `broadcastElapsed`
+ * is a no-op, so a standalone window drives its own clock exactly as before. */
+export function useInstallationClock(): InstallationClock {
+  const roleRef = useRef<"master" | "follower" | null>(
+    parseInstallationRoleFromUrl(),
+  );
+  const role = roleRef.current;
+  const isFollower = role === "follower";
+
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const overrideElapsedRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (role === null) return;
+    if (typeof BroadcastChannel === "undefined") return;
+
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channelRef.current = channel;
+
+    if (isFollower) {
+      channel.onmessage = (event: MessageEvent<InstallationClockMessage>) => {
+        const elapsed = event.data?.elapsed;
+        if (typeof elapsed === "number" && Number.isFinite(elapsed)) {
+          overrideElapsedRef.current = elapsed;
+        }
+      };
+    }
+
+    return () => {
+      channel.onmessage = null;
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [role, isFollower]);
+
+  const getOverrideElapsedMs = useCallback(
+    () => (isFollower ? overrideElapsedRef.current : null),
+    [isFollower],
+  );
+
+  const broadcastElapsed = useCallback(
+    (scaledElapsed: number) => {
+      if (role !== "master") return;
+      channelRef.current?.postMessage({ elapsed: scaledElapsed });
+    },
+    [role],
+  );
+
+  return { role, isFollower, getOverrideElapsedMs, broadcastElapsed };
+}

--- a/extension/website/shared/hooks/useInstallationClock.ts
+++ b/extension/website/shared/hooks/useInstallationClock.ts
@@ -1,16 +1,12 @@
-// ABOUTME: Shared wall-clock epoch for multi-screen installations, over localStorage + BroadcastChannel.
-// ABOUTME: Every window computes its own scaled-elapsed from an agreed epoch, so no window depends on another's rAF.
+// ABOUTME: Shared wall-clock epoch for multi-screen installations, over a BroadcastChannel.
+// ABOUTME: Every window computes its own scaled-elapsed from the master's epoch, so no window depends on another's rAF.
 
 import { useCallback, useEffect, useRef } from "react";
 import { parseInstallationRoleFromUrl } from "../config";
 
-/** Same-origin channel every installation window joins to announce/adopt the
- * shared epoch. */
+/** Same-origin channel every installation window joins. The master announces
+ * its epoch here; followers request and adopt it. */
 const CHANNEL_NAME = "wewe-installation-clock";
-
-/** localStorage key holding the shared epoch (ms since Unix epoch). Survives
- * reload and is shared across same-origin windows. */
-const EPOCH_STORAGE_KEY = "wewe-installation-epoch";
 
 interface EpochMessage {
   type: "epoch";
@@ -30,36 +26,17 @@ export interface InstallationClock {
   isInstallation: boolean;
   /** Returns `(Date.now() - epoch) * animationSpeed` when this is an
    * installation window and an epoch is known, else null. The animate loop
-   * falls back to local accumulation while null (before an epoch is adopted,
-   * or for standalone windows). Read through this accessor each frame so
+   * falls back to local accumulation while null (before the master's epoch is
+   * known, or for standalone windows). Read through this accessor each frame so
    * incoming messages don't re-run the animation-loop effect. */
   getScaledElapsedMs: (animationSpeed: number) => number | null;
 }
 
-function readStoredEpoch(): number | null {
-  try {
-    const raw = localStorage.getItem(EPOCH_STORAGE_KEY);
-    if (raw === null) return null;
-    const parsed = Number(raw);
-    return Number.isFinite(parsed) ? parsed : null;
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredEpoch(epoch: number): void {
-  try {
-    localStorage.setItem(EPOCH_STORAGE_KEY, String(epoch));
-  } catch {
-    /* localStorage may be unavailable (private mode); the in-memory ref still
-     * holds the epoch for this window's own frames. */
-  }
-}
-
-/** Wires a shared wall-clock epoch keyed off `?role=`. Any installation window
- * (master OR follower) establishes an epoch if none exists and adopts the
- * earliest epoch it sees (earliest-wins converges all windows). Inert when no
- * role is present: `getScaledElapsedMs` returns null so a standalone window
+/** Wires a shared wall-clock epoch keyed off `?role=`. The MASTER is
+ * authoritative: every master (re)load stamps a fresh epoch = now (restarting
+ * the cycle) and broadcasts it. FOLLOWERS never mint an epoch — they wait for
+ * the master's and adopt its latest (a master reload re-syncs them). Inert when
+ * no role is present: `getScaledElapsedMs` returns null so a standalone window
  * accumulates its own clock exactly as before. */
 export function useInstallationClock(): InstallationClock {
   const roleRef = useRef<"master" | "follower" | null>(
@@ -74,57 +51,49 @@ export function useInstallationClock(): InstallationClock {
   useEffect(() => {
     if (role === null) return;
 
-    // On load, adopt any epoch already persisted for this origin.
-    epochRef.current = readStoredEpoch();
-
+    const isMaster = role === "master";
     const channel =
       typeof BroadcastChannel !== "undefined"
         ? new BroadcastChannel(CHANNEL_NAME)
         : null;
 
-    /** Adopt `epoch` when it's earlier than ours (or we have none). Earliest
-     * wins so two windows that establish simultaneously converge to one. */
-    const adopt = (epoch: number) => {
-      if (!Number.isFinite(epoch)) return;
-      if (epochRef.current === null || epoch < epochRef.current) {
-        epochRef.current = epoch;
-        writeStoredEpoch(epoch);
-      }
-    };
-
-    if (channel) {
-      channel.onmessage = (event: MessageEvent<ClockMessage>) => {
-        const msg = event.data;
-        if (!msg) return;
-        if (msg.type === "epoch") {
-          const before = epochRef.current;
-          adopt(msg.epoch);
-          // If our (earlier) epoch won, re-announce it so the sender adopts it.
-          if (before !== null && before < msg.epoch) {
-            channel.postMessage({ type: "epoch", epoch: before });
-          }
-        } else if (msg.type === "epoch-request") {
-          if (epochRef.current !== null) {
-            channel.postMessage({ type: "epoch", epoch: epochRef.current });
-          }
-        }
-      };
-    }
-
-    if (epochRef.current === null) {
-      // No epoch anywhere we know of yet: establish one and announce it.
+    if (isMaster) {
+      // The master is authoritative: every master (re)load stamps a FRESH epoch
+      // = now, so the whole field restarts from the start of the cycle and all
+      // followers snap to it. It never adopts anyone else's epoch.
       const epoch = Date.now();
       epochRef.current = epoch;
-      writeStoredEpoch(epoch);
+      if (channel) {
+        channel.onmessage = (event: MessageEvent<ClockMessage>) => {
+          // Answer followers asking for the current epoch; ignore stray epoch
+          // announcements (the master owns the clock).
+          const msg = event.data;
+          if (msg?.type === "epoch-request") {
+            channel.postMessage({ type: "epoch", epoch: epochRef.current! });
+          }
+        };
+      }
       channel?.postMessage({ type: "epoch", epoch });
     } else {
-      // We have a stored epoch: announce it so any other window converges down.
-      channel?.postMessage({ type: "epoch", epoch: epochRef.current });
+      // A follower NEVER establishes an epoch. It waits for the master: until a
+      // live master announces one (or answers our request), getScaledElapsedMs
+      // returns null and the window holds. The stored epoch is deliberately NOT
+      // trusted on load — it could be stale from a previous master run, and a
+      // master reload always mints a new one, so we only ever use an epoch
+      // received live this session.
+      epochRef.current = null;
+      if (channel) {
+        channel.onmessage = (event: MessageEvent<ClockMessage>) => {
+          const msg = event.data;
+          if (msg?.type === "epoch" && Number.isFinite(msg.epoch)) {
+            epochRef.current = msg.epoch;
+          }
+        };
+      }
+      // Ask the current master for its epoch (covers a follower that loads or
+      // reloads after the master is already running).
+      channel?.postMessage({ type: "epoch-request" });
     }
-
-    // Ask anyone already running to reply with their epoch, covering the case
-    // where our localStorage was cleared but a peer window is live.
-    channel?.postMessage({ type: "epoch-request" });
 
     return () => {
       if (channel) {

--- a/extension/website/shared/hooks/useInstallationEvents.ts
+++ b/extension/website/shared/hooks/useInstallationEvents.ts
@@ -1,0 +1,178 @@
+// ABOUTME: Role-aware event source for installation windows — the master fetches
+// ABOUTME: and relays events via IndexedDB; followers read them and never fetch.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { CollectionEvent } from "../types";
+import { parseInstallationRoleFromUrl, parseTimeOfDayFromUrl } from "../config";
+import { useArchiveEvents } from "./useArchiveEvents";
+import { readEvents, writeEvents } from "../utils/installationEventStore";
+
+type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
+
+/** Same-origin channel for the tiny `events-ready` nudge. NEVER carries events —
+ * the payload lives in IndexedDB; this only tells followers to (re-)read. */
+const CHANNEL_NAME = "wewe-installation-data";
+
+interface EventsReadyMessage {
+  type: "events-ready";
+  version: number;
+}
+
+export interface InstallationEventsState {
+  events: CollectionEvent[];
+  loading: boolean;
+  error: string | null;
+  /** Force a full refetch (master/standalone). No-op for a pure follower, which
+   * never fetches — it re-reads only when the master pings. */
+  refresh: () => void;
+}
+
+export interface UseInstallationEventsParams {
+  selectedDay: string | null;
+  timeOfDay: TimeOfDay;
+  serverDomain: string;
+  activeVisualizations: string[];
+}
+
+/** Role-aware event source, keyed off `?role=`:
+ *
+ * - `master`: fetches via useArchiveEvents; whenever the events change and are
+ *   non-empty, writes them to IndexedDB and broadcasts `events-ready`. Returns
+ *   the archive events directly.
+ * - `follower`: does NOT fetch. Reads events from IndexedDB on mount and on each
+ *   `events-ready` ping. Waits (loading) until the first write exists. Falls
+ *   back to fetching itself only if IndexedDB is unavailable.
+ * - `null` (standalone archive/portrait): passes straight through to
+ *   useArchiveEvents — unchanged fetch behavior.
+ *
+ * Role is read once (via a ref) so it never changes across the window's life. */
+export function useInstallationEvents(
+  params: UseInstallationEventsParams,
+): InstallationEventsState {
+  const roleRef = useRef<"master" | "follower" | null>(
+    parseInstallationRoleFromUrl(),
+  );
+  const role = roleRef.current;
+
+  // A follower with a working IndexedDB never fetches, so useArchiveEvents must
+  // be inert for it. Passing no active visualizations makes it fetch nothing
+  // (deriveRequiredEventTypes is empty → it bails before any request). The
+  // master and standalone (null) pass the real params. If a follower's
+  // IndexedDB is unavailable it flips this ref and re-runs with real params so
+  // it can fall back to fetching.
+  const [followerMustFetch, setFollowerMustFetch] = useState(false);
+  const useLiveFetch = role !== "follower" || followerMustFetch;
+
+  const archive = useArchiveEvents({
+    selectedDay: params.selectedDay,
+    timeOfDay: params.timeOfDay,
+    serverDomain: params.serverDomain,
+    activeVisualizations: useLiveFetch ? params.activeVisualizations : [],
+  });
+
+  // ---- Master: relay fetched events to followers via IndexedDB + ping. ----
+  useEffect(() => {
+    if (role !== "master") return;
+    if (archive.events.length === 0) return;
+
+    let cancelled = false;
+    const channel =
+      typeof BroadcastChannel !== "undefined"
+        ? new BroadcastChannel(CHANNEL_NAME)
+        : null;
+
+    writeEvents(archive.events)
+      .then((): Promise<void> => {
+        if (cancelled) return Promise.resolve();
+        // Read back the version we just wrote so the ping carries it.
+        return readEvents().then((stored) => {
+          if (cancelled || !channel) return;
+          const message: EventsReadyMessage = {
+            type: "events-ready",
+            version: stored?.version ?? 0,
+          };
+          channel.postMessage(message);
+        });
+      })
+      .catch((err) => {
+        console.warn("Failed to relay installation events:", err);
+      })
+      .finally(() => {
+        channel?.close();
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [role, archive.events]);
+
+  // ---- Follower: read from IndexedDB on mount + on each ping. ----
+  const [followerEvents, setFollowerEvents] = useState<CollectionEvent[]>([]);
+  const [followerLoading, setFollowerLoading] = useState(true);
+
+  useEffect(() => {
+    if (role !== "follower") return;
+
+    let cancelled = false;
+    const channel =
+      typeof BroadcastChannel !== "undefined"
+        ? new BroadcastChannel(CHANNEL_NAME)
+        : null;
+
+    const load = () => {
+      readEvents()
+        .then((stored) => {
+          if (cancelled) return;
+          if (stored) {
+            setFollowerEvents(stored.events);
+            setFollowerLoading(false);
+          }
+          // No stored events yet: stay loading and wait for a ping.
+        })
+        .catch((err) => {
+          // IndexedDB unavailable (e.g. private mode): fall back to fetching.
+          if (cancelled) return;
+          console.warn(
+            "Installation follower cannot read IndexedDB, fetching directly:",
+            err,
+          );
+          setFollowerMustFetch(true);
+        });
+    };
+
+    if (channel) {
+      channel.onmessage = (event: MessageEvent<EventsReadyMessage>) => {
+        if (event.data?.type === "events-ready") load();
+      };
+    }
+    load();
+
+    return () => {
+      cancelled = true;
+      if (channel) {
+        channel.onmessage = null;
+        channel.close();
+      }
+    };
+  }, [role]);
+
+  const refresh = useCallback(() => {
+    archive.refresh();
+  }, [archive]);
+
+  // Follower falling back to a direct fetch surfaces archive's state.
+  if (role === "follower" && !followerMustFetch) {
+    return {
+      events: followerEvents,
+      loading: followerLoading,
+      error: null,
+      refresh,
+    };
+  }
+
+  return {
+    events: archive.events,
+    loading: archive.loading,
+    error: archive.error,
+    refresh,
+  };
+}

--- a/extension/website/shared/utils/cinematicCamera.ts
+++ b/extension/website/shared/utils/cinematicCamera.ts
@@ -24,6 +24,11 @@ export interface CinematicConfig {
   revealMs: number;
   /** reveal mode: fraction of screen width visible at the start (tightest). */
   revealStartZoom: number;
+  /** follow mode: lock onto this trail index instead of auto-picking. When set,
+   * the camera pins to that one cursor and never advances to other subjects;
+   * if the trail isn't active it holds its last known spot. null/undefined =
+   * default auto-pick behavior. */
+  forcedSubjectIndex?: number | null;
 }
 
 export interface CameraFrame {
@@ -101,6 +106,9 @@ export class CinematicCamera {
   // Last known position of the reveal subject, so the camera keeps a sensible
   // center even after that cursor finishes and drops out of activeTrails.
   private revealSubjectLast: Point | null = null;
+  // Last known position of the forced follow subject, so a locked camera holds
+  // a sensible center while that cursor is inactive (not yet started/finished).
+  private forcedSubjectLast: Point | null = null;
 
   constructor(config: CinematicConfig) {
     this.config = config;
@@ -122,6 +130,7 @@ export class CinematicCamera {
     this.revealStartMs = 0;
     this.revealSubjectIndex = null;
     this.revealSubjectLast = null;
+    this.forcedSubjectLast = null;
   }
 
   /** Request an immediate fly-through to a new subject on the next frame,
@@ -206,6 +215,25 @@ export class CinematicCamera {
     }
 
     const byIndex = new Map(activeTrails.map((t) => [t.index, t]));
+
+    // FORCED FOLLOW: pin to one trail index and never advance to other
+    // subjects. Track its live position while active; hold its last known spot
+    // (or canvas center if never seen) while inactive. Deterministic so a
+    // master and follower agree on which cursor index N refers to.
+    if (
+      this.config.mode === "follow" &&
+      this.config.forcedSubjectIndex !== null &&
+      this.config.forcedSubjectIndex !== undefined
+    ) {
+      const live = byIndex.get(this.config.forcedSubjectIndex);
+      if (live) this.forcedSubjectLast = { x: live.x, y: live.y };
+      const center =
+        this.forcedSubjectLast ?? { x: screenW / 2, y: screenH / 2 };
+      const box = boxAround(center, this.config.zoom, screenW, screenH);
+      this.lastViewBox = box;
+      this.currentCenter = center;
+      return box;
+    }
 
     // FLYING: tween regardless of subject availability; resolve on arrival.
     if (this.state === "flying" && this.flyFrom && this.flyTo) {

--- a/extension/website/shared/utils/cinematicCamera.ts
+++ b/extension/website/shared/utils/cinematicCamera.ts
@@ -29,6 +29,18 @@ export interface CinematicConfig {
    * if the trail isn't active it holds its last known spot. null/undefined =
    * default auto-pick behavior. */
   forcedSubjectIndex?: number | null;
+  /** follow mode: choose which active cursor to ride next. Called both for the
+   * initial pick and each time the current subject finishes. Receives every
+   * active candidate this frame and the index the camera is currently on (null
+   * when idle); returns the index to follow, or null to hold. Coordination logic
+   * (e.g. cross-window claims so no two screens follow the same cursor) lives in
+   * the caller — the camera stays pure. Ignored by `forcedSubjectIndex` (which
+   * takes precedence) and by reveal mode. When undefined, the camera uses its
+   * built-in lowest-progress pick (default single-window behavior). */
+  pickSubject?: (
+    candidates: Array<{ index: number; x: number; y: number; progress: number }>,
+    currentIndex: number | null,
+  ) => number | null;
 }
 
 export interface CameraFrame {
@@ -139,6 +151,23 @@ export class CinematicCamera {
     this.forceNext = true;
   }
 
+  /** The trail index the camera is currently riding in follow mode, or null.
+   * Reflects the forced/reveal subject when those modes are active. Read by
+   * dev/test tooling to verify multi-window coordination (distinct subjects). */
+  getCurrentSubjectIndex(): number | null {
+    if (this.config.mode === "reveal") return this.revealSubjectIndex;
+    if (
+      this.config.forcedSubjectIndex !== null &&
+      this.config.forcedSubjectIndex !== undefined
+    ) {
+      return this.config.forcedSubjectIndex;
+    }
+    // While flying to a new subject, report the target so the reported index
+    // switches at the moment the camera commits to the next cursor.
+    if (this.state === "flying") return this.flyTargetIndex;
+    return this.subjectIndex;
+  }
+
   /** Prefer a trail early in its draw so the camera rides most of it.
    * Deterministic: lowest progress wins (no RNG, keeps it predictable). */
   private selectNextSubject(
@@ -158,6 +187,22 @@ export class CinematicCamera {
     // than stalling.
     if (best === null && activeTrails.length > 0) best = activeTrails[0].index;
     return best;
+  }
+
+  /** Follow-mode subject selection. Delegates to an injected `pickSubject`
+   * (e.g. claims-aware cross-window coordination) when the config provides one;
+   * otherwise falls back to the built-in lowest-progress pick. `exclude` is the
+   * current subject when advancing after it finishes, and doubles as the
+   * `currentIndex` passed to an injected selector so it can keep its current
+   * subject when still valid. */
+  private pickFollowSubject(
+    activeTrails: CameraFrame["activeTrails"],
+    exclude: number | null,
+  ): number | null {
+    if (this.config.pickSubject) {
+      return this.config.pickSubject(activeTrails, exclude);
+    }
+    return this.selectNextSubject(activeTrails, exclude);
   }
 
   tick(frame: CameraFrame): ViewBox | null {
@@ -270,7 +315,7 @@ export class CinematicCamera {
 
     // IDLE: wait for a subject; leave viewBox untouched until one appears.
     if (this.state === "idle") {
-      const next = this.selectNextSubject(activeTrails, null);
+      const next = this.pickFollowSubject(activeTrails, this.subjectIndex);
       if (next === null) return this.lastViewBox; // null on very first frames
       this.subjectIndex = next;
       this.state = "following";
@@ -292,9 +337,46 @@ export class CinematicCamera {
     const finishedOrGone =
       subject === undefined || subject.progress >= 1 || this.forceNext;
 
-    if (finishedOrGone) {
+    // Coordination yield: with an injected selector, re-consult it each frame
+    // even mid-draw so the camera can hop off a cursor another window has taken
+    // (the selector returns a DIFFERENT index only when this window must yield;
+    // otherwise it returns the current index and we keep following). Skipped for
+    // the default lowest-progress path, which only advances on finish. Resolved
+    // as a normal fly-through below via `yieldTarget`.
+    let yieldTarget: number | null = null;
+    if (
+      !finishedOrGone &&
+      subject !== undefined &&
+      this.config.pickSubject &&
+      this.subjectIndex !== null
+    ) {
+      const preferred = this.config.pickSubject(activeTrails, this.subjectIndex);
+      if (
+        preferred !== null &&
+        preferred !== this.subjectIndex &&
+        byIndex.has(preferred)
+      ) {
+        yieldTarget = preferred;
+      }
+    }
+
+    if (finishedOrGone || yieldTarget !== null) {
       // Begin a fly-through to a fresh subject (or hold if none available).
-      const next = this.selectNextSubject(activeTrails, this.subjectIndex);
+      // On a forceNext (N key / next signal) the current subject may still be
+      // active — drop it from the candidate set so even a "keep current when
+      // valid" selector is forced to move to a different cursor. A coordination
+      // yield already carries its resolved target.
+      let next: number | null;
+      if (yieldTarget !== null) {
+        next = yieldTarget;
+      } else {
+        const forced = this.forceNext;
+        const candidates =
+          forced && this.subjectIndex !== null
+            ? activeTrails.filter((t) => t.index !== this.subjectIndex)
+            : activeTrails;
+        next = this.pickFollowSubject(candidates, this.subjectIndex);
+      }
       if (next === null) {
         // Nothing to fly to; keep following the current subject (don't strand
         // the camera) and clear the request so it isn't stuck pending.

--- a/extension/website/shared/utils/installationEventStore.ts
+++ b/extension/website/shared/utils/installationEventStore.ts
@@ -1,0 +1,76 @@
+// ABOUTME: Same-origin IndexedDB store the installation master writes events to
+// ABOUTME: and followers read from, so followers never fetch the ~11 MB payload.
+import { CollectionEvent } from "../types";
+
+const DB_NAME = "wewe-install";
+const STORE_NAME = "events";
+// One fixed key holds the whole event set — the store is a single-slot cache,
+// overwritten wholesale on each master write.
+const RECORD_KEY = "current";
+
+interface StoredEvents {
+  events: CollectionEvent[];
+  version: number;
+}
+
+/** Open (and create on first use) the store. Rejects when IndexedDB is
+ * unavailable (e.g. private mode) so callers can fall back to fetching. */
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB unavailable"));
+      return;
+    }
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("open failed"));
+  });
+}
+
+/** Overwrite the stored events and bump the stored version. The bumped version
+ * rides along on the `events-ready` ping so followers can tell writes apart. */
+export async function writeEvents(events: CollectionEvent[]): Promise<void> {
+  const db = await openDb();
+  const previous = await readFromDb(db);
+  const version = (previous?.version ?? 0) + 1;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      tx.objectStore(STORE_NAME).put({ events, version }, RECORD_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("write failed"));
+      tx.onabort = () => reject(tx.error ?? new Error("write aborted"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+/** Read the stored events, or null when nothing has been written yet (or
+ * IndexedDB is unavailable — the promise rejects in that case). */
+export async function readEvents(): Promise<StoredEvents | null> {
+  const db = await openDb();
+  try {
+    return await readFromDb(db);
+  } finally {
+    db.close();
+  }
+}
+
+function readFromDb(db: IDBDatabase): Promise<StoredEvents | null> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, "readonly");
+    const request = tx.objectStore(STORE_NAME).get(RECORD_KEY);
+    request.onsuccess = () => {
+      const value = request.result as StoredEvents | undefined;
+      resolve(value ?? null);
+    };
+    request.onerror = () => reject(request.error ?? new Error("read failed"));
+  });
+}

--- a/extension/website/shared/utils/installationUrls.ts
+++ b/extension/website/shared/utils/installationUrls.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Turns a saved archive/share URL into a matched set of installation
+// ABOUTME: screen URLs — one master + N coordinated followers — for multi-screen.
+
+/** One screen in a generated installation set. */
+export interface InstallationScreen {
+  /** "master" (full field, drives the clock) or "follower N" (zoomed). */
+  label: string;
+  role: "master" | "follower";
+  /** Stable follower id for cursor-claim coordination; undefined for master. */
+  followerId?: string;
+  /** The full URL to open on that screen. */
+  url: string;
+}
+
+/** Follower ids a, b, c, … (then a2, b2 … past 26, which no real install hits). */
+function followerIdForIndex(i: number): string {
+  const letter = String.fromCharCode(97 + (i % 26));
+  const cycle = Math.floor(i / 26);
+  return cycle === 0 ? letter : `${letter}${cycle + 1}`;
+}
+
+/** Build a master + `followerCount` follower URLs from a saved share URL.
+ *
+ * Every screen keeps the source URL's params (day/tod/viz/`?s=` blob) so they
+ * render identical trail data, and only differs by the installation params:
+ *   - master:   `?role=master` (full field, broadcasts the clock)
+ *   - follower: `?role=follower&cinematic=follow&follower=<id>` (zoomed; the
+ *               followers coordinate at runtime so no two ride the same cursor)
+ *
+ * `origin` overrides the source URL's origin (so a config saved on the deployed
+ * site can be pointed at localhost for testing, or vice versa). Pass the current
+ * page origin to keep everything same-origin — required for the BroadcastChannel
+ * clock/claims to connect across the windows.
+ *
+ * Any pre-existing role/cinematic/follow(er) params on the source URL are
+ * stripped first so re-running the builder on an already-installation URL is
+ * idempotent. `clean=2` is forced on so the screens read as bare art. */
+export function buildInstallationScreens(
+  sourceUrl: string,
+  followerCount: number,
+  origin?: string,
+): InstallationScreen[] {
+  const base = new URL(sourceUrl, origin || undefined);
+  if (origin) {
+    const o = new URL(origin);
+    base.protocol = o.protocol;
+    base.host = o.host;
+  }
+  // Point every screen at the installation view regardless of the source page.
+  base.pathname = "/installation/";
+
+  // Strip params the builder owns so the result is idempotent.
+  for (const key of ["role", "cinematic", "follow", "follower"]) {
+    base.searchParams.delete(key);
+  }
+  // Screens are bare art surfaces.
+  base.searchParams.set("clean", "2");
+
+  const withParams = (params: Record<string, string>): string => {
+    const u = new URL(base.toString());
+    for (const [k, v] of Object.entries(params)) u.searchParams.set(k, v);
+    return u.toString();
+  };
+
+  const screens: InstallationScreen[] = [
+    { label: "master", role: "master", url: withParams({ role: "master" }) },
+  ];
+
+  const count = Math.max(0, Math.floor(followerCount));
+  for (let i = 0; i < count; i++) {
+    const id = followerIdForIndex(i);
+    screens.push({
+      label: `follower ${id}`,
+      role: "follower",
+      followerId: id,
+      url: withParams({
+        role: "follower",
+        cinematic: "follow",
+        follower: id,
+      }),
+    });
+  }
+
+  return screens;
+}

--- a/extension/website/shared/utils/shareUrl.ts
+++ b/extension/website/shared/utils/shareUrl.ts
@@ -97,6 +97,8 @@ export function buildShareUrl({
       "cinemaVelZoom",
       "cinemaReveal",
       "cinemaStartZoom",
+      "role",
+      "follower",
     ];
     for (const key of PRESERVE) {
       const val = current.get(key);


### PR DESCRIPTION
## What

Adds a **multi-screen installation mode** for the `wewere.online` cursor-trail visualization: run one big "master" screen showing the full field plus 1–N small "follower" screens that each cinematically zoom into a different cursor, all synced, off a single computer.

New page: `/installation/`. A window's role is set by URL params (`?role=master` / `?role=follower&cinematic=follow&follower=<id>`). The saved-configs page (`/archive/saved.html`) gains an **⧉ install** builder that generates and opens the matched master + follower URL set.

## How it works (one machine, no server)

- **Clock sync** — a shared wall-clock epoch over `BroadcastChannel`. The master is authoritative: every master (re)load stamps a fresh epoch and restarts the cycle for all screens; followers derive their time from it. Because each window computes its own time from the epoch, a backgrounded/throttled window self-corrects instead of drifting.
- **Coordinated auto-follow** — followers auto-pick a cursor, hop to a new one when it finishes, and coordinate over `BroadcastChannel` so no two screens ever ride the same cursor (random pick among unclaimed; claims heartbeat + expire so a closed window frees its cursor).
- **Master event relay** — the master fetches events once (now with retry) and writes them to IndexedDB; followers read from there and **never fetch**, so a network hiccup can't blank a screen and the worker isn't hit N times.

## Isolation / maintainability

Installation logic lives in **new files** (`useInstallationClock`, `useFollowerCoordination`, `useInstallationEvents`, `installationEventStore`, `installationUrls`, `installation/installation.tsx`) and composes on top of the existing viz. Shared code gets only thin, optional hooks gated by `role !== null` — **the archive/portrait pages are unaffected** (verified: same fetch, same render, 0 errors; a stray `role` param is inert). `archive.tsx`'s fetch was extracted into a shared `useArchiveEvents` hook (behavior-preserving) so both pages share it without forking; the archive gets the fetch-retry for free.

## Scope

Only `extension/website/**` (the art project) — no `packages/`, `extension/src/`, or docs changes, so no changeset / PENDING bullet needed.

## Verified (headless)

- Master + 2 followers render in sync; followers make **0** `/events/recent` requests.
- Master backgrounded 5s → windows stay matched (no drift). Master reload → all followers restart with it.
- Follower reload → refills from IndexedDB, 0 fetches. Follower before master → holds, then fills.
- Three followers hold **distinct** cursors (0 overlaps).
- Archive page unchanged: 1 fetch, full render, 0 errors.

## Notes / follow-ups (not in this PR)

- Sync is **same-machine only** (BroadcastChannel). Cross-machine/cross-person sync would need a real-time server — out of scope.
- This relay is the **foundation for live data** (swap the archive fetch for the `/stream` feed later).
