### PR TITLE
Cycle archive playback through event batches

### DIFF
--- a/extension/website/archive/archive.tsx
+++ b/extension/website/archive/archive.tsx
@@ -65,11 +65,20 @@ const InternetMovement = () => {
     localStorage.setItem("movement_active_viz", JSON.stringify(activeVisualizations));
   }, [activeVisualizations]);
 
-  const { events, loading, error, dayCounts, refresh } = useArchiveEvents({
+  const {
+    events,
+    loading,
+    error,
+    dayCounts,
+    refresh,
+    advanceBatch,
+    batchKey,
+  } = useArchiveEvents({
     selectedDay,
     timeOfDay,
     serverDomain,
     activeVisualizations,
+    batchPlayback: true,
   });
 
   return (
@@ -105,6 +114,8 @@ const InternetMovement = () => {
         onSetFilters={setFilters}
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
+        playbackKey={batchKey}
+        onPlaybackCycleComplete={advanceBatch}
       />
     </>
   );

--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -19,6 +19,23 @@ export interface ScheduledClick {
   holdDuration?: number;
 }
 
+export const MAX_VISIBLE_CLICK_EFFECTS = 2000;
+
+export type VisibleClickEffect = ClickEffect & {
+  sourceId: string;
+};
+
+export function mergeClickEffects(
+  current: VisibleClickEffect[],
+  incoming: VisibleClickEffect[],
+): VisibleClickEffect[] {
+  const incomingSourceIds = new Set(incoming.map((effect) => effect.sourceId));
+  return [
+    ...current.filter((effect) => !incomingSourceIds.has(effect.sourceId)),
+    ...incoming,
+  ].slice(-MAX_VISIBLE_CLICK_EFFECTS);
+}
+
 interface AnimatedClicksProps {
   scheduledClicks: ScheduledClick[];
   timeRange: { duration: number };
@@ -30,12 +47,14 @@ interface AnimatedClicksProps {
 
 export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
   ({ scheduledClicks, timeRange, settings, soundEngine = null }) => {
-    const [activeClickEffects, setActiveClickEffects] = useState<ClickEffect[]>(
-      [],
-    );
+    const [activeClickEffects, setActiveClickEffects] = useState<
+      VisibleClickEffect[]
+    >([]);
     const animationRef = useRef<number>();
     const timeoutRef = useRef<number>();
     const spawnedThisCycleRef = useRef<Set<string>>(new Set());
+    const currentCycleEffectIdsRef = useRef<Set<string>>(new Set());
+    const completedCycleEffectIdsRef = useRef<Set<string>>(new Set());
 
     const animationSpeedRef = useRef(settings.animationSpeed);
     useEffect(() => {
@@ -47,20 +66,18 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       soundEngineRef.current = soundEngine;
     }, [soundEngine]);
 
-    // Ripples persist after their animation finishes — they only clear when
-    // the whole scene resets (data change, resize, or cycle restart).
-    // We do count completions so the rAF loop knows when every spawned ripple
-    // has finished animating and the cycle is safe to restart.
-    const finishedCountRef = useRef(0);
-    const handleClickComplete = useCallback((_id: string) => {
-      finishedCountRef.current += 1;
+    // Finished ripples remain as residue while their event ids are replayed.
+    // Track the current pass by rendered id so completions from a previous
+    // archive batch cannot make the next pass finish early.
+    const handleClickComplete = useCallback((id: string) => {
+      if (currentCycleEffectIdsRef.current.has(id)) {
+        completedCycleEffectIdsRef.current.add(id);
+      }
     }, []);
-
-    const spawnedCountRef = useRef(0);
 
     // Microtask-batched commits so multiple per-frame spawns don't each cause
     // their own React re-render.
-    const pendingSpawnsRef = useRef<ClickEffect[]>([]);
+    const pendingSpawnsRef = useRef<VisibleClickEffect[]>([]);
     const flushSpawnsScheduledRef = useRef(false);
     const scheduleFlushSpawns = useCallback(() => {
       if (flushSpawnsScheduledRef.current) return;
@@ -70,7 +87,7 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
         const batch = pendingSpawnsRef.current;
         if (batch.length === 0) return;
         pendingSpawnsRef.current = [];
-        setActiveClickEffects((prev) => [...prev, ...batch]);
+        setActiveClickEffects((prev) => mergeClickEffects(prev, batch));
       });
     }, []);
 
@@ -82,17 +99,18 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
     // `scheduledClicks` changes identity.
     useEffect(() => {
       if (scheduledClicks.length === 0 || timeRange.duration <= 0) {
-        setActiveClickEffects([]);
         spawnedThisCycleRef.current.clear();
+        currentCycleEffectIdsRef.current.clear();
+        completedCycleEffectIdsRef.current.clear();
         return;
       }
 
-      // Reset state when clicks or duration change so we don't carry ripples
-      // anchored to stale x/y coordinates after a resize / refetch.
+      // A new event set starts a fresh clock but retains the previous residue.
+      // Incoming events replace matching marks and the bounded visible set
+      // gradually pushes unrelated marks out without blanking the canvas.
       spawnedThisCycleRef.current.clear();
-      finishedCountRef.current = 0;
-      spawnedCountRef.current = 0;
-      setActiveClickEffects([]);
+      currentCycleEffectIdsRef.current.clear();
+      completedCycleEffectIdsRef.current.clear();
       soundEngineRef.current?.reset();
       pendingSpawnsRef.current = [];
 
@@ -134,14 +152,16 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
         for (const sc of scheduledClicks) {
           if (scaledElapsed >= sc.spawnAtMs && !spawned.has(sc.id)) {
             spawned.add(sc.id);
-            spawnedCountRef.current += 1;
             soundEngineRef.current?.triggerClick({
               x: sc.x,
               y: sc.y,
               holdDuration: sc.holdDuration,
             });
+            const renderedId = `${sc.id}-${timestamp}`;
+            currentCycleEffectIdsRef.current.add(renderedId);
             pendingSpawnsRef.current.push({
-              id: `${sc.id}-${timestamp}`,
+              id: renderedId,
+              sourceId: sc.id,
               x: sc.x,
               y: sc.y,
               color: sc.color,
@@ -159,15 +179,15 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
 
         const allSpawned = scaledElapsed >= timeRange.duration;
         const allDone =
-          spawnedCountRef.current > 0 &&
-          finishedCountRef.current >= spawnedCountRef.current;
+          currentCycleEffectIdsRef.current.size > 0 &&
+          completedCycleEffectIdsRef.current.size >=
+            currentCycleEffectIdsRef.current.size;
 
         if (allSpawned && allDone) {
           startTime = timestamp;
           spawnedThisCycleRef.current.clear();
-          finishedCountRef.current = 0;
-          spawnedCountRef.current = 0;
-          setActiveClickEffects([]);
+          currentCycleEffectIdsRef.current.clear();
+          completedCycleEffectIdsRef.current.clear();
           soundEngineRef.current?.reset();
         }
 

--- a/extension/website/shared/components/AnimatedScrollViewports.tsx
+++ b/extension/website/shared/components/AnimatedScrollViewports.tsx
@@ -33,6 +33,8 @@ const VIEWPORT_MARGIN = 8; // Gap between viewports
 interface AnimatedScrollViewportsProps {
   animations: ScrollAnimation[];
   canvasSize: { width: number; height: number };
+  repeatAnimations?: boolean;
+  onAnimationsComplete?: () => boolean;
   settings: {
     scrollSpeed: number;
     backgroundOpacity: number;
@@ -75,6 +77,16 @@ const hashString = (str: string): number => {
   }
   return Math.abs(hash);
 };
+
+export function getScrollQueueIndex(
+  currentIndex: number,
+  animationCount: number,
+  repeatAnimations: boolean,
+): number | null {
+  if (animationCount === 0) return null;
+  if (currentIndex < animationCount) return currentIndex;
+  return repeatAnimations ? 0 : null;
+}
 
 // Check if two rectangles overlap (with margin)
 const rectsOverlap = (
@@ -211,7 +223,14 @@ const calculateViewportSize = (
 };
 
 export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
-  memo(({ animations, canvasSize, settings, urlMetadata }) => {
+  memo(({
+    animations,
+    canvasSize,
+    repeatAnimations = true,
+    onAnimationsComplete,
+    settings,
+    urlMetadata,
+  }) => {
     const [activeViewports, setActiveViewports] = useState<ActiveViewport[]>(
       [],
     );
@@ -223,6 +242,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
     const lastFillCheckRef = useRef(0);
     const lastFrameUpdateRef = useRef(0);
     const startTimeRef = useRef<number | null>(null);
+    const completionSignaledRef = useRef(false);
 
     // Settings ref to avoid re-renders
     const settingsRef = useRef(settings);
@@ -256,21 +276,27 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
         }
         animationQueueRef.current = shuffled;
         queueIndexRef.current = 0;
+        completionSignaledRef.current = false;
         console.log(
           `[Scroll Dynamic] Initialized queue with ${shuffled.length} animations`,
         );
       }
     }, [animations]);
 
-    // Get next animation from queue (cycles through)
+    // Get the next animation from the queue
     const getNextAnimation = useCallback((): ScrollAnimation | null => {
       const queue = animationQueueRef.current;
-      if (queue.length === 0) return null;
+      const nextIndex = getScrollQueueIndex(
+        queueIndexRef.current,
+        queue.length,
+        repeatAnimations,
+      );
+      if (nextIndex === null) return null;
 
-      const animation = queue[queueIndexRef.current];
-      queueIndexRef.current = (queueIndexRef.current + 1) % queue.length;
+      const animation = queue[nextIndex];
+      queueIndexRef.current = nextIndex + 1;
       return animation;
-    }, []);
+    }, [repeatAnimations]);
 
     // Try to add a new viewport to an available space
     const tryAddViewport = useCallback(
@@ -481,6 +507,15 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
         if (currentTime - lastFillCheckRef.current >= FILL_CHECK_INTERVAL) {
           lastFillCheckRef.current = currentTime;
           tryAddViewport(currentTime);
+          if (
+            !repeatAnimations &&
+            queueIndexRef.current >= animationQueueRef.current.length &&
+            activeViewportsRef.current.length === 0 &&
+            !completionSignaledRef.current
+          ) {
+            completionSignaledRef.current =
+              onAnimationsComplete?.() ?? true;
+          }
         }
 
         if (currentTime - lastFrameUpdateRef.current >= FRAME_INTERVAL_MS) {
@@ -498,7 +533,14 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           cancelAnimationFrame(animationFrameRef.current);
         }
       };
-    }, [animations.length, canvasSize.width, updateViewports, tryAddViewport]);
+    }, [
+      animations.length,
+      canvasSize.width,
+      onAnimationsComplete,
+      repeatAnimations,
+      updateViewports,
+      tryAddViewport,
+    ]);
 
     if (animations.length === 0) {
       return null;

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -10,12 +10,14 @@ import React, {
 } from "react";
 import { TrailState, ClickEffect } from "../types";
 import { RippleEffect } from "./ClickRipple";
+import { createClickEffect } from "./clickEffects";
 import { useDebugHover } from "./DebugHover";
 import type { SoundEngine } from "../sound/SoundEngine";
 import type { TrailSoundFrame } from "../sound/types";
 import { getTrailRenderer } from "../styles/trailRenderers";
 import {
   buildStraightPathSegment,
+  didPlaybackCycleWrap,
   getFinishedTrailRenderRange,
 } from "../utils/trailAnimation";
 import {
@@ -409,7 +411,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         const loopedElapsed = scaledElapsed % timeRange.duration;
 
         // Detect loop wrap
-        if (loopedElapsed < prevElapsedRef.current) {
+        if (didPlaybackCycleWrap(prevElapsedRef.current, loopedElapsed)) {
           resetPlaybackTrackers();
           setActiveClickEffects([]);
           soundEngineRef.current?.reset();
@@ -592,17 +594,18 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
                 holdDuration: click.duration,
               });
 
-              pendingClicks.current.push({
-                id: `${idx}-${clickIdx}-${Date.now()}`,
-                x: result.cursorPosition.x,
-                y: result.cursorPosition.y,
-                color: rendererRef.current.getClickColor(ts.trail.color),
-                radiusFactor: Math.random(),
-                durationFactor: Math.random(),
-                startTime: Date.now(),
-                trailIndex: idx,
-                holdDuration: click.duration,
-              });
+              const clickStartTime = Date.now();
+              pendingClicks.current.push(
+                createClickEffect({
+                  id: `${idx}-${clickIdx}-${clickStartTime}`,
+                  x: result.cursorPosition.x,
+                  y: result.cursorPosition.y,
+                  color: rendererRef.current.getClickColor(ts.trail.color),
+                  startTime: clickStartTime,
+                  trailIndex: idx,
+                  holdDuration: click.duration,
+                }),
+              );
 
               clickIdx++;
             }

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -9,7 +9,7 @@ import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
   type LiveClickEffect,
-} from "./liveClickEffects";
+} from "./clickEffects";
 import {
   TrailPath,
   TrailCursor,

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -32,6 +32,7 @@ import { usePageMetaFallback } from "../hooks/usePageMetaFallback";
 import { useNavigationTimeline } from "../hooks/useNavigationTimeline";
 import { useNavigationRadial } from "../hooks/useNavigationRadial";
 import { useFollowerCoordination } from "../hooks/useFollowerCoordination";
+import { usePlaybackCycle } from "../hooks/usePlaybackCycle";
 import {
   extractDomain,
   formatFilterChip,
@@ -386,6 +387,10 @@ interface MovementCanvasProps {
    * window computes the same time from a shared wall-clock epoch. Optional so
    * pages that don't run the installation are completely unaffected. */
   getInstallationElapsedMs?: (animationSpeed: number) => number | null;
+  /** Restarts finite archive playback when the parent swaps event batches. */
+  playbackKey?: string;
+  /** Called when finite archive playback reaches the end of its batch. */
+  onPlaybackCycleComplete?: () => boolean;
 }
 
 export const MovementCanvas: React.FC<MovementCanvasProps> = ({
@@ -407,6 +412,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   live = false,
   connected = false,
   getInstallationElapsedMs,
+  playbackKey = "fixed",
+  onPlaybackCycleComplete,
 }) => {
   const settingsDefaults = useMemo(
     () => ({ ...DEFAULT_SETTINGS, ...defaultSettings }),
@@ -1035,6 +1042,15 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     keyboardCycleDuration,
   ]);
 
+  usePlaybackCycle({
+    enabled: !live && onPlaybackCycleComplete !== undefined,
+    cycleKey: playbackKey,
+    durationMs: timeRange.duration,
+    animationSpeed: settings.animationSpeed,
+    frozen: paused,
+    onComplete: onPlaybackCycleComplete,
+  });
+
   const { scheduledClicks, clickCycleDuration } = useMemo(() => {
     if (!showClicks) {
       return { scheduledClicks: [], clickCycleDuration: 0 };
@@ -1569,7 +1585,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             />
           ) : (
             <AnimatedTrails
-              key={`trails-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
+              key={`trails-${playbackKey}-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
               trailStates={trailStates}
               timeRange={timeRange}
               showClickRipples={!showClicks}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1626,7 +1626,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
         {showClicks && !paused && (
           <AnimatedClicks
-            key={`clicks-${playbackKey}-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
+            key={`clicks-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
             scheduledClicks={scheduledClicks}
             timeRange={{ duration: clickCycleDuration }}
             soundEngine={soundEnabled ? soundEngineReady : null}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1042,15 +1042,6 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     keyboardCycleDuration,
   ]);
 
-  usePlaybackCycle({
-    enabled: !live && onPlaybackCycleComplete !== undefined,
-    cycleKey: playbackKey,
-    durationMs: timeRange.duration,
-    animationSpeed: settings.animationSpeed,
-    frozen: paused,
-    onComplete: onPlaybackCycleComplete,
-  });
-
   const { scheduledClicks, clickCycleDuration } = useMemo(() => {
     if (!showClicks) {
       return { scheduledClicks: [], clickCycleDuration: 0 };
@@ -1133,6 +1124,40 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
   const { animations: scrollAnimations, urlMetadata: scrollUrlMetadata } =
     useViewportScroll(activeScrollingEvents, viewportSize, viewportSettings);
+  const scrollingControlsPlayback =
+    !live &&
+    showScrolling &&
+    vizSet.size === 1 &&
+    onPlaybackCycleComplete !== undefined;
+  const playbackCycleDuration = useMemo(() => {
+    const durations: number[] = [];
+    if (showTrails && cursorCycleDuration > 0)
+      durations.push(cursorCycleDuration);
+    if (showClicks && clickCycleDuration > 0)
+      durations.push(clickCycleDuration);
+    if (showTyping && keyboardCycleDuration > 0)
+      durations.push(keyboardCycleDuration);
+    return durations.length > 0 ? Math.max(...durations) : 60000;
+  }, [
+    clickCycleDuration,
+    cursorCycleDuration,
+    keyboardCycleDuration,
+    showClicks,
+    showTrails,
+    showTyping,
+  ]);
+
+  usePlaybackCycle({
+    enabled:
+      !live &&
+      !scrollingControlsPlayback &&
+      onPlaybackCycleComplete !== undefined,
+    cycleKey: playbackKey,
+    durationMs: playbackCycleDuration,
+    animationSpeed: settings.animationSpeed,
+    frozen: paused,
+    onComplete: onPlaybackCycleComplete,
+  });
 
   // For viewports whose URL has no captured title (no navigation event), ask
   // the worker's /page-meta endpoint to resolve title + favicon live (oEmbed
@@ -1601,7 +1626,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
         {showClicks && !paused && (
           <AnimatedClicks
-            key={`clicks-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
+            key={`clicks-${playbackKey}-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
             scheduledClicks={scheduledClicks}
             timeRange={{ duration: clickCycleDuration }}
             soundEngine={soundEnabled ? soundEngineReady : null}
@@ -1624,6 +1649,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
         {showTyping && !paused && (
           <AnimatedTyping
+            key={`typing-${playbackKey}`}
             typingStates={typingStates}
             timeRange={timeRange}
             settings={typingSettings}
@@ -1632,8 +1658,15 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
         {showScrolling && !paused && scrollAnimations && scrollAnimations.length > 0 && (
           <AnimatedScrollViewports
+            key={`scrolling-${playbackKey}`}
             animations={scrollAnimations}
             canvasSize={viewportSize}
+            repeatAnimations={!scrollingControlsPlayback}
+            onAnimationsComplete={
+              scrollingControlsPlayback
+                ? onPlaybackCycleComplete
+                : undefined
+            }
             settings={scrollSettings}
             urlMetadata={resolvedScrollMetadata}
           />

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -32,7 +32,10 @@ import { usePageMetaFallback } from "../hooks/usePageMetaFallback";
 import { useNavigationTimeline } from "../hooks/useNavigationTimeline";
 import { useNavigationRadial } from "../hooks/useNavigationRadial";
 import { useFollowerCoordination } from "../hooks/useFollowerCoordination";
-import { usePlaybackCycle } from "../hooks/usePlaybackCycle";
+import {
+  getPlaybackCycleDuration,
+  usePlaybackCycle,
+} from "../hooks/usePlaybackCycle";
 import {
   extractDomain,
   formatFilterChip,
@@ -1130,14 +1133,11 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     vizSet.size === 1 &&
     onPlaybackCycleComplete !== undefined;
   const playbackCycleDuration = useMemo(() => {
-    const durations: number[] = [];
-    if (showTrails && cursorCycleDuration > 0)
-      durations.push(cursorCycleDuration);
-    if (showClicks && clickCycleDuration > 0)
-      durations.push(clickCycleDuration);
-    if (showTyping && keyboardCycleDuration > 0)
-      durations.push(keyboardCycleDuration);
-    return durations.length > 0 ? Math.max(...durations) : 60000;
+    return getPlaybackCycleDuration([
+      showTrails ? cursorCycleDuration : 0,
+      showClicks ? clickCycleDuration : 0,
+      showTyping ? keyboardCycleDuration : 0,
+    ]);
   }, [
     clickCycleDuration,
     cursorCycleDuration,

--- a/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
@@ -1,0 +1,46 @@
+// ABOUTME: Tests continuous click playback residue across cycles and archive batches.
+// ABOUTME: Verifies replayed click effects replace prior marks within a fixed bound.
+import { describe, expect, it } from "vitest";
+import type { VisibleClickEffect } from "../AnimatedClicks";
+import {
+  MAX_VISIBLE_CLICK_EFFECTS,
+  mergeClickEffects,
+} from "../AnimatedClicks";
+
+function makeEffect(sourceId: string, startTime: number): VisibleClickEffect {
+  return {
+    id: `${sourceId}-${startTime}`,
+    sourceId,
+    x: startTime,
+    y: startTime,
+    color: "#111",
+    radiusFactor: 0.5,
+    durationFactor: 0.5,
+    startTime,
+    trailIndex: 0,
+  };
+}
+
+describe("AnimatedClicks residue", () => {
+  it("replaces a replayed click without clearing unrelated marks", () => {
+    const current = [makeEffect("click-a", 1), makeEffect("click-b", 1)];
+    const next = mergeClickEffects(current, [makeEffect("click-a", 2)]);
+
+    expect(next.map((effect) => effect.id)).toEqual([
+      "click-b-1",
+      "click-a-2",
+    ]);
+  });
+
+  it("keeps archive playback residue bounded", () => {
+    const current = Array.from(
+      { length: MAX_VISIBLE_CLICK_EFFECTS },
+      (_, index) => makeEffect(`previous-${index}`, index),
+    );
+    const next = mergeClickEffects(current, [makeEffect("incoming", 9999)]);
+
+    expect(next).toHaveLength(MAX_VISIBLE_CLICK_EFFECTS);
+    expect(next[0].sourceId).toBe("previous-1");
+    expect(next.at(-1)?.sourceId).toBe("incoming");
+  });
+});

--- a/extension/website/shared/components/__tests__/AnimatedScrollViewports.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedScrollViewports.test.ts
@@ -5,6 +5,7 @@ import type { ScrollAnimation } from "../../types";
 import { getViewportTitleText } from "../../utils/titleText";
 import {
   buildViewportAnimationTimeline,
+  getScrollQueueIndex,
   getResizeDimensionsAtTime,
   getScrollPositionAtTime,
   getZoomLevelAtTime,
@@ -83,6 +84,16 @@ describe("AnimatedScrollViewports timeline helpers", () => {
 
   it("interpolates zoom levels at a specific time", () => {
     expect(getZoomLevelAtTime(makeAnimation().zoomEvents ?? [], 500)).toBe(1.25);
+  });
+});
+
+describe("AnimatedScrollViewports queue helpers", () => {
+  it("stops after one pass when archive playback owns the queue", () => {
+    expect(getScrollQueueIndex(3, 3, false)).toBeNull();
+  });
+
+  it("wraps after one pass when repeated playback is enabled", () => {
+    expect(getScrollQueueIndex(3, 3, true)).toBe(0);
   });
 });
 

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -6,7 +6,7 @@ import type { TrailState } from "../../types";
 import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
-} from "../liveClickEffects";
+} from "../clickEffects";
 
 function trailState(): TrailState {
   return {

--- a/extension/website/shared/components/clickEffects.ts
+++ b/extension/website/shared/components/clickEffects.ts
@@ -1,10 +1,26 @@
-// ABOUTME: Converts due live-trail clicks into one-shot ripple effects.
-// ABOUTME: Tracks emitted keys so growing trails do not replay prior clicks.
+// ABOUTME: Creates one-shot click effects for archive and live cursor trails.
+// ABOUTME: Tracks live emitted keys so growing trails do not replay prior clicks.
 
 import type { ClickEffect, TrailState } from "../types";
 
 export interface LiveClickEffect extends ClickEffect {
   trailId: string;
+}
+
+export function createClickEffect(params: {
+  id: string;
+  x: number;
+  y: number;
+  color: string;
+  startTime: number;
+  trailIndex: number;
+  holdDuration?: number;
+}): ClickEffect {
+  return {
+    ...params,
+    radiusFactor: Math.random(),
+    durationFactor: Math.random(),
+  };
 }
 
 export function collectDueClickEffects(
@@ -25,16 +41,16 @@ export function collectDueClickEffects(
 
     spawnedClickKeys.add(key);
     effects.push({
-      id: key,
+      ...createClickEffect({
+        id: key,
+        x: position.x,
+        y: position.y,
+        color,
+        startTime,
+        trailIndex: 0,
+        holdDuration: click.duration,
+      }),
       trailId: trailState.trail.id,
-      x: position.x,
-      y: position.y,
-      color,
-      radiusFactor: Math.random(),
-      durationFactor: Math.random(),
-      startTime,
-      trailIndex: 0,
-      holdDuration: click.duration,
     });
   });
 

--- a/extension/website/shared/hooks/__tests__/usePlaybackCycle.test.ts
+++ b/extension/website/shared/hooks/__tests__/usePlaybackCycle.test.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Tests duration selection for finite archive playback scenes.
+// ABOUTME: Verifies active visualizations advance on their own schedules.
+
+import { describe, expect, it } from "vitest";
+import { getPlaybackCycleDuration } from "../usePlaybackCycle";
+
+describe("getPlaybackCycleDuration", () => {
+  it("uses the click schedule when invisible cursor trails have a longer cycle", () => {
+    const cursorDuration = 120000;
+    const clickDuration = 45000;
+
+    expect(getPlaybackCycleDuration([0, clickDuration, 0])).toBe(
+      clickDuration,
+    );
+    expect(getPlaybackCycleDuration([cursorDuration, clickDuration, 0])).toBe(
+      cursorDuration,
+    );
+  });
+
+  it("falls back to one minute while no active schedule is ready", () => {
+    expect(getPlaybackCycleDuration([0, 0, 0])).toBe(60000);
+  });
+});

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Fetches archived browsing events from /events/recent for the archive
-// ABOUTME: and installation pages, keyed by day + time-of-day + active viz.
+// ABOUTME: Fetches fixed or paginated browsing-event sets from /events/recent.
+// ABOUTME: Supports archive playback and installation day/time/viz filters.
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CollectionEvent, DayCounts } from "../types";
 import { deriveRequiredEventTypes } from "../components/registry";
@@ -8,8 +8,20 @@ import {
   DAILY_COUNTS_URL,
   parseTimeOfDayFromUrl,
 } from "../config";
+import {
+  ARCHIVE_BATCH_SIZE,
+  advanceArchiveBatchQueue,
+  createArchiveEventBatch,
+  selectArchiveAnchorType,
+  storePrefetchedArchiveBatch,
+  type ArchiveBatchQueue,
+  type ArchiveEventBatch,
+} from "../utils/archiveEventBatches";
 
 const EVENTS_URL = RECENT_EVENTS_URL;
+const RETRY_BACKOFFS_MS = [400, 1200];
+
+class NonRetryableFetchError extends Error {}
 
 type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
 
@@ -36,6 +48,39 @@ function midnightWindowBounds(
   return { from: from.toISOString(), to: to.toISOString() };
 }
 
+async function fetchEventType(
+  extraParams: Record<string, string>,
+  type: string,
+  domain: string,
+): Promise<CollectionEvent[]> {
+  const params = new URLSearchParams(extraParams);
+  if (domain) params.set("domain", domain);
+  params.set("type", type);
+  const url = `${EVENTS_URL}?${params}`;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= RETRY_BACKOFFS_MS.length; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, RETRY_BACKOFFS_MS[attempt - 1]),
+      );
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response.json();
+      const message = `Failed to fetch ${type} events: ${response.status}`;
+      throw response.status >= 500
+        ? new Error(message)
+        : new NonRetryableFetchError(message);
+    } catch (err) {
+      if (err instanceof NonRetryableFetchError) throw err;
+      lastError = err;
+    }
+  }
+
+  throw lastError;
+}
+
 export interface ArchiveEventsState {
   events: CollectionEvent[];
   loading: boolean;
@@ -43,24 +88,45 @@ export interface ArchiveEventsState {
   dayCounts: DayCounts;
   /** Force a full refetch of the current day/tod/viz context. */
   refresh: () => void;
+  /** Swap to the prefetched older archive batch when one is ready. */
+  advanceBatch: () => boolean;
+  /** Stable identity for restarting finite archive playback after a swap. */
+  batchKey: string;
 }
 
-/** Owns the archive event fetch. Given the current day, time-of-day window,
- * server-side domain, and active visualizations, keeps `events` populated and
- * fetches only the event types that are missing. Extracted from the archive
- * page so the installation page shares the exact same fetch behavior. */
+/** Owns browsing-event fetches for archive surfaces. Fixed mode keeps missing
+ * event types populated for installations; batch mode prefetches the next older
+ * page and wraps to the newest matching page after history is exhausted. */
 export function useArchiveEvents(params: {
   selectedDay: string | null;
   timeOfDay: TimeOfDay;
   serverDomain: string;
   activeVisualizations: string[];
+  batchPlayback?: boolean;
 }): ArchiveEventsState {
-  const { selectedDay, timeOfDay, serverDomain, activeVisualizations } = params;
+  const {
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+    batchPlayback = false,
+  } = params;
 
   const [events, setEvents] = useState<CollectionEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dayCounts, setDayCounts] = useState<DayCounts>(new Map());
+  const [batchQueue, setBatchQueue] = useState<ArchiveBatchQueue>({
+    generation: 0,
+    current: null,
+    prefetched: null,
+  });
+  const [batchKey, setBatchKey] = useState("fixed");
+  const [batchRefreshVersion, setBatchRefreshVersion] = useState(0);
+  const batchQueueRef = useRef(batchQueue);
+  const batchGenerationRef = useRef(0);
+  const batchSequenceRef = useRef(0);
+  const prefetchRequestRef = useRef("");
 
   // Track which event types we've already fetched so we only fetch missing ones
   const fetchedTypesRef = useRef<Set<string>>(new Set());
@@ -124,47 +190,15 @@ export function useArchiveEvents(params: {
       setError(null);
 
       try {
-        const buildUrl = (extraParams: Record<string, string>, type: string) => {
-          const params = new URLSearchParams(extraParams);
-          if (domain) params.set("domain", domain);
-          params.set("type", type);
-          return `${EVENTS_URL}?${params}`;
-        };
-
         // Retry with exponential backoff so a transient network hiccup or a 5xx
         // doesn't leave a window permanently blank. Only network errors and 5xx
         // responses retry (a 4xx is a real request problem — fail fast); the
         // error surfaces only after every attempt is exhausted.
-        const RETRY_BACKOFFS_MS = [400, 1200];
-        // A 4xx is a real request problem — throwing this tag skips the retry.
-        class NonRetryableFetchError extends Error {}
         const fetchOne = async (
           extraParams: Record<string, string>,
           type: string,
-        ): Promise<CollectionEvent[]> => {
-          const url = buildUrl(extraParams, type);
-          let lastError: unknown;
-          for (let attempt = 0; attempt <= RETRY_BACKOFFS_MS.length; attempt++) {
-            if (attempt > 0) {
-              await new Promise((resolve) =>
-                setTimeout(resolve, RETRY_BACKOFFS_MS[attempt - 1]),
-              );
-            }
-            try {
-              const r = await fetch(url);
-              if (r.ok) return r.json();
-              const message = `Failed to fetch ${type} events: ${r.status}`;
-              // Retry only on server errors; a 4xx fails fast.
-              throw r.status >= 500
-                ? new Error(message)
-                : new NonRetryableFetchError(message);
-            } catch (err) {
-              if (err instanceof NonRetryableFetchError) throw err;
-              lastError = err;
-            }
-          }
-          throw lastError;
-        };
+        ): Promise<CollectionEvent[]> =>
+          fetchEventType(extraParams, type, domain);
 
         let fetched: CollectionEvent[] = [];
         if (day && tod) {
@@ -240,6 +274,81 @@ export function useArchiveEvents(params: {
     [],
   );
 
+  const fetchArchiveBatch = useCallback(
+    async (
+      beforeMs: number | null,
+      day: string | null,
+      tod: TimeOfDay,
+      domain: string,
+      vizIds: string[],
+    ): Promise<ArchiveEventBatch> => {
+      const requiredTypes = deriveRequiredEventTypes(vizIds);
+      if (requiredTypes.size === 0) {
+        return createArchiveEventBatch([], [], ARCHIVE_BATCH_SIZE, null);
+      }
+      const anchorType = selectArchiveAnchorType(requiredTypes);
+      const timeOfDayBounds =
+        day && tod
+          ? midnightWindowBounds(day, tod.centerMinutes, tod.radiusMinutes)
+          : null;
+      const lowerBound = timeOfDayBounds?.from ?? day;
+      const upperBound =
+        timeOfDayBounds?.to ?? (day ? `${day}T23:59:59Z` : null);
+      const anchorParams: Record<string, string> = {
+        limit: String(ARCHIVE_BATCH_SIZE),
+      };
+      if (lowerBound) anchorParams.from = lowerBound;
+      if (beforeMs !== null) {
+        anchorParams.to = new Date(beforeMs).toISOString();
+      } else if (upperBound) {
+        anchorParams.to = upperBound;
+      }
+
+      const anchorEvents = await fetchEventType(
+        anchorParams,
+        anchorType,
+        domain,
+      );
+      if (anchorEvents.length === 0) {
+        return createArchiveEventBatch(
+          [],
+          [],
+          ARCHIVE_BATCH_SIZE,
+          lowerBound ? new Date(lowerBound).getTime() : null,
+        );
+      }
+
+      const oldestAnchorMs = Math.min(...anchorEvents.map((event) => event.ts));
+      const companionParams: Record<string, string> = {
+        limit: "20000",
+        from: new Date(oldestAnchorMs).toISOString(),
+      };
+      if (beforeMs !== null) {
+        companionParams.to = new Date(beforeMs).toISOString();
+      } else if (upperBound) {
+        companionParams.to = upperBound;
+      }
+      const companionTypes = [...requiredTypes].filter(
+        (type) => type !== anchorType,
+      );
+      const companionEvents = (
+        await Promise.all(
+          companionTypes.map((type) =>
+            fetchEventType(companionParams, type, domain),
+          ),
+        )
+      ).flat();
+
+      return createArchiveEventBatch(
+        anchorEvents,
+        companionEvents,
+        ARCHIVE_BATCH_SIZE,
+        lowerBound ? new Date(lowerBound).getTime() : null,
+      );
+    },
+    [],
+  );
+
   // Refetch when the day, server-side domain, time-of-day window, or active
   // visualizations change. time-of-day must refetch because the midnight window
   // is fetched server-side (a tight from/to bracket), not just filtered
@@ -248,14 +357,159 @@ export function useArchiveEvents(params: {
   // two effects both ran on the first render, and the duplicate fetch's late
   // resolution rebuilt the trail set and restarted the animation mid-reveal.
   useEffect(() => {
+    if (batchPlayback) return;
     fetchEvents(selectedDay, activeVisualizations, serverDomain, false, timeOfDay);
-  }, [selectedDay, serverDomain, timeOfDay, activeVisualizations, fetchEvents]);
+  }, [
+    selectedDay,
+    serverDomain,
+    timeOfDay,
+    activeVisualizations,
+    fetchEvents,
+    batchPlayback,
+  ]);
+
+  useEffect(() => {
+    if (!batchPlayback) return;
+
+    const generation = ++batchGenerationRef.current;
+    const emptyQueue: ArchiveBatchQueue = {
+      generation,
+      current: null,
+      prefetched: null,
+    };
+    batchQueueRef.current = emptyQueue;
+    batchSequenceRef.current = 0;
+    setBatchQueue(emptyQueue);
+    prefetchRequestRef.current = "";
+    setLoading(true);
+    setError(null);
+
+    fetchArchiveBatch(
+      null,
+      selectedDay,
+      timeOfDay,
+      serverDomain,
+      activeVisualizations,
+    )
+      .then((batch) => {
+        if (generation !== batchGenerationRef.current) return;
+        const queue = { ...emptyQueue, current: batch };
+        batchQueueRef.current = queue;
+        setBatchQueue(queue);
+        setEvents(batch.events);
+        setBatchKey(`${generation}:0:${batch.key}`);
+      })
+      .catch((err) => {
+        if (generation !== batchGenerationRef.current) return;
+        setError(err instanceof Error ? err.message : "Failed to fetch events");
+        console.error("Error fetching archive batch:", err);
+      })
+      .finally(() => {
+        if (generation === batchGenerationRef.current) setLoading(false);
+      });
+  }, [
+    batchPlayback,
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+    batchRefreshVersion,
+    fetchArchiveBatch,
+  ]);
+
+  useEffect(() => {
+    if (!batchPlayback || !batchQueue.current || batchQueue.prefetched) return;
+
+    const { current, generation } = batchQueue;
+    const requestKey = `${generation}:${current.key}:${current.nextBeforeMs ?? "newest"}`;
+    if (prefetchRequestRef.current === requestKey) return;
+    prefetchRequestRef.current = requestKey;
+
+    const prefetch = async () => {
+      let next = await fetchArchiveBatch(
+        current.nextBeforeMs,
+        selectedDay,
+        timeOfDay,
+        serverDomain,
+        activeVisualizations,
+      );
+      if (next.events.length === 0 && current.nextBeforeMs !== null) {
+        next = await fetchArchiveBatch(
+          null,
+          selectedDay,
+          timeOfDay,
+          serverDomain,
+          activeVisualizations,
+        );
+      }
+      if (
+        generation !== batchGenerationRef.current ||
+        batchQueueRef.current.current?.key !== current.key
+      ) {
+        return;
+      }
+      const queue = storePrefetchedArchiveBatch(
+        batchQueueRef.current,
+        generation,
+        next,
+      );
+      batchQueueRef.current = queue;
+      setBatchQueue(queue);
+    };
+
+    prefetch().catch((err) => {
+      if (generation !== batchGenerationRef.current) return;
+      console.warn("Failed to prefetch archive batch:", err);
+      prefetchRequestRef.current = "";
+    });
+  }, [
+    batchPlayback,
+    batchQueue,
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+    fetchArchiveBatch,
+  ]);
+
+  const advanceBatch = useCallback(() => {
+    const advanced = advanceArchiveBatchQueue(batchQueueRef.current);
+    if (advanced === batchQueueRef.current || !advanced.current) return false;
+    batchQueueRef.current = advanced;
+    prefetchRequestRef.current = "";
+    setBatchQueue(advanced);
+    setEvents(advanced.current.events);
+    batchSequenceRef.current++;
+    setBatchKey(
+      `${advanced.generation}:${batchSequenceRef.current}:${advanced.current.key}`,
+    );
+    return true;
+  }, []);
 
   const refresh = useCallback(() => {
+    if (batchPlayback) {
+      setBatchRefreshVersion((version) => version + 1);
+      return;
+    }
     fetchedTypesRef.current = new Set();
     lastFetchKeyRef.current = "";
     fetchEvents(selectedDay, activeVisualizations, serverDomain, true, timeOfDay);
-  }, [selectedDay, serverDomain, activeVisualizations, timeOfDay, fetchEvents]);
+  }, [
+    batchPlayback,
+    selectedDay,
+    serverDomain,
+    activeVisualizations,
+    timeOfDay,
+    fetchEvents,
+  ]);
 
-  return { events, loading, error, dayCounts, refresh };
+  return {
+    events,
+    loading,
+    error,
+    dayCounts,
+    refresh,
+    advanceBatch,
+    batchKey,
+  };
 }

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -20,6 +20,7 @@ import {
 
 const EVENTS_URL = RECENT_EVENTS_URL;
 const RETRY_BACKOFFS_MS = [400, 1200];
+const PREFETCH_RETRY_DELAY_MS = 3000;
 
 class NonRetryableFetchError extends Error {}
 
@@ -123,6 +124,7 @@ export function useArchiveEvents(params: {
   });
   const [batchKey, setBatchKey] = useState("fixed");
   const [batchRefreshVersion, setBatchRefreshVersion] = useState(0);
+  const [prefetchRetryVersion, setPrefetchRetryVersion] = useState(0);
   const batchQueueRef = useRef(batchQueue);
   const batchGenerationRef = useRef(0);
   const batchSequenceRef = useRef(0);
@@ -420,6 +422,8 @@ export function useArchiveEvents(params: {
   useEffect(() => {
     if (!batchPlayback || !batchQueue.current || batchQueue.prefetched) return;
 
+    let cancelled = false;
+    let retryTimeout: number | undefined;
     const { current, generation } = batchQueue;
     const requestKey = `${generation}:${current.key}:${current.nextBeforeMs ?? "newest"}`;
     if (prefetchRequestRef.current === requestKey) return;
@@ -458,13 +462,23 @@ export function useArchiveEvents(params: {
     };
 
     prefetch().catch((err) => {
-      if (generation !== batchGenerationRef.current) return;
+      if (cancelled || generation !== batchGenerationRef.current) return;
       console.warn("Failed to prefetch archive batch:", err);
       prefetchRequestRef.current = "";
+      retryTimeout = window.setTimeout(
+        () => setPrefetchRetryVersion((version) => version + 1),
+        PREFETCH_RETRY_DELAY_MS,
+      );
     });
+
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== undefined) window.clearTimeout(retryTimeout);
+    };
   }, [
     batchPlayback,
     batchQueue,
+    prefetchRetryVersion,
     selectedDay,
     timeOfDay,
     serverDomain,

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -23,8 +23,8 @@ import {
   RISO_COLORS,
   TRAIL_TIME_THRESHOLD,
   getColorForParticipant,
+  getColorForEvent,
   eventMatchesAnyFilter,
-  deriveSessionColor,
   type FilterChip,
 } from "../utils/eventUtils";
 
@@ -173,8 +173,7 @@ export function useCursorTrails(
       groupEvents.sort((a, b) => a.ts - b.ts);
 
       const pid = groupEvents[0].meta.pid;
-      const cursorColor = groupEvents[0].meta.cursor_color;
-      const timezone = groupEvents[0].meta.tz;
+      const firstEvent = groupEvents[0];
 
       // Determine color resolution. When randomizeColors is on, every NEW
       // trail picks a fresh palette color (so a single participant's session
@@ -186,9 +185,8 @@ export function useCursorTrails(
           trailColorIndex++;
           return c;
         }
-        if (cursorColor) {
-          return deriveSessionColor(cursorColor, trailStartTs, timezone);
-        }
+        if (firstEvent.meta.cursor_color)
+          return getColorForEvent(firstEvent, trailStartTs);
         if (!participantColors.has(pid)) {
           participantColors.set(pid, getColorForParticipant(pid));
         }

--- a/extension/website/shared/hooks/useKeyboardTyping.ts
+++ b/extension/website/shared/hooks/useKeyboardTyping.ts
@@ -10,7 +10,7 @@ import {
   TypingState,
 } from "../types";
 import {
-  getColorForParticipant,
+  getColorForEvent,
   eventMatchesAnyFilter,
   type FilterChip,
 } from "../utils/eventUtils";
@@ -215,7 +215,7 @@ export function useKeyboardTyping(
           event: firstEvent,
           x,
           y,
-          color: getColorForParticipant(firstEvent.meta.pid),
+          color: getColorForEvent(firstEvent),
           startTime: firstEvent.ts,
           sequence: mergedSequence,
         });

--- a/extension/website/shared/hooks/usePlaybackCycle.ts
+++ b/extension/website/shared/hooks/usePlaybackCycle.ts
@@ -1,0 +1,84 @@
+// ABOUTME: Drives one finite archive playback cycle independently of its visuals.
+// ABOUTME: Advances only when the next event batch is ready, then restarts by key.
+
+import { useEffect, useRef } from "react";
+
+const HIDDEN_TAB_TICK_MS = 100;
+
+export function usePlaybackCycle(params: {
+  enabled: boolean;
+  cycleKey: string;
+  durationMs: number;
+  animationSpeed: number;
+  frozen: boolean;
+  onComplete?: () => boolean;
+}): void {
+  const { enabled, cycleKey, durationMs, animationSpeed, frozen, onComplete } =
+    params;
+  const animationSpeedRef = useRef(animationSpeed);
+  const frozenRef = useRef(frozen);
+  const onCompleteRef = useRef(onComplete);
+
+  useEffect(() => {
+    animationSpeedRef.current = animationSpeed;
+  }, [animationSpeed]);
+  useEffect(() => {
+    frozenRef.current = frozen;
+  }, [frozen]);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    if (!enabled || durationMs <= 0) return;
+
+    let animationFrame: number | undefined;
+    let timeout: number | undefined;
+    let previousTimestamp: number | null = null;
+    let elapsedMs = 0;
+
+    const clearScheduledFrame = () => {
+      if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
+      if (timeout !== undefined) window.clearTimeout(timeout);
+      animationFrame = undefined;
+      timeout = undefined;
+    };
+
+    const scheduleNextFrame = () => {
+      clearScheduledFrame();
+      if (document.visibilityState === "hidden") {
+        timeout = window.setTimeout(
+          () => animate(performance.now()),
+          HIDDEN_TAB_TICK_MS,
+        );
+        return;
+      }
+      animationFrame = requestAnimationFrame(animate);
+    };
+
+    const animate = (timestamp: number) => {
+      if (previousTimestamp === null) previousTimestamp = timestamp;
+      const frameDelta = Math.min(250, timestamp - previousTimestamp);
+      previousTimestamp = timestamp;
+
+      if (!frozenRef.current) {
+        elapsedMs += frameDelta * animationSpeedRef.current;
+      }
+
+      if (elapsedMs >= durationMs) {
+        if (onCompleteRef.current?.()) return;
+        elapsedMs %= durationMs;
+      }
+
+      scheduleNextFrame();
+    };
+
+    const handleVisibilityChange = () => scheduleNextFrame();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    scheduleNextFrame();
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearScheduledFrame();
+    };
+  }, [enabled, cycleKey, durationMs]);
+}

--- a/extension/website/shared/hooks/usePlaybackCycle.ts
+++ b/extension/website/shared/hooks/usePlaybackCycle.ts
@@ -4,6 +4,16 @@
 import { useEffect, useRef } from "react";
 
 const HIDDEN_TAB_TICK_MS = 100;
+const EMPTY_PLAYBACK_DURATION_MS = 60000;
+
+export function getPlaybackCycleDuration(
+  durations: readonly number[],
+): number {
+  const activeDurations = durations.filter((duration) => duration > 0);
+  return activeDurations.length > 0
+    ? Math.max(...activeDurations)
+    : EMPTY_PLAYBACK_DURATION_MS;
+}
 
 export function usePlaybackCycle(params: {
   enabled: boolean;

--- a/extension/website/shared/hooks/usePlaybackCycle.ts
+++ b/extension/website/shared/hooks/usePlaybackCycle.ts
@@ -80,5 +80,5 @@ export function usePlaybackCycle(params: {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       clearScheduledFrame();
     };
-  }, [enabled, cycleKey, durationMs]);
+  }, [enabled, cycleKey, durationMs, frozen]);
 }

--- a/extension/website/shared/hooks/useViewportScroll.ts
+++ b/extension/website/shared/hooks/useViewportScroll.ts
@@ -4,7 +4,7 @@
 import { useMemo } from "react";
 import { CollectionEvent, ScrollAnimation } from "../types";
 import {
-  getColorForParticipant,
+  getColorForEvent,
   eventMatchesAnyFilter,
   SCROLL_SESSION_THRESHOLD,
   SCROLL_TIME_COMPRESSION,
@@ -359,7 +359,7 @@ export function useViewportScroll(
             pageUrl: animUrl,
             pageTitle: metadata?.title,
             faviconUrl: metadata?.favicon,
-            color: getColorForParticipant(mergedSessionEvents[0].meta.pid),
+            color: getColorForEvent(mergedSessionEvents[0], startTime),
             scrollEvents:
               cappedScrollEvents.length > 0 ? cappedScrollEvents : [],
             resizeEvents:

--- a/extension/website/shared/utils/__tests__/archiveEventBatches.test.ts
+++ b/extension/website/shared/utils/__tests__/archiveEventBatches.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Tests finite archive batch pagination and prefetch queue behavior.
+// ABOUTME: Covers older-page cursors, wrap markers, and stale request rejection.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  advanceArchiveBatchQueue,
+  createArchiveEventBatch,
+  selectArchiveAnchorType,
+  storePrefetchedArchiveBatch,
+  type ArchiveBatchQueue,
+  type ArchiveEventBatch,
+} from "../archiveEventBatches";
+
+function event(id: string, ts: number, type = "cursor"): CollectionEvent {
+  return {
+    id,
+    type,
+    ts,
+    data: { x: 10, y: 20, event: type === "cursor" ? "move" : "click" },
+    meta: {
+      pid: "person",
+      sid: "session",
+      url: "https://example.com",
+      vw: 100,
+      vh: 100,
+      tz: "UTC",
+    },
+  };
+}
+
+function batch(key: string): ArchiveEventBatch {
+  return { key, events: [event(key, 100)], nextBeforeMs: 99 };
+}
+
+describe("selectArchiveAnchorType", () => {
+  it("uses cursor events to define coherent multi-type playback windows", () => {
+    expect(selectArchiveAnchorType(new Set(["click", "cursor"]))).toBe("cursor");
+    expect(selectArchiveAnchorType(new Set(["keyboard"]))).toBe("keyboard");
+  });
+});
+
+describe("createArchiveEventBatch", () => {
+  it("sorts a full batch with companion events and points to the next older page", () => {
+    const result = createArchiveEventBatch(
+      [event("new", 300), event("old", 200)],
+      [event("click", 250, "click")],
+      2,
+      null,
+    );
+
+    expect(result.events.map(({ id }) => id)).toEqual(["new", "click", "old"]);
+    expect(result.nextBeforeMs).toBe(199);
+    expect(result.key).toBe("300:200:3");
+  });
+
+  it("marks a partial final page for a wrap to the newest batch", () => {
+    expect(
+      createArchiveEventBatch([event("last", 100)], [], 2, null).nextBeforeMs,
+    ).toBeNull();
+  });
+
+  it("marks the batch final when it reaches the selected lower bound", () => {
+    expect(
+      createArchiveEventBatch(
+        [event("new", 200), event("boundary", 100)],
+        [],
+        2,
+        100,
+      ).nextBeforeMs,
+    ).toBeNull();
+  });
+});
+
+describe("archive batch queue", () => {
+  it("advances only after a prefetched batch is ready", () => {
+    const current = batch("current");
+    const emptyQueue: ArchiveBatchQueue = {
+      generation: 1,
+      current,
+      prefetched: null,
+    };
+    expect(advanceArchiveBatchQueue(emptyQueue)).toBe(emptyQueue);
+
+    const next = batch("next");
+    expect(
+      advanceArchiveBatchQueue({ ...emptyQueue, prefetched: next }),
+    ).toEqual({ generation: 1, current: next, prefetched: null });
+  });
+
+  it("ignores a prefetch result from a superseded filter generation", () => {
+    const queue: ArchiveBatchQueue = {
+      generation: 2,
+      current: batch("current"),
+      prefetched: null,
+    };
+    expect(storePrefetchedArchiveBatch(queue, 1, batch("stale"))).toBe(queue);
+    expect(storePrefetchedArchiveBatch(queue, 2, batch("next")).prefetched?.key).toBe(
+      "next",
+    );
+  });
+});

--- a/extension/website/shared/utils/__tests__/eventUtils.test.ts
+++ b/extension/website/shared/utils/__tests__/eventUtils.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Tests shared event color selection for visualization sessions.
+// ABOUTME: Verifies local-time color derivation and participant fallbacks.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  deriveSessionColor,
+  getColorForEvent,
+  getColorForParticipant,
+} from "../eventUtils";
+
+function event(
+  overrides: Partial<CollectionEvent["meta"]> = {},
+): CollectionEvent {
+  return {
+    id: "event",
+    type: "cursor",
+    ts: Date.UTC(2026, 0, 1, 12, 30),
+    data: { x: 0.5, y: 0.5, event: "move" },
+    meta: {
+      pid: "participant",
+      sid: "session",
+      url: "https://example.com",
+      vw: 1920,
+      vh: 1080,
+      tz: "UTC",
+      ...overrides,
+    },
+  };
+}
+
+describe("getColorForEvent", () => {
+  it("derives the selected cursor color from the event timestamp and timezone", () => {
+    const source = event({ cursor_color: "#336699" });
+
+    expect(getColorForEvent(source)).toBe(
+      deriveSessionColor("#336699", source.ts, "UTC"),
+    );
+  });
+
+  it("uses the supplied session start timestamp", () => {
+    const source = event({ cursor_color: "#336699" });
+    const sessionStart = Date.UTC(2026, 0, 1, 0, 15);
+
+    expect(getColorForEvent(source, sessionStart)).toBe(
+      deriveSessionColor("#336699", sessionStart, "UTC"),
+    );
+  });
+
+  it("falls back to the participant palette without a selected cursor color", () => {
+    const source = event({ cursor_color: null });
+
+    expect(getColorForEvent(source)).toBe(
+      getColorForParticipant(source.meta.pid),
+    );
+  });
+});

--- a/extension/website/shared/utils/__tests__/trailAnimation.test.ts
+++ b/extension/website/shared/utils/__tests__/trailAnimation.test.ts
@@ -5,8 +5,16 @@ import { describe, expect, it } from "vitest";
 import {
   buildFreehandPathSegment,
   buildStraightPathSegment,
+  didPlaybackCycleWrap,
   getFinishedTrailRenderRange,
 } from "../trailAnimation";
+
+describe("didPlaybackCycleWrap", () => {
+  it("detects the transition from the end of one batch to its beginning", () => {
+    expect(didPlaybackCycleWrap(999, 0)).toBe(true);
+    expect(didPlaybackCycleWrap(500, 600)).toBe(false);
+  });
+});
 
 describe("buildStraightPathSegment", () => {
   it("builds the same straight path shape with an interpolated head point", () => {

--- a/extension/website/shared/utils/archiveEventBatches.ts
+++ b/extension/website/shared/utils/archiveEventBatches.ts
@@ -1,0 +1,68 @@
+// ABOUTME: Plans finite archive event batches and their older-page boundaries.
+// ABOUTME: Keeps archive pagination and stale-prefetch handling deterministic.
+
+import type { CollectionEvent } from "../types";
+
+export const ARCHIVE_BATCH_SIZE = 1000;
+
+export interface ArchiveEventBatch {
+  events: CollectionEvent[];
+  nextBeforeMs: number | null;
+  key: string;
+}
+
+export interface ArchiveBatchQueue {
+  generation: number;
+  current: ArchiveEventBatch | null;
+  prefetched: ArchiveEventBatch | null;
+}
+
+export function selectArchiveAnchorType(requiredTypes: Set<string>): string {
+  if (requiredTypes.has("cursor")) return "cursor";
+  const firstType = requiredTypes.values().next().value;
+  if (!firstType) throw new Error("Archive playback requires an event type");
+  return firstType;
+}
+
+export function createArchiveEventBatch(
+  anchorEvents: CollectionEvent[],
+  companionEvents: CollectionEvent[],
+  batchSize: number,
+  lowerBoundMs: number | null,
+): ArchiveEventBatch {
+  if (anchorEvents.length === 0) {
+    return { events: [], nextBeforeMs: null, key: "empty" };
+  }
+
+  const oldestAnchorMs = Math.min(...anchorEvents.map((event) => event.ts));
+  const nextBeforeMs =
+    anchorEvents.length < batchSize ||
+    (lowerBoundMs !== null && oldestAnchorMs <= lowerBoundMs)
+      ? null
+      : oldestAnchorMs - 1;
+  const events = [...anchorEvents, ...companionEvents].sort(
+    (a, b) => b.ts - a.ts,
+  );
+
+  return {
+    events,
+    nextBeforeMs,
+    key: `${events[0].ts}:${oldestAnchorMs}:${events.length}`,
+  };
+}
+
+export function storePrefetchedArchiveBatch(
+  queue: ArchiveBatchQueue,
+  generation: number,
+  batch: ArchiveEventBatch,
+): ArchiveBatchQueue {
+  if (generation !== queue.generation) return queue;
+  return { ...queue, prefetched: batch };
+}
+
+export function advanceArchiveBatchQueue(
+  queue: ArchiveBatchQueue,
+): ArchiveBatchQueue {
+  if (!queue.prefetched) return queue;
+  return { ...queue, current: queue.prefetched, prefetched: null };
+}

--- a/extension/website/shared/utils/eventUtils.ts
+++ b/extension/website/shared/utils/eventUtils.ts
@@ -217,6 +217,18 @@ export function getColorForParticipant(pid: string): string {
 }
 
 /**
+ * Get the participant color adjusted for the local time of an event.
+ */
+export function getColorForEvent(
+  event: CollectionEvent,
+  timestamp = event.ts,
+): string {
+  const baseColor = event.meta.cursor_color;
+  if (!baseColor) return getColorForParticipant(event.meta.pid);
+  return deriveSessionColor(baseColor, timestamp, event.meta.tz);
+}
+
+/**
  * Extract the domain from a URL, removing 'www.' prefix
  */
 export function extractDomain(url: string): string {

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -14,6 +14,13 @@ export interface FinishedTrailRenderRange {
   finishedCount: number;
 }
 
+export function didPlaybackCycleWrap(
+  previousElapsedMs: number,
+  currentElapsedMs: number,
+): boolean {
+  return currentElapsedMs < previousElapsedMs;
+}
+
 export function buildStraightPathSegment(
   points: Array<{ x: number; y: number }>,
   startIndex: number,


### PR DESCRIPTION
## Summary

- cycle `/archive` through prefetched 1,000-event pages instead of replaying one fixed response forever
- fetch the next older matching page during playback and wrap to the newest page when the filtered history is exhausted
- move archive cycle completion out of `AnimatedTrails`, so batch handoff does not depend on a specific visualization
- share click-effect construction between live and archive trail renderers

## Why

The archive should keep moving through the matching history as each playback cycle finishes. Prefetching the next page keeps that handoff immediate, while generation checks prevent filter changes from applying stale responses.

## Relationship

This is the archive-playback follow-up to #313, which is now merged.

## Verification

- `bunx vitest run extension/website/shared/utils/__tests__/archiveEventBatches.test.ts extension/website/shared/utils/__tests__/trailAnimation.test.ts extension/website/shared/components/__tests__/LiveTrails.test.ts` (15 tests)
- `bunx tsc --noEmit` in `extension/website`
- `bun run build` in `extension/website`
- real `/archive/` browser run advanced through distinct older timestamp windows while rendering each new trail set

Visual evidence is attached in the PR conversation.
