### PR TITLE
react: resolve function defaults after mount

### DIFF
--- a/.changeset/react-mounted-defaults.md
+++ b/.changeset/react-mounted-defaults.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Resolve function-form element defaults after their DOM element mounts, so React components can safely derive initial data and awareness from that element.

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -51,8 +51,8 @@ withSharedState<T, V, P>(
 
 ```tsx
 interface WithSharedStateConfig<T, V> {
-  defaultData: T;
-  myDefaultAwareness?: V;
+  defaultData: T | ((element: HTMLElement) => T);
+  myDefaultAwareness?: V | ((element: HTMLElement) => V);
   id?: string;
   tagInfo?: TagType[];
 }
@@ -60,6 +60,7 @@ interface WithSharedStateConfig<T, V> {
 
 - **`defaultData`**: required. The initial value of `data`. Survives reload.
 - **`myDefaultAwareness`**: optional. Initial value for this user's element awareness. This is ephemeral per-user presence scoped to the element. Does _not_ persist.
+- Either default can be a callback when it needs the rendered element. The callback receives the mounted `HTMLElement` once during initialization, so it can read attributes or `dataset` values; later renders do not recompute the default.
 - **`id`**: optional. Stable id for the element. If omitted, playhtml derives one from the rendered DOM; see [Dynamic elements](/docs/advanced/dynamic-elements/) for why stable ids matter.
 - **`tagInfo`**: optional. Marks the element as one of the built-in capabilities (e.g. `[TagType.CanToggle]`). See [Capabilities](/docs/capabilities/).
 
@@ -98,8 +99,8 @@ Component form of `withSharedState`. Useful when you want JSX children (render-p
 ```tsx
 interface CanPlayElementProps<T, V> {
   id?: string;
-  defaultData: T;
-  myDefaultAwareness?: V;
+  defaultData: T | ((element: HTMLElement) => T);
+  myDefaultAwareness?: V | ((element: HTMLElement) => V);
   tagInfo?: TagType[];
   standalone?: boolean;
   loading?: LoadingOptions;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "test": "vitest run --no-typecheck",
+    "test": "vitest run --no-typecheck && vitest run --config vitest.integration.config.ts --no-typecheck",
     "test:watch": "vitest --no-typecheck"
   },
   "publishConfig": {

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -18,6 +18,112 @@ describe("CanPlayElement with built-in capabilities", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
+  it("resolves function defaults from the mounted element once before setup", () => {
+    const defaultData = vi.fn((element: HTMLElement) => ({
+      color: element.dataset.color,
+    }));
+    const myDefaultAwareness = vi.fn((element: HTMLElement) => ({
+      presence: element.dataset.presence,
+    }));
+    const setupValues: Array<{
+      defaultData: unknown;
+      myDefaultAwareness: unknown;
+    }> = [];
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation((element) => {
+      setupValues.push({
+        defaultData: (element as HTMLElement & { defaultData: unknown })
+          .defaultData,
+        myDefaultAwareness: (
+          element as HTMLElement & { myDefaultAwareness: unknown }
+        ).myDefaultAwareness,
+      });
+    });
+
+    const { getByTestId } = render(
+      <React.StrictMode>
+        <CanPlayElement
+          id="function-defaults"
+          defaultData={defaultData}
+          myDefaultAwareness={myDefaultAwareness}
+        >
+          {({ data, myAwareness }) => (
+            <button
+              data-color="violet"
+              data-presence="present"
+              data-testid="function-defaults"
+            >
+              {data?.color}:{myAwareness?.presence}
+            </button>
+          )}
+        </CanPlayElement>
+      </React.StrictMode>,
+    );
+
+    const element = getByTestId("function-defaults");
+    expect(defaultData).toHaveBeenCalledTimes(1);
+    expect(defaultData).toHaveBeenCalledWith(element);
+    expect(myDefaultAwareness).toHaveBeenCalledTimes(1);
+    expect(myDefaultAwareness).toHaveBeenCalledWith(element);
+    expect(setupValues).toEqual(
+      expect.arrayContaining([
+        {
+          defaultData: { color: "violet" },
+          myDefaultAwareness: { presence: "present" },
+        },
+      ]),
+    );
+    expect(element).toHaveTextContent("violet:present");
+  });
+
+  it("keeps object defaults current when props update", () => {
+    const firstData = { color: "violet" };
+    const secondData = { color: "teal" };
+    const firstAwareness = { presence: "present" };
+    const secondAwareness = { presence: "away" };
+    const setupValues: Array<{
+      defaultData: unknown;
+      myDefaultAwareness: unknown;
+    }> = [];
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation((element) => {
+      setupValues.push({
+        defaultData: (element as HTMLElement & { defaultData: unknown })
+          .defaultData,
+        myDefaultAwareness: (
+          element as HTMLElement & { myDefaultAwareness: unknown }
+        ).myDefaultAwareness,
+      });
+    });
+
+    const { rerender } = render(
+      <CanPlayElement
+        defaultData={firstData}
+        myDefaultAwareness={firstAwareness}
+      >
+        {() => <button id="object-defaults" />}
+      </CanPlayElement>,
+    );
+
+    rerender(
+      <CanPlayElement
+        defaultData={secondData}
+        myDefaultAwareness={secondAwareness}
+      >
+        {() => <button id="object-defaults" />}
+      </CanPlayElement>,
+    );
+
+    expect(setupValues).toEqual([
+      {
+        defaultData: firstData,
+        myDefaultAwareness: firstAwareness,
+      },
+      {
+        defaultData: secondData,
+        myDefaultAwareness: secondAwareness,
+      },
+    ]);
+  });
+
   it("composes capability updateElement with React state updates for CanMove", () => {
     const capabilityUpdateElement = vi.fn();
 

--- a/packages/react/src/__tests__/function-defaults.integration.test.tsx
+++ b/packages/react/src/__tests__/function-defaults.integration.test.tsx
@@ -1,0 +1,93 @@
+// ABOUTME: Tests function-form React defaults against the initialized PlayHTML runtime.
+// ABOUTME: Verifies DOM-derived initialization does not duplicate shared writes in Strict Mode.
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { playhtml, resetPlayHTML } from "playhtml";
+import { CanPlayElement } from "../index";
+
+describe("CanPlayElement function defaults", () => {
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    delete (window as any).playhtml;
+    delete document.documentElement.dataset.playhtml;
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await playhtml.init({});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+  });
+
+  it("initializes from its mounted element without duplicate shared writes", async () => {
+    const defaultData = vi.fn((element: HTMLElement) => ({
+      color: element.dataset.color,
+    }));
+    const myDefaultAwareness = vi.fn((element: HTMLElement) => ({
+      presence: element.dataset.presence,
+    }));
+    const provider = (globalThis as any).PLAYHTML_TEST_PROVIDERS[0];
+
+    const existingElement = document.createElement("button");
+    existingElement.id = "existing-element";
+    existingElement.setAttribute("can-play", "");
+    (existingElement as any).defaultData = { color: "blue" };
+    (existingElement as any).updateElement = () => {};
+    document.body.appendChild(existingElement);
+    playhtml.setupPlayElement(existingElement);
+    await waitFor(() => {
+      expect(
+        playhtml.elementHandlers.get("can-play")?.get("existing-element"),
+      ).toBeTruthy();
+    });
+    provider.ws.send.mockClear();
+
+    const { getByTestId } = render(
+      <React.StrictMode>
+        <CanPlayElement
+          id="function-defaults"
+          defaultData={defaultData}
+          myDefaultAwareness={myDefaultAwareness}
+        >
+          {({ data, myAwareness }) => (
+            <button
+              data-color="violet"
+              data-presence="present"
+              data-testid="function-defaults"
+            >
+              {data?.color}:{myAwareness?.presence}
+            </button>
+          )}
+        </CanPlayElement>
+      </React.StrictMode>,
+    );
+
+    const element = getByTestId("function-defaults");
+    await waitFor(() => {
+      expect(
+        playhtml.elementHandlers.get("can-play")?.get("function-defaults"),
+      ).toBeTruthy();
+    });
+    const handler = playhtml.elementHandlers
+      .get("can-play")!
+      .get("function-defaults")!;
+
+    expect(defaultData).toHaveBeenCalledTimes(1);
+    expect(defaultData).toHaveBeenCalledWith(element);
+    expect(myDefaultAwareness).toHaveBeenCalledTimes(1);
+    expect(myDefaultAwareness).toHaveBeenCalledWith(element);
+    expect(handler.data).toEqual({ color: "violet" });
+    expect(handler.selfAwareness).toEqual({ presence: "present" });
+    expect(playhtml.syncedStore["can-play"]["function-defaults"]).toEqual({
+      color: "violet",
+    });
+    expect(provider.ws.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Registers can-play elements and shared-state helpers for React apps.
 // TODO: idk why but this is not getting registered otherwise??
 import * as React from "react";
-import { useContext, useEffect, useRef, useState } from "react";
+import { useContext, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { ElementAwarenessEventHandlerData, ElementInitializer, TagType, getIdForElement } from "playhtml";
 import playhtml from "./playhtml-singleton";
 import {
@@ -95,6 +95,11 @@ type ElementBinding = {
   effectiveId: string;
   domId: string;
   dataSource: string | null;
+};
+
+type ResolvedInitialValues<T, V> = {
+  defaultData: T | undefined;
+  myDefaultAwareness: V | undefined;
 };
 
 function getDataSourceElementId(dataSource?: string): string | undefined {
@@ -219,28 +224,21 @@ export function CanPlayElement<T extends object, V = any>({
   const ref = useRef<HTMLElement>(null);
   const registeredBindingRef = useRef<ElementBinding | undefined>(undefined);
   const warningKeysRef = useRef<Set<string>>(new Set());
+  const resolvedInitialValuesRef = useRef<ResolvedInitialValues<T, V> | null>(
+    null,
+  );
   const { defaultData, myDefaultAwareness } = elementProps;
-  const resolveDefaultData = (fnOrValue: T | ((el: HTMLElement) => T)) =>
-    typeof fnOrValue === "function"
-      ? // @ts-ignore
-        (fnOrValue as (el: HTMLElement) => T)(ref.current as HTMLElement)
-      : (fnOrValue as T);
-  const resolveDefaultAwareness = (
-    fnOrValue?: V | ((el: HTMLElement) => V),
-  ): V | undefined =>
-    typeof fnOrValue === "function"
-      ? // @ts-ignore
-        (fnOrValue as (el: HTMLElement) => V)(ref.current as HTMLElement)
-      : fnOrValue;
+  const defaultDataIsFunction = typeof defaultData === "function";
+  const defaultAwarenessIsFunction = typeof myDefaultAwareness === "function";
+  const [initialValuesReady, setInitialValuesReady] = useState(
+    !defaultDataIsFunction && !defaultAwarenessIsFunction,
+  );
+  const initialData = defaultDataIsFunction ? undefined : (defaultData as T);
+  const initialAwareness = defaultAwarenessIsFunction
+    ? undefined
+    : (myDefaultAwareness as V | undefined);
 
-  const [data, setData] = useState<T | undefined>(
-    defaultData !== undefined
-      ? resolveDefaultData(defaultData as T | ((el: HTMLElement) => T))
-      : undefined,
-  );
-  const initialAwareness = resolveDefaultAwareness(
-    myDefaultAwareness as V | ((el: HTMLElement) => V) | undefined,
-  );
+  const [data, setData] = useState<T | undefined>(initialData);
   const [awareness, setAwareness] = useState<V[]>(
     initialAwareness ? [initialAwareness] : [],
   );
@@ -250,6 +248,32 @@ export function CanPlayElement<T extends object, V = any>({
   const [myAwareness, setMyAwareness] = useState<V | undefined>(
     initialAwareness,
   );
+
+  useLayoutEffect(() => {
+    if (resolvedInitialValuesRef.current || !ref.current) return;
+
+    const element = ref.current;
+    const resolvedInitialValues = {
+      defaultData: defaultDataIsFunction
+        ? (defaultData as (element: HTMLElement) => T)(element)
+        : (defaultData as T | undefined),
+      myDefaultAwareness: defaultAwarenessIsFunction
+        ? (myDefaultAwareness as (element: HTMLElement) => V)(element)
+        : (myDefaultAwareness as V | undefined),
+    };
+    resolvedInitialValuesRef.current = resolvedInitialValues;
+
+    if (defaultDataIsFunction || defaultAwarenessIsFunction) {
+      setData(resolvedInitialValues.defaultData);
+      setAwareness(
+        resolvedInitialValues.myDefaultAwareness
+          ? [resolvedInitialValues.myDefaultAwareness]
+          : [],
+      );
+      setMyAwareness(resolvedInitialValues.myDefaultAwareness);
+      setInitialValuesReady(true);
+    }
+  }, []);
 
   // Capture the capability's original updateElement/updateElementAwareness so we can
   // compose them with the React state updater below. These come from the built-in
@@ -299,15 +323,31 @@ export function CanPlayElement<T extends object, V = any>({
   };
 
   useEffect(() => {
-    if (ref.current) {
+    if (initialValuesReady && ref.current) {
       const element = ref.current;
       for (const [key, value] of Object.entries(elementProps)) {
         // Skip updateElement/updateElementAwareness — they are set below as
         // composed versions that include both React state updates and DOM updates.
-        if (key === "updateElement" || key === "updateElementAwareness") continue;
+        if (
+          key === "defaultData" ||
+          key === "myDefaultAwareness" ||
+          key === "updateElement" ||
+          key === "updateElementAwareness"
+        ) {
+          continue;
+        }
         // @ts-ignore
         element[key] = value;
       }
+      const resolvedInitialValues = resolvedInitialValuesRef.current;
+      // @ts-ignore
+      element.defaultData = defaultDataIsFunction
+        ? resolvedInitialValues!.defaultData
+        : defaultData;
+      // @ts-ignore
+      element.myDefaultAwareness = defaultAwarenessIsFunction
+        ? resolvedInitialValues!.myDefaultAwareness
+        : myDefaultAwareness;
       // @ts-ignore
       element.updateElement = updateElement;
       // @ts-ignore

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/__tests__/setup.ts"],
-    exclude: ["node_modules/**", "dist/**"],
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      "src/__tests__/function-defaults.integration.test.tsx",
+    ],
   },
   resolve: {
     alias: {

--- a/packages/react/vitest.integration.config.ts
+++ b/packages/react/vitest.integration.config.ts
@@ -1,0 +1,39 @@
+// ABOUTME: Configures React integration tests against the initialized PlayHTML runtime.
+// ABOUTME: Reuses the core package's deterministic browser provider fakes.
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: [path.resolve(__dirname, "../playhtml/vitest.setup.ts")],
+    include: ["src/__tests__/function-defaults.integration.test.tsx"],
+  },
+  resolve: {
+    alias: {
+      "@playhtml/common": path.resolve(__dirname, "../common/src/index.ts"),
+      playhtml: path.resolve(__dirname, "../playhtml/src/index.ts"),
+      "react/jsx-runtime": path.resolve(
+        __dirname,
+        "../../node_modules/react/jsx-runtime",
+      ),
+      "react/jsx-dev-runtime": path.resolve(
+        __dirname,
+        "../../node_modules/react/jsx-dev-runtime",
+      ),
+      "react-dom/test-utils": path.resolve(
+        __dirname,
+        "../../node_modules/react-dom/test-utils",
+      ),
+      "react-dom/client": path.resolve(
+        __dirname,
+        "../../node_modules/react-dom/client",
+      ),
+      "react-dom": path.resolve(__dirname, "../../node_modules/react-dom"),
+      react: path.resolve(__dirname, "../../node_modules/react"),
+    },
+  },
+});


### PR DESCRIPTION
Closing: React already has access to the needed values, so function-form `defaultData` / `myDefaultAwareness` is not a supported public API. The branch has been reverted and contains no diff from `main`.