### PR TITLE
docs: point CLAUDE.md at the global papercut CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@ playhtml is a collaborative, interactive HTML library that allows elements to be
 - `bun deploy-server`: Deploy PartyKit to production
 - `bun deploy-server:staging`: Deploy PartyKit to staging
 
+## Papercuts
+
+When you hit a small friction while working — a tool call that missed and had to be retried, a confusing or undocumented setup step, a flaky command, a stale cache, a misleading error, a non-obvious gotcha — log it via `papercut -m <model> "message"` (a global CLI on the machine, not a repo script). One or two sentences: what you were doing → what got in the way (a guess at the cause/fix is a bonus). Do this proactively, in the moment, even though none of these are blocking — logged together they show where the repo needs sanding down. This is distinct from what you accomplished (that goes in your work summary / commit) and from real bugs or tracked work (those are issues).
+
+To mine a whole session for papercuts at once, `papercut review` feeds the current session transcript to a cheap model and appends what it finds; it auto-detects the latest transcript for this project. This is user-triggered — don't run the review yourself unprompted.
+
+Papercuts are stored centrally per repo on the machine (keyed by git remote), outside the repo, so nothing here is committed. If the `papercut` command isn't installed, skip logging rather than creating files in the repo.
+
 ## Architecture
 
 ### Core Library (packages/playhtml)


### PR DESCRIPTION
## Summary

Adds a short **Papercuts** section to `CLAUDE.md` documenting the convention for logging small repo frictions (retried tool calls, confusing setup, flaky commands, stale caches, misleading errors, gotchas) so agents log them proactively.

The actual tooling is a **machine-global CLI** (`papercut` / `papercut review`) that lives outside any repo and stores notes centrally per repo (keyed by git remote). That keeps both the tool and its data out of playhtml — this PR is purely the in-repo convention pointer, no scripts, no `package.json` or `.gitignore` changes.

## Why global instead of in-repo

Papercut logging isn't playhtml-specific — the transcript locator, the review model call, and the storage all work for any repo. Baking scripts into each repo would mean copy-pasting the tool everywhere and carrying workflow-specific `package.json` entries in every project. So the tool is global; only the "log papercuts here" convention lives in the repo's CLAUDE.md.

## Scope

Single change: 8-line Papercuts section in `CLAUDE.md`. No code under `packages/`, so no changeset needed.