### PR TITLE
website: render story words as text

### DIFF
--- a/website/story.html
+++ b/website/story.html
@@ -213,14 +213,21 @@
                   lastDate.toLocaleDateString();
               }
 
-              storyContent.innerHTML = data
-                .map(
-                  ({ word, color }) =>
-                    `<span class="word" style="--word-color:${getColorVar(
-                      color
-                    )}">${word}</span>`
-                )
-                .join("\n");
+              storyContent.replaceChildren(
+                ...data.flatMap(({ word, color }, index) => {
+                  const wordElement = document.createElement("span");
+                  wordElement.className = "word";
+                  wordElement.style.setProperty(
+                    "--word-color",
+                    getColorVar(color)
+                  );
+                  wordElement.textContent = String(word);
+
+                  return index === 0
+                    ? [wordElement]
+                    : [document.createTextNode("\n"), wordElement];
+                })
+              );
             };
           </script>
         </p>

--- a/website/test/storyRendering.test.ts
+++ b/website/test/storyRendering.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Tests rendering persisted words in the one-word story.
+// ABOUTME: Ensures untrusted shared text remains text instead of markup.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const storyHtml = readFileSync(
+  resolve(process.cwd(), "website/story.html"),
+  "utf8",
+);
+
+const storyScript = storyHtml.match(
+  /<script>\s*(const explicitSlurRegexes[\s\S]*?input\.updateElement = \(\{ data \}\) => \{[\s\S]*?\n\s*\};)\s*<\/script>/,
+)?.[1];
+
+function runStoryScript() {
+  if (!storyScript) {
+    throw new Error("Could not find the one-word story script");
+  }
+
+  new Function(storyScript)();
+}
+
+describe("one-word story rendering", () => {
+  test("renders hostile persisted words literally", () => {
+    document.body.innerHTML = `
+      <input id="colorPicker" type="color" />
+      <input id="wordInput" />
+      <button class="wordSubmit"></button>
+      <span id="storyContent"></span>
+      <span id="typingIndicators"></span>
+      <span id="activeUsersCount"></span>
+      <span id="lastUpdatedTime"></span>
+    `;
+    localStorage.clear();
+    Object.assign(globalThis, {
+      activeUsersCount: document.getElementById("activeUsersCount"),
+      colorPicker: document.getElementById("colorPicker"),
+      lastUpdatedTime: document.getElementById("lastUpdatedTime"),
+    });
+    runStoryScript();
+
+    const storyContent = document.getElementById("storyContent");
+    const input = document.getElementById("wordInput");
+    const hostileWord = "<svg/onload=alert()>";
+
+    input.updateElement({
+      data: [
+        { word: "together", color: "#112233", ts: 0 },
+        { word: hostileWord, color: "#abcdef", ts: 1 },
+      ],
+    });
+
+    const words = storyContent.querySelectorAll(".word");
+    expect(words).toHaveLength(2);
+    expect(words[0].textContent).toBe("together");
+    expect(words[0].style.getPropertyValue("--word-color")).toBe(
+      "17, 34, 51",
+    );
+    expect(words[1].textContent).toBe(hostileWord);
+    expect(words[1].style.getPropertyValue("--word-color")).toBe(
+      "171, 205, 239",
+    );
+    expect(storyContent.querySelector("svg, img, [onload], [onerror]")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- render persisted one-word story entries with DOM text nodes instead of HTML interpolation
- preserve each word's class, color property, order, and whitespace
- add a regression test for the stored SVG payload

## Root cause

Persisted collaborative word text was interpolated into `innerHTML`, allowing a stored HTML payload to create executable markup.

## Validation

- `bunx vitest --config website/vitest.config.mts run website/test/storyRendering.test.ts`
- `bunx tsc -p website/tsconfig.json --noEmit`
- `bunx vite build website --config vite.config.site.mts`
- real local-browser story-route verification with a normal word and `<svg/onload=alert()>` in an isolated room