### PR TITLE
Show click ripples in the live portrait

### DIFF
--- a/extension/website/portrait/live.tsx
+++ b/extension/website/portrait/live.tsx
@@ -15,7 +15,7 @@ import type { FilterChip } from "../shared/utils/eventUtils";
 // Module-scoped so its reference stays stable across the frequent re-renders
 // the live stream triggers (otherwise MovementCanvas reattaches listeners each frame).
 const noOpFetch = () => {};
-const LIVE_SETTINGS_DEFAULTS = { clickMaxRadius: 50 };
+const LIVE_SETTINGS_DEFAULTS = { clickMaxRadius: 30 };
 
 const LivePortrait = () => {
   const { events, connected } = useLiveEvents({ maxEvents: 500 });

--- a/extension/website/portrait/live.tsx
+++ b/extension/website/portrait/live.tsx
@@ -15,6 +15,7 @@ import type { FilterChip } from "../shared/utils/eventUtils";
 // Module-scoped so its reference stays stable across the frequent re-renders
 // the live stream triggers (otherwise MovementCanvas reattaches listeners each frame).
 const noOpFetch = () => {};
+const LIVE_SETTINGS_DEFAULTS = { clickMaxRadius: 50 };
 
 const LivePortrait = () => {
   const { events, connected } = useLiveEvents({ maxEvents: 500 });
@@ -85,6 +86,7 @@ const LivePortrait = () => {
         onSetFilters={setFilters}
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
+        defaultSettings={LIVE_SETTINGS_DEFAULTS}
         live
         connected={connected}
       />

--- a/extension/website/shared/components/Controls.tsx
+++ b/extension/website/shared/components/Controls.tsx
@@ -26,11 +26,11 @@ import {
   subscribeSavedConfigs,
   type SavedConfig,
 } from "../utils/savedConfigs";
-import { DEFAULT_SETTINGS } from "./settingsDefaults";
 
 interface ControlsProps {
   visible: boolean;
   settings: any;
+  settingsDefaults: Record<string, unknown>;
   setSettings: React.Dispatch<React.SetStateAction<any>>;
   loading: boolean;
   error: string | null;
@@ -76,9 +76,15 @@ const WINDOW_LENGTH_OPTIONS: Array<{ label: string; ms: number }> = [
  * `CollapsibleSection` and `PathFilterInput`). */
 const ShareConfigSection: React.FC<{
   settings: Record<string, unknown>;
+  settingsDefaults: Record<string, unknown>;
   activeVisualizations: string[];
   selectedTimeRange: { startMs: number; endMs: number } | null;
-}> = ({ settings, activeVisualizations, selectedTimeRange }) => {
+}> = ({
+  settings,
+  settingsDefaults,
+  activeVisualizations,
+  selectedTimeRange,
+}) => {
   const [copyFeedback, setCopyFeedback] = useState<"idle" | "ok" | "err">(
     "idle",
   );
@@ -91,6 +97,7 @@ const ShareConfigSection: React.FC<{
   const buildCurrentUrl = () =>
     buildShareUrl({
       settings,
+      settingsDefaults,
       activeVisualizations,
       selectedTimeRange,
       // Preserve whichever clean tier the page is currently in (set via
@@ -136,7 +143,7 @@ const ShareConfigSection: React.FC<{
       trailStyle: settings.trailStyle as string | undefined,
       trailStyleIsDefault:
         (settings.trailStyle as string | undefined) ===
-        DEFAULT_SETTINGS.trailStyle,
+        settingsDefaults.trailStyle,
       selectedTimeRange,
     });
     const name = title || autoName;
@@ -701,6 +708,7 @@ export const Controls: React.FC<ControlsProps> = memo(
   ({
     visible,
     settings,
+    settingsDefaults,
     setSettings,
     loading,
     error,
@@ -715,6 +723,13 @@ export const Controls: React.FC<ControlsProps> = memo(
     selectedTimeRange,
     onSelectTimeRange,
   }) => {
+    const clickSettingsDefaults = useMemo(
+      () =>
+        Object.fromEntries(
+          Object.keys(CLICK_DEFAULTS).map((key) => [key, settingsDefaults[key]]),
+        ),
+      [settingsDefaults],
+    );
     // Membership check for viz-specific Controls sections. Each viz-tagged
     // section (Cursor / Click / Keyboard / Scroll / Navigation Settings)
     // only renders when its viz id is in the active list — surfaces stay
@@ -824,6 +839,7 @@ export const Controls: React.FC<ControlsProps> = memo(
       >
         <ShareConfigSection
           settings={settings}
+          settingsDefaults={settingsDefaults}
           activeVisualizations={activeVisualizations}
           selectedTimeRange={selectedTimeRange ?? null}
         />
@@ -1260,7 +1276,7 @@ export const Controls: React.FC<ControlsProps> = memo(
             <button
               type="button"
               onClick={() =>
-                setSettings((s: any) => ({ ...s, ...CLICK_DEFAULTS }))
+                setSettings((s: any) => ({ ...s, ...clickSettingsDefaults }))
               }
               style={{
                 fontSize: "11px",

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -1,10 +1,15 @@
-// ABOUTME: Live cursor-trail animator. Renders the current trail set directly
-// ABOUTME: (id-keyed, React owns add/remove/grow); the rAF loop draws each trail
-// ABOUTME: by its own progress since first seen. No snapshot/eviction state.
+// ABOUTME: Animates id-keyed live cursor trails and their click ripples.
+// ABOUTME: React owns trail lifetimes while one frame loop draws current progress.
 
 import React, { useEffect, useRef, useState, memo } from "react";
-import { TrailState } from "../types";
+import type { TrailState } from "../types";
 import { getTrailRenderer } from "../styles/trailRenderers";
+import { RippleEffect, type RippleSettings } from "./ClickRipple";
+import {
+  collectDueClickEffects,
+  retainClickEffectsForActiveTrails,
+  type LiveClickEffect,
+} from "./liveClickEffects";
 import {
   TrailPath,
   TrailCursor,
@@ -63,10 +68,11 @@ interface KeptTrail {
 interface LiveTrailsProps {
   trailStates: TrailState[];
   frozen?: boolean;
+  showClickRipples?: boolean;
   /** Called with trail ids once they have fully faded out and been removed, so
    * the owner can free their accumulated events. */
   onTrailsRemoved?: (ids: string[]) => void;
-  settings: {
+  settings: RippleSettings & {
     strokeWidth: number;
     trailOpacity: number;
     animationSpeed: number;
@@ -75,7 +81,16 @@ interface LiveTrailsProps {
 }
 
 export const LiveTrails: React.FC<LiveTrailsProps> = memo(
-  ({ trailStates, frozen = false, onTrailsRemoved, settings }) => {
+  ({
+    trailStates,
+    frozen = false,
+    showClickRipples = false,
+    onTrailsRemoved,
+    settings,
+  }) => {
+    const [activeClickEffects, setActiveClickEffects] = useState<
+      LiveClickEffect[]
+    >([]);
     const svgRef = useRef<SVGSVGElement>(null);
     const pathLayerRef = useRef<SVGGElement>(null);
     const animationRef = useRef<number | undefined>(undefined);
@@ -83,6 +98,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const consecutiveErrorsRef = useRef(0);
 
     const renderer = getTrailRenderer(settings.trailVisualStyle ?? "color");
+    const rendererRef = useRef(renderer);
+    useEffect(() => {
+      rendererRef.current = renderer;
+    }, [renderer]);
 
     // Settings via refs so the loop reads latest without restarting.
     const strokeWidthRef = useRef(settings.strokeWidth);
@@ -96,6 +115,16 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     useEffect(() => {
       frozenRef.current = frozen;
     }, [frozen]);
+
+    const showClickRipplesRef = useRef(showClickRipples);
+    useEffect(() => {
+      showClickRipplesRef.current = showClickRipples;
+      if (!showClickRipples) setActiveClickEffects([]);
+    }, [showClickRipples]);
+
+    const spawnedClickKeysByTrailRef = useRef<Map<string, Set<string>>>(
+      new Map(),
+    );
 
     // Per-trail draw state. `seenAt` is the clock time the trail began drawing;
     // progress = (clock - seenAt) / drawDuration, so it traces over its real
@@ -140,6 +169,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       if (removedIdsRef.current.length > 0) {
         const ids = removedIdsRef.current;
         removedIdsRef.current = [];
+        const removed = new Set(ids);
+        setActiveClickEffects((effects) =>
+          retainClickEffectsForActiveTrails(effects, removed),
+        );
         onRemovedRef.current?.(ids);
       }
     }, [kept]);
@@ -178,6 +211,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           } else {
             // Fully faded — drop, and report so its events can be freed.
             removedIdsRef.current.push(id);
+            spawnedClickKeysByTrailRef.current.delete(id);
           }
         }
         // Brand-new live trails not already in `kept`.
@@ -224,6 +258,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               // Fully faded — drop, and report so its events can be freed.
               changed = true;
               removedIdsRef.current.push(tid);
+              spawnedClickKeysByTrailRef.current.delete(tid);
             }
           }
           return changed ? next : prev;
@@ -395,6 +430,25 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             progress,
           );
 
+          if (result && showClickRipplesRef.current) {
+            let spawnedClickKeys = spawnedClickKeysByTrailRef.current.get(key);
+            if (!spawnedClickKeys) {
+              spawnedClickKeys = new Set();
+              spawnedClickKeysByTrailRef.current.set(key, spawnedClickKeys);
+            }
+            const effects = collectDueClickEffects(
+              ts,
+              result.trailProgress,
+              spawnedClickKeys,
+              result.cursorPosition,
+              rendererRef.current.getClickColor(ts.trail.color),
+              Date.now(),
+            );
+            if (effects.length > 0) {
+              setActiveClickEffects((active) => [...active, ...effects]);
+            }
+          }
+
           // Show the cursor at the moving draw-head while the trail is still
           // actively tracing (not caught up, not settled, not departing).
           const cursorHandle = cursorHandles.current.get(key);
@@ -438,7 +492,6 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         document.removeEventListener("visibilitychange", onVisibility);
         clearScheduled();
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     return (
@@ -450,6 +503,14 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         preserveAspectRatio="none"
         style={{ position: "absolute", top: 0, left: 0, pointerEvents: "none" }}
       >
+        {showClickRipples &&
+          activeClickEffects.map((effect) => (
+            <RippleEffect
+              key={effect.id}
+              effect={effect}
+              settings={settings}
+            />
+          ))}
         <g ref={pathLayerRef}>
           {kept.map((entry) => {
             const ts = entry.trail;

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -323,8 +323,10 @@ function playShutterSound() {
 // only persist when the user explicitly modifies a control.
 const SETTINGS_STORAGE_KEY = "internet-movement-settings-v2";
 
-const loadSettings = () => {
-  const defaults = DEFAULT_SETTINGS;
+type MovementSettings = typeof DEFAULT_SETTINGS;
+
+const loadSettings = (defaultSettings: Partial<MovementSettings> = {}) => {
+  const defaults = { ...DEFAULT_SETTINGS, ...defaultSettings };
   const urlOverrides = parseSettingsFromUrl();
 
   try {
@@ -374,6 +376,8 @@ interface MovementCanvasProps {
   /** Initial sound-on state. The AudioContext will still start suspended
    * until the user's first gesture (browser autoplay policy). */
   defaultSoundEnabled?: boolean;
+  /** Route-specific defaults applied before stored settings and URL overrides. */
+  defaultSettings?: Partial<MovementSettings>;
   live?: boolean;
   /** Live-stream connection status, gates the people-count readout. */
   connected?: boolean;
@@ -399,11 +403,16 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   activeVisualizations,
   onSetActiveVisualizations,
   defaultSoundEnabled = false,
+  defaultSettings,
   live = false,
   connected = false,
   getInstallationElapsedMs,
 }) => {
-  const [settings, setSettings] = useState(loadSettings());
+  const settingsDefaults = useMemo(
+    () => ({ ...DEFAULT_SETTINGS, ...defaultSettings }),
+    [defaultSettings],
+  );
+  const [settings, setSettings] = useState(() => loadSettings(defaultSettings));
   const [controlsVisible, setControlsVisible] = useState(false);
   const [cinematic, setCinematic] = useState<CinematicConfig | null>(() =>
     parseCinematicFromUrl(),
@@ -641,6 +650,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       try {
         const next = buildShareUrl({
           settings,
+          settingsDefaults,
           activeVisualizations,
           selectedTimeRange,
           clean: parseCleanFromUrl(),
@@ -656,7 +666,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       }
     }, 200);
     return () => window.clearTimeout(timer);
-  }, [settings, activeVisualizations, selectedTimeRange]);
+  }, [settings, settingsDefaults, activeVisualizations, selectedTimeRange]);
 
   // Keyboard shortcuts:
   //   double-tap D — toggle controls panel
@@ -1287,6 +1297,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       <Controls
         visible={controlsVisible}
         settings={settings}
+        settingsDefaults={settingsDefaults}
         setSettings={setSettingsFromControls}
         loading={loading}
         error={error}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1552,6 +1552,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               key={`live-trails-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
               trailStates={trailStates}
               frozen={paused}
+              showClickRipples={!showClicks}
               onTrailsRemoved={handleTrailsRemoved}
               settings={trailAnimationSettings}
             />

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Tests one-shot click spawning for the live cursor-trail renderer.
+// ABOUTME: Covers trail growth without replaying clicks already shown.
+
+import { describe, expect, it, vi } from "vitest";
+import type { TrailState } from "../../types";
+import {
+  collectDueClickEffects,
+  retainClickEffectsForActiveTrails,
+} from "../liveClickEffects";
+
+function trailState(): TrailState {
+  return {
+    trail: {
+      id: "participant|https://example.com",
+      points: [
+        { x: 0, y: 0, ts: 0 },
+        { x: 100, y: 100, ts: 1000 },
+      ],
+      color: "#123456",
+      opacity: 1,
+      startTime: 0,
+      endTime: 1000,
+      clicks: [],
+    },
+    startOffsetMs: 0,
+    durationMs: 1000,
+    variedPoints: [
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+    ],
+    clicksWithProgress: [
+      { x: 25, y: 25, ts: 250, progress: 0.25 },
+      { x: 75, y: 75, ts: 750, progress: 0.75, duration: 1200 },
+    ],
+  };
+}
+
+describe("collectDueClickEffects", () => {
+  it("emits each click once as live playback reaches it", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const spawned = new Set<string>();
+    const state = trailState();
+
+    expect(
+      collectDueClickEffects(
+        state,
+        0.2,
+        spawned,
+        { x: 10, y: 20 },
+        "#abcdef",
+        1000,
+      ),
+    ).toEqual([]);
+
+    const firstEffects = collectDueClickEffects(
+      state,
+      0.5,
+      spawned,
+      { x: 30, y: 40 },
+      "#abcdef",
+      1000,
+    );
+    expect(firstEffects).toEqual([
+      expect.objectContaining({
+        id: "participant|https://example.com|250|0",
+        trailId: "participant|https://example.com",
+        x: 30,
+        y: 40,
+        color: "#abcdef",
+        startTime: 1000,
+      }),
+    ]);
+
+    expect(
+      collectDueClickEffects(
+        state,
+        0.8,
+        spawned,
+        { x: 70, y: 80 },
+        "#abcdef",
+        1100,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        id: "participant|https://example.com|750|1",
+        x: 70,
+        y: 80,
+        holdDuration: 1200,
+        startTime: 1100,
+      }),
+    ]);
+
+    expect(
+      collectDueClickEffects(
+        state,
+        1,
+        spawned,
+        { x: 90, y: 100 },
+        "#abcdef",
+        1200,
+      ),
+    ).toEqual([]);
+
+    expect(
+      retainClickEffectsForActiveTrails(firstEffects, new Set(["other-trail"])),
+    ).toBe(firstEffects);
+    expect(
+      retainClickEffectsForActiveTrails(
+        firstEffects,
+        new Set(["participant|https://example.com"]),
+      ),
+    ).toEqual([]);
+
+    random.mockRestore();
+  });
+});

--- a/extension/website/shared/components/liveClickEffects.ts
+++ b/extension/website/shared/components/liveClickEffects.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Converts due live-trail clicks into one-shot ripple effects.
+// ABOUTME: Tracks emitted keys so growing trails do not replay prior clicks.
+
+import type { ClickEffect, TrailState } from "../types";
+
+export interface LiveClickEffect extends ClickEffect {
+  trailId: string;
+}
+
+export function collectDueClickEffects(
+  trailState: TrailState,
+  progress: number,
+  spawnedClickKeys: Set<string>,
+  position: { x: number; y: number },
+  color: string,
+  startTime: number,
+): LiveClickEffect[] {
+  const effects: LiveClickEffect[] = [];
+
+  trailState.clicksWithProgress.forEach((click, index) => {
+    if (click.progress > progress) return;
+
+    const key = `${trailState.trail.id}|${click.ts}|${index}`;
+    if (spawnedClickKeys.has(key)) return;
+
+    spawnedClickKeys.add(key);
+    effects.push({
+      id: key,
+      trailId: trailState.trail.id,
+      x: position.x,
+      y: position.y,
+      color,
+      radiusFactor: Math.random(),
+      durationFactor: Math.random(),
+      startTime,
+      trailIndex: 0,
+      holdDuration: click.duration,
+    });
+  });
+
+  return effects;
+}
+
+export function retainClickEffectsForActiveTrails(
+  effects: LiveClickEffect[],
+  removedTrailIds: Set<string>,
+): LiveClickEffect[] {
+  const retained = effects.filter(
+    (effect) => !removedTrailIds.has(effect.trailId),
+  );
+  return retained.length === effects.length ? effects : retained;
+}

--- a/extension/website/shared/utils/__tests__/shareUrl.test.ts
+++ b/extension/website/shared/utils/__tests__/shareUrl.test.ts
@@ -8,7 +8,7 @@ import { buildShareUrl } from "../shareUrl";
 
 describe("buildShareUrl", () => {
   it("omits settings that match route-specific defaults", () => {
-    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 50 };
+    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 30 };
 
     expect(
       buildShareUrl({
@@ -22,7 +22,7 @@ describe("buildShareUrl", () => {
   });
 
   it("serializes an override of the route-specific default", () => {
-    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 50 };
+    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 30 };
     const url = buildShareUrl({
       settings: { ...settingsDefaults, clickMaxRadius: 40 },
       settingsDefaults,

--- a/extension/website/shared/utils/__tests__/shareUrl.test.ts
+++ b/extension/website/shared/utils/__tests__/shareUrl.test.ts
@@ -1,0 +1,36 @@
+// ABOUTME: Tests route-specific defaults in movement share URLs.
+// ABOUTME: Keeps clean live portrait URLs free of default-setting blobs.
+
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ACTIVE_VISUALIZATIONS } from "../../components/registry";
+import { DEFAULT_SETTINGS } from "../../components/settingsDefaults";
+import { buildShareUrl } from "../shareUrl";
+
+describe("buildShareUrl", () => {
+  it("omits settings that match route-specific defaults", () => {
+    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 50 };
+
+    expect(
+      buildShareUrl({
+        settings: settingsDefaults,
+        settingsDefaults,
+        activeVisualizations: DEFAULT_ACTIVE_VISUALIZATIONS,
+        selectedTimeRange: null,
+        baseUrl: "https://wewere.online/portrait/",
+      }),
+    ).toBe("https://wewere.online/portrait/");
+  });
+
+  it("serializes an override of the route-specific default", () => {
+    const settingsDefaults = { ...DEFAULT_SETTINGS, clickMaxRadius: 50 };
+    const url = buildShareUrl({
+      settings: { ...settingsDefaults, clickMaxRadius: 40 },
+      settingsDefaults,
+      activeVisualizations: DEFAULT_ACTIVE_VISUALIZATIONS,
+      selectedTimeRange: null,
+      baseUrl: "https://wewere.online/portrait/",
+    });
+
+    expect(new URL(url).searchParams.has("s")).toBe(true);
+  });
+});

--- a/extension/website/shared/utils/settingsSpec.ts
+++ b/extension/website/shared/utils/settingsSpec.ts
@@ -250,23 +250,23 @@ interface SerializeResult {
   blob: string | null;
 }
 
-/** Serialize the diff between `settings` and `DEFAULT_SETTINGS` into a
+/** Serialize the diff between `settings` and the route's effective defaults into a
  * `{headline, blob}` pair. The caller decides where to place each in the
  * URL. Per-viz headline params drop out when their viz isn't active —
  * sharing a trails config doesn't leak the navigation sliders.
  *
  * Everything that diverges and isn't a headline key rides in the blob,
  * including settings not declared in `HEADLINE_SPECS` at all. So the blob
- * is automatically future-proof: add a new setting to
- * `settingsDefaults.ts` and it round-trips through share URLs with no
- * other code change. */
+ * is automatically future-proof: add a new setting to the effective defaults
+ * and it round-trips through share URLs with no other code change. */
 export function serializeSpec(
   settings: Record<string, unknown>,
   activeVizIds: ReadonlySet<string>,
+  settingsDefaults: Record<string, unknown> = DEFAULT_SETTINGS,
 ): SerializeResult {
   const headline: Record<string, string> = {};
   const blob: Record<string, unknown> = {};
-  const defaults = DEFAULT_SETTINGS as unknown as Record<string, unknown>;
+  const defaults = settingsDefaults;
 
   // 1) Headline pass — only emit if it would also pass the viz gate.
   for (const spec of HEADLINE_SPECS) {

--- a/extension/website/shared/utils/shareUrl.ts
+++ b/extension/website/shared/utils/shareUrl.ts
@@ -16,6 +16,8 @@ function sameVizSet(a: string[], b: string[]): boolean {
 
 export interface BuildShareUrlInput {
   settings: Record<string, unknown>;
+  /** Effective defaults for this route. */
+  settingsDefaults?: Record<string, unknown>;
   activeVisualizations: string[];
   selectedTimeRange: { startMs: number; endMs: number } | null;
   /** Optional override; defaults to current `window.location.origin + pathname`. */
@@ -40,6 +42,7 @@ export interface BuildShareUrlInput {
  */
 export function buildShareUrl({
   settings,
+  settingsDefaults,
   activeVisualizations,
   selectedTimeRange,
   baseUrl,
@@ -63,7 +66,7 @@ export function buildShareUrl({
   // viz mode, etc.) get their own readable URL keys; everything else
   // diverging from defaults rides in a single base64 blob (`?s=...`) so
   // URLs stay bounded as the settings tree grows.
-  const { headline, blob } = serializeSpec(settings, vizSet);
+  const { headline, blob } = serializeSpec(settings, vizSet, settingsDefaults);
   for (const [param, value] of Object.entries(headline)) {
     url.searchParams.set(param, value);
   }

--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { LiveTrails } from "@movement/components/LiveTrails";
 import { LiveIndicator } from "@movement/components/LiveIndicator";
 import { WordmarkClock } from "@movement/components/WordmarkClock";
+import { CLICK_DEFAULTS } from "@movement/components/clickDefaults";
 import { useCursorTrails } from "@movement/hooks/useCursorTrails";
 import { summarizeActiveLocations } from "@movement/utils/eventUtils";
 import { useLiveEvents } from "@movement/hooks/useLiveEvents";
@@ -116,17 +117,8 @@ const ANIMATION_SETTINGS = {
   pointSize: 4,
   trailOpacity: 0.5,
   animationSpeed: 1.0,
-  clickMinRadius: 10,
-  clickMaxRadius: 50,
-  clickCoreRadius: 3,
-  clickMinDuration: 600,
-  clickMaxDuration: 1200,
-  clickExpansionDuration: 400,
-  clickStrokeWidth: 1,
-  clickOpacity: 0.4,
-  clickNumRings: 2,
-  clickRingDelayMs: 80,
-  clickAnimationStopPoint: 0.8,
+  ...CLICK_DEFAULTS,
+  clickMaxRadius: 30,
 };
 
 export default function App() {

--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -117,7 +117,7 @@ const ANIMATION_SETTINGS = {
   trailOpacity: 0.5,
   animationSpeed: 1.0,
   clickMinRadius: 10,
-  clickMaxRadius: 30,
+  clickMaxRadius: 50,
   clickCoreRadius: 3,
   clickMinDuration: 600,
   clickMaxDuration: 1200,
@@ -179,6 +179,7 @@ export default function App() {
         {trailStates.length > 0 && (
           <LiveTrails
             trailStates={trailStates}
+            showClickRipples
             onTrailsRemoved={handleTrailsRemoved}
             settings={ANIMATION_SETTINGS}
           />


### PR DESCRIPTION
## Summary

- render click ripples from the live WebSocket event stream alongside live cursor trails
- show the streamed click ripples on both the live portrait and the homepage
- use the archive ripple timing, stroke, opacity, and ring settings, and keep completed ripples visible until their trail disappears
- use a 30px max radius on both live surfaces
- treat route-specific settings as defaults in controls and share-URL serialization

## Why

Both pages were already receiving click events, but `LiveTrails` defaulted click ripples off. The homepage also had a dormant custom ripple preset with a 1px stroke, lower opacity, fewer rings, and much faster expansion, which looked noticeably thinner than the archive and portrait once enabled.

## Impact

Live visitors now see click activity consistently on the portrait and homepage. Both surfaces share the archive visual treatment with a 30px live radius. The clean `/portrait/` URL remains clean at its route-specific default, while explicit setting overrides still serialize into share URLs.

## Validation

- `bun run test --run website/shared` — 44 tests passed
- `bunx tsc -p tsconfig.json` from `extension/website` — passed
- `bun run build` from `extension/website` — passed
- focused ESLint on the changed homepage and settings files — 0 errors
- verified in the in-app browser that homepage ripple rings render at 4px stroke and 0.6 opacity, and that the portrait max-radius control reports 30px