### PR TITLE
Remove cursor trails from touches visualization

### DIFF
--- a/extension/website/touches/sketch.ts
+++ b/extension/website/touches/sketch.ts
@@ -1,4 +1,4 @@
-// ABOUTME: p5 sketch for the touches page — replays comet-like cursors on the
+// ABOUTME: p5 sketch for the touches page — replays cursor dots on the
 // ABOUTME: co-presence timeline and fires nebula collision bursts where they touch
 
 import p5 from "p5";
@@ -32,7 +32,6 @@ export type MarkStyle =
 /** Live-tunable settings the sketch reads every frame. */
 export interface SketchSettings {
   speed: number;
-  afterglowMs: number;
   showCursors: boolean;
   /** Dark sky mode: additive glow against near-black. Off = linen paper,
    * where marks blend like ink instead of light. */
@@ -44,7 +43,6 @@ export interface SketchSettings {
 
 const BURST_LIFE_MS = 2800;
 const BURST_MAX_RADIUS = 95;
-const CURSOR_WAKE_MS = 450;
 /** How far ahead of a touch its before-glow starts building (timeline ms). */
 const FORESHADOW_MS = 3500;
 const MARK_RADIUS = 13;
@@ -579,37 +577,21 @@ export function createTouchesSketch(
       for (let i = 0; i < nextTouchIndex; i++) stampMark(data.touches[i]);
     };
 
-    /** Koi in a pond: moving cursors are a small soft-glowing body with a
-     * thin whisker of a wake — ambient presence, not a comet show. The glow
-     * swells with `imminence` (0-1) as a touch approaches. */
+    /** Moving cursors are soft-glowing dots. The glow swells with
+     * `imminence` (0-1) as a touch approaches. */
     const drawCursor = (trail: Trail, realTs: number, imminence: number) => {
       const pos = motionAt(trail, realTs);
       const night = settingsRef.current.night;
       const color = inkAdjusted(p.color(trail.color), night);
 
       // Parked cursors (wide sample bracket) sit dim and still, like faint
-      // stars — no tail, no interpolated drift across idle gaps.
+      // stars, without interpolating across idle gaps.
       if (!pos.live) {
         color.setAlpha(night ? 120 : 80);
         p.noStroke();
         p.fill(color);
         p.circle(pos.x, pos.y, night ? 4.5 : 6);
         return;
-      }
-
-      // Thin wake, quickly fading.
-      const steps = 8;
-      let prev: { x: number; y: number } = pos;
-      for (let i = 1; i <= steps; i++) {
-        const t = realTs - (CURSOR_WAKE_MS * i) / steps;
-        if (t <= trail.startTime) break;
-        const point = positionAt(trail, Math.max(t, trail.startTime));
-        const falloff = 1 - i / (steps + 1);
-        color.setAlpha((night ? 90 : 70) * falloff * falloff);
-        p.stroke(color);
-        p.strokeWeight(0.4 + 1.5 * falloff);
-        p.line(prev.x, prev.y, point.x, point.y);
-        prev = point;
       }
 
       // Soft body glow, swelling as a touch nears.
@@ -641,35 +623,10 @@ export function createTouchesSketch(
       p.circle(pos.x, pos.y, 5.5 + imminence * 1.5);
     };
 
-    /** The moments before: as a touch nears, the two cursors' upcoming
-     * paths to the meeting point fade in as faint threads and a glimmer
-     * grows where they will meet. */
-    const drawForeglow = (
-      touch: CursorTouch,
-      factor: number,
-      realTs: number,
-    ) => {
+    /** The moments before: as a touch nears, a glimmer grows where the
+     * cursors will meet. */
+    const drawTouchGlimmer = (touch: CursorTouch, factor: number) => {
       const night = settingsRef.current.night;
-      for (const trailIndex of [touch.trailA, touch.trailB]) {
-        const trail = data.trails[trailIndex];
-        if (touch.ts <= realTs) continue;
-        const color = inkAdjusted(p.color(trail.color), night);
-        color.setAlpha((night ? 85 : 80) * factor);
-        p.noFill();
-        p.stroke(color);
-        p.strokeWeight(1.1);
-        p.beginShape();
-        for (let ts = realTs; ts <= touch.ts; ts += 120) {
-          const pos = positionAt(trail, ts);
-          p.vertex(pos.x, pos.y);
-        }
-        p.vertex(
-          positionAt(trail, touch.ts).x,
-          positionAt(trail, touch.ts).y,
-        );
-        p.endShape();
-      }
-
       const ctx = p.drawingContext as CanvasRenderingContext2D;
       ctx.save();
       ctx.globalCompositeOperation = glowComposite();
@@ -895,35 +852,6 @@ export function createTouchesSketch(
       ctx.restore();
     };
 
-    const drawAfterglow = (burst: Burst, realTs: number) => {
-      const { afterglowMs } = settingsRef.current;
-      if (afterglowMs <= 0) return;
-      const age = playElapsed - burst.startPlayMs;
-      if (age > afterglowMs) return;
-      const fade = 1 - age / afterglowMs;
-
-      for (const trailIndex of [burst.touch.trailA, burst.touch.trailB]) {
-        const trail = data.trails[trailIndex];
-        const from = burst.touch.ts;
-        const to = Math.min(realTs, trail.endTime);
-        if (to <= from) continue;
-        const color = inkAdjusted(
-          p.color(trail.color),
-          settingsRef.current.night,
-        );
-        color.setAlpha((settingsRef.current.night ? 90 : 80) * fade);
-        p.noFill();
-        p.stroke(color);
-        p.strokeWeight(1.5);
-        p.beginShape();
-        for (let ts = from; ts <= to; ts += 120) {
-          const pos = positionAt(trail, ts);
-          p.vertex(pos.x, pos.y);
-        }
-        p.endShape();
-      }
-    };
-
     p.draw = () => {
       const settings = settingsRef.current;
       playElapsed += Math.min(250, p.deltaTime) * settings.speed;
@@ -960,9 +888,7 @@ export function createTouchesSketch(
         nextTouchIndex++;
       }
       bursts = bursts.filter(
-        (burst) =>
-          playElapsed - burst.startPlayMs <=
-          Math.max(BURST_LIFE_MS, settings.afterglowMs),
+        (burst) => playElapsed - burst.startPlayMs <= BURST_LIFE_MS,
       );
 
       // The moments before: touches coming up within the foreshadow window
@@ -986,9 +912,8 @@ export function createTouchesSketch(
         }
       }
 
-      for (const burst of bursts) drawAfterglow(burst, realTs);
       for (const entry of upcoming) {
-        drawForeglow(entry.touch, entry.factor, realTs);
+        drawTouchGlimmer(entry.touch, entry.factor);
       }
 
       if (settings.showCursors) {

--- a/extension/website/touches/sketchGlsl.ts
+++ b/extension/website/touches/sketchGlsl.ts
@@ -9,14 +9,12 @@ import {
   CursorTouch,
   playToReal,
   realToPlay,
-  positionAt,
   motionAt,
 } from "./detect";
 
 const BURST_LIFE_MS = 2000;
 const BURST_QUAD_PX = 260;
 const REMNANT_QUAD_PX = 56;
-const CURSOR_TAIL_MS = 900;
 
 const VERT = `
 precision highp float;
@@ -195,23 +193,6 @@ export function createTouchesSketchGlsl(
         return;
       }
 
-      // Comet tail tapering from head width to a whisker.
-      const steps = 14;
-      let prev = { x, y };
-      for (let i = 1; i <= steps; i++) {
-        const t = realTs - (CURSOR_TAIL_MS * i) / steps;
-        if (t <= trail.startTime) break;
-        const point = positionAt(trail, Math.max(t, trail.startTime));
-        const px = point.x - p.width / 2;
-        const py = point.y - p.height / 2;
-        const falloff = 1 - i / (steps + 1);
-        color.setAlpha(210 * falloff * falloff);
-        p.stroke(color);
-        p.strokeWeight(0.6 + 7 * falloff);
-        p.line(prev.x, prev.y, px, py);
-        prev = { x: px, y: py };
-      }
-
       // Additive halo rings for glow, then the head with a hot core.
       p.blendMode(p.ADD);
       p.noStroke();
@@ -226,32 +207,6 @@ export function createTouchesSketchGlsl(
       p.circle(x, y, 8.5);
       p.fill(255, 252, 240, 235);
       p.circle(x, y, 3.2);
-    };
-
-    const drawAfterglow = (burst: Burst, realTs: number) => {
-      const { afterglowMs } = settingsRef.current;
-      if (afterglowMs <= 0) return;
-      const age = playElapsed - burst.startPlayMs;
-      if (age > afterglowMs) return;
-      const fade = 1 - age / afterglowMs;
-
-      for (const trailIndex of [burst.touch.trailA, burst.touch.trailB]) {
-        const trail = data.trails[trailIndex];
-        const from = burst.touch.ts;
-        const to = Math.min(realTs, trail.endTime);
-        if (to <= from) continue;
-        const color = p.color(trail.color);
-        color.setAlpha(90 * fade);
-        p.noFill();
-        p.stroke(color);
-        p.strokeWeight(1.5);
-        p.beginShape();
-        for (let ts = from; ts <= to; ts += 120) {
-          const pos = positionAt(trail, ts);
-          p.vertex(pos.x - p.width / 2, pos.y - p.height / 2);
-        }
-        p.endShape();
-      }
     };
 
     const drawBurst = (burst: Burst) => {
@@ -311,12 +266,8 @@ export function createTouchesSketchGlsl(
         nextTouchIndex++;
       }
       bursts = bursts.filter(
-        (burst) =>
-          playElapsed - burst.startPlayMs <=
-          Math.max(BURST_LIFE_MS, settings.afterglowMs),
+        (burst) => playElapsed - burst.startPlayMs <= BURST_LIFE_MS,
       );
-
-      for (const burst of bursts) drawAfterglow(burst, realTs);
 
       if (settings.showCursors) {
         for (const trail of data.trails) {

--- a/extension/website/touches/sketchPinwheel.ts
+++ b/extension/website/touches/sketchPinwheel.ts
@@ -5,10 +5,8 @@ import p5 from "p5";
 import { Trail } from "../shared/types";
 import {
   CursorTouch,
-  TimeSegment,
   playToReal,
   realToPlay,
-  positionAt,
   motionAt,
 } from "./detect";
 
@@ -16,7 +14,6 @@ import { SketchData, SketchSettings } from "./sketch";
 
 const BURST_LIFE_MS = 1600;
 const BURST_MAX_RADIUS = 90;
-const CURSOR_TAIL_MS = 700;
 const MARK_RADIUS = 11;
 
 interface Burst {
@@ -88,29 +85,14 @@ export function createTouchesSketchPinwheel(
       const pos = motionAt(trail, realTs);
       const color = p.color(trail.color);
 
-      // Parked cursors (wide sample bracket) sit dim and still — no tail, no
-      // interpolated drift across idle gaps.
+      // Parked cursors (wide sample bracket) sit dim and still, without
+      // interpolating across idle gaps.
       if (!pos.live) {
         color.setAlpha(80);
         p.noStroke();
         p.fill(color);
         p.circle(pos.x, pos.y, 7);
         return;
-      }
-
-      // Short comet tail so motion reads without drawing whole trails.
-      p.noFill();
-      const steps = 6;
-      for (let i = 1; i <= steps; i++) {
-        const t0 = realTs - (CURSOR_TAIL_MS * i) / steps;
-        const t1 = realTs - (CURSOR_TAIL_MS * (i - 1)) / steps;
-        if (t1 <= trail.startTime) break;
-        const a = positionAt(trail, Math.max(t0, trail.startTime));
-        const b = positionAt(trail, Math.max(t1, trail.startTime));
-        color.setAlpha(140 * (1 - i / (steps + 1)));
-        p.stroke(color);
-        p.strokeWeight(2.5 * (1 - i / (steps + 2)));
-        p.line(a.x, a.y, b.x, b.y);
       }
 
       color.setAlpha(255);
@@ -173,32 +155,6 @@ export function createTouchesSketchPinwheel(
       p.circle(touch.x, touch.y, radius * 2);
     };
 
-    const drawAfterglow = (burst: Burst, realTs: number) => {
-      const { afterglowMs } = settingsRef.current;
-      if (afterglowMs <= 0) return;
-      const age = playElapsed - burst.startPlayMs;
-      if (age > afterglowMs) return;
-      const fade = 1 - age / afterglowMs;
-
-      for (const trailIndex of [burst.touch.trailA, burst.touch.trailB]) {
-        const trail = data.trails[trailIndex];
-        const from = burst.touch.ts;
-        const to = Math.min(realTs, trail.endTime);
-        if (to <= from) continue;
-        const color = p.color(trail.color);
-        color.setAlpha(70 * fade);
-        p.noFill();
-        p.stroke(color);
-        p.strokeWeight(1.5);
-        p.beginShape();
-        for (let ts = from; ts <= to; ts += 120) {
-          const pos = positionAt(trail, ts);
-          p.vertex(pos.x, pos.y);
-        }
-        p.endShape();
-      }
-    };
-
     p.draw = () => {
       const settings = settingsRef.current;
       playElapsed += Math.min(250, p.deltaTime) * settings.speed;
@@ -232,12 +188,8 @@ export function createTouchesSketchPinwheel(
         nextTouchIndex++;
       }
       bursts = bursts.filter(
-        (burst) =>
-          playElapsed - burst.startPlayMs <=
-          Math.max(BURST_LIFE_MS, settings.afterglowMs),
+        (burst) => playElapsed - burst.startPlayMs <= BURST_LIFE_MS,
       );
-
-      for (const burst of bursts) drawAfterglow(burst, realTs);
 
       if (settings.showCursors) {
         for (const trail of data.trails) {

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -91,7 +91,6 @@ const CursorTouches = () => {
 
   const [touchRadius, setTouchRadius] = useState(20);
   const [speed, setSpeed] = useState(1);
-  const [afterglowSec, setAfterglowSec] = useState(2);
   const [showCursors, setShowCursors] = useState(true);
   const [samePersonOk, setSamePersonOk] = useState(false);
   const [night, setNight] = useState(false);
@@ -142,7 +141,6 @@ const CursorTouches = () => {
   // Settings the sketch reads every frame without re-instantiating.
   const settingsRef = useRef<SketchSettings>({
     speed,
-    afterglowMs: afterglowSec * 1000,
     showCursors,
     night,
     markStyle,
@@ -150,12 +148,11 @@ const CursorTouches = () => {
   useEffect(() => {
     settingsRef.current = {
       speed,
-      afterglowMs: afterglowSec * 1000,
       showCursors,
       night,
       markStyle,
     };
-  }, [speed, afterglowSec, showCursors, night, markStyle]);
+  }, [speed, showCursors, night, markStyle]);
 
   const hostRef = useRef<HTMLDivElement>(null);
   // The replayed moment's real date/time, written imperatively from the
@@ -296,17 +293,6 @@ const CursorTouches = () => {
               max={120}
               value={speed}
               onChange={(e) => setSpeed(Number(e.target.value))}
-              style={styles.slider}
-            />
-          </div>
-          <div style={styles.row}>
-            <span>afterglow: {afterglowSec}s</span>
-            <input
-              type="range"
-              min={0}
-              max={15}
-              value={afterglowSec}
-              onChange={(e) => setAfterglowSec(Number(e.target.value))}
               style={styles.slider}
             />
           </div>


### PR DESCRIPTION
## Summary

- remove cursor wakes, pre-collision future-route threads, and post-collision trails from all three touches renderers
- keep cursor dots, pre-collision glimmer and swelling, touch detection, and collision marks unchanged
- remove the afterglow control now that it no longer controls any rendered trail

## Why

The nebula renderer deliberately sampled and redrew each cursor's known future route for 3.5 seconds before a collision. Recalculating those paths every frame produced the long, apparently random lines and visible wobble near contact.

## Validation

- `bunx tsc --noEmit` in `extension/website`
- scoped ESLint on the four changed touches files
- `bun run build` in `extension/website`
- browser playback on `/touches/` with real cursor data at 120x, including renderer-switch smoke checks for nebula, GLSL, and pinwheel

The full website lint command still reports pre-existing configuration and baseline errors outside this change.