### PR TITLE
Extension: preserve imported event history

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,6 +2,7 @@
 
 - The inventory shortcut moved to Ctrl+Shift+B on Windows/Linux (Cmd+Shift+I on Mac is unchanged), freeing Ctrl+Shift+E for an in-progress emote wheel.
 - Firefox now keeps one reliable browser-session identity without adding warnings to webpage consoles.
+- Restored and imported history now preserves its sync state and accurate activity totals.
 
 <!--
 Add a bullet here in any PR that changes the extension itself (extension/src/**

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,7 +2,7 @@
 
 - The inventory shortcut moved to Ctrl+Shift+B on Windows/Linux (Cmd+Shift+I on Mac is unchanged), freeing Ctrl+Shift+E for an in-progress emote wheel.
 - Firefox now keeps one reliable browser-session identity without adding warnings to webpage consoles.
-- Restored and imported history now preserves its sync state and accurate activity totals.
+- Restored history no longer uploads again, while offline history in imported files stays queued to sync.
 
 <!--
 Add a bullet here in any PR that changes the extension itself (extension/src/**

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -225,6 +225,39 @@ describe("LocalEventStore aggregates", () => {
     expect(agg.pendingFocusTs).toBe(1_000);
     expect(agg.pendingFocusUrl).toBe("https://example.com/page");
   });
+
+  it("rebuilds aggregates from unique events in chronological order after a bulk import", async () => {
+    const store = createStore();
+    const focus = {
+      ...event("focus-event", "navigation"),
+      ts: 1_000,
+      data: { event: "focus" },
+    };
+    const blur = {
+      ...event("blur-event", "navigation"),
+      ts: 7_000,
+      data: { event: "blur" },
+    };
+
+    await store.addImportedEvents([blur, focus]);
+    await store.addImportedEvents([blur, focus]);
+
+    const [domainStats, pageStats, globalStats] = await Promise.all([
+      store.getSessionStats("example.com"),
+      store.getSessionStats("example.com", "https://example.com/page"),
+      store.getGlobalStats(),
+    ]);
+
+    for (const stats of [domainStats, pageStats, globalStats]) {
+      expect(stats).toMatchObject({
+        totalTimeMs: 6_000,
+        sessionCount: 1,
+        eventsByType: { navigation: 2 },
+        firstVisit: 1_000,
+        lastVisit: 7_000,
+      });
+    }
+  });
 });
 
 describe("LocalEventStore aggregate migrations", () => {
@@ -491,6 +524,20 @@ describe("LocalEventStore pending uploads", () => {
     expect((sourceEvent as StoredTestEvent).uploadState).toBeUndefined();
     expect((events[0] as StoredTestEvent).uploaded).toBeUndefined();
     expect((events[0] as StoredTestEvent).uploadState).toBeUndefined();
+  });
+
+  it("does not return trusted imported history as pending", async () => {
+    const store = createStore();
+
+    await store.addEvents([event("new-cursor", "cursor")]);
+    await store.addImportedEvents([
+      event("imported-cursor", "cursor"),
+      event("imported-navigation", "navigation"),
+    ]);
+
+    await expect(store.getPendingEvents(100)).resolves.toEqual([
+      expect.objectContaining({ id: "new-cursor" }),
+    ]);
   });
 
   it("backfills existing events with missing uploaded flags as pending", async () => {

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -239,8 +239,8 @@ describe("LocalEventStore aggregates", () => {
       data: { event: "blur" },
     };
 
-    await store.addImportedEvents([blur, focus]);
-    await store.addImportedEvents([blur, focus]);
+    await store.addRestoredEvents([blur, focus]);
+    await store.addRestoredEvents([blur, focus]);
 
     const [domainStats, pageStats, globalStats] = await Promise.all([
       store.getSessionStats("example.com"),
@@ -526,17 +526,26 @@ describe("LocalEventStore pending uploads", () => {
     expect((events[0] as StoredTestEvent).uploadState).toBeUndefined();
   });
 
-  it("does not return trusted imported history as pending", async () => {
+  it("keeps a pending event pending when it is exported and imported", async () => {
     const store = createStore();
 
-    await store.addEvents([event("new-cursor", "cursor")]);
-    await store.addImportedEvents([
-      event("imported-cursor", "cursor"),
-      event("imported-navigation", "navigation"),
-    ]);
+    await store.addEvents([event("offline-cursor", "cursor")]);
+    const [exportedEvent] = await store.getAllEvents();
+    await store.addImportedEvents([exportedEvent]);
 
     await expect(store.getPendingEvents(100)).resolves.toEqual([
-      expect.objectContaining({ id: "new-cursor" }),
+      expect.objectContaining({ id: "offline-cursor" }),
+    ]);
+  });
+
+  it("does not return trusted restored history as pending", async () => {
+    const store = createStore();
+
+    await store.addRestoredEvents([event("restored-cursor", "cursor")]);
+
+    await expect(store.getPendingEvents(100)).resolves.toEqual([]);
+    await expect(store.getAllEvents()).resolves.toEqual([
+      expect.objectContaining({ id: "restored-cursor" }),
     ]);
   });
 

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -601,7 +601,7 @@ export default defineBackground(() => {
           const parsed = JSON.parse(json)
           if (parsed.version !== 1) throw new Error('Unsupported export version')
           const events = parsed.events as CollectionEvent[]
-          await store.addEvents(events)
+          await store.addImportedEvents(events)
           reply({ success: true, imported: events.length })
         } catch (e) {
           console.error('[Background] IMPORT_EVENTS error:', e)
@@ -624,7 +624,7 @@ export default defineBackground(() => {
             'fetching all server events')
           const { events, countsByType } = await fetchEventsByPid(pid)
           console.log('[Background] Fetched', events.length, 'events, writing to IDB...')
-          await store.addEvents(events)
+          await store.addImportedEvents(events)
           console.log('[Background] RESTORE_FROM_SERVER complete')
           reply({
             success: true,

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -624,7 +624,7 @@ export default defineBackground(() => {
             'fetching all server events')
           const { events, countsByType } = await fetchEventsByPid(pid)
           console.log('[Background] Fetched', events.length, 'events, writing to IDB...')
-          await store.addImportedEvents(events)
+          await store.addRestoredEvents(events)
           console.log('[Background] RESTORE_FROM_SERVER complete')
           reply({
             success: true,

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -508,6 +508,12 @@ export class LocalEventStore {
       return;
     }
 
+    await this.rebuildSessionStats();
+  }
+
+  private async rebuildSessionStats(): Promise<void> {
+    if (!this.db) return;
+
     await this.writeStatsBackfillState("running");
 
     if (VERBOSE) {
@@ -524,7 +530,7 @@ export class LocalEventStore {
       req.onsuccess = () => {
         const cursor = req.result;
         if (cursor) {
-          const evt = cursor.value as CollectionEvent;
+          const evt = toCollectionEvent(cursor.value as StoredCollectionEvent);
           if (!this.eventIdsPendingStatsAfterBackfill.has(evt.id)) {
             events.push(evt);
           }
@@ -1249,6 +1255,18 @@ export class LocalEventStore {
         console.error("[LocalEventStore] Failed to update domain stats:", e);
       }
     }
+  }
+
+  /**
+   * Store imported history as already uploaded and rebuild aggregates from the
+   * unique stored events in chronological order.
+   */
+  async addImportedEvents(events: CollectionEvent[]): Promise<void> {
+    await this.ensureSessionStatsBackfilled();
+    await this.addEvents(events.map((event) => ({ ...event, uploaded: true })));
+    await this.rebuildSessionStats();
+    await this.writeStatsBackfillState("complete");
+    this.statsBackfillComplete = true;
   }
 
   private static emptyAggregate(key: string, domain: string): DomainStatsAggregate {

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -1257,16 +1257,20 @@ export class LocalEventStore {
     }
   }
 
-  /**
-   * Store imported history as already uploaded and rebuild aggregates from the
-   * unique stored events in chronological order.
-   */
+  /** Rebuild aggregates after importing event history from a file. */
   async addImportedEvents(events: CollectionEvent[]): Promise<void> {
     await this.ensureSessionStatsBackfilled();
-    await this.addEvents(events.map((event) => ({ ...event, uploaded: true })));
+    await this.addEvents(events);
     await this.rebuildSessionStats();
     await this.writeStatsBackfillState("complete");
     this.statsBackfillComplete = true;
+  }
+
+  /** Store server-restored history as uploaded before rebuilding aggregates. */
+  async addRestoredEvents(events: CollectionEvent[]): Promise<void> {
+    await this.addImportedEvents(
+      events.map((event) => ({ ...event, uploaded: true })),
+    );
   }
 
   private static emptyAggregate(key: string, domain: string): DomainStatsAggregate {


### PR DESCRIPTION
## Summary
- Preserve pending upload state for manual file imports.
- Store server-restored events as already uploaded.
- Rebuild global, domain, and page aggregates from unique persisted rows in chronological order after importing or restoring history.
- Cover duplicate newest-first navigation restores, offline export/import uploads, and trusted restore upload state.

## Verification
- Package build completed.
- Extension test suite passed: 53 files, 342 tests.
- Production extension build completed.
- Conservative local code review on the original change: no findings.

## Notes
- Added an extension release-note bullet because this changes shipped import/restore behavior.
- Workspace lint remains blocked by pre-existing TypeScript failures in unrelated extension website/worker files.