### PR TITLE
Fix element teardown and toggle readonly

### DIFF
--- a/.changeset/cleanup-element-listeners.md
+++ b/.changeset/cleanup-element-listeners.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Clean up built-in element listeners when an element is removed so remounting and dragging do not leave stale handlers active.

--- a/.changeset/cleanup-element-listeners.md
+++ b/.changeset/cleanup-element-listeners.md
@@ -2,4 +2,4 @@
 "playhtml": patch
 ---
 
-Clean up built-in element listeners when an element is removed so remounting and dragging do not leave stale handlers active.
+Clean up built-in element listeners when an element is removed so remounting and dragging do not leave stale handlers active, and install listeners when callbacks are added after setup.

--- a/.changeset/fix-toggle-readonly.md
+++ b/.changeset/fix-toggle-readonly.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Make `CanToggleElement` apply its `readOnly` prop so read-only shared toggles cannot write data.

--- a/.changeset/fix-toggle-readonly.md
+++ b/.changeset/fix-toggle-readonly.md
@@ -2,4 +2,4 @@
 "@playhtml/react": patch
 ---
 
-Make `CanToggleElement` apply its `readOnly` prop so read-only shared toggles cannot write data.
+Make `CanToggleElement` apply its `readOnly` prop so read-only shared toggles cannot write data, and keep React event callbacks current after rerenders.

--- a/.changeset/fix-toggle-readonly.md
+++ b/.changeset/fix-toggle-readonly.md
@@ -2,4 +2,4 @@
 "@playhtml/react": patch
 ---
 
-Make `CanToggleElement` apply its `readOnly` prop so read-only shared toggles cannot write data, and keep React event callbacks current after rerenders.
+Make `CanToggleElement` apply its `readOnly` prop so read-only shared toggles cannot write data, and activate React event callbacks added after rerenders.

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -174,6 +174,60 @@ describe("ElementHandler", () => {
     expect(onDrag).toHaveBeenCalledTimes(1);
   });
 
