### PR TITLE
worker: keep metadata history monotonic

### DIFF
--- a/extension/db/migrations/page_metadata_history_atomic.sql
+++ b/extension/db/migrations/page_metadata_history_atomic.sql
@@ -1,3 +1,6 @@
+-- ABOUTME: Serializes page metadata history transitions in PostgreSQL.
+-- ABOUTME: Enforces one current row and tracks the latest observation timestamp.
+
 do $$
 begin
   if exists (
@@ -18,6 +21,16 @@ create unique index idx_page_metadata_history_current
   on public.page_metadata_history (page_ref)
   where valid_to_ts is null;
 
+alter table public.page_metadata_history
+  add column if not exists latest_observed_at_ts timestamptz;
+
+update public.page_metadata_history
+set latest_observed_at_ts = valid_from_ts
+where latest_observed_at_ts is null;
+
+alter table public.page_metadata_history
+  alter column latest_observed_at_ts set not null;
+
 create or replace function public.record_page_metadata_snapshot(
   p_page_ref text,
   p_canonical_url text,
@@ -32,22 +45,26 @@ set search_path = public
 as $$
 declare
   current_metadata_hash text;
-  current_valid_from_ts timestamptz;
+  current_latest_observed_at_ts timestamptz;
 begin
   perform pg_advisory_xact_lock(hashtextextended(p_page_ref, 0));
 
-  select metadata_hash, valid_from_ts
-  into current_metadata_hash, current_valid_from_ts
+  select metadata_hash, latest_observed_at_ts
+  into current_metadata_hash, current_latest_observed_at_ts
   from public.page_metadata_history
   where page_ref = p_page_ref
     and valid_to_ts is null
   for update;
 
-  if found and p_observed_at_ts <= current_valid_from_ts then
+  if found and p_observed_at_ts <= current_latest_observed_at_ts then
     return false;
   end if;
 
   if found and current_metadata_hash = p_metadata_hash then
+    update public.page_metadata_history
+    set latest_observed_at_ts = p_observed_at_ts
+    where page_ref = p_page_ref
+      and valid_to_ts is null;
     return false;
   end if;
 
@@ -65,6 +82,7 @@ begin
     favicon_url,
     metadata_hash,
     valid_from_ts,
+    latest_observed_at_ts,
     valid_to_ts
   ) values (
     p_page_ref,
@@ -72,6 +90,7 @@ begin
     p_title,
     p_favicon_url,
     p_metadata_hash,
+    p_observed_at_ts,
     p_observed_at_ts,
     null
   );

--- a/extension/db/migrations/page_metadata_history_atomic.sql
+++ b/extension/db/migrations/page_metadata_history_atomic.sql
@@ -1,0 +1,81 @@
+do $$
+begin
+  if exists (
+    select 1
+    from public.page_metadata_history
+    where valid_to_ts is null
+    group by page_ref
+    having count(*) > 1
+  ) then
+    raise exception 'page_metadata_history has multiple current rows; resolve them before applying this migration';
+  end if;
+end;
+$$;
+
+drop index if exists public.idx_page_metadata_history_current;
+
+create unique index idx_page_metadata_history_current
+  on public.page_metadata_history (page_ref)
+  where valid_to_ts is null;
+
+create or replace function public.record_page_metadata_snapshot(
+  p_page_ref text,
+  p_canonical_url text,
+  p_title text,
+  p_favicon_url text,
+  p_metadata_hash text,
+  p_observed_at_ts timestamptz
+)
+returns boolean
+language plpgsql
+set search_path = public
+as $$
+declare
+  current_metadata_hash text;
+  current_valid_from_ts timestamptz;
+begin
+  perform pg_advisory_xact_lock(hashtextextended(p_page_ref, 0));
+
+  select metadata_hash, valid_from_ts
+  into current_metadata_hash, current_valid_from_ts
+  from public.page_metadata_history
+  where page_ref = p_page_ref
+    and valid_to_ts is null
+  for update;
+
+  if found and p_observed_at_ts <= current_valid_from_ts then
+    return false;
+  end if;
+
+  if found and current_metadata_hash = p_metadata_hash then
+    return false;
+  end if;
+
+  if found then
+    update public.page_metadata_history
+    set valid_to_ts = p_observed_at_ts
+    where page_ref = p_page_ref
+      and valid_to_ts is null;
+  end if;
+
+  insert into public.page_metadata_history (
+    page_ref,
+    canonical_url,
+    title,
+    favicon_url,
+    metadata_hash,
+    valid_from_ts,
+    valid_to_ts
+  ) values (
+    p_page_ref,
+    p_canonical_url,
+    p_title,
+    p_favicon_url,
+    p_metadata_hash,
+    p_observed_at_ts,
+    null
+  );
+
+  return true;
+end;
+$$;

--- a/extension/db/tests/page_metadata_history_atomic.test.sh
+++ b/extension/db/tests/page_metadata_history_atomic.test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ABOUTME: Verifies page metadata history transitions against real PostgreSQL.
+# ABOUTME: Exercises watermark handling and advisory-lock serialization.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+migration_path="$script_dir/../migrations/page_metadata_history_atomic.sql"
+container="page-metadata-history-test-$$"
+
+cleanup() {
+  docker rm -f "$container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+run_sql() {
+  docker exec "$container" psql -X -v ON_ERROR_STOP=1 -At -U postgres -d playhtml -c "$1"
+}
+
+assert_equals() {
+  if [[ "$1" != "$2" ]]; then
+    echo "Expected '$1', got '$2'" >&2
+    exit 1
+  fi
+}
+
+call_snapshot() {
+  run_sql "select public.record_page_metadata_snapshot('$1', 'https://example.com/', '$2', '', '$3', '$4'::timestamptz)"
+}
+
+docker run --rm -d --name "$container" -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=playhtml postgres:15-alpine >/dev/null
+
+until run_sql "select 1" >/dev/null 2>&1; do
+  sleep 0.1
+done
+
+run_sql "create extension if not exists pgcrypto" >/dev/null
+run_sql "create table public.page_metadata_history (id uuid primary key default gen_random_uuid(), page_ref text not null, canonical_url text not null, title text not null, favicon_url text not null, metadata_hash text not null, valid_from_ts timestamptz not null, valid_to_ts timestamptz null, created_at timestamptz not null default now())" >/dev/null
+run_sql "create index idx_page_metadata_history_current on public.page_metadata_history (page_ref) where valid_to_ts is null" >/dev/null
+docker cp "$migration_path" "$container:/page_metadata_history_atomic.sql"
+docker exec "$container" psql -X -v ON_ERROR_STOP=1 -U postgres -d playhtml -f /page_metadata_history_atomic.sql >/dev/null
+
+assert_equals "t" "$(call_snapshot page-watermark A hash-a '1970-01-01T00:01:40Z')"
+assert_equals "f" "$(call_snapshot page-watermark A hash-a '1970-01-01T00:05:00Z')"
+assert_equals "f" "$(call_snapshot page-watermark B hash-b '1970-01-01T00:03:20Z')"
+assert_equals "hash-a" "$(run_sql "select metadata_hash from public.page_metadata_history where page_ref = 'page-watermark' and valid_to_ts is null")"
+assert_equals "t" "$(run_sql "select valid_from_ts = '1970-01-01T00:01:40Z'::timestamptz from public.page_metadata_history where page_ref = 'page-watermark' and valid_to_ts is null")"
+assert_equals "t" "$(run_sql "select latest_observed_at_ts = '1970-01-01T00:05:00Z'::timestamptz from public.page_metadata_history where page_ref = 'page-watermark' and valid_to_ts is null")"
+
+assert_equals "t" "$(call_snapshot page-concurrent A hash-a '1970-01-01T00:01:40Z')"
+docker exec "$container" psql -X -v ON_ERROR_STOP=1 -U postgres -d playhtml -c "begin; select pg_advisory_xact_lock(hashtextextended('page-concurrent', 0)); select pg_sleep(1); commit" >/dev/null &
+lock_pid=$!
+
+for _ in $(seq 1 50); do
+  if [[ "$(run_sql "select count(*) from pg_locks where locktype = 'advisory'")" -gt 0 ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+call_snapshot page-concurrent B hash-b '1970-01-01T00:03:20Z' >/dev/null &
+older_pid=$!
+call_snapshot page-concurrent A hash-a '1970-01-01T00:05:00Z' >/dev/null &
+newer_pid=$!
+
+wait "$lock_pid" "$older_pid" "$newer_pid"
+
+assert_equals "1" "$(run_sql "select count(*) from public.page_metadata_history where page_ref = 'page-concurrent' and valid_to_ts is null")"
+assert_equals "hash-a" "$(run_sql "select metadata_hash from public.page_metadata_history where page_ref = 'page-concurrent' and valid_to_ts is null")"
+assert_equals "t" "$(run_sql "select latest_observed_at_ts = '1970-01-01T00:05:00Z'::timestamptz from public.page_metadata_history where page_ref = 'page-concurrent' and valid_to_ts is null")"

--- a/extension/worker/package.json
+++ b/extension/worker/package.json
@@ -9,7 +9,8 @@
     "tail": "wrangler tail --config wrangler.toml",
     "secret": "wrangler --config wrangler.toml secret",
     "secrets": "wrangler --config wrangler.toml secret list",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:db": "../db/tests/page_metadata_history_atomic.test.sh"
   },
   "dependencies": {
     "@playhtml/extension-types": "workspace:*",

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -186,21 +186,8 @@ describe('handleIngest', () => {
     await expect(res.json()).resolves.toMatchObject({ page_metadata_inserted: 1 });
   });
 
-  it('serializes concurrent snapshots for the same page through the metadata RPC', async () => {
-    let current: { metadataHash: string; observedAtTs: string } | undefined;
-    metadataHistoryRpc.mockImplementation(async (_functionName, params) => {
-      if (current && params.p_observed_at_ts <= current.observedAtTs) {
-        return { data: false, error: null };
-      }
-
-      current = {
-        metadataHash: params.p_metadata_hash,
-        observedAtTs: params.p_observed_at_ts,
-      };
-      return { data: true, error: null };
-    });
-
-    const [first, second] = await Promise.all([
+  it('sends concurrent snapshots through the metadata RPC', async () => {
+    await Promise.all([
       handleIngest(
         makeRequest([
           makeNavigationEvent('concurrent-first', { metadataHash: 'hash-first' }),
@@ -218,11 +205,5 @@ describe('handleIngest', () => {
     ]);
 
     expect(metadataHistoryRpc).toHaveBeenCalledTimes(2);
-    await expect(first.json()).resolves.toMatchObject({ page_metadata_inserted: 1 });
-    await expect(second.json()).resolves.toMatchObject({ page_metadata_inserted: 0 });
-    expect(current).toEqual({
-      metadataHash: 'hash-first',
-      observedAtTs: new Date(1_700_000_000_000).toISOString(),
-    });
   });
 });

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -9,15 +9,7 @@ const collectionEvents = {
   select: vi.fn(),
 };
 
-const pageMetadataHistory = {
-  select: vi.fn(),
-  in: vi.fn(),
-  is: vi.fn(),
-  update: vi.fn(),
-  eq: vi.fn(),
-  insert: vi.fn(),
-  single: vi.fn(),
-};
+const metadataHistoryRpc = vi.fn();
 
 vi.mock('../lib/supabase', () => ({
   createSupabaseClient: vi.fn(() => ({
@@ -25,11 +17,9 @@ vi.mock('../lib/supabase', () => ({
       if (table === 'collection_events') {
         return collectionEvents;
       }
-      if (table === 'page_metadata_history') {
-        return pageMetadataHistory;
-      }
       throw new Error(`Unexpected table: ${table}`);
     }),
+    rpc: metadataHistoryRpc,
   })),
 }));
 
@@ -89,13 +79,7 @@ describe('handleIngest', () => {
   beforeEach(() => {
     collectionEvents.upsert.mockReset();
     collectionEvents.select.mockReset();
-    pageMetadataHistory.select.mockReset();
-    pageMetadataHistory.in.mockReset();
-    pageMetadataHistory.is.mockReset();
-    pageMetadataHistory.update.mockReset();
-    pageMetadataHistory.eq.mockReset();
-    pageMetadataHistory.insert.mockReset();
-    pageMetadataHistory.single.mockReset();
+    metadataHistoryRpc.mockReset();
     waitUntil.mockReset();
 
     collectionEvents.upsert.mockReturnValue({
@@ -105,21 +89,7 @@ describe('handleIngest', () => {
     });
     collectionEvents.select.mockResolvedValue({ data: [{ id: 'event-1' }], error: null });
 
-    pageMetadataHistory.select.mockReturnValue(pageMetadataHistory);
-    pageMetadataHistory.in.mockReturnValue(pageMetadataHistory);
-    pageMetadataHistory.is.mockResolvedValue({ data: [], error: null });
-    pageMetadataHistory.insert.mockReturnValue(pageMetadataHistory);
-    pageMetadataHistory.update.mockReturnValue(pageMetadataHistory);
-    pageMetadataHistory.eq.mockResolvedValue({ error: null });
-    pageMetadataHistory.single.mockResolvedValue({
-      data: {
-        id: 'metadata-1',
-        page_ref: 'page-1',
-        metadata_hash: 'hash-1',
-        valid_from_ts: new Date(1_700_000_000_000).toISOString(),
-      },
-      error: null,
-    });
+    metadataHistoryRpc.mockResolvedValue({ data: true, error: null });
   });
 
   it('accepts event upserts without selecting inserted row ids', async () => {
@@ -151,17 +121,7 @@ describe('handleIngest', () => {
   });
 
   it('ignores an older retry that would overwrite the current metadata', async () => {
-    pageMetadataHistory.is.mockResolvedValue({
-      data: [
-        {
-          id: 'metadata-current',
-          page_ref: 'page-1',
-          metadata_hash: 'hash-current',
-          valid_from_ts: new Date(1_700_000_000_100).toISOString(),
-        },
-      ],
-      error: null,
-    });
+    metadataHistoryRpc.mockResolvedValue({ data: false, error: null });
 
     const res = await handleIngest(
       makeRequest([
@@ -174,8 +134,10 @@ describe('handleIngest', () => {
     );
 
     expect(res.status).toBe(200);
-    expect(pageMetadataHistory.update).not.toHaveBeenCalled();
-    expect(pageMetadataHistory.insert).not.toHaveBeenCalled();
+    expect(metadataHistoryRpc).toHaveBeenCalledWith(
+      'record_page_metadata_snapshot',
+      expect.objectContaining({ p_metadata_hash: 'hash-retried' }),
+    );
     await expect(res.json()).resolves.toMatchObject({ page_metadata_inserted: 0 });
   });
 
@@ -198,27 +160,69 @@ describe('handleIngest', () => {
     );
 
     expect(res.status).toBe(200);
-    expect(pageMetadataHistory.insert).toHaveBeenCalledTimes(2);
-    expect(pageMetadataHistory.insert).toHaveBeenNthCalledWith(
+    expect(metadataHistoryRpc).toHaveBeenCalledTimes(2);
+    expect(metadataHistoryRpc).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ metadata_hash: 'hash-older' }),
+      'record_page_metadata_snapshot',
+      expect.objectContaining({ p_metadata_hash: 'hash-older' }),
     );
-    expect(pageMetadataHistory.insert).toHaveBeenNthCalledWith(
+    expect(metadataHistoryRpc).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ metadata_hash: 'hash-newest' }),
+      'record_page_metadata_snapshot',
+      expect.objectContaining({ p_metadata_hash: 'hash-newest' }),
     );
-    expect(pageMetadataHistory.update).toHaveBeenCalledWith({
-      valid_to_ts: new Date(1_700_000_000_200).toISOString(),
-    });
   });
 
   it('does not duplicate history when a navigation event id is retried', async () => {
     const event = makeNavigationEvent('duplicate-event');
+    metadataHistoryRpc
+      .mockResolvedValueOnce({ data: true, error: null })
+      .mockResolvedValueOnce({ data: false, error: null });
 
     const res = await handleIngest(makeRequest([event, event]), ENV, CTX);
 
     expect(res.status).toBe(200);
-    expect(pageMetadataHistory.insert).toHaveBeenCalledTimes(1);
+    expect(metadataHistoryRpc).toHaveBeenCalledTimes(2);
     await expect(res.json()).resolves.toMatchObject({ page_metadata_inserted: 1 });
+  });
+
+  it('serializes concurrent snapshots for the same page through the metadata RPC', async () => {
+    let current: { metadataHash: string; observedAtTs: string } | undefined;
+    metadataHistoryRpc.mockImplementation(async (_functionName, params) => {
+      if (current && params.p_observed_at_ts <= current.observedAtTs) {
+        return { data: false, error: null };
+      }
+
+      current = {
+        metadataHash: params.p_metadata_hash,
+        observedAtTs: params.p_observed_at_ts,
+      };
+      return { data: true, error: null };
+    });
+
+    const [first, second] = await Promise.all([
+      handleIngest(
+        makeRequest([
+          makeNavigationEvent('concurrent-first', { metadataHash: 'hash-first' }),
+        ]),
+        ENV,
+        CTX,
+      ),
+      handleIngest(
+        makeRequest([
+          makeNavigationEvent('concurrent-second', { metadataHash: 'hash-second' }),
+        ]),
+        ENV,
+        CTX,
+      ),
+    ]);
+
+    expect(metadataHistoryRpc).toHaveBeenCalledTimes(2);
+    await expect(first.json()).resolves.toMatchObject({ page_metadata_inserted: 1 });
+    await expect(second.json()).resolves.toMatchObject({ page_metadata_inserted: 0 });
+    expect(current).toEqual({
+      metadataHash: 'hash-first',
+      observedAtTs: new Date(1_700_000_000_000).toISOString(),
+    });
   });
 });

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -54,18 +54,25 @@ function makeRequest(events: unknown[]): Request {
   });
 }
 
-function makeNavigationEvent(id: string) {
+function makeNavigationEvent(
+  id: string,
+  {
+    ts = 1_700_000_000_000,
+    title = 'Example',
+    metadataHash = 'hash-1',
+  }: { ts?: number; title?: string; metadataHash?: string } = {},
+) {
   return {
     id,
     type: 'navigation',
-    ts: 1_700_000_000_000,
+    ts,
     data: {
       event: 'focus',
       page_ref: 'page-1',
       canonical_url: 'https://example.com/',
-      title: 'Example',
+      title,
       favicon_url: 'https://example.com/favicon.ico',
-      metadata_hash: 'hash-1',
+      metadata_hash: metadataHash,
     },
     meta: {
       pid: 'pid',
@@ -102,11 +109,14 @@ describe('handleIngest', () => {
     pageMetadataHistory.in.mockReturnValue(pageMetadataHistory);
     pageMetadataHistory.is.mockResolvedValue({ data: [], error: null });
     pageMetadataHistory.insert.mockReturnValue(pageMetadataHistory);
+    pageMetadataHistory.update.mockReturnValue(pageMetadataHistory);
+    pageMetadataHistory.eq.mockResolvedValue({ error: null });
     pageMetadataHistory.single.mockResolvedValue({
       data: {
         id: 'metadata-1',
         page_ref: 'page-1',
         metadata_hash: 'hash-1',
+        valid_from_ts: new Date(1_700_000_000_000).toISOString(),
       },
       error: null,
     });
@@ -138,5 +148,77 @@ describe('handleIngest', () => {
       duplicates: 0,
       page_metadata_inserted: 1,
     });
+  });
+
+  it('ignores an older retry that would overwrite the current metadata', async () => {
+    pageMetadataHistory.is.mockResolvedValue({
+      data: [
+        {
+          id: 'metadata-current',
+          page_ref: 'page-1',
+          metadata_hash: 'hash-current',
+          valid_from_ts: new Date(1_700_000_000_100).toISOString(),
+        },
+      ],
+      error: null,
+    });
+
+    const res = await handleIngest(
+      makeRequest([
+        makeNavigationEvent('retried-event', {
+          metadataHash: 'hash-retried',
+        }),
+      ]),
+      ENV,
+      CTX,
+    );
+
+    expect(res.status).toBe(200);
+    expect(pageMetadataHistory.update).not.toHaveBeenCalled();
+    expect(pageMetadataHistory.insert).not.toHaveBeenCalled();
+    await expect(res.json()).resolves.toMatchObject({ page_metadata_inserted: 0 });
+  });
+
+  it('keeps metadata snapshots in observation order within one request', async () => {
+    const res = await handleIngest(
+      makeRequest([
+        makeNavigationEvent('newest-event', {
+          ts: 1_700_000_000_200,
+          title: 'Newest title',
+          metadataHash: 'hash-newest',
+        }),
+        makeNavigationEvent('older-event', {
+          ts: 1_700_000_000_100,
+          title: 'Older title',
+          metadataHash: 'hash-older',
+        }),
+      ]),
+      ENV,
+      CTX,
+    );
+
+    expect(res.status).toBe(200);
+    expect(pageMetadataHistory.insert).toHaveBeenCalledTimes(2);
+    expect(pageMetadataHistory.insert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ metadata_hash: 'hash-older' }),
+    );
+    expect(pageMetadataHistory.insert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ metadata_hash: 'hash-newest' }),
+    );
+    expect(pageMetadataHistory.update).toHaveBeenCalledWith({
+      valid_to_ts: new Date(1_700_000_000_200).toISOString(),
+    });
+  });
+
+  it('does not duplicate history when a navigation event id is retried', async () => {
+    const event = makeNavigationEvent('duplicate-event');
+
+    const res = await handleIngest(makeRequest([event, event]), ENV, CTX);
+
+    expect(res.status).toBe(200);
+    expect(pageMetadataHistory.insert).toHaveBeenCalledTimes(1);
+    await expect(res.json()).resolves.toMatchObject({ page_metadata_inserted: 1 });
   });
 });

--- a/extension/worker/src/routes/ingest.ts
+++ b/extension/worker/src/routes/ingest.ts
@@ -38,13 +38,6 @@ interface NavigationLikeData {
   [key: string]: unknown;
 }
 
-interface CurrentMetadataRow {
-  id: string;
-  page_ref: string;
-  metadata_hash: string;
-  valid_from_ts: string;
-}
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -97,65 +90,25 @@ async function persistPageMetadataHistory(
   }
 
   const sortedSnapshots = [...snapshots].sort((a, b) => a.observed_at_ts - b.observed_at_ts);
-  const refs = [...new Set(sortedSnapshots.map((s) => s.page_ref))];
-  const currentByRef = new Map<string, CurrentMetadataRow>();
-
-  const { data: currentRows, error: currentError } = await supabase
-    .from('page_metadata_history')
-    .select('id, page_ref, metadata_hash, valid_from_ts')
-    .in('page_ref', refs)
-    .is('valid_to_ts', null);
-
-  if (currentError) {
-    throw currentError;
-  }
-
-  for (const row of (currentRows || []) as CurrentMetadataRow[]) {
-    currentByRef.set(row.page_ref, row);
-  }
-
   let insertedCount = 0;
 
   for (const snapshot of sortedSnapshots) {
-    const current = currentByRef.get(snapshot.page_ref);
-    if (current && snapshot.observed_at_ts <= new Date(current.valid_from_ts).getTime()) {
-      continue;
+    const { data: inserted, error } = await supabase.rpc('record_page_metadata_snapshot', {
+      p_page_ref: snapshot.page_ref,
+      p_canonical_url: snapshot.canonical_url,
+      p_title: snapshot.title,
+      p_favicon_url: snapshot.favicon_url,
+      p_metadata_hash: snapshot.metadata_hash,
+      p_observed_at_ts: new Date(snapshot.observed_at_ts).toISOString(),
+    });
+
+    if (error) {
+      throw error;
     }
 
-    if (current && current.metadata_hash === snapshot.metadata_hash) {
-      continue;
+    if (inserted) {
+      insertedCount++;
     }
-
-    if (current) {
-      const { error: closeError } = await supabase
-        .from('page_metadata_history')
-        .update({ valid_to_ts: new Date(snapshot.observed_at_ts).toISOString() })
-        .eq('id', current.id);
-      if (closeError) {
-        throw closeError;
-      }
-    }
-
-    const { data: insertedRow, error: insertError } = await supabase
-      .from('page_metadata_history')
-      .insert({
-        page_ref: snapshot.page_ref,
-        canonical_url: snapshot.canonical_url,
-        title: snapshot.title,
-        favicon_url: snapshot.favicon_url,
-        metadata_hash: snapshot.metadata_hash,
-        valid_from_ts: new Date(snapshot.observed_at_ts).toISOString(),
-        valid_to_ts: null,
-      })
-      .select('id, page_ref, metadata_hash, valid_from_ts')
-      .single();
-
-    if (insertError) {
-      throw insertError;
-    }
-
-    currentByRef.set(snapshot.page_ref, insertedRow as CurrentMetadataRow);
-    insertedCount++;
   }
 
   return insertedCount;

--- a/extension/worker/src/routes/ingest.ts
+++ b/extension/worker/src/routes/ingest.ts
@@ -42,6 +42,7 @@ interface CurrentMetadataRow {
   id: string;
   page_ref: string;
   metadata_hash: string;
+  valid_from_ts: string;
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -101,7 +102,7 @@ async function persistPageMetadataHistory(
 
   const { data: currentRows, error: currentError } = await supabase
     .from('page_metadata_history')
-    .select('id, page_ref, metadata_hash')
+    .select('id, page_ref, metadata_hash, valid_from_ts')
     .in('page_ref', refs)
     .is('valid_to_ts', null);
 
@@ -117,6 +118,10 @@ async function persistPageMetadataHistory(
 
   for (const snapshot of sortedSnapshots) {
     const current = currentByRef.get(snapshot.page_ref);
+    if (current && snapshot.observed_at_ts <= new Date(current.valid_from_ts).getTime()) {
+      continue;
+    }
+
     if (current && current.metadata_hash === snapshot.metadata_hash) {
       continue;
     }
@@ -142,7 +147,7 @@ async function persistPageMetadataHistory(
         valid_from_ts: new Date(snapshot.observed_at_ts).toISOString(),
         valid_to_ts: null,
       })
-      .select('id, page_ref, metadata_hash')
+      .select('id, page_ref, metadata_hash, valid_from_ts')
       .single();
 
     if (insertError) {


### PR DESCRIPTION
## Summary

- Keep page metadata history monotonic by observation timestamp.
- Ignore delayed or duplicate navigation snapshots that are not newer than the current row.
- Cover older retries, exact duplicate event IDs, and chronological handling of an out-of-order batch.

## Root cause

The history write ran after the event upsert but queried only the current metadata hash. A delayed retry with different metadata could close a newer row at an older timestamp and replace it as current.

## Validation

- `bun run test` in `extension/worker` (45 tests)
- Conservative local review: no findings.

