### PR TITLE
docs: fix shared-state React example

### DIFF
--- a/apps/docs/src/__tests__/docs-examples.test.ts
+++ b/apps/docs/src/__tests__/docs-examples.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./docs-snippets";
 
 const CAPABILITIES = "capabilities.mdx";
+const SHARED_ELEMENTS = "advanced/shared-elements.md";
 
 function findSnippet(
   file: string,
@@ -50,6 +51,20 @@ describe("docs snippet extractor", () => {
 
     const toggleBlock = htmlBlocks.find((s) => s.nearestHeading === "can-toggle");
     expect(toggleBlock?.code).toContain("can-toggle");
+  });
+
+  it("keeps the shared-state React consumer example self-contained", () => {
+    const snippet = extractSnippets(SHARED_ELEMENTS).find(
+      (s) => s.lang === "tsx" && s.code.includes("withSharedState"),
+    );
+    if (!snippet) {
+      throw new Error(`No withSharedState snippet found in ${SHARED_ELEMENTS}`);
+    }
+
+    expect(snippet.code).toContain("withSharedState,");
+    expect(snippet.code).toContain("dataSourceReadOnly: true");
+    expect(snippet.code).toContain("({ data }) =>");
+    expect(snippet.code).not.toMatch(/\bProps\b/);
   });
 
   it("honors the ignore-test opt-out and partial-snippet placeholder", () => {

--- a/apps/docs/src/content/docs/advanced/shared-elements.md
+++ b/apps/docs/src/content/docs/advanced/shared-elements.md
@@ -72,7 +72,11 @@ Best practice: keep consumer-only capabilities orthogonal to the shared data sha
 #### React usage
 
 ```tsx
-import { CanMoveElement, CanToggleElement } from "@playhtml/react";
+import {
+  CanMoveElement,
+  CanToggleElement,
+  withSharedState,
+} from "@playhtml/react";
 
 // Source
 <CanMoveElement id="couch" shared>
@@ -89,12 +93,14 @@ import { CanMoveElement, CanToggleElement } from "@playhtml/react";
   <div>🔒</div>
 </CanToggleElement>
 
-// Use with `withSharedState`
+// Read shared state with `withSharedState`
 export const Status = withSharedState(
-  { defaultData: { on: false }, dataSource: "thissite.com#status" },
-  ({ data, setData }, props: Props) => {
-    return <div>{data.on ? "🔒" : "🔓"}</div>;
-  }
+  {
+    defaultData: { on: false },
+    dataSource: "thissite.com#status",
+    dataSourceReadOnly: true,
+  },
+  ({ data }) => <div>{data.on ? "🔒" : "🔓"}</div>,
 );
 ```
 


### PR DESCRIPTION
Fixes the shared-elements React example so it imports withSharedState, does not reference an undefined Props type, and shows a read-only consumer using dataSourceReadOnly. Adds a focused docs test that guards the example's self-contained import/callback shape. Root cause: the snippet used withSharedState without importing it and annotated an undeclared Props type. Validation: bun run test and bun run build in apps/docs after bun build-packages.