### PR TITLE
ci: fix load test workflow paths

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -12,6 +12,7 @@ on:
           - fridge
           - mirror
           - live-chat
+          - walking-together
       users:
         description: "Total users (split across workers)"
         required: true
@@ -80,11 +81,13 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: cd load-test && bun install
+        working-directory: tools/load-test
+        run: bun install --frozen-lockfile
 
       - name: Run load test
+        working-directory: tools/load-test
         run: |
-          bun load-test/src/runner.ts \
+          bun src/runner.ts \
             --scenario ${{ inputs.scenario }} \
             --users ${{ needs.setup.outputs.users_per_worker }} \
             --duration ${{ inputs.duration }} \
@@ -98,8 +101,8 @@ jobs:
         with:
           name: results-worker-${{ matrix.worker_index }}
           path: |
-            results.txt
-            load-test/data/runs.db
+            tools/load-test/results.txt
+            tools/load-test/data/runs.db
 
   summary:
     needs: [setup, worker]


### PR DESCRIPTION
## Summary

Fixes the manual load-test workflow after the harness moved to `tools/load-test`.

- install and run the package from its actual working directory
- upload the package-local text and SQLite results
- expose PR #165's `walking-together` scenario in the workflow dispatch menu

## Root cause

The workflow still referenced the previous root-level `load-test` directory, so dependency installation, runner execution, and artifact collection could not find the harness outputs.

## Validation

- `cd tools/load-test && bun install --frozen-lockfile`
- `cd tools/load-test && bun test`
- `cd tools/load-test && bun src/runner.ts`
- `bun run load-test --`
- YAML parse and `git diff --check`

No remote load test was run.
