### PR TITLE
Support primitive page data updates

### DIFF
--- a/.changeset/page-data-primitive-roots.md
+++ b/.changeset/page-data-primitive-roots.md
@@ -1,0 +1,7 @@
+---
+"@playhtml/common": patch
+"playhtml": patch
+"@playhtml/react": patch
+---
+
+Page-data channels can now update primitive roots with functional updates that return the next value.

--- a/apps/docs/src/content/docs/data/page-data.mdx
+++ b/apps/docs/src/content/docs/data/page-data.mdx
@@ -37,10 +37,22 @@ function VisitCounter() {
   </TabItem>
 </Tabs>
 
+Channels can also hold a primitive value. Pass the next value directly or return
+the next value from a functional update:
+
+```js
+const viewCount = playhtml.createPageData("viewCount", 0);
+viewCount.setData((value) => value + 1);
+```
+
+For object and array channels, function updates are mutators: edit the draft in
+place and ignore its return value. For primitive channels, the function's return
+value becomes the next stored value.
+
 The vanilla channel handle exposes four methods (`usePageData` wraps these for you):
 
 - **`getData()`**: read the current value synchronously.
-- **`setData(value | (draft) => void)`**: write. Accepts a replacement value or a mutator function, with the same merge semantics as element `setData`; see [data essentials](/docs/data/data-essentials/).
+- **`setData(value | updater)`**: write. Pass a replacement value, mutate an object/array draft in place, or return the next primitive value from an updater; see [data essentials](/docs/data/data-essentials/).
 - **`onUpdate(cb)`**: subscribe to changes. Returns an unsubscribe function.
 - **`destroy()`**: detach the channel and its observers. Call this when the channel is no longer needed (e.g. on teardown) to avoid leaking the subscription.
 

--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -341,7 +341,7 @@ views.onUpdate((n) => {
 | Method | Description |
 |---|---|
 | `getData(): T` | Returns the current value. |
-| `setData(data: T \| ((draft: T) => void)): void` | Updates the value. Pass a mutator function for nested objects. |
+| `setData(data: T \| updater): void` | Updates the value. Mutate object/array drafts in place; an updater for a primitive returns its next value. |
 | `onUpdate(callback: (data: T) => void): () => void` | Subscribes to changes. Returns an unsubscribe function. |
 | `destroy(): void` | Tears down the channel and removes all subscriptions. |
 

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -345,10 +345,14 @@ The type parameter is an assertion about your channel's shape; no runtime valida
 Subscribe to a [page-level data channel](/docs/data/page-data/), persistent state not tied to any element. The shape mirrors `useState`.
 
 ```tsx
+type PageDataSetter<T> = T extends object
+  ? T | ((draft: T) => void)
+  : T | ((value: T) => T);
+
 function usePageData<T>(
   name: string,
   defaultValue: T,
-): [T, (data: T | ((draft: T) => void)) => void];
+): [T, (data: PageDataSetter<T>) => void];
 ```
 
 ```tsx
@@ -356,7 +360,14 @@ const [counter, setCounter] = usePageData("visits", { count: 0 });
 setCounter((draft) => { draft.count += 1; });
 ```
 
-`defaultValue` is read only on first mount and when `name` changes. `setCounter` accepts a replacement value or a mutator function, with the same merge semantics as element `setData`.
+For primitive channels, a functional update returns the next value:
+
+```tsx
+const [viewCount, setViewCount] = usePageData("viewCount", 0);
+setViewCount((value) => value + 1);
+```
+
+`defaultValue` is read only on first mount and when `name` changes. `setCounter` accepts a replacement value or a mutator function. Object and array mutators edit their draft in place; primitive updaters return the next value.
 
 ### `usePresenceRoom`
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -396,9 +396,13 @@ export * from "./sharedElements";
 export * from "./cursor-types";
 import type { Cursor, PlayerIdentity } from "./cursor-types";
 
+export type PageDataSetter<T> = T extends object
+  ? T | ((draft: T) => void)
+  : T | ((value: T) => T);
+
 export interface PageDataChannel<T> {
   getData(): T;
-  setData(data: T | ((draft: T) => void)): void;
+  setData(data: PageDataSetter<T>): void;
   onUpdate(callback: (data: T) => void): () => void;
   destroy(): void;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -396,7 +396,7 @@ export * from "./sharedElements";
 export * from "./cursor-types";
 import type { Cursor, PlayerIdentity } from "./cursor-types";
 
-export type PageDataSetter<T> = T extends object
+export type PageDataSetter<T> = [T] extends [object]
   ? T | ((draft: T) => void)
   : T | ((value: T) => T);
 

--- a/packages/common/src/page-data.types.ts
+++ b/packages/common/src/page-data.types.ts
@@ -1,0 +1,12 @@
+// ABOUTME: Type-checks nullable page-data channels through the public setter type.
+// ABOUTME: Ensures functional updaters receive the channel's complete value union.
+
+import type { PageDataChannel } from "./index";
+
+interface Item {
+  id: string;
+}
+
+declare const channel: PageDataChannel<Item | null>;
+
+channel.setData((value) => value ?? { id: "first" });

--- a/packages/playhtml/src/__tests__/page-data.test.ts
+++ b/packages/playhtml/src/__tests__/page-data.test.ts
@@ -28,6 +28,29 @@ describe("playhtml.createPageData", () => {
     expect(channel.getData()).toEqual({ count: 10 });
   });
 
+  it("ignores terse object mutator returns", async () => {
+    const channel = playhtml.createPageData("test-terse-mutator", { count: 0 });
+
+    channel.setData((draft) => draft.count++);
+    await new Promise((r) => queueMicrotask(r));
+
+    expect(channel.getData()).toEqual({ count: 1 });
+  });
+
+  it("replaces primitive roots with values and functional updates", async () => {
+    const channel = playhtml.createPageData("test-primitive-root", 0);
+    const updates: number[] = [];
+    channel.onUpdate((value) => updates.push(value));
+
+    channel.setData(1);
+    await new Promise((r) => queueMicrotask(r));
+    channel.setData((value) => value + 1);
+    await new Promise((r) => queueMicrotask(r));
+
+    expect(channel.getData()).toBe(2);
+    expect(updates).toEqual([1, 2]);
+  });
+
   it("onUpdate fires on local changes", async () => {
     const channel = playhtml.createPageData("test-onupdate", { count: 0 });
     const updates: any[] = [];

--- a/packages/playhtml/src/__tests__/page-data.test.ts
+++ b/packages/playhtml/src/__tests__/page-data.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import { getYjsDoc, syncedStore } from "@syncedstore/core";
+import * as Y from "yjs";
 import { playhtml } from "../index";
+import { createPageDataChannel, PAGE_TAG } from "../page-data";
+
+function createPageDataTestDeps(
+  store: ReturnType<typeof syncedStore<{ play: Record<string, Record<string, unknown>> }>>,
+) {
+  const doc = getYjsDoc(store);
+  const proxyByTagAndId = new Map<string, Map<string, unknown>>();
+  const yObserverByKey = new Map<string, (...args: unknown[]) => void>();
+
+  return {
+    ensureProxy<T>(tag: string, id: string, defaultData: T): T {
+      if (!proxyByTagAndId.has(tag)) proxyByTagAndId.set(tag, new Map());
+      const proxies = proxyByTagAndId.get(tag)!;
+      if (!proxies.has(id)) {
+        store.play[tag] ??= {};
+        store.play[tag][id] ??= defaultData;
+        proxies.set(id, store.play[tag][id]);
+      }
+      return proxies.get(id) as T;
+    },
+    getProxy: (tag: string, id: string) => proxyByTagAndId.get(tag)?.get(id),
+    getDoc: () => doc,
+    getStorePlay: () => store.play,
+    proxyByTagAndId,
+    yObserverByKey,
+    channelRefCounts: new Map<string, number>(),
+    channelListeners: new Map<string, Set<(data: unknown) => void>>(),
+  };
+}
 
 beforeAll(async () => {
   await playhtml.init({});
@@ -49,6 +80,32 @@ describe("playhtml.createPageData", () => {
 
     expect(channel.getData()).toBe(2);
     expect(updates).toEqual([1, 2]);
+  });
+
+  it("uses a remotely updated primitive value for functional updates", () => {
+    const firstStore = syncedStore<{ play: Record<string, Record<string, unknown>> }>({
+      play: {},
+    });
+    const secondStore = syncedStore<{ play: Record<string, Record<string, unknown>> }>({
+      play: {},
+    });
+    const firstDoc = getYjsDoc(firstStore);
+    const secondDoc = getYjsDoc(secondStore);
+    const secondChannel = createPageDataChannel(
+      "view-count",
+      0,
+      createPageDataTestDeps(secondStore),
+    );
+
+    Y.applyUpdate(firstDoc, Y.encodeStateAsUpdate(secondDoc));
+    firstStore.play[PAGE_TAG]!["view-count"] = 1;
+    Y.applyUpdate(secondDoc, Y.encodeStateAsUpdate(firstDoc));
+
+    expect(secondChannel.getData()).toBe(1);
+
+    secondChannel.setData((value) => value + 1);
+
+    expect(secondChannel.getData()).toBe(2);
   });
 
   it("onUpdate fires on local changes", async () => {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -2924,6 +2924,7 @@ export type {
   ElementAwarenessEventHandlerData,
   ElementInitializer,
   PageDataChannel,
+  PageDataSetter,
   PlayerIdentity,
   Cursor,
   CursorPresence,

--- a/packages/playhtml/src/page-data.ts
+++ b/packages/playhtml/src/page-data.ts
@@ -190,6 +190,9 @@ export function createPageDataChannel<T>(
       }
       const proxy = currentProxy;
       const isObjectRoot = proxy !== null && typeof proxy === "object";
+      const currentValue = isObjectRoot
+        ? proxy
+        : storePlay()[PAGE_TAG]?.[name] as T;
       if (typeof data === "function" && isObjectRoot) {
         doc().transact(() => {
           applyPageDataUpdate(data as PageDataSetter<T>, proxy);
@@ -197,7 +200,7 @@ export function createPageDataChannel<T>(
         return;
       }
 
-      const nextValue = applyPageDataUpdate(data, proxy);
+      const nextValue = applyPageDataUpdate(data, currentValue);
 
       if (isObjectRoot) {
         doc().transact(() => {

--- a/packages/playhtml/src/page-data.ts
+++ b/packages/playhtml/src/page-data.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Implements PageDataChannel — named persistent data channels
 // ABOUTME: not tied to DOM elements, backed by existing SyncedStore/Yjs.
 
-import type { PageDataChannel } from "@playhtml/common";
+import type { PageDataChannel, PageDataSetter } from "@playhtml/common";
 import { clonePlain, deepReplaceIntoProxy } from "@playhtml/common";
 import { getYjsValue } from "@syncedstore/core";
 import type * as Y from "yjs";
@@ -29,6 +29,49 @@ function pageDataObserverKey(name: string): string {
   return `${PAGE_TAG}:${name}`;
 }
 
+type PageDataObserver = ((...args: unknown[]) => void) & {
+  target?: any;
+  mode?: "deep" | "shallow";
+};
+
+function applyPageDataUpdate<T>(data: PageDataSetter<T>, value: T): T {
+  if (typeof data !== "function") return data as T;
+  if (value !== null && typeof value === "object") {
+    (data as (draft: T) => void)(value);
+    return value;
+  }
+  return (data as (value: T) => T)(value);
+}
+
+function notifyPageDataListeners<T>(
+  name: string,
+  deps: PageDataDeps,
+  listeners: Set<(data: T) => void>,
+): void {
+  const currentProxy = deps.getStorePlay()[PAGE_TAG]?.[name];
+  if (currentProxy === undefined) return;
+  const plain = clonePlain(currentProxy) as T;
+  for (const cb of listeners) {
+    cb(plain);
+  }
+}
+
+function detachPageDataObserver(name: string, deps: PageDataDeps): void {
+  const observerKey = pageDataObserverKey(name);
+  const observer = yObserverByKeyGet(deps, observerKey);
+  if (!observer) return;
+  if (observer.mode === "deep") observer.target?.unobserveDeep(observer);
+  if (observer.mode === "shallow") observer.target?.unobserve(observer);
+  deps.yObserverByKey.delete(observerKey);
+}
+
+function yObserverByKeyGet(
+  deps: PageDataDeps,
+  observerKey: string,
+): PageDataObserver | undefined {
+  return deps.yObserverByKey.get(observerKey) as PageDataObserver | undefined;
+}
+
 function attachPageDataObserver<T>(
   name: string,
   deps: PageDataDeps,
@@ -37,23 +80,34 @@ function attachPageDataObserver<T>(
   const { getStorePlay, yObserverByKey } = deps;
   const observerKey = pageDataObserverKey(name);
   if (yObserverByKey.has(observerKey)) return;
-  const yVal = getYjsValue(getStorePlay()[PAGE_TAG]?.[name]);
-  if (!yVal || typeof (yVal as any).observeDeep !== "function") return;
+  const currentValue = getStorePlay()[PAGE_TAG]?.[name];
+  const yVal = getYjsValue(currentValue);
   let scheduled = false;
-  const observer = () => {
+  const notify = () => {
     if (scheduled) return;
     scheduled = true;
     queueMicrotask(() => {
       scheduled = false;
-      const currentProxy = getStorePlay()[PAGE_TAG]?.[name];
-      if (!currentProxy) return;
-      const plain = clonePlain(currentProxy) as T;
-      for (const cb of listeners) {
-        cb(plain);
-      }
+      notifyPageDataListeners(name, deps, listeners);
     });
   };
-  (yVal as any).observeDeep(observer);
+  if (yVal && typeof (yVal as any).observeDeep === "function") {
+    const observer = notify as PageDataObserver;
+    observer.target = yVal;
+    observer.mode = "deep";
+    (yVal as any).observeDeep(observer);
+    yObserverByKey.set(observerKey, observer);
+    return;
+  }
+
+  const pageData = getYjsValue(getStorePlay()[PAGE_TAG]);
+  if (!pageData || typeof (pageData as any).observe !== "function") return;
+  const observer = ((event: { keysChanged?: Set<string> }) => {
+    if (event.keysChanged?.has(name)) notify();
+  }) as PageDataObserver;
+  observer.target = pageData;
+  observer.mode = "shallow";
+  (pageData as any).observe(observer);
   yObserverByKey.set(observerKey, observer);
 }
 
@@ -62,13 +116,10 @@ export function refreshPageDataChannels(deps: PageDataDeps): void {
 
   for (const [name, listeners] of channelListeners) {
     const currentProxy = getStorePlay()[PAGE_TAG]?.[name];
-    if (!currentProxy) continue;
+    if (currentProxy === undefined) continue;
 
     attachPageDataObserver(name, deps, listeners);
-    const plain = clonePlain(currentProxy);
-    for (const cb of listeners) {
-      cb(plain);
-    }
+    notifyPageDataListeners(name, deps, listeners);
   }
 }
 
@@ -79,7 +130,7 @@ export function createPageDataChannel<T>(
 ): PageDataChannel<T> {
   const {
     ensureProxy, getProxy, getDoc, getStorePlay, proxyByTagAndId,
-    yObserverByKey, channelRefCounts, channelListeners,
+    channelRefCounts, channelListeners,
   } = deps;
   // Read live each use so we follow a room-change store/doc swap.
   const storePlay = () => getStorePlay();
@@ -121,31 +172,48 @@ export function createPageDataChannel<T>(
   return {
     getData(): T {
       if (destroyed) throw new Error(`PageDataChannel "${name}" has been destroyed`);
-      return clonePlain(storePlay()[PAGE_TAG]?.[name] ?? defaultValue) as T;
+      const value = storePlay()[PAGE_TAG]?.[name];
+      return clonePlain(value === undefined ? defaultValue : value) as T;
     },
 
-    setData(data: T | ((draft: T) => void)): void {
+    setData(data: PageDataSetter<T>): void {
       if (destroyed) throw new Error(`PageDataChannel "${name}" has been destroyed`);
       // Re-acquire the proxy if it's gone (e.g. a room change cleared page-data
       // out from under this still-alive handle). ensureProxy re-seeds the
       // default into a fresh value and attachObserver re-attaches the deep
       // observer, wired to this channel's preserved listener set — so the
       // handle keeps both writing AND notifying after the reset.
-      let currentProxy = getProxy(PAGE_TAG, name) as T | null | undefined;
-      if (currentProxy == null) {
+      let currentProxy = getProxy(PAGE_TAG, name) as T | undefined;
+      if (currentProxy === undefined) {
         currentProxy = ensureProxy<T>(PAGE_TAG, name, defaultValue) as T;
         attachObserver();
       }
       const proxy = currentProxy;
-      if (typeof data === "function") {
+      const isObjectRoot = proxy !== null && typeof proxy === "object";
+      if (typeof data === "function" && isObjectRoot) {
         doc().transact(() => {
-          (data as (draft: T) => void)(proxy);
+          applyPageDataUpdate(data as PageDataSetter<T>, proxy);
         });
-      } else {
-        doc().transact(() => {
-          deepReplaceIntoProxy(proxy, data);
-        });
+        return;
       }
+
+      const nextValue = applyPageDataUpdate(data, proxy);
+
+      if (isObjectRoot) {
+        doc().transact(() => {
+          deepReplaceIntoProxy(proxy, nextValue);
+        });
+        return;
+      }
+
+      detachPageDataObserver(name, deps);
+      doc().transact(() => {
+        storePlay()[PAGE_TAG] ??= {};
+        storePlay()[PAGE_TAG]![name] = clonePlain(nextValue);
+        proxyByTagAndId.get(PAGE_TAG)?.set(name, storePlay()[PAGE_TAG]![name]);
+      });
+      attachObserver();
+      notifyPageDataListeners(name, deps, listeners);
     },
 
     onUpdate(callback: (data: T) => void): () => void {
@@ -173,15 +241,7 @@ export function createPageDataChannel<T>(
         channelRefCounts.delete(name);
         channelListeners.delete(name);
 
-        const key = pageDataObserverKey(name);
-        const obs = yObserverByKey.get(key);
-        if (obs) {
-          const yVal = getYjsValue(storePlay()[PAGE_TAG]?.[name]);
-          if (yVal && typeof (yVal as any).unobserveDeep === "function") {
-            (yVal as any).unobserveDeep(obs);
-          }
-          yObserverByKey.delete(key);
-        }
+        detachPageDataObserver(name, deps);
 
         const tagMap = proxyByTagAndId.get(PAGE_TAG);
         if (tagMap) {

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -139,6 +139,29 @@ describe("usePageData", () => {
 
     await waitFor(() => expect(getByText("42")).toBeDefined());
   });
+
+  it("supports functional updates for primitive page data", async () => {
+    let captured: ReturnType<typeof usePageData<number>> | null = null;
+
+    function TestComponent() {
+      captured = usePageData("view-count", 0);
+      return <div>{captured[0]}</div>;
+    }
+
+    const { getByText } = render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    await waitFor(() => expect(getByText("0")).toBeDefined());
+
+    act(() => {
+      captured![1]((value) => value + 1);
+    });
+
+    await waitFor(() => expect(getByText("1")).toBeDefined());
+  });
 });
 
 describe("usePresenceRoom", () => {

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -8,6 +8,7 @@ import playhtml from "./playhtml-singleton";
 import {
   CursorPresenceView,
   PageDataChannel,
+  PageDataSetter,
   PlayerIdentity,
   PresenceRoom,
   PresenceView,
@@ -109,7 +110,7 @@ export function usePresence<T extends Record<string, unknown> = Record<string, u
 export function usePageData<T>(
   name: string,
   defaultValue: T,
-): [T, (data: T | ((draft: T) => void)) => void] {
+): [T, (data: PageDataSetter<T>) => void] {
   const { isLoading } = useContext(PlayContext);
   const [data, setDataState] = useState<T>(defaultValue);
   const channelRef = useRef<PageDataChannel<T> | null>(null);
@@ -130,7 +131,7 @@ export function usePageData<T>(
   }, [isLoading, name]);
 
   const setData = useCallback(
-    (next: T | ((draft: T) => void)) => {
+    (next: PageDataSetter<T>) => {
       const channel = channelRef.current;
       if (isLoading || !channel) {
         warnPreInit(`usePageData("${name}").setData`);

--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -190,6 +190,10 @@
         <!-- Empty mount point — the reaction button below is rendered by its
              `view` (registered in the script). -->
         <div id="reactionBtn" can-play></div>
+        <div>
+          <p>Here's a page-level visit counter!</p>
+          <button id="visitCounter">0 visits</button>
+        </div>
     </div>
 
         <!-- Option 1 (simplest, no customization) -->
@@ -232,6 +236,18 @@
             </button>
           `;
         },
+      });
+
+      await playhtml.ready;
+      const visitCounter = playhtml.createPageData("visit-count", 0);
+      const visitButton = document.getElementById("visitCounter");
+      const renderVisitCount = (value) => {
+        visitButton.textContent = `${value} visits`;
+      };
+      renderVisitCount(visitCounter.getData());
+      visitCounter.onUpdate(renderVisitCount);
+      visitButton.addEventListener("click", () => {
+        visitCounter.setData((value) => value + 1);
       });
 
       // Make playhtml available globally for script.js

--- a/templates/react-starter/src/App.tsx
+++ b/templates/react-starter/src/App.tsx
@@ -11,6 +11,7 @@ import {
   CanGrowElement,
   CanHoverElement,
   CanDuplicateElement,
+  usePageData,
   withSharedState,
 } from "@playhtml/react";
 
@@ -107,6 +108,16 @@ const ReactionButton = withSharedState(
     );
   }
 );
+
+function VisitCounter() {
+  const [count, setCount] = usePageData("visit-count", 0);
+
+  return (
+    <button onClick={() => setCount((value) => value + 1)}>
+      {count} visits
+    </button>
+  );
+}
 
 function App() {
   const [highlightedCapability, setHighlightedCapability] = useState<string | null>(null);
@@ -260,6 +271,11 @@ function App() {
           <div style={{ marginTop: "2rem" }}>
             <p>Here's a reaction button! Everyone can see how many people have reacted</p>
             <ReactionButton />
+          </div>
+
+          <div style={{ marginTop: "2rem" }}>
+            <p>Here's a page-level visit counter!</p>
+            <VisitCounter />
           </div>
 
           <hr style={{ margin: "3rem 0", border: "none", borderTop: "4px solid #fff" }} />


### PR DESCRIPTION
## Summary
- Support direct replacement and functional updates for primitive page-data roots.
- Read primitive functional updates from the live page-data store after remote Yjs replacements.
- Preserve object and array draft mutators, including terse returns such as d => d.count++.
- Document the contract and add working visit-counter examples to both starters.

## Root cause
Primitive values were held in the page-data map, but the existing replacement helper only mutated object and array proxies. Functional returns were ignored. The initial primitive implementation also retained a stale scalar in proxyByTagAndId after a peer replacement.

## Regression coverage
A two-document Yjs test seeds B with cached 0, applies A's remote update to 1, verifies B reads 1, then verifies B's value => value + 1 writes 2.

## PR #264 integration
#264 overlaps PageDataChannel.setData for server-gated writes. Keep this branch's root-replacement and PageDataSetter behavior, and derive its gated before snapshot from the same live primitive store value. Then mutate object drafts or use primitive updater returns before buildGatedWriteOps. The server already sends that value as a replace operation. I applied and type-checked that combined hunk against #264.

## Validation
- bun run build and bun run test in packages/playhtml: 364 tests passed
- bun run build and bun run test in packages/react: 44 tests passed
- Temporary #264 integration: packages/playhtml build and page-data suite passed