### PR TITLE
Fix stale archive filter results

### DIFF
--- a/extension/website/archive/archive.tsx
+++ b/extension/website/archive/archive.tsx
@@ -44,7 +44,7 @@ function midnightWindowBounds(
   return { from: from.toISOString(), to: to.toISOString() };
 }
 
-const InternetMovement = () => {
+export const InternetMovement = () => {
   const [events, setEvents] = useState<CollectionEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -103,6 +103,8 @@ const InternetMovement = () => {
   const fetchedTypesRef = useRef<Set<string>>(new Set());
   // Track the last domain+day combo we fetched for so we know when to force refresh
   const lastFetchKeyRef = useRef<string>("");
+  // Ignore any request that completed after a newer filter request started.
+  const requestGenerationRef = useRef(0);
 
   // Fetch daily counts for the heatmap calendar
   useEffect(() => {
@@ -131,6 +133,7 @@ const InternetMovement = () => {
       forceRefresh = false,
       tod: ReturnType<typeof parseTimeOfDayFromUrl> | null = null,
     ) => {
+      const requestGeneration = ++requestGenerationRef.current;
       const requiredTypes = deriveRequiredEventTypes(vizIds);
 
       if (requiredTypes.size === 0) {
@@ -232,6 +235,8 @@ const InternetMovement = () => {
           fetched = results.flat();
         }
 
+        if (requestGeneration !== requestGenerationRef.current) return;
+
         // Track what we've fetched
         for (const t of typesToFetch) {
           fetchedTypesRef.current.add(t);
@@ -243,9 +248,11 @@ const InternetMovement = () => {
           setEvents((prev) => [...prev, ...fetched]);
         }
       } catch (err) {
+        if (requestGeneration !== requestGenerationRef.current) return;
         setError(err instanceof Error ? err.message : "Failed to fetch events");
         console.error("Error fetching events:", err);
       } finally {
+        if (requestGeneration !== requestGenerationRef.current) return;
         setLoading(false);
       }
     },
@@ -307,6 +314,7 @@ const InternetMovement = () => {
   );
 };
 
-ReactDOM.createRoot(
-  document.getElementById("reactContent") as HTMLElement,
-).render(<InternetMovement />);
+const root = document.getElementById("reactContent");
+if (root) {
+  ReactDOM.createRoot(root).render(<InternetMovement />);
+}

--- a/extension/website/shared/hooks/__tests__/archiveRequestRace.test.tsx
+++ b/extension/website/shared/hooks/__tests__/archiveRequestRace.test.tsx
@@ -1,0 +1,146 @@
+// ABOUTME: Tests that archive filter changes ignore superseded event responses.
+// ABOUTME: Exercises the archive component with deterministic out-of-order fetches.
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CollectionEvent } from "../../types";
+
+vi.mock("../../components/MovementCanvas", () => ({
+  MovementCanvas: ({
+    events,
+    loading,
+    error,
+    onSetFilters,
+  }: {
+    events: CollectionEvent[];
+    loading: boolean;
+    error: string | null;
+    onSetFilters: (filters: { domain: string; path: string }[]) => void;
+  }) => (
+    <>
+      <output data-testid="events">{events.map((event) => event.id).join(",")}</output>
+      <output data-testid="loading">{String(loading)}</output>
+      <output data-testid="error">{error ?? ""}</output>
+      <button
+        onClick={() => onSetFilters([{ domain: "new.example", path: "" }])}
+      >
+        use new filter
+      </button>
+    </>
+  ),
+}));
+
+import { InternetMovement } from "../../../archive/archive";
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+let root: Root | null = null;
+
+async function renderArchive() {
+  const container = document.createElement("div");
+  root = createRoot(container);
+  await act(async () => root?.render(<InternetMovement />));
+  return container;
+}
+
+function outputText(container: HTMLElement, testId: string) {
+  return container.querySelector(`[data-testid="${testId}"]`)?.textContent;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function response(events: CollectionEvent[]) {
+  return { ok: true, json: async () => events } as Response;
+}
+
+function event(id: string): CollectionEvent {
+  return {
+    id,
+    type: "cursor",
+    ts: 1,
+    data: { x: 0.5, y: 0.5 },
+    meta: {
+      sid: "session",
+      pid: "person",
+      url: "https://example.com",
+      vw: 1,
+      vh: 1,
+      tz: "UTC",
+    },
+  };
+}
+
+describe("archive filter requests", () => {
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = null;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/archive/");
+    localStorage.clear();
+  });
+
+  it("keeps the later filter's results when the earlier request resolves last", async () => {
+    const firstEvents = deferred<Response>();
+    const secondEvents = deferred<Response>();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("daily-counts")) return Promise.resolve(response([]));
+      return url.includes("domain=new.example") ? secondEvents.promise : firstEvents.promise;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const container = await renderArchive();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => container.querySelector<HTMLButtonElement>("button")?.click());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    await act(async () => secondEvents.resolve(response([event("new")])));
+    await vi.waitFor(() => expect(outputText(container, "events")).toBe("new"));
+    expect(outputText(container, "loading")).toBe("false");
+
+    await act(async () => firstEvents.resolve(response([event("stale")])));
+    await vi.waitFor(() => expect(outputText(container, "loading")).toBe("false"));
+    expect(outputText(container, "events")).toBe("new");
+  });
+
+  it("does not surface an error from a superseded request", async () => {
+    window.history.replaceState({}, "", "/archive/?day=2026-01-01");
+    const firstEvents = deferred<Response>();
+    const secondEvents = deferred<Response>();
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("daily-counts")) return Promise.resolve(response([]));
+      return url.includes("domain=new.example") ? secondEvents.promise : firstEvents.promise;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const container = await renderArchive();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => container.querySelector<HTMLButtonElement>("button")?.click());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+
+    await act(async () => secondEvents.resolve(response([event("new")])));
+    await vi.waitFor(() => expect(outputText(container, "events")).toBe("new"));
+
+    await act(async () => firstEvents.reject(new Error("stale request failed")));
+    await vi.waitFor(() => expect(outputText(container, "loading")).toBe("false"));
+    expect(outputText(container, "events")).toBe("new");
+    expect(outputText(container, "error")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- ignore archive event responses that finish after a newer filter or refresh request begins
- add deterministic out-of-order component coverage for stale success and stale errors

## Root cause

Each request could update event state and fetch bookkeeping after it awaited its network response, even if a later filter request had already replaced the active context.

## Validation

- `bun run build-packages`
- `bun run test --run` (341 tests)
- `bun run build` in `extension/website`

`bun run lint` in `extension/website` reaches TypeScript successfully but then fails because the installed ESLint 9 toolchain cannot find a flat config.

## Integration

`origin/feat/installation-multiscreen` extracts this same fetch logic to `useArchiveEvents`; apply the same generation guard there when integrating so the refactor does not reintroduce the race.