+  it("installs onDragStart added after setup without onDrag", () => {
+    const onDragStart = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    handler.setEventHandlers({ onDragStart });
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    element.dispatchEvent(new Event("touchstart", { bubbles: true, cancelable: true }));
+    document.dispatchEvent(new Event("touchend", { bubbles: true }));
+
+    expect(onDragStart).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops drag behavior when callbacks are removed", () => {
+    const onDrag = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onDrag,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(element.classList.contains("cursordown")).toBe(true);
+
+    handler.setEventHandlers({});
+    expect(element.classList.contains("cursordown")).toBe(false);
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    const mouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const touchStart = new Event("touchstart", {
+      bubbles: true,
+      cancelable: true,
+    });
+    element.dispatchEvent(mouseDown);
+    element.dispatchEvent(touchStart);
+
+    expect(onDrag).not.toHaveBeenCalled();
+    expect(mouseDown.defaultPrevented).toBe(false);
+    expect(touchStart.defaultPrevented).toBe(false);
+    expect(element.classList.contains("cursordown")).toBe(false);
+  });
+
   it("keeps imperative callbacks disabled for views", () => {
     const onClick = vi.fn();
     const handler = new ElementHandler({

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -43,6 +43,113 @@ describe("ElementHandler", () => {
     expect(updateElement).toHaveBeenCalledTimes(1);
   });
 
+  it("removes built-in click, drag, and reset listeners on destroy", () => {
+    const onClick = vi.fn();
+    const onDrag = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onClick,
+      onDrag,
+      resetShortcut: "shiftKey",
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+    const reset = vi.spyOn(handler, "reset");
+
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+    expect(onDrag).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    handler.destroy();
+    handler.destroy();
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(onClick).toHaveBeenCalledTimes(2);
+    expect(onDrag).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes an active drag's document listeners on destroy", () => {
+    const onDrag = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onDrag,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    expect(element.classList.contains("cursordown")).toBe(true);
+
+    handler.destroy();
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(onDrag).not.toHaveBeenCalled();
+    expect(element.classList.contains("cursordown")).toBe(false);
+  });
+
+  it("removes an active touch drag's document listeners on destroy", () => {
+    const onDrag = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onDrag,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    element.dispatchEvent(new Event("touchstart", { bubbles: true, cancelable: true }));
+    expect(element.classList.contains("cursordown")).toBe(true);
+
+    handler.destroy();
+    document.dispatchEvent(new Event("touchmove", { bubbles: true, cancelable: true }));
+    document.dispatchEvent(new Event("touchend", { bubbles: true }));
+
+    expect(onDrag).not.toHaveBeenCalled();
+    expect(element.classList.contains("cursordown")).toBe(false);
+  });
+
+  it("reinstalls built-in listeners once after destroy and reinitialize", () => {
+    const onClick = vi.fn();
+    const onDrag = vi.fn();
+    const elementData = {
+      element,
+      defaultData: {},
+      onClick,
+      onDrag,
+      resetShortcut: "shiftKey" as const,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData;
+    const handler = new ElementHandler(elementData);
+    const reset = vi.spyOn(handler, "reset");
+
+    handler.destroy();
+    handler.reinitializeElementData(elementData);
+    handler.reinitializeElementData(elementData);
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true, shiftKey: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onDrag).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
   it("setData calls onChange and does not directly mutate internal state", () => {
     const updateElement = vi.fn();
     const onChange = vi.fn();

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -150,6 +150,47 @@ describe("ElementHandler", () => {
     expect(reset).toHaveBeenCalledTimes(1);
   });
 
+  it("installs callbacks added after setup without duplicate listeners", () => {
+    const onClick = vi.fn();
+    const onDragStart = vi.fn();
+    const onDrag = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    handler.setEventHandlers({ onClick, onDragStart, onDrag });
+    handler.setEventHandlers({ onClick, onDragStart, onDrag });
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    expect(onDrag).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps imperative callbacks disabled for views", () => {
+    const onClick = vi.fn();
+    const handler = new ElementHandler({
+      element,
+      defaultData: {},
+      view: () => "" as any,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: vi.fn(),
+    } as unknown as ElementData);
+
+    handler.setEventHandlers({ onClick });
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it("setData calls onChange and does not directly mutate internal state", () => {
     const updateElement = vi.fn();
     const onChange = vi.fn();

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -281,6 +281,27 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(el.classList.contains("clicked")).toBe(false);
   });
 
+  it("blocks writes from explicitly read-only data-source consumers", async () => {
+    const el = document.createElement("div");
+    el.id = "read-only-toggle";
+    el.setAttribute("can-toggle", "");
+    el.setAttribute("data-source", "/room#toggle");
+    el.setAttribute("data-source-read-only", "");
+    document.body.appendChild(el);
+    await playhtml.setupPlayElementForTag(el, "can-toggle");
+
+    const handler = playhtml
+      .elementHandlers!.get("can-toggle")!
+      .get("toggle")!;
+    handler.setData({ on: true });
+    await new Promise((resolve) => queueMicrotask(resolve));
+
+    expect(handler.data).toEqual({ on: false });
+    expect(playhtml.syncedStore["can-toggle"]["toggle"]).toEqual({
+      on: false,
+    });
+  });
+
   it("removes handlers for unmounted elements so replacements can register", async () => {
     const first = document.createElement("div");
     first.id = "remount-test";

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -281,11 +281,19 @@ export class ElementHandler<T = any, U = any, V = any> {
     onDragStart,
   }: Pick<ElementData<T>, "onClick" | "onDrag" | "onDragStart">): void {
     const element = this.element;
+    const hadDragHandler = Boolean(this.onDrag || this.onDragStart);
     if (this.view) {
+      if (hadDragHandler) {
+        this.removeActiveDragListeners();
+      }
       this.onClick = undefined;
       this.onDrag = undefined;
       this.onDragStart = undefined;
       return;
+    }
+    const hasDragHandler = Boolean(onDrag || onDragStart);
+    if (hadDragHandler && !hasDragHandler) {
+      this.removeActiveDragListeners();
     }
     if (onClick && !this.clickListener) {
       this.clickListener = (e) => {
@@ -293,8 +301,9 @@ export class ElementHandler<T = any, U = any, V = any> {
       };
       element.addEventListener("click", this.clickListener);
     }
-    if (onDrag && !this.touchStartListener) {
+    if (hasDragHandler && !this.touchStartListener) {
       this.touchStartListener = (e) => {
+        if (!this.onDrag && !this.onDragStart) return;
         // To prevent scrolling the page while dragging
         e.preventDefault();
         this.removeActiveDragListeners();
@@ -321,8 +330,9 @@ export class ElementHandler<T = any, U = any, V = any> {
       };
       element.addEventListener("touchstart", this.touchStartListener);
     }
-    if (onDrag && !this.mouseDownListener) {
+    if (hasDragHandler && !this.mouseDownListener) {
       this.mouseDownListener = (e) => {
+        if (!this.onDrag && !this.onDragStart) return;
         // To prevent dragging images behavior conflicting.
         e.preventDefault();
         this.removeActiveDragListeners();

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -62,6 +62,11 @@ export class ElementHandler<T = any, U = any, V = any> {
   private descendantObserver?: MutationObserver;
   private dataUpdateListeners = new Set<() => void>();
   private scheduleSetupDataWrite?: (write: () => void) => void;
+  private clickListener?: (e: MouseEvent) => void;
+  private touchStartListener?: (e: TouchEvent) => void;
+  private mouseDownListener?: (e: MouseEvent) => void;
+  private resetShortcutListener?: (e: MouseEvent) => void;
+  private activeDragCleanup?: () => void;
 
   // event handlers
   onClick?: (
@@ -148,6 +153,27 @@ export class ElementHandler<T = any, U = any, V = any> {
   destroy(): void {
     this.descendantObserver?.disconnect();
     this.descendantObserver = undefined;
+    if (this.clickListener) {
+      this.element.removeEventListener("click", this.clickListener);
+      this.clickListener = undefined;
+    }
+    if (this.touchStartListener) {
+      this.element.removeEventListener("touchstart", this.touchStartListener);
+      this.touchStartListener = undefined;
+    }
+    if (this.mouseDownListener) {
+      this.element.removeEventListener("mousedown", this.mouseDownListener);
+      this.mouseDownListener = undefined;
+    }
+    if (this.resetShortcutListener) {
+      this.element.removeEventListener("click", this.resetShortcutListener);
+      this.resetShortcutListener = undefined;
+    }
+    this.removeActiveDragListeners();
+    this.onClick = undefined;
+    this.onDrag = undefined;
+    this.onDragStart = undefined;
+    this.resetShortcut = undefined;
     const cleanup = this.onUnmount;
     this.onUnmount = undefined;
     if (cleanup) {
@@ -209,16 +235,18 @@ export class ElementHandler<T = any, U = any, V = any> {
     }
 
     // Handle all the event handlers
-    if (onClick && !this.onClick) {
-      element.addEventListener("click", (e) => {
+    if (onClick && !this.clickListener) {
+      this.clickListener = (e) => {
         this.onClick?.(e, this.getEventHandlerData());
-      });
+      };
+      element.addEventListener("click", this.clickListener);
     }
     this.onClick = onClick;
-    if (onDrag && !this.onDrag) {
-      element.addEventListener("touchstart", (e) => {
+    if (onDrag && !this.touchStartListener) {
+      this.touchStartListener = (e) => {
         // To prevent scrolling the page while dragging
         e.preventDefault();
+        this.removeActiveDragListeners();
         element.classList.add("cursordown");
 
         // Need to be able to not persist everything in the data, causing some lag.
@@ -228,17 +256,25 @@ export class ElementHandler<T = any, U = any, V = any> {
           e.preventDefault();
           this.onDrag?.(e, this.getEventHandlerData());
         };
-        const onDragStop = (e: TouchEvent) => {
+        const onDragStop = () => {
           element.classList.remove("cursordown");
           document.removeEventListener("touchmove", onMove);
           document.removeEventListener("touchend", onDragStop);
+          if (this.activeDragCleanup === onDragStop) {
+            this.activeDragCleanup = undefined;
+          }
         };
+        this.activeDragCleanup = onDragStop;
         document.addEventListener("touchmove", onMove);
         document.addEventListener("touchend", onDragStop);
-      });
-      element.addEventListener("mousedown", (e) => {
+      };
+      element.addEventListener("touchstart", this.touchStartListener);
+    }
+    if (onDrag && !this.mouseDownListener) {
+      this.mouseDownListener = (e) => {
         // To prevent dragging images behavior conflicting.
         e.preventDefault();
+        this.removeActiveDragListeners();
         // Need to be able to not persist everything in the data, causing some lag.
         this.onDragStart?.(e, this.getEventHandlerData());
         element.classList.add("cursordown");
@@ -247,24 +283,29 @@ export class ElementHandler<T = any, U = any, V = any> {
           e.preventDefault();
           this.onDrag?.(e, this.getEventHandlerData());
         };
-        const onMouseUp = (e: MouseEvent) => {
+        const onMouseUp = () => {
           element.classList.remove("cursordown");
           document.removeEventListener("mousemove", onMouseMove);
           document.removeEventListener("mouseup", onMouseUp);
+          if (this.activeDragCleanup === onMouseUp) {
+            this.activeDragCleanup = undefined;
+          }
         };
+        this.activeDragCleanup = onMouseUp;
         document.addEventListener("mousemove", onMouseMove);
         document.addEventListener("mouseup", onMouseUp);
-      });
+      };
+      element.addEventListener("mousedown", this.mouseDownListener);
     }
     this.onDrag = onDrag;
     this.onDragStart = onDragStart;
 
     // Handle advanced settings
-    if (resetShortcut && !this.resetShortcut) {
+    if (resetShortcut && !this.resetShortcutListener) {
       // @ts-ignore
       element.reset = this.reset;
 
-      element.addEventListener("click", (e) => {
+      this.resetShortcutListener = (e) => {
         switch (this.resetShortcut) {
           case "ctrlKey":
             if (!e.ctrlKey) {
@@ -292,9 +333,16 @@ export class ElementHandler<T = any, U = any, V = any> {
         this.reset();
         e.preventDefault();
         e.stopPropagation();
-      });
+      };
+      element.addEventListener("click", this.resetShortcutListener);
     }
     this.resetShortcut = resetShortcut;
+  }
+
+  private removeActiveDragListeners(): void {
+    this.activeDragCleanup?.();
+    this.activeDragCleanup = undefined;
+    this.element.classList.remove("cursordown");
   }
 
   get data(): T {

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -234,14 +234,65 @@ export class ElementHandler<T = any, U = any, V = any> {
       onDragStart = undefined;
     }
 
-    // Handle all the event handlers
+    this.setEventHandlers({ onClick, onDrag, onDragStart });
+
+    // Handle advanced settings
+    if (resetShortcut && !this.resetShortcutListener) {
+      // @ts-ignore
+      element.reset = this.reset;
+
+      this.resetShortcutListener = (e) => {
+        switch (this.resetShortcut) {
+          case "ctrlKey":
+            if (!e.ctrlKey) {
+              return;
+            }
+            break;
+          case "altKey":
+            if (!e.altKey) {
+              return;
+            }
+            break;
+          case "shiftKey":
+            if (!e.shiftKey) {
+              return;
+            }
+            break;
+          case "metaKey":
+            if (!e.metaKey) {
+              return;
+            }
+            break;
+          default:
+            return;
+        }
+        this.reset();
+        e.preventDefault();
+        e.stopPropagation();
+      };
+      element.addEventListener("click", this.resetShortcutListener);
+    }
+    this.resetShortcut = resetShortcut;
+  }
+
+  setEventHandlers({
+    onClick,
+    onDrag,
+    onDragStart,
+  }: Pick<ElementData<T>, "onClick" | "onDrag" | "onDragStart">): void {
+    const element = this.element;
+    if (this.view) {
+      this.onClick = undefined;
+      this.onDrag = undefined;
+      this.onDragStart = undefined;
+      return;
+    }
     if (onClick && !this.clickListener) {
       this.clickListener = (e) => {
         this.onClick?.(e, this.getEventHandlerData());
       };
       element.addEventListener("click", this.clickListener);
     }
-    this.onClick = onClick;
     if (onDrag && !this.touchStartListener) {
       this.touchStartListener = (e) => {
         // To prevent scrolling the page while dragging
@@ -297,46 +348,9 @@ export class ElementHandler<T = any, U = any, V = any> {
       };
       element.addEventListener("mousedown", this.mouseDownListener);
     }
+    this.onClick = onClick;
     this.onDrag = onDrag;
     this.onDragStart = onDragStart;
-
-    // Handle advanced settings
-    if (resetShortcut && !this.resetShortcutListener) {
-      // @ts-ignore
-      element.reset = this.reset;
-
-      this.resetShortcutListener = (e) => {
-        switch (this.resetShortcut) {
-          case "ctrlKey":
-            if (!e.ctrlKey) {
-              return;
-            }
-            break;
-          case "altKey":
-            if (!e.altKey) {
-              return;
-            }
-            break;
-          case "shiftKey":
-            if (!e.shiftKey) {
-              return;
-            }
-            break;
-          case "metaKey":
-            if (!e.metaKey) {
-              return;
-            }
-            break;
-          default:
-            return;
-        }
-        this.reset();
-        e.preventDefault();
-        e.stopPropagation();
-      };
-      element.addEventListener("click", this.resetShortcutListener);
-    }
-    this.resetShortcut = resetShortcut;
   }
 
   private removeActiveDragListeners(): void {

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -222,7 +222,6 @@ describe("CanPlayElement with built-in capabilities", () => {
 
     const firstClick = vi.fn();
     const firstDragStart = vi.fn();
-    const firstDrag = vi.fn();
     const secondClick = vi.fn();
     const secondDragStart = vi.fn();
     const secondDrag = vi.fn();
@@ -264,7 +263,6 @@ describe("CanPlayElement with built-in capabilities", () => {
       renderElement({
         onClick: firstClick,
         onDragStart: firstDragStart,
-        onDrag: firstDrag,
       }),
     );
     element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -284,12 +282,20 @@ describe("CanPlayElement with built-in capabilities", () => {
     document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
     document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
 
+    rerender(renderElement({}));
+    const mouseDownAfterRemoval = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    element.dispatchEvent(mouseDownAfterRemoval);
+
     expect(firstClick).toHaveBeenCalledTimes(1);
     expect(firstDragStart).toHaveBeenCalledTimes(1);
-    expect(firstDrag).toHaveBeenCalledTimes(1);
     expect(secondClick).toHaveBeenCalledTimes(1);
     expect(secondDragStart).toHaveBeenCalledTimes(1);
     expect(secondDrag).toHaveBeenCalledTimes(1);
+    expect(mouseDownAfterRemoval.defaultPrevented).toBe(false);
+    expect(element.classList.contains("cursordown")).toBe(false);
 
     unmount();
     playhtml.elementHandlers = originalHandlers;

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -227,9 +227,9 @@ describe("CanPlayElement with built-in capabilities", () => {
     const secondDragStart = vi.fn();
     const secondDrag = vi.fn();
     const renderElement = (props: {
-      onClick: () => void;
-      onDragStart: () => void;
-      onDrag: () => void;
+      onClick?: () => void;
+      onDragStart?: () => void;
+      onDrag?: () => void;
     }) => (
       <CanPlayElement
         id="rerender-handler"
@@ -243,11 +243,7 @@ describe("CanPlayElement with built-in capabilities", () => {
     );
 
     const { container, rerender, unmount } = render(
-      renderElement({
-        onClick: firstClick,
-        onDragStart: firstDragStart,
-        onDrag: firstDrag,
-      }),
+      renderElement({}),
     );
     const element = container.querySelector("[can-play]") as HTMLElement;
     handlers.get(TagType.CanPlay)!.set(
@@ -264,6 +260,13 @@ describe("CanPlayElement with built-in capabilities", () => {
       } as any),
     );
 
+    rerender(
+      renderElement({
+        onClick: firstClick,
+        onDragStart: firstDragStart,
+        onDrag: firstDrag,
+      }),
+    );
     element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
     document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -6,7 +6,7 @@ import { act, render } from "@testing-library/react";
 import { fireEvent } from "@testing-library/dom";
 import "@testing-library/dom";
 import { CanPlayElement, withSharedState } from "../index";
-import { CanMoveElement } from "../elements";
+import { CanMoveElement, CanToggleElement } from "../elements";
 import playhtml from "../playhtml-singleton";
 import { TagType } from "playhtml";
 import type { ElementAwarenessEventHandlerData } from "playhtml";
@@ -285,6 +285,18 @@ describe("CanPlayElement with built-in capabilities", () => {
       "#selector-bounded-child",
     ) as HTMLElement;
     expect(element.getAttribute("can-move-bounds")).toBe("#fridge");
+  });
+
+  it("CanToggleElement stamps read-only consumers", () => {
+    const { container } = render(
+      <CanToggleElement dataSource="/room#toggle" readOnly standalone>
+        <button id="read-only-toggle">toggle</button>
+      </CanToggleElement>,
+    );
+    const element = container.querySelector("#read-only-toggle") as HTMLElement;
+
+    expect(element).toHaveAttribute("data-source", "/room#toggle");
+    expect(element).toHaveAttribute("data-source-read-only");
   });
 
   it("does not re-render when synced data is a fresh reference but equal in value", () => {

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -213,6 +213,85 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect(removeSpy).not.toHaveBeenCalled();
   });
 
+  it("refreshes built-in event handlers after a React rerender", async () => {
+    const { ElementHandler } = await import("../../../playhtml/src/elements");
+    const handlers = new Map([[TagType.CanPlay, new Map()]]);
+    const originalHandlers = playhtml.elementHandlers;
+    playhtml.elementHandlers = handlers as any;
+    vi.mocked(playhtml.setupPlayElement).mockReset();
+
+    const firstClick = vi.fn();
+    const firstDragStart = vi.fn();
+    const firstDrag = vi.fn();
+    const secondClick = vi.fn();
+    const secondDragStart = vi.fn();
+    const secondDrag = vi.fn();
+    const renderElement = (props: {
+      onClick: () => void;
+      onDragStart: () => void;
+      onDrag: () => void;
+    }) => (
+      <CanPlayElement
+        id="rerender-handler"
+        defaultData={{}}
+        onClick={props.onClick}
+        onDragStart={props.onDragStart}
+        onDrag={props.onDrag}
+      >
+        {() => <div>play</div>}
+      </CanPlayElement>
+    );
+
+    const { container, rerender, unmount } = render(
+      renderElement({
+        onClick: firstClick,
+        onDragStart: firstDragStart,
+        onDrag: firstDrag,
+      }),
+    );
+    const element = container.querySelector("[can-play]") as HTMLElement;
+    handlers.get(TagType.CanPlay)!.set(
+      element.id,
+      new ElementHandler({
+        element,
+        defaultData: {},
+        onClick: (element as any).onClick,
+        onDrag: (element as any).onDrag,
+        onDragStart: (element as any).onDragStart,
+        onChange: vi.fn(),
+        onAwarenessChange: vi.fn(),
+        triggerAwarenessUpdate: vi.fn(),
+      } as any),
+    );
+
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    rerender(
+      renderElement({
+        onClick: secondClick,
+        onDragStart: secondDragStart,
+        onDrag: secondDrag,
+      }),
+    );
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    element.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+
+    expect(firstClick).toHaveBeenCalledTimes(1);
+    expect(firstDragStart).toHaveBeenCalledTimes(1);
+    expect(firstDrag).toHaveBeenCalledTimes(1);
+    expect(secondClick).toHaveBeenCalledTimes(1);
+    expect(secondDragStart).toHaveBeenCalledTimes(1);
+    expect(secondDrag).toHaveBeenCalledTimes(1);
+
+    unmount();
+    playhtml.elementHandlers = originalHandlers;
+  });
+
   it("removes the mounted element on unmount", () => {
     const setupSpy = vi
       .spyOn(playhtml, "setupPlayElement")

--- a/packages/react/src/elements.tsx
+++ b/packages/react/src/elements.tsx
@@ -108,7 +108,7 @@ export function CanToggleElement({
       {...(dataSource ? { dataSource } : {})}
       {...(shared ? { shared } : {})}
       {...(standalone ? { standalone } : {})}
-      {...(readOnly ? { "data-source-read-only": "" } : {})}
+      {...(readOnly ? { dataSourceReadOnly: true } : {})}
       children={(renderData) => {
         const renderedChildren = renderSingleChildOrPlayable(
           children,

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -319,9 +319,11 @@ export function CanPlayElement<T extends object, V = any>({
         for (const tag of Object.keys(computedTagInfo) as TagType[]) {
           const handler = handlers.get(tag)?.get(elementId);
           if (!handler || handler.element !== element) continue;
-          handler.onClick = elementProps.onClick;
-          handler.onDrag = elementProps.onDrag;
-          handler.onDragStart = elementProps.onDragStart;
+          handler.setEventHandlers({
+            onClick: elementProps.onClick,
+            onDrag: elementProps.onDrag,
+            onDragStart: elementProps.onDragStart,
+          });
         }
       }
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -313,6 +313,18 @@ export function CanPlayElement<T extends object, V = any>({
       // @ts-ignore
       element.updateElementAwareness = updateElementAwareness;
 
+      const elementId = getIdForElement(element);
+      const handlers = playhtml.elementHandlers;
+      if (elementId && handlers instanceof Map) {
+        for (const tag of Object.keys(computedTagInfo) as TagType[]) {
+          const handler = handlers.get(tag)?.get(elementId);
+          if (!handler || handler.element !== element) continue;
+          handler.onClick = elementProps.onClick;
+          handler.onDrag = elementProps.onDrag;
+          handler.onDragStart = elementProps.onDragStart;
+        }
+      }
+
       // Setup the element, which will handle data-source discovery if needed
       try {
         const currentBinding = getElementBinding(element);


### PR DESCRIPTION
## Summary
- Clean up ElementHandler-installed listeners, including active document drag listeners, on destroy and allow a destroyed handler to reinitialize once.
- Forward CanToggleElement readOnly through the canonical dataSourceReadOnly prop.
- Keep CanPlayElement click and drag callbacks current after React rerenders without repeating setup.
- Add core and React regressions plus patch changesets for playhtml and @playhtml/react.

## Validation
- bun run test in packages/playhtml (366 tests)
- bun run test in packages/react (45 tests)
- bun run build-packages

## Docs and starters
- No updates: existing docs already describe CanToggleElement readOnly and its DOM attribute; starter templates do not demonstrate a read-only shared toggle.