### PR TITLE
Clean up cursor chat teardown

### DIFF
--- a/.changeset/tidy-cursor-chat.md
+++ b/.changeset/tidy-cursor-chat.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Clean up cursor chat keyboard, timer, and DOM resources when cursor presence is destroyed.

--- a/packages/playhtml/src/cursors/__tests__/chat.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/chat.test.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Tests CursorChat's document event and DOM cleanup lifecycle.
+// ABOUTME: Covers teardown and recreation without stale chat resources.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CursorChat } from "../chat";
+
+function dispatchKey(key: string): boolean {
+  return document.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key }),
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+  document.head.querySelectorAll("style").forEach((style) => style.remove());
+});
+
+describe("CursorChat", () => {
+  it("releases its document listener, timer, UI, and styles when destroyed", () => {
+    vi.useFakeTimers();
+    const onMessageUpdate = vi.fn();
+    const chat = new CursorChat({ onMessageUpdate });
+
+    expect(document.body.querySelector(".playhtml-chat-container")).not.toBeNull();
+    expect(document.head.querySelectorAll("style")).toHaveLength(1);
+
+    expect(dispatchKey("/")).toBe(false);
+    expect(dispatchKey("h")).toBe(false);
+    expect(onMessageUpdate).toHaveBeenLastCalledWith("h");
+    const callbackCountBeforeDestroy = onMessageUpdate.mock.calls.length;
+
+    chat.destroy();
+    chat.destroy();
+
+    expect(document.body.querySelector(".playhtml-chat-container")).toBeNull();
+    expect(document.head.querySelectorAll("style")).toHaveLength(0);
+    expect(dispatchKey("/")).toBe(true);
+    expect(dispatchKey("h")).toBe(true);
+    vi.advanceTimersByTime(10_000);
+    expect(onMessageUpdate).toHaveBeenCalledTimes(callbackCountBeforeDestroy);
+  });
+
+  it("does not stack listeners or styles across recreation cycles", () => {
+    const firstMessageUpdate = vi.fn();
+    const firstChat = new CursorChat({ onMessageUpdate: firstMessageUpdate });
+    firstChat.destroy();
+
+    const secondMessageUpdate = vi.fn();
+    const secondChat = new CursorChat({ onMessageUpdate: secondMessageUpdate });
+
+    expect(document.body.querySelectorAll(".playhtml-chat-container")).toHaveLength(1);
+    expect(document.head.querySelectorAll("style")).toHaveLength(1);
+    expect(dispatchKey("/")).toBe(false);
+    expect(dispatchKey("h")).toBe(false);
+    expect(firstMessageUpdate).not.toHaveBeenCalled();
+    expect(secondMessageUpdate).toHaveBeenLastCalledWith("h");
+
+    secondChat.destroy();
+  });
+});

--- a/packages/playhtml/src/cursors/chat.ts
+++ b/packages/playhtml/src/cursors/chat.ts
@@ -1,4 +1,5 @@
-// Chat functionality for cursor presence, based on cursor-party
+// ABOUTME: Provides the keyboard-driven chat input for cursor presence.
+// ABOUTME: Manages the chat's owned document listener and DOM resources.
 
 export interface ChatOptions {
   onMessageUpdate?: (message: string | null) => void;
@@ -8,6 +9,8 @@ export class CursorChat {
   private listening: boolean = false;
   private message: string = "";
   private chatElement: HTMLElement | null = null;
+  private styleElement: HTMLStyleElement | null = null;
+  private keydownHandler: ((event: KeyboardEvent) => void) | null = null;
   private timeout: ReturnType<typeof setTimeout> | null = null;
   private options: ChatOptions;
 
@@ -22,7 +25,7 @@ export class CursorChat {
   }
 
   private setupKeyboardHandlers(): void {
-    const handleKeyDown = (event: KeyboardEvent) => {
+    this.keydownHandler = (event: KeyboardEvent) => {
       // Reset any timeouts
       if (this.timeout) {
         clearTimeout(this.timeout);
@@ -63,7 +66,7 @@ export class CursorChat {
       }
     };
 
-    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keydown", this.keydownHandler);
   }
 
   private setListening(listening: boolean): void {
@@ -80,10 +83,10 @@ export class CursorChat {
   private createChatElement(): void {
     if (this.chatElement) return;
 
-    const style = document.createElement("style");
+    this.styleElement = document.createElement("style");
     // TODO: make background color themed based on your cursor color
     // TODO: allow customization from developers/users
-    style.textContent = `
+    this.styleElement.textContent = `
       .playhtml-chat-container {
         box-sizing: border-box;
         position: fixed;
@@ -135,7 +138,7 @@ export class CursorChat {
         background-color: transparent;
       }
     `;
-    document.head.appendChild(style);
+    document.head.appendChild(this.styleElement);
 
     this.chatElement = document.createElement("div");
     this.chatElement.className = "playhtml-chat-container";
@@ -188,13 +191,24 @@ export class CursorChat {
   }
 
   public destroy(): void {
-    if (this.timeout) {
+    if (this.keydownHandler) {
+      document.removeEventListener("keydown", this.keydownHandler);
+      this.keydownHandler = null;
+    }
+
+    if (this.timeout !== null) {
       clearTimeout(this.timeout);
+      this.timeout = null;
     }
 
     if (this.chatElement) {
       this.chatElement.remove();
       this.chatElement = null;
+    }
+
+    if (this.styleElement) {
+      this.styleElement.remove();
+      this.styleElement = null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the CursorChat document keydown listener and injected style node on destroy.
- Clear the owned timeout and chat UI idempotently.
- Cover teardown event behavior and recreate cycles with jsdom tests.

## Validation
- Focused chat test: bun run test -- src/cursors/__tests__/chat.test.ts
- Core suite: bun run test
- Workspace package build: bun run build-packages

## Docs
No docs or starter update: this is an internal teardown fix. The enableChat API and user-visible behavior are unchanged, and neither starter enables cursor chat.

## Review
Local review found no issues.