### PR TITLE
Constrain can-move bounds during dragging

### DIFF
--- a/.changeset/quiet-move-bounds.md
+++ b/.changeset/quiet-move-bounds.md
@@ -1,0 +1,6 @@
+---
+"@playhtml/common": patch
+"playhtml": patch
+---
+
+Apply `can-move-bounds` only while dragging so setup preserves initial CSS layout and persisted positions instead of rewriting them from pre-insertion or client-specific geometry.

--- a/apps/docs/src/content/docs/capabilities.mdx
+++ b/apps/docs/src/content/docs/capabilities.mdx
@@ -70,7 +70,9 @@ import { CanMoveElement } from "@playhtml/react";
 
 ### Constraining the drag area
 
-Use `can-move-bounds` (vanilla) or the `bounds` prop (React) to keep the element inside a container. The value is an element id (with or without the leading `#`) or any valid CSS selector.
+Use `can-move-bounds` (vanilla) or the `bounds` prop (React) to constrain an element while it is dragged.
+The value is an element id (with or without the leading `#`) or any valid CSS selector.
+Bounds apply only during dragging. They do not rewrite the element's initial CSS layout or persisted position during setup.
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
@@ -97,7 +99,9 @@ import { CanMoveElement } from "@playhtml/react";
   </TabItem>
 </Tabs>
 
-The **cursor** can go past the container edge; only the element's position is clamped. By default, the whole element stays inside the container. Two knobs let you opt into partial overhang while keeping a visible slice inside:
+The **cursor** can go past the container edge.
+During a drag, only the element's position is clamped. By default, the whole element stays inside the container.
+Two knobs let you opt into partial overhang while keeping a visible slice inside:
 
 - `can-move-bounds-min-visible` / `boundsMinVisible`: fraction `(0–1)` of the element to keep inside. Default `1` pins fully inside; lower values allow part of the element to hang over the edge. `0` drops the fraction constraint entirely.
 - `can-move-bounds-min-visible-px` / `boundsMinVisiblePx`: absolute pixel floor. Default `60`; it applies when `min-visible` allows partial overhang.
@@ -115,7 +119,7 @@ The effective slice on each axis is `max(fraction × size, pxFloor)`. Set both t
   🧲
 </div>
 
-<!-- Default bounds keep the whole magnet visible. -->
+<!-- Default bounds keep the whole magnet visible while dragging. -->
 <div can-move can-move-bounds="fridge" id="tiny-magnet" style="width: 40px;">
   🌶️
 </div>

--- a/apps/docs/src/content/docs/reference/capabilities.md
+++ b/apps/docs/src/content/docs/reference/capabilities.md
@@ -70,9 +70,8 @@ can-move-bounds=".arenas"       <!-- CSS selector — first match wins -->
 
 An id lookup is tried first; if that fails, the value is used as a CSS selector.
 
-The cursor can move past the edge; only the element's position is clamped.
-
-On mount, playhtml re-clamps stored positions that now fall outside the container.
+While dragging, the cursor can move past the edge; only the element's position is clamped.
+Setup leaves the element's initial CSS layout and persisted position unchanged.
 
 #### `can-move-bounds-min-visible`
 

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -146,9 +146,11 @@ interface CanMoveElementProps {
 }
 ```
 
-- **`bounds`**: id or CSS selector of the container to keep the element inside. `"arena"`, `"#arena"`, and `".grid"` all work.
+- **`bounds`**: id or CSS selector of the container that constrains dragging. `"arena"`, `"#arena"`, and `".grid"` all work.
 - **`boundsMinVisible`**: fraction (`0–1`) of the element that must stay inside `bounds` on every edge. Default `1`, which keeps the full element inside. Lower values allow part of the element to hang over the edge; `0` drops the fraction constraint entirely.
 - **`boundsMinVisiblePx`**: absolute pixel floor on the keep-visible slice. Default `60`; it applies when `boundsMinVisible` allows partial overhang.
+
+Bounds apply only during dragging. Setup does not rewrite the element's initial CSS layout or persisted position.
 
 The effective keep-visible slice on each axis is `max(boundsMinVisible × size, boundsMinVisiblePx)`. Set both knobs to `0` to opt fully out of the keep-visible guarantee. See [`can-move` in the capabilities reference](/docs/capabilities/#can-move) for the interaction details.
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -296,9 +296,9 @@ export type GrowData = {
 export const CanDuplicateTo = "can-duplicate-to";
 /**
  * Optional id (`my-arena`, `#my-arena`) or selector (`.arena`) of a container;
- * `can-move` clamps the element's position inside it. The cursor itself is
- * unconstrained — you can drag past the edge — the element just stops at the
- * bounds.
+ * `can-move` clamps the element's position inside it while dragging. Initial
+ * layout and persisted positions are not rewritten during setup. The cursor
+ * itself is unconstrained — only the dragged element stops at the bounds.
  */
 export const CanMoveBounds = "can-move-bounds";
 /**
@@ -498,18 +498,6 @@ export const TagTypeToElement: DefaultTagInitializers = {
     defaultLocalData: { startMouseX: 0, startMouseY: 0 },
     updateElement: ({ element, data }) => {
       element.style.transform = `translate(${data.x}px, ${data.y}px)`;
-    },
-    onMount: ({ getData, getElement, setData }) => {
-      const element = getElement();
-      const boundsRoot = getMoveBoundsRoot(element);
-      if (!boundsRoot) return;
-      const data = getData();
-      const clampedData = roundMoveData(
-        getMoveBoundsClamp(element, boundsRoot, data, data),
-      );
-      if (clampedData.x !== data.x || clampedData.y !== data.y) {
-        setData(clampedData);
-      }
     },
     onDragStart: (
       e: MouseEvent | TouchEvent,

--- a/packages/playhtml/src/__tests__/can-move-bounds.test.ts
+++ b/packages/playhtml/src/__tests__/can-move-bounds.test.ts
@@ -192,7 +192,7 @@ describe("can-move bounds clamp", () => {
     expect(state.data.y).toBe(-30);
   });
 
-  it("normalizes persisted out-of-bounds data on mount", () => {
+  it("does not rewrite initial data to satisfy bounds on mount", () => {
     const { element, state, setData } = makeDragHarness({
       elementWidth: 400,
       elementHeight: 400,
@@ -212,7 +212,8 @@ describe("can-move bounds clamp", () => {
       setData,
     } as any);
 
-    expect(setData).toHaveBeenCalledWith({ x: 600, y: 0 });
+    expect(setData).not.toHaveBeenCalled();
+    expect(element.style.transform).toBe("translate(900px, 0px)");
   });
 
   it("respects a custom min-visible fraction (floor disabled)", () => {


### PR DESCRIPTION
## Summary

- apply `can-move-bounds` only during drag interactions
- preserve initial CSS layout and persisted positions during setup
- align regression coverage and developer docs with the drag-only contract

## Why

`can-move` previously normalized bounded positions during mount. Programmatically created elements measured before DOM insertion reported a zero rect, causing the bounds container's viewport offset (and scroll position) to be persisted as a non-zero translation. More broadly, mount-time normalization rewrote shared state using one client's layout even though bounds are otherwise enforced during dragging.

## Validation

- `bun build-packages`
- `cd packages/playhtml && bun run test` (37 files, 372 tests)
- `bun build-site`
- real-browser verification at `scrollY = 200`: setup preserved `(0, 0)` and a persisted `(500, 0)` position; dragging still clamped to `(200, 0)`
- `git diff --check`

## Docs and starters

Updated capability and React API docs. Starter templates are unchanged because the API and usage are unchanged.