### PR TITLE
Add searchable docs examples gallery

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -87,6 +87,7 @@ export default defineConfig({
       //
       //   Start        → getting-started, concepts, using-react
       //   Capabilities → capabilities (single page)
+      //   Examples     → autogenerate (examples/)
       //   Data         → autogenerate (data/)
       //   Advanced     → autogenerate (advanced/)
       //   Integrations → autogenerate (integrations/)
@@ -97,7 +98,7 @@ export default defineConfig({
       // reasons — so they have to be hand-rolled. Everything below is in a
       // real subdirectory, so we let Starlight autogenerate from the
       // `sidebar.order` frontmatter on each page. New pages added to
-      // data/ / advanced/ / integrations/ / reference/ show up in the
+      // examples/ / data/ / advanced/ / integrations/ / reference/ show up in the
       // sidebar automatically — set `sidebar.order` in the page frontmatter
       // to control position within its group.
       //
@@ -132,6 +133,7 @@ export default defineConfig({
             { label: "Custom elements", slug: "custom-elements" },
           ],
         },
+        { label: "Examples", autogenerate: { directory: "examples" } },
         { label: "Data", autogenerate: { directory: "data" } },
         { label: "Advanced", autogenerate: { directory: "advanced" } },
         { label: "Integrations", autogenerate: { directory: "integrations" } },

--- a/apps/docs/src/components/examples/ExampleCatalogue.tsx
+++ b/apps/docs/src/components/examples/ExampleCatalogue.tsx
@@ -1,0 +1,322 @@
+// ABOUTME: Renders the searchable catalogue of canonical examples and external sites.
+// ABOUTME: Loads the curated Are.na channel without blocking repo-owned examples.
+
+import { useEffect, useMemo, useState } from "react";
+import type { ExampleRecipeSummary } from "../playground/recipes/types";
+import {
+  ARENA_CHANNEL_URL,
+  ARENA_CONTENTS_URL,
+  filterExamples,
+  filterSites,
+  isArenaContentsResponse,
+  mapArenaSites,
+  type SiteSummary,
+  type SourceFilter,
+} from "./catalogue";
+import styles from "./examples.module.css";
+
+type ExampleCatalogueProps = {
+  examples: readonly ExampleRecipeSummary[];
+};
+
+const SOURCE_FILTERS: Array<{ value: SourceFilter; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "examples", label: "Examples" },
+  { value: "sites", label: "Sites" },
+];
+
+function SearchIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="11" cy="11" r="6.5" />
+      <path d="m16 16 4 4" />
+    </svg>
+  );
+}
+
+function ArrowIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M5 12h13M13 7l5 5-5 5" />
+    </svg>
+  );
+}
+
+function ExternalIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M14 5h5v5M19 5l-8 8" />
+      <path d="M18 13v5H6V6h5" />
+    </svg>
+  );
+}
+
+function ExampleCard({ example }: { example: ExampleRecipeSummary }) {
+  const labels = Array.from(
+    new Set([...example.capabilities, ...example.tags]),
+  ).slice(0, 3);
+
+  return (
+    <article className={styles.card} data-source="example">
+      <div className={styles.cardBody}>
+        <div className={styles.cardMeta}>
+          <span className={`${styles.sourceBadge} ${styles.exampleBadge}`}>
+            Example
+          </span>
+          <span className={styles.difficulty}>{example.difficulty}</span>
+        </div>
+        <h2 className={styles.cardTitle}>{example.title}</h2>
+        <p className={styles.cardDescription}>{example.description}</p>
+        {labels.length > 0 && (
+          <ul className={styles.tagList} aria-label="Topics">
+            {labels.map((label) => (
+              <li key={label}>{label}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className={styles.cardActions}>
+        <a
+          className={`${styles.primaryAction} sl-link-button primary`}
+          href={example.docsHref}
+        >
+          Open example
+          <ArrowIcon />
+        </a>
+        <a
+          className={`${styles.secondaryAction} sl-link-button secondary`}
+          href={`/docs/play#id=${encodeURIComponent(example.id)}`}
+        >
+          Remix
+        </a>
+      </div>
+    </article>
+  );
+}
+
+function SiteCard({ site }: { site: SiteSummary }) {
+  return (
+    <article className={styles.card} data-source="site">
+      <div className={styles.siteMedia}>
+        {site.imageUrl ? (
+          <img
+            src={site.imageUrl}
+            alt={site.imageAlt ?? ""}
+            loading="lazy"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <span className={styles.sitePlaceholder}>{site.hostname}</span>
+        )}
+      </div>
+
+      <div className={styles.cardBody}>
+        <div className={styles.cardMeta}>
+          <span className={`${styles.sourceBadge} ${styles.siteBadge}`}>
+            Site
+          </span>
+          <span className={styles.hostname}>{site.hostname}</span>
+        </div>
+        <h2 className={styles.cardTitle}>{site.title}</h2>
+        {site.author && <p className={styles.author}>by {site.author}</p>}
+        {site.description && (
+          <p className={styles.cardDescription}>{site.description}</p>
+        )}
+      </div>
+
+      <div className={styles.cardActions}>
+        <a
+          className={`${styles.primaryAction} sl-link-button primary`}
+          href={site.href}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Visit site
+          <ExternalIcon />
+        </a>
+      </div>
+    </article>
+  );
+}
+
+export function ExampleCatalogue({ examples }: ExampleCatalogueProps) {
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [sites, setSites] = useState<SiteSummary[]>([]);
+  const [sitesState, setSitesState] = useState<"loading" | "loaded" | "failed">(
+    "loading",
+  );
+  const [requestVersion, setRequestVersion] = useState(0);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    setSitesState("loading");
+
+    async function loadSites() {
+      try {
+        const response = await fetch(ARENA_CONTENTS_URL, {
+          signal: abortController.signal,
+          headers: { Accept: "application/json" },
+        });
+        if (!response.ok) {
+          throw new Error(`Are.na returned ${response.status}`);
+        }
+
+        const payload: unknown = await response.json();
+        if (!isArenaContentsResponse(payload)) {
+          throw new Error("Are.na returned an unexpected response");
+        }
+        if (!abortController.signal.aborted) {
+          setSites(mapArenaSites(payload));
+          setSitesState("loaded");
+        }
+      } catch {
+        if (!abortController.signal.aborted) {
+          setSitesState("failed");
+        }
+      }
+    }
+
+    void loadSites();
+    return () => abortController.abort();
+  }, [requestVersion]);
+
+  const visibleExamples = useMemo(
+    () => (sourceFilter === "sites" ? [] : filterExamples(examples, query)),
+    [examples, query, sourceFilter],
+  );
+  const visibleSites = useMemo(
+    () => (sourceFilter === "examples" ? [] : filterSites(sites, query)),
+    [query, sites, sourceFilter],
+  );
+  const resultCount = visibleExamples.length + visibleSites.length;
+  const sitesAreVisible = sourceFilter !== "examples";
+  const showEmptyState =
+    resultCount === 0 && !(sitesAreVisible && sitesState === "loading");
+
+  return (
+    <section
+      className={`${styles.catalogue} not-content`}
+      aria-label="Examples catalogue"
+    >
+      <div className={styles.controls}>
+        <label className={styles.searchLabel}>
+          <span>Search examples</span>
+          <span className={styles.searchField}>
+            <SearchIcon />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Try sound, physics, can-move…"
+              aria-controls="examples-catalogue-results"
+            />
+          </span>
+        </label>
+
+        <fieldset
+          className={styles.filters}
+          aria-labelledby="examples-source-label"
+        >
+          <span id="examples-source-label" className={styles.filterLabel}>
+            Source
+          </span>
+          <div className={styles.filterButtons}>
+            {SOURCE_FILTERS.map((filter) => (
+              <button
+                key={filter.value}
+                type="button"
+                aria-pressed={sourceFilter === filter.value}
+                onClick={() => setSourceFilter(filter.value)}
+              >
+                {filter.label}
+              </button>
+            ))}
+          </div>
+        </fieldset>
+      </div>
+
+      <div className={styles.resultsHeader}>
+        <p className={styles.resultCount} aria-live="polite">
+          {resultCount} {resultCount === 1 ? "result" : "results"}
+        </p>
+        <p className={styles.attribution}>
+          Sites are curated on{" "}
+          <a href={ARENA_CHANNEL_URL} target="_blank" rel="noreferrer">
+            Are.na
+            <ExternalIcon />
+          </a>
+        </p>
+      </div>
+
+      {sitesAreVisible && sitesState === "loading" && (
+        <p className={styles.sitesStatus} role="status">
+          Loading sites from Are.na…
+        </p>
+      )}
+
+      {sitesAreVisible && sitesState === "failed" && (
+        <aside className={styles.sitesError}>
+          <div>
+            <strong>Sites could not load.</strong>
+            <span>The examples in these docs are still available.</span>
+          </div>
+          <div className={styles.errorActions}>
+            <button
+              type="button"
+              onClick={() => setRequestVersion((v) => v + 1)}
+            >
+              Try again
+            </button>
+            <a href={ARENA_CHANNEL_URL} target="_blank" rel="noreferrer">
+              Browse on Are.na
+              <ExternalIcon />
+            </a>
+          </div>
+        </aside>
+      )}
+
+      <div id="examples-catalogue-results" className={styles.resultGroups}>
+        {visibleExamples.length > 0 && (
+          <section
+            className={styles.resultGroup}
+            aria-labelledby="examples-heading"
+          >
+            <h2 id="examples-heading" className={styles.groupTitle}>
+              Examples
+            </h2>
+            <div className={styles.cardGrid}>
+              {visibleExamples.map((example) => (
+                <ExampleCard key={example.id} example={example} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {visibleSites.length > 0 && (
+          <section
+            className={styles.resultGroup}
+            aria-labelledby="sites-heading"
+          >
+            <h2 id="sites-heading" className={styles.groupTitle}>
+              Community sites
+            </h2>
+            <div className={styles.cardGrid}>
+              {visibleSites.map((site) => (
+                <SiteCard key={site.id} site={site} />
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+
+      {showEmptyState && (
+        <div className={styles.emptyState}>
+          <strong>No examples found.</strong>
+          <span>Try another search or source.</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/docs/src/components/examples/ExampleCatalogue.tsx
+++ b/apps/docs/src/components/examples/ExampleCatalogue.tsx
@@ -2,7 +2,6 @@
 // ABOUTME: Loads the curated Are.na channel without blocking repo-owned examples.
 
 import { useEffect, useMemo, useState } from "react";
-import type { ExampleRecipeSummary } from "../playground/recipes/types";
 import {
   ARENA_CHANNEL_URL,
   ARENA_CONTENTS_URL,
@@ -13,10 +12,11 @@ import {
   type SiteSummary,
   type SourceFilter,
 } from "./catalogue";
+import type { CatalogueExampleSummary } from "./examples";
 import styles from "./examples.module.css";
 
 type ExampleCatalogueProps = {
-  examples: readonly ExampleRecipeSummary[];
+  examples: readonly CatalogueExampleSummary[];
 };
 
 const SOURCE_FILTERS: Array<{ value: SourceFilter; label: string }> = [
@@ -51,7 +51,7 @@ function ExternalIcon() {
   );
 }
 
-function ExampleCard({ example }: { example: ExampleRecipeSummary }) {
+function ExampleCard({ example }: { example: CatalogueExampleSummary }) {
   const labels = Array.from(
     new Set([...example.capabilities, ...example.tags]),
   ).slice(0, 3);
@@ -61,7 +61,7 @@ function ExampleCard({ example }: { example: ExampleRecipeSummary }) {
       <div className={styles.cardBody}>
         <div className={styles.cardMeta}>
           <span className={`${styles.sourceBadge} ${styles.exampleBadge}`}>
-            Example
+            {example.kind === "recipe" ? "Recipe" : "Docs demo"}
           </span>
           <span className={styles.difficulty}>{example.difficulty}</span>
         </div>
@@ -81,15 +81,17 @@ function ExampleCard({ example }: { example: ExampleRecipeSummary }) {
           className={`${styles.primaryAction} sl-link-button primary`}
           href={example.docsHref}
         >
-          Open example
+          {example.kind === "recipe" ? "Open example" : "View demo"}
           <ArrowIcon />
         </a>
-        <a
-          className={`${styles.secondaryAction} sl-link-button secondary`}
-          href={`/docs/play#id=${encodeURIComponent(example.id)}`}
-        >
-          Remix
-        </a>
+        {example.remixId && (
+          <a
+            className={`${styles.secondaryAction} sl-link-button secondary`}
+            href={`/docs/play#id=${encodeURIComponent(example.remixId)}`}
+          >
+            Remix
+          </a>
+        )}
       </div>
     </article>
   );

--- a/apps/docs/src/components/examples/__tests__/catalogue.test.ts
+++ b/apps/docs/src/components/examples/__tests__/catalogue.test.ts
@@ -1,0 +1,173 @@
+// ABOUTME: Verifies Are.na mapping, destination deduplication, and catalogue search.
+// ABOUTME: Keeps malformed external blocks from breaking the examples index.
+
+import { describe, expect, it } from "vitest";
+import type { ExampleRecipeSummary } from "../../playground/recipes/types";
+import {
+  deduplicateSitesByUrl,
+  filterExamples,
+  filterSites,
+  isArenaContentsResponse,
+  isUsefulSiteDescription,
+  mapArenaSites,
+  type SiteSummary,
+} from "../catalogue";
+
+const EXAMPLE: ExampleRecipeSummary = {
+  id: "shared-transport",
+  title: "Synchronized sound",
+  description: "Play a cue and keep a shared audio timeline in sync.",
+  tags: ["audio", "events"],
+  capabilities: ["can-play"],
+  difficulty: "advanced",
+  docsHref: "/docs/examples/shared-transport/",
+};
+
+describe("mapArenaSites", () => {
+  it("maps public V3 Link blocks and prefers the small image rendition", () => {
+    const sites = mapArenaSites({
+      meta: { total_count: 1 },
+      data: [
+        {
+          id: 42,
+          type: "Link",
+          visibility: "public",
+          title: "Music Room by Casey",
+          description: { plain: "Make a beat together." },
+          source: {
+            url: "https://music.example/room",
+            title: "Music Room",
+          },
+          image: {
+            alt_text: "A shared sequencer",
+            src: "https://images.example/original.png",
+            small: { src: "https://images.example/small.png" },
+          },
+        },
+      ],
+    });
+
+    expect(sites).toEqual([
+      {
+        id: "arena-42",
+        title: "Music Room",
+        description: "Make a beat together.",
+        href: "https://music.example/room",
+        hostname: "music.example",
+        imageUrl: "https://images.example/small.png",
+        imageAlt: "A shared sequencer",
+      },
+    ]);
+  });
+
+  it("ignores non-links, private blocks, and invalid destinations", () => {
+    expect(
+      mapArenaSites({
+        data: [
+          { id: 1, type: "Text", visibility: "public" },
+          {
+            id: 2,
+            type: "Link",
+            visibility: "private",
+            source: { url: "https://private.example" },
+          },
+          {
+            id: 3,
+            type: "Link",
+            visibility: "public",
+            source: { url: "javascript:alert(1)" },
+          },
+          { id: 4, type: "Link", visibility: "public" },
+        ],
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns an empty list for a malformed response", () => {
+    expect(isArenaContentsResponse({ contents: [] })).toBe(false);
+    expect(isArenaContentsResponse({ data: [] })).toBe(true);
+    expect(mapArenaSites({ contents: [] })).toEqual([]);
+    expect(mapArenaSites(null)).toEqual([]);
+  });
+
+  it("hides loading and punctuation placeholders from site descriptions", () => {
+    expect(isUsefulSiteDescription("A collaborative music room.")).toBe(true);
+    expect(isUsefulSiteDescription("connecting…")).toBe(false);
+    expect(isUsefulSiteDescription("?")).toBe(false);
+  });
+
+  it("extracts an author marker from the first description line", () => {
+    const [site] = mapArenaSites({
+      data: [
+        {
+          id: 43,
+          type: "Link",
+          visibility: "public",
+          title: "Casey",
+          description: { plain: "By: Casey Example\n\nMake a beat together." },
+          source: {
+            url: "https://music.example/room",
+            title: "Music Room",
+          },
+        },
+      ],
+    });
+
+    expect(site.author).toBe("Casey Example");
+    expect(site.description).toBe("Make a beat together.");
+    expect(filterSites([site], "Casey Example")).toEqual([site]);
+  });
+});
+
+describe("deduplicateSitesByUrl", () => {
+  it("keeps the newest channel entry for equivalent destination URLs", () => {
+    const newest: SiteSummary = {
+      id: "arena-9",
+      title: "Current listing",
+      description: "",
+      href: "https://example.com/project/#about",
+      hostname: "example.com",
+    };
+    const older: SiteSummary = {
+      id: "arena-4",
+      title: "Earlier listing",
+      description: "",
+      href: "https://example.com/project",
+      hostname: "example.com",
+    };
+    const other: SiteSummary = {
+      id: "arena-3",
+      title: "Another site",
+      description: "",
+      href: "https://another.example/",
+      hostname: "another.example",
+    };
+
+    expect(deduplicateSitesByUrl([newest, older, other])).toEqual([
+      newest,
+      other,
+    ]);
+  });
+});
+
+describe("catalogue filtering", () => {
+  const site: SiteSummary = {
+    id: "arena-8",
+    title: "Cinderblock Yard",
+    description: "A collaborative physics playground.",
+    href: "https://yard.example/",
+    hostname: "yard.example",
+  };
+
+  it("searches example metadata and capability names", () => {
+    expect(filterExamples([EXAMPLE], "CAN-PLAY")).toEqual([EXAMPLE]);
+    expect(filterExamples([EXAMPLE], "audio")).toEqual([EXAMPLE]);
+    expect(filterExamples([EXAMPLE], "drawing")).toEqual([]);
+  });
+
+  it("searches site titles, descriptions, and hostnames", () => {
+    expect(filterSites([site], "physics")).toEqual([site]);
+    expect(filterSites([site], "yard.example")).toEqual([site]);
+    expect(filterSites([site], "sound")).toEqual([]);
+  });
+});

--- a/apps/docs/src/components/examples/__tests__/catalogue.test.ts
+++ b/apps/docs/src/components/examples/__tests__/catalogue.test.ts
@@ -117,6 +117,27 @@ describe("mapArenaSites", () => {
     expect(site.description).toBe("Make a beat together.");
     expect(filterSites([site], "Casey Example")).toEqual([site]);
   });
+
+  it("maps the author field from Are.na metadata", () => {
+    const [site] = mapArenaSites({
+      data: [
+        {
+          id: 44,
+          type: "Link",
+          visibility: "public",
+          description: { plain: "A collaborative drawing surface." },
+          metadata: { author: "João Bernardo Narciso" },
+          source: {
+            url: "https://drawing.example/",
+            title: "Shared Drawing",
+          },
+        },
+      ],
+    });
+
+    expect(site.author).toBe("João Bernardo Narciso");
+    expect(filterSites([site], "João Bernardo Narciso")).toEqual([site]);
+  });
 });
 
 describe("deduplicateSitesByUrl", () => {

--- a/apps/docs/src/components/examples/__tests__/catalogue.test.ts
+++ b/apps/docs/src/components/examples/__tests__/catalogue.test.ts
@@ -2,7 +2,6 @@
 // ABOUTME: Keeps malformed external blocks from breaking the examples index.
 
 import { describe, expect, it } from "vitest";
-import type { ExampleRecipeSummary } from "../../playground/recipes/types";
 import {
   deduplicateSitesByUrl,
   filterExamples,
@@ -12,8 +11,9 @@ import {
   mapArenaSites,
   type SiteSummary,
 } from "../catalogue";
+import { catalogueExamples, type CatalogueExampleSummary } from "../examples";
 
-const EXAMPLE: ExampleRecipeSummary = {
+const EXAMPLE: CatalogueExampleSummary = {
   id: "shared-transport",
   title: "Synchronized sound",
   description: "Play a cue and keep a shared audio timeline in sync.",
@@ -21,7 +21,24 @@ const EXAMPLE: ExampleRecipeSummary = {
   capabilities: ["can-play"],
   difficulty: "advanced",
   docsHref: "/docs/examples/shared-transport/",
+  kind: "recipe",
+  remixId: "shared-transport",
 };
+
+describe("catalogueExamples", () => {
+  it("includes complete recipes and inline docs demos without duplicate ids", () => {
+    expect(
+      catalogueExamples.filter((example) => example.kind === "recipe"),
+    ).toHaveLength(3);
+    expect(
+      catalogueExamples.filter((example) => example.kind === "docs-demo"),
+    ).toHaveLength(16);
+    expect(new Set(catalogueExamples.map((example) => example.id)).size).toBe(
+      catalogueExamples.length,
+    );
+    expect(filterExamples(catalogueExamples, "docs demo")).toHaveLength(16);
+  });
+});
 
 describe("mapArenaSites", () => {
   it("maps public V3 Link blocks and prefers the small image rendition", () => {
@@ -183,6 +200,7 @@ describe("catalogue filtering", () => {
   it("searches example metadata and capability names", () => {
     expect(filterExamples([EXAMPLE], "CAN-PLAY")).toEqual([EXAMPLE]);
     expect(filterExamples([EXAMPLE], "audio")).toEqual([EXAMPLE]);
+    expect(filterExamples([EXAMPLE], "recipe")).toEqual([EXAMPLE]);
     expect(filterExamples([EXAMPLE], "drawing")).toEqual([]);
   });
 

--- a/apps/docs/src/components/examples/catalogue.ts
+++ b/apps/docs/src/components/examples/catalogue.ts
@@ -125,6 +125,7 @@ function mapArenaBlock(value: unknown): SiteSummary | undefined {
   if (!destination) return undefined;
 
   const description = readNestedRecord(value, "description");
+  const metadata = readNestedRecord(value, "metadata");
   const image = readNestedRecord(value, "image");
   const smallImage = image ? readNestedRecord(image, "small") : undefined;
   const sourceTitle = source ? readString(source.title) : undefined;
@@ -133,12 +134,15 @@ function mapArenaBlock(value: unknown): SiteSummary | undefined {
     ? readString(description.plain)
     : undefined;
   const siteDescription = parseSiteDescription(descriptionText);
+  const author =
+    (metadata ? readString(metadata.author) : undefined) ??
+    siteDescription.author;
 
   return {
     id: `arena-${id}`,
     title,
     description: siteDescription.description,
-    ...(siteDescription.author ? { author: siteDescription.author } : {}),
+    ...(author ? { author } : {}),
     href: destination.href,
     hostname: destination.hostname.replace(/^www\./, ""),
     imageUrl:

--- a/apps/docs/src/components/examples/catalogue.ts
+++ b/apps/docs/src/components/examples/catalogue.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Maps the public Are.na sites channel into catalogue entries.
 // ABOUTME: Provides URL deduplication and text filtering for the examples index.
 
-import type { ExampleRecipeSummary } from "../playground/recipes/types";
+import type { CatalogueExampleSummary } from "./examples";
 
 export const ARENA_CHANNEL_URL =
   "https://www.are.na/spencer-chang/playhtml-sites";
@@ -173,15 +173,16 @@ function includesQuery(values: Array<string | undefined>, query: string) {
 }
 
 export function filterExamples(
-  examples: readonly ExampleRecipeSummary[],
+  examples: readonly CatalogueExampleSummary[],
   query: string,
-): ExampleRecipeSummary[] {
+): CatalogueExampleSummary[] {
   return examples.filter((example) =>
     includesQuery(
       [
         example.title,
         example.description,
         example.difficulty,
+        example.kind === "recipe" ? "recipe" : "docs demo",
         ...example.tags,
         ...example.capabilities,
       ],

--- a/apps/docs/src/components/examples/catalogue.ts
+++ b/apps/docs/src/components/examples/catalogue.ts
@@ -1,0 +1,199 @@
+// ABOUTME: Maps the public Are.na sites channel into catalogue entries.
+// ABOUTME: Provides URL deduplication and text filtering for the examples index.
+
+import type { ExampleRecipeSummary } from "../playground/recipes/types";
+
+export const ARENA_CHANNEL_URL =
+  "https://www.are.na/spencer-chang/playhtml-sites";
+export const ARENA_CONTENTS_URL =
+  "https://api.are.na/v3/channels/playhtml-sites/contents?per=100";
+
+export type SiteSummary = {
+  id: `arena-${number}`;
+  title: string;
+  description: string;
+  author?: string;
+  href: string;
+  hostname: string;
+  imageUrl?: string;
+  imageAlt?: string;
+};
+
+export type SourceFilter = "all" | "examples" | "sites";
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readNestedRecord(
+  record: UnknownRecord,
+  key: string,
+): UnknownRecord | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function parsePublicUrl(value: unknown): URL | undefined {
+  const href = readString(value);
+  if (!href) return undefined;
+
+  try {
+    const url = new URL(href);
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? url
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeSiteUrl(href: string): string | undefined {
+  const url = parsePublicUrl(href);
+  if (!url) return undefined;
+
+  url.hash = "";
+  const pathname = url.pathname.replace(/\/+$/, "") || "/";
+  return `${url.origin}${pathname}${url.search}`;
+}
+
+export function deduplicateSitesByUrl(
+  sites: readonly SiteSummary[],
+): SiteSummary[] {
+  const seen = new Set<string>();
+  return sites.filter((site) => {
+    const normalizedUrl = normalizeSiteUrl(site.href);
+    if (!normalizedUrl || seen.has(normalizedUrl)) return false;
+    seen.add(normalizedUrl);
+    return true;
+  });
+}
+
+export function isArenaContentsResponse(
+  response: unknown,
+): response is { data: unknown[] } {
+  return isRecord(response) && Array.isArray(response.data);
+}
+
+export function isUsefulSiteDescription(description: string): boolean {
+  return !/^(?:\?+|connecting(?:\.{3}|…)?|loading(?:\.{3}|…)?)$/i.test(
+    description.trim(),
+  );
+}
+
+function parseSiteDescription(description: string | undefined): {
+  author?: string;
+  description: string;
+} {
+  if (!description) return { description: "" };
+
+  const [firstLine, ...remainingLines] = description.split(/\r?\n/);
+  const authorMatch = firstLine.match(/^by:\s*(.+)$/i);
+  if (!authorMatch) {
+    return {
+      description: isUsefulSiteDescription(description) ? description : "",
+    };
+  }
+
+  const author = authorMatch[1].trim();
+  const remainingDescription = remainingLines.join("\n").trim();
+  return {
+    ...(author ? { author } : {}),
+    description:
+      remainingDescription && isUsefulSiteDescription(remainingDescription)
+        ? remainingDescription
+        : "",
+  };
+}
+
+function mapArenaBlock(value: unknown): SiteSummary | undefined {
+  if (!isRecord(value)) return undefined;
+  if (value.type !== "Link" || value.visibility !== "public") return undefined;
+
+  const id = value.id;
+  if (typeof id !== "number" || !Number.isFinite(id)) return undefined;
+
+  const source = readNestedRecord(value, "source");
+  const destination = source ? parsePublicUrl(source.url) : undefined;
+  if (!destination) return undefined;
+
+  const description = readNestedRecord(value, "description");
+  const image = readNestedRecord(value, "image");
+  const smallImage = image ? readNestedRecord(image, "small") : undefined;
+  const sourceTitle = source ? readString(source.title) : undefined;
+  const title = sourceTitle ?? readString(value.title) ?? destination.hostname;
+  const descriptionText = description
+    ? readString(description.plain)
+    : undefined;
+  const siteDescription = parseSiteDescription(descriptionText);
+
+  return {
+    id: `arena-${id}`,
+    title,
+    description: siteDescription.description,
+    ...(siteDescription.author ? { author: siteDescription.author } : {}),
+    href: destination.href,
+    hostname: destination.hostname.replace(/^www\./, ""),
+    imageUrl:
+      (smallImage ? readString(smallImage.src) : undefined) ??
+      (image ? readString(image.src) : undefined),
+    imageAlt: image ? readString(image.alt_text) : undefined,
+  };
+}
+
+export function mapArenaSites(response: unknown): SiteSummary[] {
+  if (!isArenaContentsResponse(response)) return [];
+
+  const mapped = response.data
+    .map(mapArenaBlock)
+    .filter((site): site is SiteSummary => site !== undefined);
+
+  // Are.na returns channel contents newest first, so first occurrence wins.
+  return deduplicateSitesByUrl(mapped);
+}
+
+function includesQuery(values: Array<string | undefined>, query: string) {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return true;
+
+  return values.some((value) =>
+    value?.toLocaleLowerCase().includes(normalizedQuery),
+  );
+}
+
+export function filterExamples(
+  examples: readonly ExampleRecipeSummary[],
+  query: string,
+): ExampleRecipeSummary[] {
+  return examples.filter((example) =>
+    includesQuery(
+      [
+        example.title,
+        example.description,
+        example.difficulty,
+        ...example.tags,
+        ...example.capabilities,
+      ],
+      query,
+    ),
+  );
+}
+
+export function filterSites(
+  sites: readonly SiteSummary[],
+  query: string,
+): SiteSummary[] {
+  return sites.filter((site) =>
+    includesQuery(
+      [site.title, site.description, site.author, site.hostname],
+      query,
+    ),
+  );
+}

--- a/apps/docs/src/components/examples/examples.module.css
+++ b/apps/docs/src/components/examples/examples.module.css
@@ -2,6 +2,7 @@
 /* ABOUTME: Defines responsive cards, source filters, loading, and failure states. */
 
 .catalogue {
+  container-type: inline-size;
   margin-top: 1.75rem;
   color: var(--ph-ink);
   font-family: var(--ph-font-body);
@@ -10,6 +11,8 @@
 .controls {
   display: grid;
   gap: 1rem;
+  width: min(36rem, 100%);
+  max-width: 100%;
   padding: 1rem;
   background: var(--ph-paper-warm);
   border: 1px solid var(--ph-hairline);
@@ -90,7 +93,6 @@
 
 .filterButtons {
   display: flex;
-  flex-wrap: wrap;
   gap: 0.45rem;
 }
 
@@ -452,13 +454,11 @@
   font-size: 0.9rem;
 }
 
-@media (min-width: 42rem) {
+@container (min-width: 48rem) {
   .controls {
     width: fit-content;
-    max-width: 100%;
     grid-template-columns: minmax(16rem, 36rem) auto;
     align-items: end;
-    justify-content: start;
   }
 }
 

--- a/apps/docs/src/components/examples/examples.module.css
+++ b/apps/docs/src/components/examples/examples.module.css
@@ -1,0 +1,493 @@
+/* ABOUTME: Styles the examples catalogue with the docs paper-and-ink design system. */
+/* ABOUTME: Defines responsive cards, source filters, loading, and failure states. */
+
+.catalogue {
+  margin-top: 1.75rem;
+  color: var(--ph-ink);
+  font-family: var(--ph-font-body);
+}
+
+.controls {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  background: var(--ph-paper-warm);
+  border: 1px solid var(--ph-hairline);
+  border-radius: 6px;
+  box-shadow: var(--ph-shadow-brick);
+}
+
+.searchLabel {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 0;
+  color: var(--ph-ink-2);
+  font-family: var(--ph-font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.searchField {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-height: 2.75rem;
+  padding-inline: 0.8rem;
+  background: var(--ph-paper);
+  border: 1.5px solid var(--ph-ink);
+  border-radius: 4px;
+}
+
+.searchField:focus-within {
+  outline: 3px solid var(--ph-ultramarine-wash);
+  border-color: var(--ph-ultramarine-deep);
+}
+
+.searchField svg {
+  width: 1.05rem;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: var(--ph-ink-3);
+  stroke-linecap: round;
+  stroke-width: 1.7;
+}
+
+.searchField input {
+  width: 100%;
+  min-width: 0;
+  padding: 0.65rem 0;
+  color: var(--ph-ink);
+  font: 1rem var(--ph-font-body);
+  background: transparent;
+  border: 0;
+  outline: 0;
+}
+
+.searchField input::placeholder {
+  color: var(--ph-ink-3);
+  opacity: 1;
+}
+
+.filters {
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.filterLabel {
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--ph-ink-2);
+  font-family: var(--ph-font-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.filterButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.filterButtons button,
+.sitesError button {
+  box-sizing: border-box;
+  min-height: 2.35rem;
+  margin: 0;
+  padding: 0.45rem 0.8rem;
+  color: var(--ph-ink-2);
+  font: 700 0.88rem var(--ph-font-body);
+  line-height: 1.2;
+  background: var(--ph-paper);
+  border: 1px solid var(--ph-hairline);
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    color var(--ph-motion-fast),
+    background var(--ph-motion-fast),
+    border-color var(--ph-motion-fast);
+}
+
+.filterButtons button:hover,
+.sitesError button:hover {
+  color: var(--ph-ink);
+  border-color: var(--ph-ink);
+}
+
+.filterButtons button[aria-pressed="true"] {
+  color: var(--ph-paper);
+  background: var(--ph-ultramarine);
+  border-color: var(--ph-ink);
+  box-shadow: 1px 1px 0 var(--ph-ink);
+}
+
+.filterButtons button:focus-visible,
+.sitesError button:focus-visible,
+.catalogue a:focus-visible {
+  outline: 3px solid var(--ph-mustard);
+  outline-offset: 2px;
+}
+
+.resultsHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.3rem;
+  padding-bottom: 0.65rem;
+  border-bottom: 1px dashed var(--ph-hairline);
+}
+
+.resultCount,
+.attribution,
+.sitesStatus {
+  margin: 0;
+  color: var(--ph-ink-3);
+  font-family: var(--ph-font-mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.resultCount {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.attribution a,
+.errorActions a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.attribution svg,
+.errorActions svg,
+.cardActions svg {
+  width: 0.95rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.sitesStatus {
+  padding: 0.8rem 0;
+}
+
+.sitesError {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 0.85rem 1rem;
+  background: var(--ph-mustard-wash);
+  border: 1px solid var(--ph-mustard);
+  border-left: 4px solid var(--ph-mustard);
+  border-radius: 4px;
+}
+
+.sitesError > div:first-child {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.sitesError strong {
+  color: var(--ph-ink);
+  font-family: var(--ph-font-display);
+  font-size: 0.95rem;
+}
+
+.sitesError span {
+  color: var(--ph-ink-2);
+  font-size: 0.86rem;
+}
+
+.errorActions {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 0.7rem;
+}
+
+.errorActions a {
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.resultGroups {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.25rem;
+}
+
+.resultGroup {
+  min-width: 0;
+}
+
+.groupTitle {
+  margin: 0 0 0.65rem;
+  color: var(--ph-ink-2);
+  font-family: var(--ph-font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  line-height: 1.5;
+  text-transform: uppercase;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 20rem), 1fr));
+  align-items: start;
+  gap: 1.25rem;
+}
+
+.card {
+  display: flex;
+  min-width: 0;
+  min-height: 24rem;
+  margin: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--ph-paper-warm);
+  border: 1px solid var(--ph-hairline);
+  border-radius: 4px;
+  box-shadow: var(--ph-shadow-brick);
+  transition:
+    box-shadow var(--ph-motion),
+    border-color var(--ph-motion);
+}
+
+.card:hover {
+  border-color: var(--ph-ink);
+  box-shadow: 4px 4px 0 var(--ph-ink);
+}
+
+.card[data-source="example"] {
+  min-height: 0;
+}
+
+.siteMedia {
+  position: relative;
+  display: grid;
+  min-height: 10.5rem;
+  aspect-ratio: 16 / 10;
+  overflow: hidden;
+  border-bottom: 1px solid var(--ph-hairline);
+}
+
+.siteMedia {
+  place-items: center;
+  color: var(--ph-ink-3);
+  background: var(--ph-paper-deep);
+}
+
+.siteMedia img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--ph-motion-slow);
+}
+
+.card:hover .siteMedia img {
+  transform: scale(1.025);
+}
+
+.sitePlaceholder {
+  max-width: 85%;
+  overflow-wrap: anywhere;
+  font-family: var(--ph-font-mono);
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.cardBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 1rem 1rem 0.85rem;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  min-height: 1.4rem;
+}
+
+.sourceBadge {
+  padding: 0.18rem 0.45rem;
+  font-family: var(--ph-font-mono);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+}
+
+.exampleBadge {
+  color: var(--ph-ultramarine-deep);
+  background: var(--ph-ultramarine-wash);
+}
+
+.siteBadge {
+  color: var(--ph-sage-deep);
+  background: var(--ph-sage-wash);
+}
+
+.difficulty,
+.hostname {
+  overflow: hidden;
+  color: var(--ph-ink-3);
+  font-family: var(--ph-font-mono);
+  font-size: 0.72rem;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.difficulty {
+  text-transform: capitalize;
+}
+
+.cardTitle {
+  margin: 0.75rem 0 0;
+  color: var(--ph-ink);
+  font-family: var(--ph-font-display);
+  font-size: 1.2rem;
+  font-weight: 750;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.cardDescription {
+  display: -webkit-box;
+  margin: 0.5rem 0 0;
+  overflow: hidden;
+  color: var(--ph-ink-2);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.author {
+  margin: 0.35rem 0 0;
+  color: var(--ph-ink-3);
+  font-family: var(--ph-font-mono);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: auto 0 0;
+  padding: 0.9rem 0 0;
+  list-style: none;
+}
+
+.tagList li {
+  margin: 0;
+  padding: 0.15rem 0.4rem;
+  color: var(--ph-ink-3);
+  font-family: var(--ph-font-mono);
+  font-size: 0.68rem;
+  line-height: 1.35;
+  background: var(--ph-paper);
+  border: 1px solid var(--ph-hairline-soft);
+  border-radius: 3px;
+}
+
+.cardActions {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.8rem 1rem 1rem;
+  border-top: 1px solid var(--ph-hairline-soft);
+}
+
+.catalogue .primaryAction,
+.catalogue .secondaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  text-decoration: none;
+}
+
+.emptyState {
+  display: grid;
+  place-items: center;
+  gap: 0.25rem;
+  min-height: 12rem;
+  margin-top: 1.25rem;
+  padding: 2rem;
+  color: var(--ph-ink-2);
+  text-align: center;
+  background: var(--ph-paper-warm);
+  border: 1px dashed var(--ph-hairline);
+  border-radius: 4px;
+}
+
+.emptyState strong {
+  color: var(--ph-ink);
+  font-family: var(--ph-font-display);
+  font-size: 1.1rem;
+}
+
+.emptyState span {
+  font-size: 0.9rem;
+}
+
+@media (min-width: 42rem) {
+  .controls {
+    width: fit-content;
+    max-width: 100%;
+    grid-template-columns: minmax(16rem, 36rem) auto;
+    align-items: end;
+    justify-content: start;
+  }
+}
+
+@media (max-width: 35rem) {
+  .resultsHeader,
+  .sitesError {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .errorActions {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    min-height: 0;
+  }
+
+  .cardActions {
+    align-items: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .siteMedia img,
+  .primaryAction,
+  .secondaryAction {
+    transition: none;
+  }
+}

--- a/apps/docs/src/components/examples/examples.ts
+++ b/apps/docs/src/components/examples/examples.ts
@@ -1,0 +1,189 @@
+// ABOUTME: Lists every repo-owned example shown in the searchable docs catalogue.
+// ABOUTME: Combines complete playground recipes with smaller demos embedded in guide pages.
+
+import { exampleRecipeSummaries } from "../playground/recipes";
+import type { ExampleDifficulty } from "../playground/recipes/types";
+
+export type CatalogueExampleSummary = {
+  id: string;
+  title: string;
+  description: string;
+  tags: readonly string[];
+  capabilities: readonly string[];
+  difficulty: ExampleDifficulty;
+  docsHref: string;
+  kind: "recipe" | "docs-demo";
+  remixId?: string;
+};
+
+const docsDemoSummaries: CatalogueExampleSummary[] = [
+  {
+    id: "can-move-demo",
+    title: "Drag a hat and cat",
+    description: "Drag two shared objects and keep them inside a bounded area.",
+    tags: ["dragging", "bounds", "React"],
+    capabilities: ["can-move"],
+    difficulty: "starter",
+    docsHref: "/docs/capabilities/#can-move",
+    kind: "docs-demo",
+  },
+  {
+    id: "can-toggle-demo",
+    title: "Shared toggle",
+    description: "Click a switch and share its on or off state with every reader.",
+    tags: ["switch", "boolean", "React"],
+    capabilities: ["can-toggle"],
+    difficulty: "starter",
+    docsHref: "/docs/capabilities/#can-toggle",
+    kind: "docs-demo",
+  },
+  {
+    id: "can-grow-demo",
+    title: "Grow a balloon",
+    description: "Grow or shrink a balloon and share its current scale.",
+    tags: ["scale", "click", "React"],
+    capabilities: ["can-grow"],
+    difficulty: "starter",
+    docsHref: "/docs/capabilities/#can-grow",
+    kind: "docs-demo",
+  },
+  {
+    id: "can-spin-demo",
+    title: "Spin a wheel",
+    description: "Drag a wheel to rotate it for everyone on the page.",
+    tags: ["rotation", "dragging", "React"],
+    capabilities: ["can-spin"],
+    difficulty: "starter",
+    docsHref: "/docs/capabilities/#can-spin",
+    kind: "docs-demo",
+  },
+  {
+    id: "can-hover-demo",
+    title: "Shared hover",
+    description: "Hover over a target and show that live state to other readers.",
+    tags: ["presence", "awareness", "React"],
+    capabilities: ["can-hover"],
+    difficulty: "starter",
+    docsHref: "/docs/capabilities/#can-hover",
+    kind: "docs-demo",
+  },
+  {
+    id: "can-duplicate-demo",
+    title: "Duplicate rabbits",
+    description: "Create shared copies from one template and reset the collection.",
+    tags: ["cloning", "dynamic elements", "React"],
+    capabilities: ["can-duplicate"],
+    difficulty: "intermediate",
+    docsHref: "/docs/capabilities/#can-duplicate",
+    kind: "docs-demo",
+  },
+  {
+    id: "doodle-strip-demo",
+    title: "Shared doodle strip",
+    description: "Draw a tiny face and add it to a shared strip capped at 20 doodles.",
+    tags: ["drawing", "canvas", "shared list"],
+    capabilities: ["can-play"],
+    difficulty: "intermediate",
+    docsHref: "/docs/custom-elements/#play-doodle",
+    kind: "docs-demo",
+  },
+  {
+    id: "emoji-mirror-demo",
+    title: "Emoji-only mirrored textarea",
+    description: "Filter a textarea to emoji and mirror its value to every reader.",
+    tags: ["textarea", "input filtering", "Vanilla HTML"],
+    capabilities: ["can-mirror"],
+    difficulty: "starter",
+    docsHref: "/docs/custom-elements/#example-an-emoji-only-textarea",
+    kind: "docs-demo",
+  },
+  {
+    id: "growing-list-mirror-demo",
+    title: "Growing mirrored list",
+    description: "Append list items and mirror the changing child list without custom data.",
+    tags: ["dynamic DOM", "lists", "Vanilla HTML"],
+    capabilities: ["can-mirror"],
+    difficulty: "starter",
+    docsHref: "/docs/custom-elements/#example-a-list-you-can-add-children-to",
+    kind: "docs-demo",
+  },
+  {
+    id: "shared-counter-demo",
+    title: "Shared click counter",
+    description: "Increment one persistent count shared by everyone reading the page.",
+    tags: ["counter", "shared data", "React"],
+    capabilities: ["can-play"],
+    difficulty: "intermediate",
+    docsHref: "/docs/custom-elements/#play-counter",
+    kind: "docs-demo",
+  },
+  {
+    id: "shared-guestbook-demo",
+    title: "Shared guestbook",
+    description: "Add notes to a capped shared list rendered from reactive data.",
+    tags: ["guestbook", "lists", "reactive view"],
+    capabilities: ["can-play"],
+    difficulty: "intermediate",
+    docsHref: "/docs/custom-elements/#play-guestbook",
+    kind: "docs-demo",
+  },
+  {
+    id: "shared-prize-wheel-demo",
+    title: "Shared prize wheel",
+    description: "Run one seeded animation so every reader lands on the same result.",
+    tags: ["animation", "requestUpdate", "shared seed"],
+    capabilities: ["can-play"],
+    difficulty: "advanced",
+    docsHref: "/docs/custom-elements/#play-spinner",
+    kind: "docs-demo",
+  },
+  {
+    id: "mirror-controls-playground",
+    title: "Native controls mirror playground",
+    description: "Test shared forms, contenteditable fields, hover, focus, and nested elements.",
+    tags: ["forms", "contenteditable", "playground"],
+    capabilities: ["can-mirror"],
+    difficulty: "advanced",
+    docsHref: "/docs/advanced/mirror-playground/#hover",
+    kind: "docs-demo",
+  },
+  {
+    id: "rain-event-demo",
+    title: "Send a rain event",
+    description: "Trigger a temporary rain effect for everyone currently connected.",
+    tags: ["events", "animation", "transient"],
+    capabilities: [],
+    difficulty: "intermediate",
+    docsHref: "/docs/data/events/#rain-event-demo",
+    kind: "docs-demo",
+  },
+  {
+    id: "live-reactions-demo",
+    title: "Live reactions",
+    description: "Broadcast short-lived emoji reactions without storing shared state.",
+    tags: ["events", "emoji", "transient"],
+    capabilities: [],
+    difficulty: "intermediate",
+    docsHref: "/docs/data/events/#live-reactions-demo",
+    kind: "docs-demo",
+  },
+  {
+    id: "online-indicator-demo",
+    title: "Online presence indicator",
+    description: "Show one live colored dot for each reader currently on the page.",
+    tags: ["presence", "online", "React"],
+    capabilities: [],
+    difficulty: "intermediate",
+    docsHref: "/docs/data/presence/#online-indicator-demo",
+    kind: "docs-demo",
+  },
+];
+
+export const catalogueExamples: CatalogueExampleSummary[] = [
+  ...exampleRecipeSummaries.map((example) => ({
+    ...example,
+    kind: "recipe" as const,
+    remixId: example.id,
+  })),
+  ...docsDemoSummaries,
+];

--- a/apps/docs/src/components/playground/Playground.tsx
+++ b/apps/docs/src/components/playground/Playground.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Editor } from "./Editor";
 import { Preview } from "./Preview";
 import { starterRecipe } from "./recipes/_starter";
+import { getPlayableRecipe } from "./recipes";
 import {
   parseHash,
   encodeHashPayload,
@@ -17,7 +18,7 @@ import "./playground.css";
 
 export function Playground() {
   // The "canonical" source for the loaded recipe. We diff against this to
-  // know whether the user has edited away from the starter (controls the
+  // know whether the user has edited away from the canonical recipe (controls the
   // "edited" indicator and the visibility of the Reset button).
   const [recipeId, setRecipeId] = useState<string>("_starter");
   const [canonicalSource, setCanonicalSource] = useState<string>(starterRecipe.html);
@@ -38,55 +39,46 @@ export function Playground() {
 
   // Initial load: parse hash, prune stale drafts, silently restore draft if
   // one exists. No banner — the reader gets back exactly where they were.
-  // The "edited" indicator + Reset to starter button (below) make the
+  // The "edited" indicator + reset button make the
   // edited state legible without being in the way every refresh.
   useEffect(() => {
     pruneStaleDrafts();
 
-    // Determine canonical source for the recipe id (Phase 1: only _starter)
-    const canonicalForId = (id: string): string => {
-      if (id === "_starter") return starterRecipe.html;
-      // Phase 2 will add canonical recipe lookup here.
-      return starterRecipe.html;
-    };
+    function loadRecipeFromHash() {
+      const loaded = parseHash(window.location.hash, getPlayableRecipe, starterRecipe);
+      const canonical = getPlayableRecipe(loaded.recipeId)?.html ?? starterRecipe.html;
+      setRecipeId(loaded.recipeId);
+      setCanonicalSource(canonical);
+      setRoomId(loaded.roomId);
+      fromPayloadRef.current = loaded.fromPayload;
 
-    const loaded = parseHash(window.location.hash, starterRecipe.html);
-    const canon = canonicalForId(loaded.recipeId);
-    setRecipeId(loaded.recipeId);
-    setCanonicalSource(canon);
-    setRoomId(loaded.roomId);
-    fromPayloadRef.current = loaded.fromPayload;
-
-    // Derive sessionId for URL encoding. If loaded from payload, the room
-    // id is `recipe:<base>:<sessionId>`; else it's the localStorage editor
-    // room id and that's also our sessionId.
-    if (loaded.fromPayload) {
-      const parts = loaded.roomId.split(":");
-      sessionIdRef.current = parts[parts.length - 1] ?? "";
-    } else {
-      sessionIdRef.current = loaded.roomId; // edit-<recipe>-<random>
-    }
-
-    // Source-of-truth resolution. Three cases:
-    //   1. URL has a payload (#c=...) — payload wins, never silently mix
-    //      in a local draft (the URL is shareable; honoring it is the
-    //      whole point).
-    //   2. Local draft exists and differs from canonical — restore it
-    //      silently. URL hash already encodes the source on every edit
-    //      (fork-on-first-edit handles the room-id update for us).
-    //   3. Otherwise — load the canonical recipe.
-    if (loaded.fromPayload) {
-      setEditorSource(loaded.source);
-    } else {
-      const draft = loadDraft(loaded.recipeId);
-      if (draft && draft.source !== canon) {
-        setEditorSource(draft.source);
+      // Derive sessionId for URL encoding. If loaded from payload, the room
+      // id is `recipe:<base>:<sessionId>`; else it's the localStorage editor
+      // room id and that's also our sessionId.
+      if (loaded.fromPayload) {
+        const parts = loaded.roomId.split(":");
+        sessionIdRef.current = parts[parts.length - 1] ?? "";
       } else {
-        setEditorSource(loaded.source);
+        sessionIdRef.current = loaded.roomId;
       }
+
+      // A payload is the explicit source of truth. Canonical links may restore
+      // a local draft when it differs from the registered recipe.
+      if (loaded.fromPayload) {
+        setEditorSource(loaded.source);
+      } else {
+        const draft = loadDraft(loaded.recipeId);
+        setEditorSource(
+          draft && draft.source !== canonical ? draft.source : loaded.source,
+        );
+      }
+
+      setSeedNonce((n) => n + 1);
     }
 
-    setSeedNonce((n) => n + 1);
+    loadRecipeFromHash();
+    window.addEventListener("hashchange", loadRecipeFromHash);
+    return () => window.removeEventListener("hashchange", loadRecipeFromHash);
   }, []);
 
   // Listen for the Preview's reload request (the reload button dispatches
@@ -124,13 +116,10 @@ export function Playground() {
       saveDraft(recipeId, source, canonicalSource);
 
       // Update URL hash with payload (or strip if source matches canonical).
-      // Oversize remixes silently keep the previous hash — sharing UI is
-      // hidden in Phase 1 until we have a proper named-remix backend, so
-      // there's no point surfacing the size limit to the reader yet.
+      // Oversize remixes silently keep the previous hash because the editor
+      // does not expose a sharing action for payloads above the URL limit.
       if (source === canonicalSource) {
-        if (window.location.hash) {
-          history.replaceState(null, "", window.location.pathname + window.location.search);
-        }
+        replaceCanonicalHash(recipeId, roomId);
         return;
       }
       const enc = encodeHashPayload({
@@ -141,24 +130,21 @@ export function Playground() {
       if (enc.tooLarge) return; // Skip URL update; payload too large
       history.replaceState(null, "", `${window.location.pathname}${window.location.search}#${enc.hash}`);
     },
-    [recipeId, canonicalSource],
+    [recipeId, canonicalSource, roomId],
   );
 
   // Reset to the canonical recipe. Confirms once before discarding because
   // the action is destructive (any unsaved edits go away).
   const handleResetToStarter = useCallback(() => {
     const ok = window.confirm(
-      "Discard your edits and reset to the starter? This cannot be undone.",
+      "Discard your edits and reset to this example? This cannot be undone.",
     );
     if (!ok) return;
     discardDraft(recipeId);
     setEditorSource(canonicalSource);
     setSeedNonce((n) => n + 1);
-    // Drop the URL hash payload so refreshing lands cleanly on canonical
-    if (window.location.hash) {
-      history.replaceState(null, "", window.location.pathname + window.location.search);
-    }
-  }, [recipeId, canonicalSource]);
+    replaceCanonicalHash(recipeId, roomId);
+  }, [recipeId, canonicalSource, roomId]);
 
   const handleCopySource = useCallback(async () => {
     try {
@@ -239,9 +225,9 @@ export function Playground() {
             type="button"
             className="ph-play-reset-btn"
             onClick={handleResetToStarter}
-            title="Discard your edits and reload the starter"
+            title="Discard your edits and reload this example"
           >
-            Reset to starter
+            Reset example
           </button>
         )}
       </div>
@@ -275,4 +261,15 @@ export function Playground() {
       </div>
     </div>
   );
+}
+
+function replaceCanonicalHash(recipeId: string, roomId: string): void {
+  const baseUrl = window.location.pathname + window.location.search;
+  if (recipeId === "_starter") {
+    history.replaceState(null, "", baseUrl);
+    return;
+  }
+
+  const params = new URLSearchParams({ id: recipeId, room: roomId });
+  history.replaceState(null, "", `${baseUrl}#${params}`);
 }

--- a/apps/docs/src/components/playground/Preview.tsx
+++ b/apps/docs/src/components/playground/Preview.tsx
@@ -2,21 +2,7 @@
 // ABOUTME: Connection / presence / room id are surfaced inside the iframe via the dev panel.
 import { useEffect, useRef, useState } from "react";
 import { buildIframeSrcdoc } from "./iframe-template";
-// Vite's `?raw` import reads the file at build/dev time and inlines its
-// source as a string. We use it to load the workspace playhtml ESM build
-// and hand the iframe a blob: URL pointing at it. This means library
-// edits to packages/playhtml/src/* reflect in the iframe after a rebuild
-// of the playhtml package (`bun run -C packages/playhtml build`).
-//
-// Why not unpkg: the published version doesn't have this branch's dev
-// panel changes (position attribute, console panel). Why not a Vite
-// import directly: the iframe is sandboxed without allow-same-origin and
-// runs in a different document context, so the parent's already-resolved
-// module URLs aren't visible to it. Blob URLs work cross-origin.
-//
-// The relative path bypasses Vite's `playhtml` alias (which points at
-// the source, not the built dist) and reaches the dist file directly.
-import playhtmlSource from "../../../../../packages/playhtml/dist/playhtml.es.js?raw";
+import { makePlayhtmlModuleUrl } from "./playhtml-module";
 
 export type PreviewProps = {
   source: string;
@@ -28,26 +14,20 @@ export type PreviewProps = {
 export function Preview(props: PreviewProps) {
   const { source, roomId, reloadNonce } = props;
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // Blob URL pointing at the workspace playhtml ESM source. Created once
-  // per Preview lifetime; the iframe template uses it inside its
-  // importmap so `import { playhtml } from "playhtml"` resolves here.
-  const [playhtmlBlobUrl, setPlayhtmlBlobUrl] = useState<string | null>(null);
+  // The built workspace module is encoded as a self-contained data URL so
+  // the opaque sandbox can import it without reaching into the parent page.
+  const [playhtmlModuleUrl, setPlayhtmlModuleUrl] = useState<string | null>(null);
 
   useEffect(() => {
-    const blob = new Blob([playhtmlSource], { type: "application/javascript" });
-    const url = URL.createObjectURL(blob);
-    setPlayhtmlBlobUrl(url);
-    return () => {
-      URL.revokeObjectURL(url);
-    };
+    setPlayhtmlModuleUrl(makePlayhtmlModuleUrl());
   }, []);
 
   // (Re)mount the iframe whenever source, roomId, reloadNonce, or the
-  // playhtml blob URL changes. We replace the iframe element entirely so
+  // PlayHTML module URL changes. We replace the iframe element entirely so
   // the old playhtml provider tears down cleanly (per spec §4.9).
   useEffect(() => {
     if (!containerRef.current) return;
-    if (!playhtmlBlobUrl) return; // Wait for blob URL on first mount
+    if (!playhtmlModuleUrl) return;
 
     const iframe = document.createElement("iframe");
     // Sandbox: scripts + popups only, no allow-same-origin. Per spec §4.2
@@ -67,7 +47,7 @@ export function Preview(props: PreviewProps) {
 
     iframe.srcdoc = buildIframeSrcdoc({
       recipeHtml: source,
-      playhtmlUrl: playhtmlBlobUrl,
+      playhtmlUrl: playhtmlModuleUrl,
       roomId,
     });
 
@@ -79,7 +59,7 @@ export function Preview(props: PreviewProps) {
       // Remove iframe on unmount (StrictMode double-invoke or component unmount)
       iframe.remove();
     };
-  }, [source, roomId, reloadNonce, playhtmlBlobUrl]);
+  }, [source, roomId, reloadNonce, playhtmlModuleUrl]);
 
   return (
     <div className="ph-preview-pane">

--- a/apps/docs/src/components/playground/RecipeCodeTabs.astro
+++ b/apps/docs/src/components/playground/RecipeCodeTabs.astro
@@ -17,6 +17,10 @@ type Props = {
 const { recipe } = Astro.props;
 const playgroundParams = new URLSearchParams({ id: recipe.id });
 const playgroundHref = `/docs/play/#${playgroundParams}`;
+const codeThemes = {
+  light: "github-light",
+  dark: "github-dark",
+} as const;
 ---
 
 <section class="ph-recipe-code">
@@ -35,14 +39,13 @@ const playgroundHref = `/docs/play/#${playgroundParams}`;
       <p class="ph-recipe-code__action">
         <LinkButton href={playgroundHref}>Open Vanilla HTML in playground</LinkButton>
       </p>
-      <div class="ph-recipe-code__file">
-        <span class="ph-recipe-code__filename">index.html</span>
-        <Code
-          code={recipe.html}
-          lang="html"
-          class="ph-recipe-code__block"
-        />
-      </div>
+      <Code
+        code={recipe.html}
+        lang="html"
+        themes={codeThemes}
+        defaultColor="light"
+        class="ph-recipe-code__block"
+      />
     </TabItem>
 
     <TabItem label="React">
@@ -50,18 +53,19 @@ const playgroundHref = `/docs/play/#${playgroundParams}`;
         Start with a React + TypeScript project, install the packages below,
         then replace <code>src/App.tsx</code> with the component.
       </p>
-      <div class="ph-recipe-code__file">
-        <span class="ph-recipe-code__filename">Terminal</span>
-        <Code code={recipe.react.install} lang="shell" />
-      </div>
-      <div class="ph-recipe-code__file">
-        <span class="ph-recipe-code__filename">src/App.tsx</span>
-        <Code
-          code={recipe.react.code}
-          lang="tsx"
-          class="ph-recipe-code__block"
-        />
-      </div>
+      <Code
+        code={recipe.react.install}
+        lang="shell"
+        themes={codeThemes}
+        defaultColor="light"
+      />
+      <Code
+        code={recipe.react.code}
+        lang="tsx"
+        themes={codeThemes}
+        defaultColor="light"
+        class="ph-recipe-code__block"
+      />
     </TabItem>
   </Tabs>
 </section>
@@ -73,30 +77,6 @@ const playgroundHref = `/docs/play/#${playgroundParams}`;
 
   .ph-recipe-code__action {
     margin-block: 1rem;
-  }
-
-  .ph-recipe-code__file {
-    margin-block: 1rem;
-  }
-
-  .ph-recipe-code__filename {
-    display: block;
-    width: fit-content;
-    padding: 0.35rem 0.65rem;
-    color: var(--ph-ink-2);
-    background: var(--ph-paper-warm);
-    border: 1px solid var(--ph-ink);
-    border-bottom: 0;
-    border-radius: 4px 4px 0 0;
-    font-family: var(--ph-font-mono);
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-  }
-
-  :global(.ph-recipe-code__file .astro-code) {
-    margin-top: 0;
   }
 
   :global(.ph-recipe-code__block) {

--- a/apps/docs/src/components/playground/RecipeCodeTabs.astro
+++ b/apps/docs/src/components/playground/RecipeCodeTabs.astro
@@ -1,0 +1,106 @@
+---
+// ABOUTME: Renders complete Vanilla HTML and React implementations for a docs recipe.
+// ABOUTME: Keeps framework tabs, copyable code, setup notes, and vanilla playground links uniform.
+
+import {
+  LinkButton,
+  TabItem,
+  Tabs,
+} from "@astrojs/starlight/components";
+import { Code } from "astro:components";
+import type { ExampleRecipe } from "./recipes/types";
+
+type Props = {
+  recipe: ExampleRecipe;
+};
+
+const { recipe } = Astro.props;
+const playgroundParams = new URLSearchParams({ id: recipe.id });
+const playgroundHref = `/docs/play/#${playgroundParams}`;
+---
+
+<section class="ph-recipe-code">
+  <h2>Copy the code</h2>
+  <p>
+    Both versions use the same shared data and behavior. The live playground
+    runs the Vanilla HTML version.
+  </p>
+
+  <Tabs syncKey="framework">
+    <TabItem label="Vanilla HTML">
+      <p>
+        Save this as <code>index.html</code>, or open it in the playground to
+        test and change it.
+      </p>
+      <p class="ph-recipe-code__action">
+        <LinkButton href={playgroundHref}>Open Vanilla HTML in playground</LinkButton>
+      </p>
+      <div class="ph-recipe-code__file">
+        <span class="ph-recipe-code__filename">index.html</span>
+        <Code
+          code={recipe.html}
+          lang="html"
+          class="ph-recipe-code__block"
+        />
+      </div>
+    </TabItem>
+
+    <TabItem label="React">
+      <p>
+        Start with a React + TypeScript project, install the packages below,
+        then replace <code>src/App.tsx</code> with the component.
+      </p>
+      <div class="ph-recipe-code__file">
+        <span class="ph-recipe-code__filename">Terminal</span>
+        <Code code={recipe.react.install} lang="shell" />
+      </div>
+      <div class="ph-recipe-code__file">
+        <span class="ph-recipe-code__filename">src/App.tsx</span>
+        <Code
+          code={recipe.react.code}
+          lang="tsx"
+          class="ph-recipe-code__block"
+        />
+      </div>
+    </TabItem>
+  </Tabs>
+</section>
+
+<style>
+  .ph-recipe-code {
+    margin-block: 2rem;
+  }
+
+  .ph-recipe-code__action {
+    margin-block: 1rem;
+  }
+
+  .ph-recipe-code__file {
+    margin-block: 1rem;
+  }
+
+  .ph-recipe-code__filename {
+    display: block;
+    width: fit-content;
+    padding: 0.35rem 0.65rem;
+    color: var(--ph-ink-2);
+    background: var(--ph-paper-warm);
+    border: 1px solid var(--ph-ink);
+    border-bottom: 0;
+    border-radius: 4px 4px 0 0;
+    font-family: var(--ph-font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  :global(.ph-recipe-code__file .astro-code) {
+    margin-top: 0;
+  }
+
+  :global(.ph-recipe-code__block) {
+    max-height: min(70vh, 42rem);
+    overflow: auto;
+  }
+</style>

--- a/apps/docs/src/components/playground/RecipeCodeTabs.astro
+++ b/apps/docs/src/components/playground/RecipeCodeTabs.astro
@@ -37,7 +37,7 @@ const codeThemes = {
         test and change it.
       </p>
       <p class="ph-recipe-code__action">
-        <LinkButton href={playgroundHref}>Open Vanilla HTML in playground</LinkButton>
+        <LinkButton href={playgroundHref}>Remix</LinkButton>
       </p>
       <Code
         code={recipe.html}

--- a/apps/docs/src/components/playground/RecipeExample.tsx
+++ b/apps/docs/src/components/playground/RecipeExample.tsx
@@ -1,0 +1,97 @@
+// ABOUTME: Renders a canonical docs recipe in a shared-room iframe with testing controls.
+// ABOUTME: Reuses the same recipe source that powers catalogue cards and the playground.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { buildIframeSrcdoc } from "./iframe-template";
+import { makePlayhtmlModuleUrl } from "./playhtml-module";
+import type { ExampleRecipe } from "./recipes/types";
+import "./recipe-example.css";
+
+type RecipeExampleProps = {
+  recipe: ExampleRecipe;
+};
+
+function makeRoomId(recipeId: string): string {
+  return `example-${recipeId}-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
+}
+
+export function RecipeExample({ recipe }: RecipeExampleProps) {
+  const iframeHostRef = useRef<HTMLDivElement | null>(null);
+  const [roomId, setRoomId] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const existingRoom = url.searchParams.get("room");
+    const nextRoom = existingRoom || makeRoomId(recipe.id);
+
+    if (!existingRoom) {
+      url.searchParams.set("room", nextRoom);
+      history.replaceState(null, "", url);
+    }
+
+    setRoomId(nextRoom);
+  }, [recipe.id]);
+
+  useEffect(() => {
+    if (!roomId || !iframeHostRef.current) return;
+
+    const playhtmlUrl = makePlayhtmlModuleUrl();
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("sandbox", "allow-scripts allow-popups");
+    iframe.title = `${recipe.title} live example`;
+    iframe.srcdoc = buildIframeSrcdoc({
+      recipeHtml: recipe.html,
+      playhtmlUrl,
+      roomId,
+      showDevPanel: false,
+    });
+
+    iframeHostRef.current.replaceChildren(iframe);
+
+    return () => {
+      iframe.remove();
+    };
+  }, [recipe, roomId]);
+
+  const playgroundHref = useMemo(() => {
+    if (!roomId) return "/docs/play/";
+    const hash = new URLSearchParams({ id: recipe.id, room: roomId });
+    return `/docs/play/#${hash}`;
+  }, [recipe.id, roomId]);
+
+  async function copyTestLink() {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      window.prompt("Copy this URL, then paste it into a private window:", window.location.href);
+    }
+  }
+
+  return (
+    <section className="ph-recipe-example" aria-label={`${recipe.title} interactive example`}>
+      <div className="ph-recipe-example__bar">
+        <span>Live example</span>
+        <span className="ph-recipe-example__room">Room {roomId || "connecting…"}</span>
+      </div>
+      <div className="ph-recipe-example__frame" ref={iframeHostRef} />
+      <div className="ph-recipe-example__actions">
+        <a className="ph-recipe-example__button" href={playgroundHref} target="_blank" rel="noreferrer">
+          Open code in playground
+        </a>
+        <button className="ph-recipe-example__button ph-recipe-example__button--quiet" type="button" onClick={copyTestLink}>
+          {copied ? "Copied test link" : "Copy private-window link"}
+        </button>
+      </div>
+      <div className="ph-recipe-example__test">
+        <strong>Test it with another person</strong>
+        <ol>
+          <li>Keep this page open in your normal window.</li>
+          <li>Copy the private-window link, then paste it into a private or incognito window.</li>
+          <li>Interact in either window and watch the other one update.</li>
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/apps/docs/src/components/playground/RecipeExample.tsx
+++ b/apps/docs/src/components/playground/RecipeExample.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { buildIframeSrcdoc } from "./iframe-template";
 import { makePlayhtmlModuleUrl } from "./playhtml-module";
+import { isValidRoomId } from "./recipe-loader";
 import type { ExampleRecipe } from "./recipes/types";
 import "./recipe-example.css";
 
@@ -22,9 +23,12 @@ export function RecipeExample({ recipe }: RecipeExampleProps) {
   useEffect(() => {
     const url = new URL(window.location.href);
     const existingRoom = url.searchParams.get("room");
-    const nextRoom = existingRoom || makeRoomId(recipe.id);
+    const nextRoom =
+      existingRoom && isValidRoomId(existingRoom)
+        ? existingRoom
+        : makeRoomId(recipe.id);
 
-    if (!existingRoom) {
+    if (existingRoom !== nextRoom) {
       url.searchParams.set("room", nextRoom);
       history.replaceState(null, "", url);
     }

--- a/apps/docs/src/components/playground/RecipeExample.tsx
+++ b/apps/docs/src/components/playground/RecipeExample.tsx
@@ -82,7 +82,7 @@ export function RecipeExample({ recipe }: RecipeExampleProps) {
       <div className="ph-recipe-example__frame" ref={iframeHostRef} />
       <div className="ph-recipe-example__actions">
         <a className="ph-recipe-example__button" href={playgroundHref} target="_blank" rel="noreferrer">
-          Open code in playground
+          Remix
         </a>
         <button className="ph-recipe-example__button ph-recipe-example__button--quiet" type="button" onClick={copyTestLink}>
           {copied ? "Copied test link" : "Copy private-window link"}

--- a/apps/docs/src/components/playground/__tests__/iframe-template.test.ts
+++ b/apps/docs/src/components/playground/__tests__/iframe-template.test.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Verifies recipe iframes receive the requested room and panel behavior.
+// ABOUTME: Protects the shared wrapper used by full playground and inline docs embeds.
+import { describe, expect, it } from "vitest";
+import { buildIframeSrcdoc } from "../iframe-template";
+
+const recipeHtml = "<!doctype html><html><head><title>Test</title></head><body></body></html>";
+
+describe("buildIframeSrcdoc", () => {
+  it("injects the shared room and hides development chrome for docs embeds", () => {
+    const result = buildIframeSrcdoc({
+      recipeHtml,
+      playhtmlUrl: "blob:test",
+      roomId: "example-test-abcd1234",
+      showDevPanel: false,
+    });
+
+    expect(result).toContain('const FORCED_ROOM = "example-test-abcd1234"');
+    expect(result).toContain("#playhtml-dev-root { display: none !important; }");
+    expect(result).toContain('for (const storageName of ["localStorage", "sessionStorage"])');
+    expect(result).toContain("makeMemoryStorage()");
+    expect(result).not.toContain("trigger.click()");
+  });
+
+  it("opens the development panel in the playground", () => {
+    const result = buildIframeSrcdoc({
+      recipeHtml,
+      playhtmlUrl: "blob:test",
+      roomId: "edit-test-abcd1234",
+    });
+
+    expect(result).toContain("trigger.click()");
+    expect(result).toContain('root.dataset.position = "bottom"');
+  });
+});

--- a/apps/docs/src/components/playground/__tests__/iframe-template.test.ts
+++ b/apps/docs/src/components/playground/__tests__/iframe-template.test.ts
@@ -31,4 +31,15 @@ describe("buildIframeSrcdoc", () => {
     expect(result).toContain("trigger.click()");
     expect(result).toContain('root.dataset.position = "bottom"');
   });
+
+  it("escapes room ids before embedding them in an inline script", () => {
+    const result = buildIframeSrcdoc({
+      recipeHtml,
+      playhtmlUrl: "blob:test",
+      roomId: '</script><script>window.injected = true</script>',
+    });
+
+    expect(result).not.toContain('</script><script>window.injected');
+    expect(result).toContain('\\u003c/script>\\u003cscript>window.injected');
+  });
 });

--- a/apps/docs/src/components/playground/__tests__/playhtml-module.test.ts
+++ b/apps/docs/src/components/playground/__tests__/playhtml-module.test.ts
@@ -1,0 +1,15 @@
+// ABOUTME: Verifies the sandbox module is self-contained before recipe frames import it.
+// ABOUTME: Prevents built PlayHTML chunks from retaining unusable relative imports.
+import { describe, expect, it } from "vitest";
+import { makePlayhtmlModuleUrl } from "../playhtml-module";
+
+describe("makePlayhtmlModuleUrl", () => {
+  it("inlines the leaf editor dependency into a data URL", () => {
+    const moduleUrl = makePlayhtmlModuleUrl();
+    const source = atob(moduleUrl.slice(moduleUrl.indexOf(",") + 1));
+
+    expect(moduleUrl).toMatch(/^data:text\/javascript;base64,/);
+    expect(source).not.toContain('"./leafEditor.es.js"');
+    expect(source).toContain('from "data:text/javascript;base64,');
+  });
+});

--- a/apps/docs/src/components/playground/__tests__/recipe-loader.test.ts
+++ b/apps/docs/src/components/playground/__tests__/recipe-loader.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Verifies canonical playground recipes and explicit shared rooms load from hashes.
+// ABOUTME: Guards fallback behavior so broken example links never produce an empty editor.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseHash } from "../recipe-loader";
+import type { RunnableRecipe } from "../recipes/types";
+
+const starter: RunnableRecipe = { id: "_starter", html: "<p>starter</p>" };
+const sound: RunnableRecipe = { id: "synchronized-sound", html: "<p>sound</p>" };
+
+function findRecipe(id: string): RunnableRecipe | undefined {
+  return [starter, sound].find((recipe) => recipe.id === id);
+}
+
+describe("parseHash", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("loads a canonical example into an explicit shared room", () => {
+    const loaded = parseHash(
+      "#id=synchronized-sound&room=example-synchronized-sound-1234abcd",
+      findRecipe,
+      starter,
+    );
+
+    expect(loaded).toEqual({
+      recipeId: "synchronized-sound",
+      source: "<p>sound</p>",
+      roomId: "example-synchronized-sound-1234abcd",
+      fromPayload: false,
+    });
+  });
+
+  it("falls back when a recipe id is unknown", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const loaded = parseHash("#id=missing", findRecipe, starter);
+
+    expect(loaded.recipeId).toBe("_starter");
+    expect(loaded.source).toBe(starter.html);
+    expect(loaded.roomId).toMatch(/^edit-_starter-/);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("rejects malformed room ids", () => {
+    const loaded = parseHash(
+      "#id=synchronized-sound&room=../../not-a-room",
+      findRecipe,
+      starter,
+    );
+
+    expect(loaded.roomId).toMatch(/^edit-synchronized-sound-/);
+  });
+});

--- a/apps/docs/src/components/playground/__tests__/recipe-loader.test.ts
+++ b/apps/docs/src/components/playground/__tests__/recipe-loader.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Verifies canonical playground recipes and explicit shared rooms load from hashes.
 // ABOUTME: Guards fallback behavior so broken example links never produce an empty editor.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { parseHash } from "../recipe-loader";
+import { isValidRoomId, parseHash } from "../recipe-loader";
 import type { RunnableRecipe } from "../recipes/types";
 
 const starter: RunnableRecipe = { id: "_starter", html: "<p>starter</p>" };
@@ -48,5 +48,12 @@ describe("parseHash", () => {
     );
 
     expect(loaded.roomId).toMatch(/^edit-synchronized-sound-/);
+  });
+});
+
+describe("isValidRoomId", () => {
+  it("accepts generated room ids and rejects inline-script content", () => {
+    expect(isValidRoomId("example-shared-audio-file-a1b2c3d4")).toBe(true);
+    expect(isValidRoomId('</script><script>alert(1)</script>')).toBe(false);
   });
 });

--- a/apps/docs/src/components/playground/iframe-template.ts
+++ b/apps/docs/src/components/playground/iframe-template.ts
@@ -104,6 +104,7 @@ export function buildIframeSrcdoc(args: IframeTemplateArgs): string {
   panelStyles.textContent = "#playhtml-dev-root { display: none !important; }";
   document.head.append(panelStyles);`;
 
+  const serializedRoomId = JSON.stringify(roomId).replaceAll("<", "\\u003c");
   const bootstrap = `
 <script type="importmap">
 {
@@ -143,7 +144,7 @@ export function buildIframeSrcdoc(args: IframeTemplateArgs): string {
   // record resolves. With a static import the patch lands BEFORE the
   // recipe's call to playhtml.init runs.
   import { playhtml } from "playhtml";
-  const FORCED_ROOM = ${JSON.stringify(roomId)};
+  const FORCED_ROOM = ${serializedRoomId};
   const originalInit = playhtml.init;
   playhtml.init = function patchedInit(opts) {
     return originalInit.call(this, { ...(opts ?? {}), room: FORCED_ROOM });

--- a/apps/docs/src/components/playground/iframe-template.ts
+++ b/apps/docs/src/components/playground/iframe-template.ts
@@ -1,15 +1,15 @@
-// ABOUTME: Builds the srcdoc HTML wrapper for a playground iframe — injects
-// ABOUTME: importmap, dev panel bottom-position bootstrap, and base CSS reset.
+// ABOUTME: Builds the srcdoc wrapper used by playground and docs example iframes.
+// ABOUTME: Injects the playhtml import, shared room, and optional development panel.
 
 export type IframeTemplateArgs = {
   /** Recipe source. Must be a complete <!doctype html> document. */
   recipeHtml: string;
-  /** Resolved playhtml URL (currently always unpkg; the workspace dev shim
-      is bypassed because Astro's dev server blocks cross-origin subresource
-      requests from sandboxed iframes that lack `allow-same-origin`). */
+  /** Self-contained URL for the built PlayHTML module. */
   playhtmlUrl: string;
   /** Room id the iframe's playhtml should join. */
   roomId: string;
+  /** Whether the playground development panel should open below the recipe. */
+  showDevPanel?: boolean;
 };
 
 // Inlined dev-panel-bottom CSS. Originally lived as a separate stylesheet at
@@ -65,11 +65,10 @@ const DEV_PANEL_BOTTOM_CSS = `
  *   2. Inline <style> with dev-panel-bottom override CSS (inlined to avoid
  *      Astro dev-server cross-origin block on sandboxed iframe subresources).
  *   3. A small bootstrap script that overrides playhtml.init's room option
- *      AND sets data-position="bottom" on the dev panel root (and clicks
- *      the trigger to auto-open it) once playhtml mounts.
+ *      and configures the development panel for the current surface.
  */
 export function buildIframeSrcdoc(args: IframeTemplateArgs): string {
-  const { recipeHtml, playhtmlUrl, roomId } = args;
+  const { recipeHtml, playhtmlUrl, roomId, showDevPanel = true } = args;
 
   // The recipe's <script type="module"> calls `playhtml.init({...})`. We
   // need to override that init's `room` option so the iframe joins the
@@ -79,36 +78,8 @@ export function buildIframeSrcdoc(args: IframeTemplateArgs): string {
   //
   // We also run a MutationObserver to catch the dev panel root the moment
   // playhtml mounts it, set data-position, and auto-open it.
-  const bootstrap = `
-<script type="importmap">
-{
-  "imports": {
-    "playhtml": ${JSON.stringify(playhtmlUrl)}
-  }
-}
-</script>
-<style>${DEV_PANEL_BOTTOM_CSS}</style>
-<script type="module">
-  // Monkey-patch playhtml.init to inject our roomId. Static import (not
-  // dynamic) so the bootstrap's body runs before the recipe's <script
-  // type="module"> body — both modules await the same playhtml import,
-  // but document order determines which body runs first once the module
-  // record resolves. With a static import the patch lands BEFORE the
-  // recipe's call to playhtml.init runs.
-  import { playhtml } from "playhtml";
-  const FORCED_ROOM = ${JSON.stringify(roomId)};
-  const originalInit = playhtml.init;
-  playhtml.init = function patchedInit(opts) {
-    return originalInit.call(this, { ...(opts ?? {}), room: FORCED_ROOM });
-  };
-
-  // Watch for the dev panel to mount. When the root appears, set
-  // data-position="bottom" so the consumer CSS layout kicks in, then
-  // wait for the trigger button to render and click it to auto-open.
-  // The two phases need to be separate because in setupDevUI() the root
-  // is created first, then the trigger is appended, then the bar is
-  // appended — between the root mount and the trigger mount we'd miss
-  // the click target if we tried to do both in one tick.
+  const developmentPanelBootstrap = showDevPanel
+    ? `
   let positioned = false;
   let opened = false;
   const obs = new MutationObserver(() => {
@@ -127,7 +98,58 @@ export function buildIframeSrcdoc(args: IframeTemplateArgs): string {
       }
     }
   });
-  obs.observe(document.documentElement, { childList: true, subtree: true });
+  obs.observe(document.documentElement, { childList: true, subtree: true });`
+    : `
+  const panelStyles = document.createElement("style");
+  panelStyles.textContent = "#playhtml-dev-root { display: none !important; }";
+  document.head.append(panelStyles);`;
+
+  const bootstrap = `
+<script type="importmap">
+{
+  "imports": {
+    "playhtml": ${JSON.stringify(playhtmlUrl)}
+  }
+}
+</script>
+<style>${DEV_PANEL_BOTTOM_CSS}</style>
+<script>
+  function makeMemoryStorage() {
+    const values = new Map();
+    return {
+      get length() { return values.size; },
+      clear() { values.clear(); },
+      getItem(key) { return values.has(String(key)) ? values.get(String(key)) : null; },
+      key(index) { return Array.from(values.keys())[index] ?? null; },
+      removeItem(key) { values.delete(String(key)); },
+      setItem(key, value) { values.set(String(key), String(value)); },
+    };
+  }
+
+  for (const storageName of ["localStorage", "sessionStorage"]) {
+    try {
+      window[storageName].length;
+    } catch {
+      Object.defineProperty(window, storageName, { value: makeMemoryStorage() });
+    }
+  }
+
+</script>
+<script type="module">
+  // Monkey-patch playhtml.init to inject our roomId. Static import (not
+  // dynamic) so the bootstrap's body runs before the recipe's <script
+  // type="module"> body — both modules await the same playhtml import,
+  // but document order determines which body runs first once the module
+  // record resolves. With a static import the patch lands BEFORE the
+  // recipe's call to playhtml.init runs.
+  import { playhtml } from "playhtml";
+  const FORCED_ROOM = ${JSON.stringify(roomId)};
+  const originalInit = playhtml.init;
+  playhtml.init = function patchedInit(opts) {
+    return originalInit.call(this, { ...(opts ?? {}), room: FORCED_ROOM });
+  };
+
+  ${developmentPanelBootstrap}
 </script>
 `;
 

--- a/apps/docs/src/components/playground/playhtml-module.ts
+++ b/apps/docs/src/components/playground/playhtml-module.ts
@@ -1,0 +1,28 @@
+// ABOUTME: Builds a self-contained PlayHTML module URL for sandboxed recipe iframes.
+// ABOUTME: Inlines the bundle's relative leaf-editor import before data URL encoding.
+import playhtmlSource from "../../../../../packages/playhtml/dist/playhtml.es.js?raw";
+import leafEditorSource from "../../../../../packages/playhtml/dist/leafEditor.es.js?raw";
+
+function makeModuleDataUrl(source: string): string {
+  const bytes = new TextEncoder().encode(source);
+  let binary = "";
+  const chunkSize = 32_768;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return `data:text/javascript;base64,${btoa(binary)}`;
+}
+
+export function makePlayhtmlModuleUrl(): string {
+  const leafEditorUrl = makeModuleDataUrl(leafEditorSource);
+  const bundledSource = playhtmlSource.replace(
+    '"./leafEditor.es.js"',
+    JSON.stringify(leafEditorUrl),
+  );
+
+  if (bundledSource === playhtmlSource) {
+    throw new Error("PlayHTML bundle is missing its expected leaf editor import");
+  }
+
+  return makeModuleDataUrl(bundledSource);
+}

--- a/apps/docs/src/components/playground/recipe-example.css
+++ b/apps/docs/src/components/playground/recipe-example.css
@@ -1,0 +1,116 @@
+/* ABOUTME: Styles canonical recipe embeds and their multi-window testing controls. */
+/* ABOUTME: Uses the docs palette so runnable examples feel native to Starlight pages. */
+
+.ph-recipe-example {
+  margin: 1.5rem 0 2rem;
+  border: 1px solid var(--ph-ink, #1c1c1c);
+  background: var(--ph-paper, #f4efe5);
+  box-shadow: 4px 4px 0 var(--ph-ink, #1c1c1c);
+  color: var(--ph-ink, #1c1c1c);
+}
+
+.ph-recipe-example__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.85rem;
+  border-bottom: 1px solid var(--ph-ink, #1c1c1c);
+  background: var(--ph-sage, #c3d1b7);
+  font-family: var(--ph-font-display, ui-sans-serif, system-ui, sans-serif);
+  font-weight: 700;
+}
+
+.ph-recipe-example__room {
+  overflow: hidden;
+  color: var(--ph-ink-3, #6a6a66);
+  font-family: var(--ph-font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ph-recipe-example__frame {
+  height: min(68vh, 34rem);
+  min-height: 24rem;
+  background: #fff;
+}
+
+.ph-recipe-example__frame iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+}
+
+.ph-recipe-example__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border-top: 1px solid var(--ph-hairline, rgba(28, 28, 28, 0.18));
+  background: var(--ph-paper-warm, #ebe4d5);
+}
+
+.ph-recipe-example__button {
+  appearance: none;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--ph-ink, #1c1c1c);
+  border-radius: 0;
+  background: var(--ph-mustard, #e8a63a);
+  box-shadow: 2px 2px 0 var(--ph-ink, #1c1c1c);
+  color: var(--ph-ink, #1c1c1c) !important;
+  cursor: pointer;
+  font: 700 0.82rem/1.2 var(--ph-font-body, ui-sans-serif, system-ui, sans-serif);
+  text-decoration: none !important;
+}
+
+.ph-recipe-example__button:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 3px 3px 0 var(--ph-ink, #1c1c1c);
+}
+
+.ph-recipe-example__button:active {
+  transform: translate(2px, 2px);
+  box-shadow: none;
+}
+
+.ph-recipe-example__button--quiet {
+  background: var(--ph-paper, #f4efe5);
+}
+
+.ph-recipe-example__test {
+  padding: 0.9rem 1rem 0.75rem;
+  border-top: 1px solid var(--ph-hairline, rgba(28, 28, 28, 0.18));
+  background: var(--ph-ultramarine-wash, rgba(39, 75, 158, 0.08));
+  font-size: 0.86rem;
+}
+
+.ph-recipe-example__test strong {
+  font-family: var(--ph-font-display, ui-sans-serif, system-ui, sans-serif);
+}
+
+.ph-recipe-example__test ol {
+  margin: 0.45rem 0 0 1.15rem;
+  padding: 0;
+}
+
+.ph-recipe-example__test li + li {
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 40rem) {
+  .ph-recipe-example__bar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .ph-recipe-example__frame {
+    height: 34rem;
+  }
+
+  .ph-recipe-example__room {
+    max-width: 100%;
+  }
+}

--- a/apps/docs/src/components/playground/recipe-loader.ts
+++ b/apps/docs/src/components/playground/recipe-loader.ts
@@ -1,9 +1,10 @@
 // ABOUTME: URL-hash <-> editor state, lz-string remix encoding, and localStorage
 // ABOUTME: management for editor room ids and source drafts.
 import LZString from "lz-string";
+import type { RunnableRecipe } from "./recipes/types";
 
 export type LoadedRecipe = {
-  /** Base recipe id (e.g. "_starter" or in Phase 2: "toggle-basic"). */
+  /** Base recipe id (e.g. "_starter" or "synchronized-sound"). */
   recipeId: string;
   /** Current source code in the editor. */
   source: string;
@@ -53,16 +54,17 @@ export function getEditorRoomId(recipeId: string): string {
 
 /**
  * Parse the current URL hash and resolve to the recipe to load. Falls back
- * to the starter when no recognized hash is present.
+ * to the provided default when no recognized hash is present.
  *
  * Hash forms:
- *   (empty)            → starter
- *   #id=<recipe>       → canonical recipe (Phase 2; in Phase 1 only "_starter" is recognized)
+ *   (empty)            → fallback recipe
+ *   #id=<recipe>       → canonical recipe
  *   #c=<lz-payload>    → remix payload
  */
 export function parseHash(
   hash: string,
-  starterSource: string,
+  findRecipe: (id: string) => RunnableRecipe | undefined,
+  fallbackRecipe: RunnableRecipe,
 ): LoadedRecipe {
   const stripped = hash.startsWith("#") ? hash.slice(1) : hash;
   const params = new URLSearchParams(stripped);
@@ -78,29 +80,35 @@ export function parseHash(
         fromPayload: true,
       };
     }
-    // Malformed payload — fall through to starter
+    // Malformed payload — fall through to the canonical default.
   }
 
-  const id = params.get("id");
-  if (id === "_starter" || id === null || id === "") {
+  const requestedId = params.get("id") || fallbackRecipe.id;
+  const recipe = findRecipe(requestedId);
+  if (recipe) {
     return {
-      recipeId: "_starter",
-      source: starterSource,
-      roomId: getEditorRoomId("_starter"),
+      recipeId: recipe.id,
+      source: recipe.html,
+      roomId: getRequestedRoomId(params) || getEditorRoomId(recipe.id),
       fromPayload: false,
     };
   }
 
-  // Phase 2 will add canonical-recipe lookup here. In Phase 1, an unknown
-  // id falls back to the starter (with a console warning so the dev
-  // notices).
-  console.warn(`[playground] Unknown recipe id "${id}" — falling back to starter.`);
+  console.warn(
+    `[playground] Unknown recipe id "${requestedId}" — falling back to ${fallbackRecipe.id}.`,
+  );
   return {
-    recipeId: "_starter",
-    source: starterSource,
-    roomId: getEditorRoomId("_starter"),
+    recipeId: fallbackRecipe.id,
+    source: fallbackRecipe.html,
+    roomId: getRequestedRoomId(params) || getEditorRoomId(fallbackRecipe.id),
     fromPayload: false,
   };
+}
+
+function getRequestedRoomId(params: URLSearchParams): string | null {
+  const room = params.get("room");
+  if (!room) return null;
+  return /^[a-zA-Z0-9:_-]{1,120}$/.test(room) ? room : null;
 }
 
 /**

--- a/apps/docs/src/components/playground/recipe-loader.ts
+++ b/apps/docs/src/components/playground/recipe-loader.ts
@@ -108,7 +108,11 @@ export function parseHash(
 function getRequestedRoomId(params: URLSearchParams): string | null {
   const room = params.get("room");
   if (!room) return null;
-  return /^[a-zA-Z0-9:_-]{1,120}$/.test(room) ? room : null;
+  return isValidRoomId(room) ? room : null;
+}
+
+export function isValidRoomId(roomId: string): boolean {
+  return /^[a-zA-Z0-9:_-]{1,120}$/.test(roomId);
 }
 
 /**

--- a/apps/docs/src/components/playground/recipes/__tests__/matter-physics.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/matter-physics.test.ts
@@ -1,0 +1,50 @@
+// ABOUTME: Checks the canonical Matter.js recipe's shared-state safety invariants.
+// ABOUTME: Guards its stable element setup, keyed data, throttling, and controller model.
+
+import { describe, expect, it } from "vitest";
+import { matterPhysicsRecipe } from "../matter-physics";
+
+describe("matter physics recipe", () => {
+  it("is a complete canonical recipe", () => {
+    expect(matterPhysicsRecipe.id).toBe("matter-physics");
+    expect(matterPhysicsRecipe.docsHref).toBe(
+      "/docs/examples/matter-physics/",
+    );
+    expect(matterPhysicsRecipe.html).toMatch(/^<!doctype html>/);
+    expect(matterPhysicsRecipe.html).toContain(
+      'id="physics-world" can-play',
+    );
+    expect(matterPhysicsRecipe.html).toContain(
+      'from "https://esm.sh/matter-js@0.20.0"',
+    );
+  });
+
+  it("configures the can-play element before initialization", () => {
+    const source = matterPhysicsRecipe.html;
+    const configPosition = source.indexOf("worldElement.defaultData =");
+    const updatePosition = source.indexOf("worldElement.updateElement =");
+    const mountPosition = source.indexOf("worldElement.onMount =");
+    const initPosition = source.indexOf("await playhtml.init(");
+
+    expect(configPosition).toBeGreaterThan(-1);
+    expect(updatePosition).toBeGreaterThan(configPosition);
+    expect(mountPosition).toBeGreaterThan(updatePosition);
+    expect(initPosition).toBeGreaterThan(mountPosition);
+  });
+
+  it("uses one controller and bounded, throttled keyed writes", () => {
+    const source = matterPhysicsRecipe.html;
+
+    expect(source).toContain("const SYNC_INTERVAL_MS = 100;");
+    expect(source).toContain("draft.controllerId !== CLIENT_ID");
+    expect(source).toContain("draft.bodies[id].x = transform.x;");
+    expect(source).toContain("Math.max(BODY_SIZE / 2");
+    expect(source).toContain("resetLocalBodies();");
+
+    const updateBody = source.slice(
+      source.indexOf("worldElement.updateElement ="),
+      source.indexOf("worldElement.onMount ="),
+    );
+    expect(updateBody).not.toContain("setData");
+  });
+});

--- a/apps/docs/src/components/playground/recipes/__tests__/shared-audio-file.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/shared-audio-file.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Verifies the shared audio-file recipe uses a real file and safe writes.
+// ABOUTME: Guards the local audio permission and shared transport boundaries.
+import { describe, expect, it } from "vitest";
+import { sharedAudioFileRecipe } from "../shared-audio-file";
+
+describe("sharedAudioFileRecipe", () => {
+  it("is a complete canonical recipe backed by an audio file", () => {
+    expect(sharedAudioFileRecipe.id).toBe("shared-audio-file");
+    expect(sharedAudioFileRecipe.docsHref).toBe(
+      "/docs/examples/shared-audio-file/",
+    );
+    expect(sharedAudioFileRecipe.html).toContain(
+      'id="shared-audio-player" class="player" can-play',
+    );
+    expect(sharedAudioFileRecipe.html).toContain("<audio");
+    expect(sharedAudioFileRecipe.html).toContain("t-rex-roar.mp3");
+  });
+
+  it("configures the element before playhtml initializes", () => {
+    const source = sharedAudioFileRecipe.html;
+    const initIndex = source.indexOf("await playhtml.init");
+
+    expect(source.indexOf("player.defaultData")).toBeLessThan(initIndex);
+    expect(source.indexOf("player.updateElement")).toBeLessThan(initIndex);
+    expect(source.indexOf("player.onClick")).toBeLessThan(initIndex);
+    expect(source.indexOf("player.onMount")).toBeLessThan(initIndex);
+  });
+
+  it("writes shared data only from explicit controls", () => {
+    const source = sharedAudioFileRecipe.html;
+    const updateStart = source.indexOf("player.updateElement");
+    const clickStart = source.indexOf("player.onClick");
+    const mountStart = source.indexOf("player.onMount");
+    const initStart = source.indexOf("await playhtml.init");
+
+    expect(source.slice(updateStart, clickStart)).not.toContain("setData(");
+    expect(source.slice(mountStart, initStart)).not.toContain("setData(");
+    expect(source.slice(clickStart, mountStart).match(/setData\(/g)).toHaveLength(2);
+  });
+});

--- a/apps/docs/src/components/playground/recipes/__tests__/synchronized-sound.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/synchronized-sound.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Verifies the synchronized-sound recipe keeps its collaboration boundaries intact.
+// ABOUTME: Guards autoplay, event, timeline, and config-before-init requirements in source.
+import { describe, expect, it } from "vitest";
+import { synchronizedSoundRecipe } from "../synchronized-sound";
+
+describe("synchronizedSoundRecipe", () => {
+  it("is a complete canonical recipe", () => {
+    expect(synchronizedSoundRecipe.id).toBe("synchronized-sound");
+    expect(synchronizedSoundRecipe.docsHref).toBe(
+      "/docs/examples/synchronized-sound/",
+    );
+    expect(synchronizedSoundRecipe.html).toContain("<!doctype html>");
+    expect(synchronizedSoundRecipe.html).toContain(
+      'id="sound-transport" can-play',
+    );
+  });
+
+  it("configures the stable element before playhtml initializes", () => {
+    const source = synchronizedSoundRecipe.html;
+    const initIndex = source.indexOf("await playhtml.init");
+
+    expect(source.indexOf("soundTransport.defaultData")).toBeLessThan(initIndex);
+    expect(source.indexOf("soundTransport.updateElement")).toBeLessThan(
+      initIndex,
+    );
+    expect(source.indexOf("soundTransport.onClick")).toBeLessThan(initIndex);
+    expect(source.indexOf("soundTransport.onMount")).toBeLessThan(initIndex);
+  });
+
+  it("uses an event for cues and shared wall-clock data for the transport", () => {
+    const source = synchronizedSoundRecipe.html;
+
+    expect(source).toContain("playhtml.dispatchPlayEvent");
+    expect(source).toContain("synchronized-sound-cue");
+    expect(source).toContain("startedAtMs");
+    expect(source).toContain("Date.now()");
+    expect(source).toContain("window.AudioContext");
+    expect(source).not.toMatch(/<audio|\.mp3|\.wav|\.ogg/i);
+  });
+
+  it("never writes shared data from render or scheduling callbacks", () => {
+    const source = synchronizedSoundRecipe.html;
+    const updateStart = source.indexOf("soundTransport.updateElement");
+    const clickStart = source.indexOf("soundTransport.onClick");
+    const mountStart = source.indexOf("soundTransport.onMount");
+    const initStart = source.indexOf("await playhtml.init");
+
+    expect(source.slice(updateStart, clickStart)).not.toContain("setData(");
+    expect(source.slice(mountStart, initStart)).not.toContain("setData(");
+    expect(source.slice(clickStart, mountStart).match(/setData\(/g)).toHaveLength(2);
+  });
+});

--- a/apps/docs/src/components/playground/recipes/_starter.ts
+++ b/apps/docs/src/components/playground/recipes/_starter.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Single-file HTML starter loaded by bare /play. Showcase of the
 // ABOUTME: most-used playhtml capabilities, designed for "see the range, keep what you want."
+import type { RunnableRecipe } from "./types";
 
 // Images are pulled from the live playhtml.fun deployment.
 // Why: the iframe is sandboxed without allow-same-origin (spec §4.2,
@@ -14,7 +15,7 @@
 // copies because that's the URL that works inside the sandboxed iframe.
 const IMG_BASE = "https://playhtml.fun/playground-starter";
 
-export const starterRecipe: { id: string; html: string } = {
+export const starterRecipe: RunnableRecipe = {
   id: "_starter",
   html: `<!doctype html>
 <html lang="en">

--- a/apps/docs/src/components/playground/recipes/index.ts
+++ b/apps/docs/src/components/playground/recipes/index.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Registers every canonical example available in the docs and playground.
+// ABOUTME: Exposes metadata without HTML for the searchable examples catalogue.
+import { starterRecipe } from "./_starter";
+import { matterPhysicsRecipe } from "./matter-physics";
+import { sharedAudioFileRecipe } from "./shared-audio-file";
+import { synchronizedSoundRecipe } from "./synchronized-sound";
+import type { ExampleRecipeSummary, RunnableRecipe } from "./types";
+
+export const exampleRecipes = [
+  sharedAudioFileRecipe,
+  synchronizedSoundRecipe,
+  matterPhysicsRecipe,
+];
+export const playableRecipes: readonly RunnableRecipe[] = [starterRecipe, ...exampleRecipes];
+
+export const exampleRecipeSummaries: ExampleRecipeSummary[] = exampleRecipes.map(
+  ({ html: _html, ...summary }) => summary,
+);
+
+export function getPlayableRecipe(id: string): RunnableRecipe | undefined {
+  return playableRecipes.find((recipe) => recipe.id === id);
+}

--- a/apps/docs/src/components/playground/recipes/index.ts
+++ b/apps/docs/src/components/playground/recipes/index.ts
@@ -14,7 +14,7 @@ export const exampleRecipes = [
 export const playableRecipes: readonly RunnableRecipe[] = [starterRecipe, ...exampleRecipes];
 
 export const exampleRecipeSummaries: ExampleRecipeSummary[] = exampleRecipes.map(
-  ({ html: _html, ...summary }) => summary,
+  ({ html: _html, react: _react, ...summary }) => summary,
 );
 
 export function getPlayableRecipe(id: string): RunnableRecipe | undefined {

--- a/apps/docs/src/components/playground/recipes/matter-physics.ts
+++ b/apps/docs/src/components/playground/recipes/matter-physics.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Keeps one browser in control while remote browsers interpolate shared transforms.
 
 import type { ExampleRecipe } from "./types";
+import { matterPhysicsReactSource } from "./react/matter-physics";
 
 export const matterPhysicsRecipe: ExampleRecipe = {
   id: "matter-physics",
@@ -12,6 +13,12 @@ export const matterPhysicsRecipe: ExampleRecipe = {
   capabilities: ["can-play"],
   difficulty: "advanced",
   docsHref: "/docs/examples/matter-physics/",
+  react: {
+    install:
+      "npm install playhtml @playhtml/react matter-js\n" +
+      "npm install --save-dev @types/matter-js",
+    code: matterPhysicsReactSource,
+  },
   html: `<!doctype html>
 <html lang="en">
 <head>

--- a/apps/docs/src/components/playground/recipes/matter-physics.ts
+++ b/apps/docs/src/components/playground/recipes/matter-physics.ts
@@ -1,0 +1,500 @@
+// ABOUTME: Defines the canonical collaborative Matter.js physics recipe.
+// ABOUTME: Keeps one browser in control while remote browsers interpolate shared transforms.
+
+import type { ExampleRecipe } from "./types";
+
+export const matterPhysicsRecipe: ExampleRecipe = {
+  id: "matter-physics",
+  title: "Shared Matter.js physics",
+  description:
+    "Drag, drop, add, and reset a small set of physics bodies shared across browsers.",
+  tags: ["physics", "Matter.js", "dragging", "multiplayer"],
+  capabilities: ["can-play"],
+  difficulty: "advanced",
+  docsHref: "/docs/examples/matter-physics/",
+  html: `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Shared Matter.js physics</title>
+  <style>
+    :root {
+      color: #3d3833;
+      background: #f7f3ea;
+      font-family: system-ui, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      min-width: 320px;
+      margin: 0;
+      padding: clamp(16px, 4vw, 36px);
+    }
+
+    main {
+      width: min(720px, 100%);
+      margin: 0 auto;
+    }
+
+    header {
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 14px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(30px, 7vw, 56px);
+      letter-spacing: -0.05em;
+      line-height: 0.95;
+    }
+
+    header p {
+      max-width: 260px;
+      margin: 0;
+      color: #6b6560;
+      font-family: ui-monospace, monospace;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 10px;
+    }
+
+    button {
+      border: 2px solid #3d3833;
+      border-radius: 999px;
+      padding: 8px 14px;
+      color: #3d3833;
+      background: #fffdf8;
+      font: 700 13px/1 ui-monospace, monospace;
+      cursor: pointer;
+    }
+
+    button:hover:not(:disabled) { background: #ffe95c; }
+    button:disabled { cursor: default; opacity: 0.45; }
+
+    #physics-status {
+      margin-left: auto;
+      color: #6b6560;
+      font: 12px/1.3 ui-monospace, monospace;
+    }
+
+    #physics-world {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 10;
+      overflow: hidden;
+      border: 2px solid #3d3833;
+      border-radius: 18px;
+      touch-action: none;
+      user-select: none;
+      background:
+        linear-gradient(rgba(61, 56, 51, 0.08) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(61, 56, 51, 0.08) 1px, transparent 1px),
+        #dff6ef;
+      background-size: 32px 32px;
+    }
+
+    #physics-world::after {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      height: 14px;
+      background: #3d3833;
+      content: "";
+    }
+
+    .body {
+      position: absolute;
+      top: 0;
+      left: 0;
+      display: grid;
+      width: 76px;
+      height: 76px;
+      place-items: center;
+      border: 2px solid #3d3833;
+      border-radius: 16px;
+      padding: 0;
+      color: #3d3833;
+      box-shadow: 0 5px 0 rgba(61, 56, 51, 0.18);
+      cursor: grab;
+      font: 700 18px/1 ui-monospace, monospace;
+      transform-origin: center;
+      will-change: transform;
+    }
+
+    .body:active { cursor: grabbing; }
+    .body:nth-child(3n + 1) { background: #ff8fa3; }
+    .body:nth-child(3n + 2) { background: #ffe95c; }
+    .body:nth-child(3n) { background: #8ed8ff; }
+
+    .note {
+      margin: 10px 4px 0;
+      color: #6b6560;
+      font-size: 13px;
+    }
+
+    @media (max-width: 560px) {
+      header { display: block; }
+      header p { margin-top: 8px; }
+      #physics-status { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Shared physics</h1>
+      <p>Drag a block, then let go. Its Matter.js motion syncs to everyone.</p>
+    </header>
+
+    <div class="toolbar">
+      <button id="add-body" type="button" disabled>Add body</button>
+      <button id="reset-bodies" type="button" disabled>Reset</button>
+      <span id="physics-status" role="status">Joining room…</span>
+    </div>
+
+    <div id="physics-world" can-play aria-label="Shared physics world"></div>
+    <p class="note">The last person to interact controls the simulation.</p>
+  </main>
+
+  <script type="module">
+    import Matter from "https://esm.sh/matter-js@0.20.0";
+    import { playhtml } from "playhtml";
+
+    const { Bodies, Body, Composite, Engine, Sleeping } = Matter;
+    const WORLD_WIDTH = 640;
+    const WORLD_HEIGHT = 400;
+    const BODY_SIZE = 76;
+    const SYNC_INTERVAL_MS = 100;
+    const POSITION_THRESHOLD = 0.5;
+    const ANGLE_THRESHOLD = 0.01;
+    const MAX_BODIES = 6;
+    const CLIENT_ID = crypto.randomUUID();
+
+    const INITIAL_BODIES = {
+      "body-a": { x: 245, y: 320, angle: 0 },
+      "body-b": { x: 320, y: 220, angle: 0.08 },
+      "body-c": { x: 395, y: 320, angle: 0 },
+    };
+
+    const worldElement = document.getElementById("physics-world");
+    const addButton = document.getElementById("add-body");
+    const resetButton = document.getElementById("reset-bodies");
+    const statusElement = document.getElementById("physics-status");
+
+    if (!worldElement || !addButton || !resetButton || !statusElement) {
+      throw new Error("The physics recipe is missing required elements");
+    }
+
+    const engine = Engine.create({ enableSleeping: true });
+    const bodies = new Map();
+    const bodyElements = new Map();
+    const remoteTargets = new Map();
+    let getData;
+    let setData;
+    let controlsWorld = false;
+    let draggedBody = null;
+    let dragPointerId = null;
+    let dragOffset = { x: 0, y: 0 };
+    let lastFrameAt = 0;
+    let lastSyncAt = 0;
+    let lastPublished = {};
+
+    const boundaryOptions = { isStatic: true, friction: 1, restitution: 0 };
+    Composite.add(engine.world, [
+      Bodies.rectangle(WORLD_WIDTH / 2, WORLD_HEIGHT + 20, WORLD_WIDTH + 80, 50, boundaryOptions),
+      Bodies.rectangle(-20, WORLD_HEIGHT / 2, 40, WORLD_HEIGHT * 2, boundaryOptions),
+      Bodies.rectangle(WORLD_WIDTH + 20, WORLD_HEIGHT / 2, 40, WORLD_HEIGHT * 2, boundaryOptions),
+      Bodies.rectangle(WORLD_WIDTH / 2, -20, WORLD_WIDTH + 80, 40, boundaryOptions),
+    ]);
+
+    function validateData(data) {
+      if (!data || typeof data !== "object" || !data.bodies || typeof data.bodies !== "object") {
+        throw new Error("Shared physics requires a keyed bodies object");
+      }
+      if (typeof data.controllerId !== "string") {
+        throw new Error("Shared physics requires a controllerId string");
+      }
+    }
+
+    function createBody(id, transform) {
+      const body = Bodies.rectangle(transform.x, transform.y, BODY_SIZE, BODY_SIZE, {
+        angle: transform.angle,
+        friction: 0.8,
+        frictionAir: 0.025,
+        restitution: 0.15,
+        sleepThreshold: 35,
+        label: id,
+      });
+      const element = document.createElement("button");
+      element.type = "button";
+      element.id = "physics-" + id;
+      element.className = "body";
+      element.dataset.bodyId = id;
+      element.setAttribute("aria-label", "Physics body " + id);
+      element.textContent = String(bodyElements.size + 1);
+
+      bodies.set(id, body);
+      bodyElements.set(id, element);
+      worldElement.appendChild(element);
+      Composite.add(engine.world, body);
+      return body;
+    }
+
+    function removeBody(id) {
+      const body = bodies.get(id);
+      if (body) Composite.remove(engine.world, body);
+      bodies.delete(id);
+      remoteTargets.delete(id);
+      bodyElements.get(id)?.remove();
+      bodyElements.delete(id);
+    }
+
+    function setControlMode(shouldControl) {
+      if (controlsWorld === shouldControl) return;
+      controlsWorld = shouldControl;
+      lastPublished = {};
+
+      for (const body of bodies.values()) {
+        if (body === draggedBody) continue;
+        Body.setStatic(body, !shouldControl);
+        if (shouldControl) Sleeping.set(body, false);
+      }
+
+      statusElement.textContent = shouldControl ? "You control the simulation" : "Watching shared motion";
+    }
+
+    function applySharedState(data) {
+      validateData(data);
+      const sharedIds = new Set(Object.keys(data.bodies));
+
+      for (const id of bodies.keys()) {
+        if (!sharedIds.has(id)) removeBody(id);
+      }
+
+      for (const [id, transform] of Object.entries(data.bodies)) {
+        if (!bodies.has(id)) createBody(id, transform);
+        remoteTargets.set(id, transform);
+      }
+
+      setControlMode(data.controllerId === CLIENT_ID);
+      addButton.disabled = sharedIds.size >= MAX_BODIES;
+      resetButton.disabled = false;
+    }
+
+    function claimControl() {
+      setControlMode(true);
+      setData((draft) => {
+        draft.controllerId = CLIENT_ID;
+      });
+    }
+
+    function pointInWorld(event) {
+      const rect = worldElement.getBoundingClientRect();
+      return {
+        x: ((event.clientX - rect.left) / rect.width) * WORLD_WIDTH,
+        y: ((event.clientY - rect.top) / rect.height) * WORLD_HEIGHT,
+      };
+    }
+
+    function handlePointerDown(event) {
+      const element = event.target.closest("[data-body-id]");
+      if (!element) return;
+      const body = bodies.get(element.dataset.bodyId);
+      if (!body) return;
+
+      event.preventDefault();
+      claimControl();
+      const point = pointInWorld(event);
+      draggedBody = body;
+      dragPointerId = event.pointerId;
+      dragOffset = {
+        x: body.position.x - point.x,
+        y: body.position.y - point.y,
+      };
+      Body.setStatic(body, true);
+      worldElement.setPointerCapture(event.pointerId);
+    }
+
+    function handlePointerMove(event) {
+      if (!draggedBody || event.pointerId !== dragPointerId) return;
+      const point = pointInWorld(event);
+      Body.setPosition(draggedBody, {
+        x: Math.max(BODY_SIZE / 2, Math.min(WORLD_WIDTH - BODY_SIZE / 2, point.x + dragOffset.x)),
+        y: Math.max(BODY_SIZE / 2, Math.min(WORLD_HEIGHT - BODY_SIZE / 2, point.y + dragOffset.y)),
+      });
+    }
+
+    function handlePointerUp(event) {
+      if (!draggedBody || event.pointerId !== dragPointerId) return;
+      Body.setStatic(draggedBody, false);
+      Body.setVelocity(draggedBody, { x: 0, y: 0 });
+      Sleeping.set(draggedBody, false);
+      draggedBody = null;
+      dragPointerId = null;
+      if (worldElement.hasPointerCapture(event.pointerId)) {
+        worldElement.releasePointerCapture(event.pointerId);
+      }
+      publishTransforms(performance.now(), true);
+    }
+
+    function addBody() {
+      const data = getData();
+      validateData(data);
+      if (Object.keys(data.bodies).length >= MAX_BODIES) return;
+
+      const id = "body-" + crypto.randomUUID();
+      setControlMode(true);
+      setData((draft) => {
+        draft.controllerId = CLIENT_ID;
+        draft.bodies[id] = { x: WORLD_WIDTH / 2, y: 70, angle: 0 };
+      });
+    }
+
+    function resetLocalBodies() {
+      for (const id of [...bodies.keys()]) {
+        if (!INITIAL_BODIES[id]) removeBody(id);
+      }
+
+      for (const [id, transform] of Object.entries(INITIAL_BODIES)) {
+        const body = bodies.get(id) || createBody(id, transform);
+        Body.setPosition(body, { x: transform.x, y: transform.y });
+        Body.setAngle(body, transform.angle);
+        Body.setVelocity(body, { x: 0, y: 0 });
+        Body.setAngularVelocity(body, 0);
+        Sleeping.set(body, false);
+      }
+      lastPublished = {};
+    }
+
+    function resetBodies() {
+      setControlMode(true);
+      resetLocalBodies();
+      setData((draft) => {
+        draft.controllerId = CLIENT_ID;
+        for (const id of Object.keys(draft.bodies)) delete draft.bodies[id];
+        for (const [id, transform] of Object.entries(INITIAL_BODIES)) {
+          draft.bodies[id] = { ...transform };
+        }
+      });
+    }
+
+    function boundedTransform(body) {
+      return {
+        x: Math.round(Math.max(BODY_SIZE / 2, Math.min(WORLD_WIDTH - BODY_SIZE / 2, body.position.x)) * 10) / 10,
+        y: Math.round(Math.max(BODY_SIZE / 2, Math.min(WORLD_HEIGHT - BODY_SIZE / 2, body.position.y)) * 10) / 10,
+        angle: Math.round(body.angle * 1000) / 1000,
+      };
+    }
+
+    function transformChanged(next, previous) {
+      return !previous ||
+        Math.abs(next.x - previous.x) >= POSITION_THRESHOLD ||
+        Math.abs(next.y - previous.y) >= POSITION_THRESHOLD ||
+        Math.abs(next.angle - previous.angle) >= ANGLE_THRESHOLD;
+    }
+
+    function publishTransforms(now, force = false) {
+      if (!controlsWorld || (!force && now - lastSyncAt < SYNC_INTERVAL_MS)) return;
+      const current = Object.fromEntries(
+        [...bodies].map(([id, body]) => [id, boundedTransform(body)]),
+      );
+      const changed = Object.entries(current).filter(
+        ([id, transform]) => transformChanged(transform, lastPublished[id]),
+      );
+      if (changed.length === 0) return;
+
+      setData((draft) => {
+        if (draft.controllerId !== CLIENT_ID) return;
+        for (const [id, transform] of changed) {
+          if (!draft.bodies[id]) continue;
+          draft.bodies[id].x = transform.x;
+          draft.bodies[id].y = transform.y;
+          draft.bodies[id].angle = transform.angle;
+        }
+      });
+      lastPublished = current;
+      lastSyncAt = now;
+    }
+
+    function interpolateRemoteBodies() {
+      for (const [id, target] of remoteTargets) {
+        const body = bodies.get(id);
+        if (!body) continue;
+        Body.setPosition(body, {
+          x: body.position.x + (target.x - body.position.x) * 0.22,
+          y: body.position.y + (target.y - body.position.y) * 0.22,
+        });
+        Body.setAngle(body, body.angle + (target.angle - body.angle) * 0.22);
+      }
+    }
+
+    function render() {
+      const rect = worldElement.getBoundingClientRect();
+      const scaleX = rect.width / WORLD_WIDTH;
+      const scaleY = rect.height / WORLD_HEIGHT;
+      for (const [id, body] of bodies) {
+        const element = bodyElements.get(id);
+        const width = BODY_SIZE * scaleX;
+        const height = BODY_SIZE * scaleY;
+        element.style.width = width + "px";
+        element.style.height = height + "px";
+        element.style.transform =
+          "translate(" +
+          (body.position.x * scaleX - width / 2) + "px, " +
+          (body.position.y * scaleY - height / 2) + "px) rotate(" +
+          body.angle + "rad)";
+      }
+    }
+
+    function animate(now) {
+      const delta = lastFrameAt ? Math.min(now - lastFrameAt, 32) : 1000 / 60;
+      lastFrameAt = now;
+
+      if (controlsWorld) {
+        Engine.update(engine, delta);
+        const isMoving = draggedBody || [...bodies.values()].some((body) => !body.isSleeping);
+        if (isMoving) publishTransforms(now);
+      } else {
+        interpolateRemoteBodies();
+      }
+
+      render();
+      requestAnimationFrame(animate);
+    }
+
+    worldElement.defaultData = {
+      controllerId: "",
+      bodies: structuredClone(INITIAL_BODIES),
+    };
+    worldElement.updateElement = ({ data }) => applySharedState(data);
+    worldElement.onMount = (context) => {
+      getData = context.getData;
+      setData = context.setData;
+      statusElement.textContent = "Watching shared motion";
+    };
+
+    worldElement.addEventListener("pointerdown", handlePointerDown);
+    worldElement.addEventListener("pointermove", handlePointerMove);
+    worldElement.addEventListener("pointerup", handlePointerUp);
+    worldElement.addEventListener("pointercancel", handlePointerUp);
+    addButton.addEventListener("click", addBody);
+    resetButton.addEventListener("click", resetBodies);
+    requestAnimationFrame(animate);
+
+    await playhtml.init({ developmentMode: true });
+  </script>
+</body>
+</html>`,
+};

--- a/apps/docs/src/components/playground/recipes/react/__tests__/matter-physics.test.ts
+++ b/apps/docs/src/components/playground/recipes/react/__tests__/matter-physics.test.ts
@@ -1,0 +1,78 @@
+// ABOUTME: Verifies the copy-paste React Matter.js recipe parses and preserves sync boundaries.
+// ABOUTME: Guards its provider, stable element, controller, and throttled keyed writes.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import { matterPhysicsReactSource } from "../matter-physics";
+
+describe("React Matter.js physics source", () => {
+  it("is a syntactically valid, complete App.tsx snippet", () => {
+    const result = ts.transpileModule(matterPhysicsReactSource, {
+      compilerOptions: {
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+      reportDiagnostics: true,
+    });
+    const errors = (result.diagnostics ?? []).filter(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+    );
+
+    expect(errors).toEqual([]);
+    expect(matterPhysicsReactSource).toContain(
+      'from "@playhtml/react"',
+    );
+    expect(matterPhysicsReactSource).toContain("<PlayProvider");
+    expect(matterPhysicsReactSource).toContain(
+      'id: "shared-physics-world"',
+    );
+    expect(matterPhysicsReactSource).toContain(
+      'id="shared-physics-world"',
+    );
+  });
+
+  it("keeps one controller and throttles bounded keyed writes", () => {
+    expect(matterPhysicsReactSource).toContain(
+      "const SYNC_INTERVAL_MS = 100;",
+    );
+    expect(matterPhysicsReactSource).toContain(
+      "draft.controllerId !== clientIdRef.current",
+    );
+    expect(matterPhysicsReactSource).toContain(
+      "draft.bodies[id].x = transform.x;",
+    );
+    expect(matterPhysicsReactSource).toContain(
+      "Math.min(WORLD_WIDTH - BODY_SIZE / 2",
+    );
+    expect(matterPhysicsReactSource).toContain(
+      "interpolateRemoteBodies();",
+    );
+  });
+
+  it("writes from controls or the authority animation callback", () => {
+    const reconcileStart = matterPhysicsReactSource.indexOf(
+      "useEffect(() => {\n      const sharedIds",
+    );
+    const controllerEffectStart = matterPhysicsReactSource.indexOf(
+      "useEffect(() => {\n      setControlMode",
+    );
+    const animationEffectStart = matterPhysicsReactSource.indexOf(
+      "useEffect(() => {\n      let animationFrame",
+    );
+    const renderStart = matterPhysicsReactSource.indexOf(
+      "const controlsWorld =",
+    );
+
+    expect(reconcileStart).toBeGreaterThan(-1);
+    expect(controllerEffectStart).toBeGreaterThan(reconcileStart);
+    expect(animationEffectStart).toBeGreaterThan(controllerEffectStart);
+    expect(renderStart).toBeGreaterThan(animationEffectStart);
+    expect(
+      matterPhysicsReactSource.slice(reconcileStart, controllerEffectStart),
+    ).not.toContain("setData(");
+    expect(
+      matterPhysicsReactSource.slice(animationEffectStart, renderStart),
+    ).not.toContain("setData(");
+  });
+});

--- a/apps/docs/src/components/playground/recipes/react/__tests__/sound-recipes.test.ts
+++ b/apps/docs/src/components/playground/recipes/react/__tests__/sound-recipes.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Verifies both copy-paste React sound examples keep their sync boundaries.
+// ABOUTME: Guards provider usage, stable ids, event wiring, and explicit shared writes.
+import { describe, expect, it } from "vitest";
+import { sharedAudioFileReactSource } from "../shared-audio-file";
+import { synchronizedSoundReactSource } from "../synchronized-sound";
+
+describe("React sound recipe sources", () => {
+  it.each([
+    ["shared audio file", sharedAudioFileReactSource],
+    ["synchronized sound", synchronizedSoundReactSource],
+  ])("provides a complete %s app", (_name, source) => {
+    expect(source).toContain('from "@playhtml/react"');
+    expect(source).toContain("<PlayProvider");
+    expect(source).toContain("withSharedState<TransportData>");
+    expect(source).toContain("defaultData:");
+    expect(source).toContain("export default function App()");
+    expect(source).toContain("<style>");
+  });
+
+  it("keeps audio-file writes in named click handlers", () => {
+    const source = sharedAudioFileReactSource;
+    const effectStart = source.indexOf("useEffect(() =>");
+    const enableStart = source.indexOf("async function enableAudio");
+    const toggleStart = source.indexOf("function togglePlayback");
+    const renderStart = source.indexOf("const progress =");
+
+    expect(source.slice(effectStart, enableStart)).not.toContain("setData(");
+    expect(source.slice(toggleStart, renderStart).match(/setData\(/g)).toHaveLength(
+      2,
+    );
+    expect(source).toContain('id: "shared-audio-player"');
+    expect(source).toContain('id="shared-audio-player"');
+  });
+
+  it("uses context events and user handlers in the generated-sound app", () => {
+    const source = synchronizedSoundReactSource;
+    const firstEffect = source.indexOf("useEffect(() =>");
+    const enableStart = source.indexOf("async function enableAudio");
+    const toggleStart = source.indexOf("function toggleTransport");
+    const renderStart = source.indexOf("const activeStep =");
+
+    expect(source).toContain("usePlayContext()");
+    expect(source).toContain("registerPlayEventListener(CUE_EVENT");
+    expect(source).toContain("removePlayEventListener(CUE_EVENT");
+    expect(source).toContain("dispatchPlayEvent({ type: CUE_EVENT })");
+    expect(source.slice(firstEffect, enableStart)).not.toContain("setData(");
+    expect(source.slice(toggleStart, renderStart).match(/setData\(/g)).toHaveLength(
+      2,
+    );
+    expect(source).toContain('id: "sound-transport"');
+    expect(source).toContain('id="sound-transport"');
+    expect(source).not.toMatch(/<audio(?:\s|>)|\.mp3|\.wav|\.ogg/i);
+  });
+});

--- a/apps/docs/src/components/playground/recipes/react/__tests__/sound-recipes.test.ts
+++ b/apps/docs/src/components/playground/recipes/react/__tests__/sound-recipes.test.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Verifies both copy-paste React sound examples keep their sync boundaries.
 // ABOUTME: Guards provider usage, stable ids, event wiring, and explicit shared writes.
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 import { sharedAudioFileReactSource } from "../shared-audio-file";
 import { synchronizedSoundReactSource } from "../synchronized-sound";
@@ -9,6 +10,19 @@ describe("React sound recipe sources", () => {
     ["shared audio file", sharedAudioFileReactSource],
     ["synchronized sound", synchronizedSoundReactSource],
   ])("provides a complete %s app", (_name, source) => {
+    const result = ts.transpileModule(source, {
+      compilerOptions: {
+        jsx: ts.JsxEmit.ReactJSX,
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+      },
+      reportDiagnostics: true,
+    });
+    const errors = (result.diagnostics ?? []).filter(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+    );
+
+    expect(errors).toEqual([]);
     expect(source).toContain('from "@playhtml/react"');
     expect(source).toContain("<PlayProvider");
     expect(source).toContain("withSharedState<TransportData>");

--- a/apps/docs/src/components/playground/recipes/react/matter-physics.ts
+++ b/apps/docs/src/components/playground/recipes/react/matter-physics.ts
@@ -1,0 +1,626 @@
+// ABOUTME: Exports the copy-paste React source for the collaborative Matter.js recipe.
+// ABOUTME: Keeps the complete App.tsx example available to Starlight code blocks.
+
+export const matterPhysicsReactSource = `// ABOUTME: Runs one shared Matter.js world through PlayHTML's React bindings.
+// ABOUTME: Lets one browser simulate while remote browsers interpolate shared transforms.
+// npm install react react-dom playhtml @playhtml/react matter-js
+// npm install --save-dev typescript @types/react @types/react-dom @types/matter-js
+
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type Ref,
+} from "react";
+import Matter from "matter-js";
+import { PlayProvider, withSharedState } from "@playhtml/react";
+
+type Transform = {
+  x: number;
+  y: number;
+  angle: number;
+};
+
+type PhysicsData = {
+  controllerId: string;
+  bodies: Record<string, Transform>;
+};
+
+const { Bodies, Body, Composite, Engine, Sleeping } = Matter;
+type PhysicsBody = ReturnType<typeof Bodies.rectangle>;
+
+const WORLD_WIDTH = 640;
+const WORLD_HEIGHT = 400;
+const BODY_SIZE = 76;
+const SYNC_INTERVAL_MS = 100;
+const POSITION_THRESHOLD = 0.5;
+const ANGLE_THRESHOLD = 0.01;
+const MAX_BODIES = 6;
+
+const INITIAL_BODIES: Record<string, Transform> = {
+  "body-a": { x: 245, y: 320, angle: 0 },
+  "body-b": { x: 320, y: 220, angle: 0.08 },
+  "body-c": { x: 395, y: 320, angle: 0 },
+};
+
+const STYLES = \`
+  :root {
+    color: #3d3833;
+    background: #f7f3ea;
+    font-family: system-ui, sans-serif;
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    min-width: 320px;
+    margin: 0;
+    padding: clamp(16px, 4vw, 36px);
+  }
+
+  .physics-app {
+    width: min(720px, 100%);
+    margin: 0 auto;
+  }
+
+  .physics-app header {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 14px;
+  }
+
+  .physics-app h1 {
+    margin: 0;
+    font-size: clamp(30px, 7vw, 56px);
+    letter-spacing: -0.05em;
+    line-height: 0.95;
+  }
+
+  .physics-app header p {
+    max-width: 260px;
+    margin: 0;
+    color: #6b6560;
+    font: 12px/1.5 ui-monospace, monospace;
+  }
+
+  .physics-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+  }
+
+  .physics-app button {
+    border: 2px solid #3d3833;
+    border-radius: 999px;
+    padding: 8px 14px;
+    color: #3d3833;
+    background: #fffdf8;
+    font: 700 13px/1 ui-monospace, monospace;
+    cursor: pointer;
+  }
+
+  .physics-app button:hover:not(:disabled) { background: #ffe95c; }
+  .physics-app button:disabled { cursor: default; opacity: 0.45; }
+
+  .physics-status {
+    margin-left: auto;
+    color: #6b6560;
+    font: 12px/1.3 ui-monospace, monospace;
+  }
+
+  .physics-world {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 10;
+    overflow: hidden;
+    border: 2px solid #3d3833;
+    border-radius: 18px;
+    touch-action: none;
+    user-select: none;
+    background:
+      linear-gradient(rgba(61, 56, 51, 0.08) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(61, 56, 51, 0.08) 1px, transparent 1px),
+      #dff6ef;
+    background-size: 32px 32px;
+  }
+
+  .physics-world::after {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 14px;
+    background: #3d3833;
+    content: "";
+  }
+
+  .physics-body {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    display: grid;
+    width: 76px;
+    height: 76px;
+    place-items: center;
+    border: 2px solid #3d3833;
+    border-radius: 16px;
+    padding: 0;
+    color: #3d3833;
+    box-shadow: 0 5px 0 rgba(61, 56, 51, 0.18);
+    cursor: grab;
+    font: 700 18px/1 ui-monospace, monospace;
+    transform-origin: center;
+    will-change: transform;
+  }
+
+  .physics-body:active { cursor: grabbing; }
+  .physics-body:nth-child(3n + 1) { background: #ff8fa3; }
+  .physics-body:nth-child(3n + 2) { background: #ffe95c; }
+  .physics-body:nth-child(3n) { background: #8ed8ff; }
+
+  .physics-note {
+    margin: 10px 4px 0;
+    color: #6b6560;
+    font-size: 13px;
+  }
+
+  @media (max-width: 560px) {
+    .physics-app header { display: block; }
+    .physics-app header p { margin-top: 8px; }
+    .physics-status { display: none; }
+  }
+\`;
+
+function createEngine() {
+  const engine = Engine.create({ enableSleeping: true });
+  const boundaryOptions = { isStatic: true, friction: 1, restitution: 0 };
+  Composite.add(engine.world, [
+    Bodies.rectangle(
+      WORLD_WIDTH / 2,
+      WORLD_HEIGHT + 20,
+      WORLD_WIDTH + 80,
+      50,
+      boundaryOptions,
+    ),
+    Bodies.rectangle(
+      -20,
+      WORLD_HEIGHT / 2,
+      40,
+      WORLD_HEIGHT * 2,
+      boundaryOptions,
+    ),
+    Bodies.rectangle(
+      WORLD_WIDTH + 20,
+      WORLD_HEIGHT / 2,
+      40,
+      WORLD_HEIGHT * 2,
+      boundaryOptions,
+    ),
+    Bodies.rectangle(
+      WORLD_WIDTH / 2,
+      -20,
+      WORLD_WIDTH + 80,
+      40,
+      boundaryOptions,
+    ),
+  ]);
+  return engine;
+}
+
+function createPhysicsBody(id: string, transform: Transform): PhysicsBody {
+  return Bodies.rectangle(
+    transform.x,
+    transform.y,
+    BODY_SIZE,
+    BODY_SIZE,
+    {
+      angle: transform.angle,
+      friction: 0.8,
+      frictionAir: 0.025,
+      restitution: 0.15,
+      sleepThreshold: 35,
+      label: id,
+    },
+  );
+}
+
+function boundedTransform(body: PhysicsBody): Transform {
+  return {
+    x:
+      Math.round(
+        Math.max(
+          BODY_SIZE / 2,
+          Math.min(WORLD_WIDTH - BODY_SIZE / 2, body.position.x),
+        ) * 10,
+      ) / 10,
+    y:
+      Math.round(
+        Math.max(
+          BODY_SIZE / 2,
+          Math.min(WORLD_HEIGHT - BODY_SIZE / 2, body.position.y),
+        ) * 10,
+      ) / 10,
+    angle: Math.round(body.angle * 1000) / 1000,
+  };
+}
+
+function transformChanged(
+  next: Transform,
+  previous: Transform | undefined,
+): boolean {
+  return (
+    !previous ||
+    Math.abs(next.x - previous.x) >= POSITION_THRESHOLD ||
+    Math.abs(next.y - previous.y) >= POSITION_THRESHOLD ||
+    Math.abs(next.angle - previous.angle) >= ANGLE_THRESHOLD
+  );
+}
+
+const SharedPhysics = withSharedState<PhysicsData>(
+  {
+    id: "shared-physics-world",
+    defaultData: {
+      controllerId: "",
+      bodies: structuredClone(INITIAL_BODIES),
+    },
+  },
+  ({ data, setData, ref }) => {
+    const clientIdRef = useRef("");
+    if (!clientIdRef.current) clientIdRef.current = crypto.randomUUID();
+
+    const engine = useMemo(createEngine, []);
+    const worldRef = useRef<HTMLDivElement | null>(null);
+    const bodiesRef = useRef(new Map<string, PhysicsBody>());
+    const bodyElementsRef = useRef(new Map<string, HTMLButtonElement>());
+    const remoteTargetsRef = useRef(new Map<string, Transform>());
+    const controlsWorldRef = useRef(false);
+    const draggedBodyRef = useRef<PhysicsBody | null>(null);
+    const dragPointerIdRef = useRef<number | null>(null);
+    const dragOffsetRef = useRef({ x: 0, y: 0 });
+    const lastFrameAtRef = useRef(0);
+    const lastSyncAtRef = useRef(0);
+    const lastPublishedRef = useRef<Record<string, Transform>>({});
+    const publishRef = useRef<(now: number, force?: boolean) => void>(() => {});
+
+    function removeLocalBody(id: string) {
+      const body = bodiesRef.current.get(id);
+      if (body) Composite.remove(engine.world, body);
+      bodiesRef.current.delete(id);
+      bodyElementsRef.current.delete(id);
+      remoteTargetsRef.current.delete(id);
+    }
+
+    function setControlMode(shouldControl: boolean) {
+      if (controlsWorldRef.current === shouldControl) return;
+      controlsWorldRef.current = shouldControl;
+      lastPublishedRef.current = {};
+
+      for (const body of bodiesRef.current.values()) {
+        if (body === draggedBodyRef.current) continue;
+        Body.setStatic(body, !shouldControl);
+        if (shouldControl) Sleeping.set(body, false);
+      }
+    }
+
+    useEffect(() => {
+      const sharedIds = new Set(Object.keys(data.bodies));
+
+      for (const id of bodiesRef.current.keys()) {
+        if (!sharedIds.has(id)) removeLocalBody(id);
+      }
+
+      for (const [id, transform] of Object.entries(data.bodies)) {
+        if (!bodiesRef.current.has(id)) {
+          const body = createPhysicsBody(id, transform);
+          bodiesRef.current.set(id, body);
+          Composite.add(engine.world, body);
+        }
+        remoteTargetsRef.current.set(id, { ...transform });
+      }
+    }, [data.bodies, engine]);
+
+    useEffect(() => {
+      setControlMode(data.controllerId === clientIdRef.current);
+    }, [data.controllerId]);
+
+    function claimControl() {
+      setControlMode(true);
+      setData((draft) => {
+        draft.controllerId = clientIdRef.current;
+      });
+    }
+
+    function pointInWorld(event: ReactPointerEvent<HTMLElement>) {
+      const world = worldRef.current;
+      if (!world) return null;
+      const rect = world.getBoundingClientRect();
+      return {
+        x: ((event.clientX - rect.left) / rect.width) * WORLD_WIDTH,
+        y: ((event.clientY - rect.top) / rect.height) * WORLD_HEIGHT,
+      };
+    }
+
+    function handlePointerDown(
+      event: ReactPointerEvent<HTMLButtonElement>,
+      id: string,
+    ) {
+      const body = bodiesRef.current.get(id);
+      const point = pointInWorld(event);
+      const world = worldRef.current;
+      if (!body || !point || !world) return;
+
+      event.preventDefault();
+      claimControl();
+      draggedBodyRef.current = body;
+      dragPointerIdRef.current = event.pointerId;
+      dragOffsetRef.current = {
+        x: body.position.x - point.x,
+        y: body.position.y - point.y,
+      };
+      Body.setStatic(body, true);
+      world.setPointerCapture(event.pointerId);
+    }
+
+    function handlePointerMove(event: ReactPointerEvent<HTMLElement>) {
+      const body = draggedBodyRef.current;
+      if (!body || event.pointerId !== dragPointerIdRef.current) return;
+      const point = pointInWorld(event);
+      if (!point) return;
+
+      Body.setPosition(body, {
+        x: Math.max(
+          BODY_SIZE / 2,
+          Math.min(
+            WORLD_WIDTH - BODY_SIZE / 2,
+            point.x + dragOffsetRef.current.x,
+          ),
+        ),
+        y: Math.max(
+          BODY_SIZE / 2,
+          Math.min(
+            WORLD_HEIGHT - BODY_SIZE / 2,
+            point.y + dragOffsetRef.current.y,
+          ),
+        ),
+      });
+    }
+
+    function handlePointerUp(event: ReactPointerEvent<HTMLElement>) {
+      const body = draggedBodyRef.current;
+      if (!body || event.pointerId !== dragPointerIdRef.current) return;
+
+      Body.setStatic(body, false);
+      Body.setVelocity(body, { x: 0, y: 0 });
+      Sleeping.set(body, false);
+      draggedBodyRef.current = null;
+      dragPointerIdRef.current = null;
+      if (worldRef.current?.hasPointerCapture(event.pointerId)) {
+        worldRef.current.releasePointerCapture(event.pointerId);
+      }
+      publishRef.current(performance.now(), true);
+    }
+
+    function addBody() {
+      if (Object.keys(data.bodies).length >= MAX_BODIES) return;
+      const id = "body-" + crypto.randomUUID();
+
+      setControlMode(true);
+      setData((draft) => {
+        draft.controllerId = clientIdRef.current;
+        draft.bodies[id] = { x: WORLD_WIDTH / 2, y: 70, angle: 0 };
+      });
+    }
+
+    function resetLocalBodies() {
+      for (const id of [...bodiesRef.current.keys()]) {
+        if (!INITIAL_BODIES[id]) removeLocalBody(id);
+      }
+
+      for (const [id, transform] of Object.entries(INITIAL_BODIES)) {
+        let body = bodiesRef.current.get(id);
+        if (!body) {
+          body = createPhysicsBody(id, transform);
+          bodiesRef.current.set(id, body);
+          Composite.add(engine.world, body);
+        }
+        Body.setPosition(body, { x: transform.x, y: transform.y });
+        Body.setAngle(body, transform.angle);
+        Body.setVelocity(body, { x: 0, y: 0 });
+        Body.setAngularVelocity(body, 0);
+        Sleeping.set(body, false);
+      }
+      lastPublishedRef.current = {};
+    }
+
+    function resetBodies() {
+      setControlMode(true);
+      resetLocalBodies();
+      setData((draft) => {
+        draft.controllerId = clientIdRef.current;
+        for (const id of Object.keys(draft.bodies)) delete draft.bodies[id];
+        for (const [id, transform] of Object.entries(INITIAL_BODIES)) {
+          draft.bodies[id] = { ...transform };
+        }
+      });
+    }
+
+    publishRef.current = (now, force = false) => {
+      if (
+        !controlsWorldRef.current ||
+        (!force && now - lastSyncAtRef.current < SYNC_INTERVAL_MS)
+      ) {
+        return;
+      }
+
+      const current = Object.fromEntries(
+        [...bodiesRef.current].map(([id, body]) => [
+          id,
+          boundedTransform(body),
+        ]),
+      );
+      const changed = Object.entries(current).filter(([id, transform]) =>
+        transformChanged(transform, lastPublishedRef.current[id]),
+      );
+      if (changed.length === 0) return;
+
+      setData((draft) => {
+        if (draft.controllerId !== clientIdRef.current) return;
+        for (const [id, transform] of changed) {
+          if (!draft.bodies[id]) continue;
+          draft.bodies[id].x = transform.x;
+          draft.bodies[id].y = transform.y;
+          draft.bodies[id].angle = transform.angle;
+        }
+      });
+      lastPublishedRef.current = current;
+      lastSyncAtRef.current = now;
+    };
+
+    useEffect(() => {
+      let animationFrame = 0;
+
+      function interpolateRemoteBodies() {
+        for (const [id, target] of remoteTargetsRef.current) {
+          const body = bodiesRef.current.get(id);
+          if (!body) continue;
+          Body.setPosition(body, {
+            x: body.position.x + (target.x - body.position.x) * 0.22,
+            y: body.position.y + (target.y - body.position.y) * 0.22,
+          });
+          Body.setAngle(
+            body,
+            body.angle + (target.angle - body.angle) * 0.22,
+          );
+        }
+      }
+
+      function renderBodies() {
+        const world = worldRef.current;
+        if (!world) return;
+        const rect = world.getBoundingClientRect();
+        const scaleX = rect.width / WORLD_WIDTH;
+        const scaleY = rect.height / WORLD_HEIGHT;
+
+        for (const [id, body] of bodiesRef.current) {
+          const element = bodyElementsRef.current.get(id);
+          if (!element) continue;
+          const width = BODY_SIZE * scaleX;
+          const height = BODY_SIZE * scaleY;
+          element.style.width = width + "px";
+          element.style.height = height + "px";
+          element.style.transform =
+            "translate(" +
+            (body.position.x * scaleX - width / 2) +
+            "px, " +
+            (body.position.y * scaleY - height / 2) +
+            "px) rotate(" +
+            body.angle +
+            "rad)";
+        }
+      }
+
+      function animate(now: number) {
+        const delta = lastFrameAtRef.current
+          ? Math.min(now - lastFrameAtRef.current, 32)
+          : 1000 / 60;
+        lastFrameAtRef.current = now;
+
+        if (controlsWorldRef.current) {
+          Engine.update(engine, delta);
+          const isMoving =
+            draggedBodyRef.current ||
+            [...bodiesRef.current.values()].some((body) => !body.isSleeping);
+          if (isMoving) publishRef.current(now);
+        } else {
+          interpolateRemoteBodies();
+        }
+
+        renderBodies();
+        animationFrame = requestAnimationFrame(animate);
+      }
+
+      animationFrame = requestAnimationFrame(animate);
+      return () => cancelAnimationFrame(animationFrame);
+    }, [engine]);
+
+    const controlsWorld = data.controllerId === clientIdRef.current;
+    const bodyIds = Object.keys(data.bodies);
+
+    return (
+      <section
+        id="shared-physics-world"
+        className="physics-app"
+        ref={ref as Ref<HTMLElement>}
+      >
+        <style>{STYLES}</style>
+        <header>
+          <h1>Shared physics</h1>
+          <p>Drag a block, then let go. Its Matter.js motion syncs to everyone.</p>
+        </header>
+
+        <div className="physics-toolbar">
+          <button
+            type="button"
+            onClick={addBody}
+            disabled={bodyIds.length >= MAX_BODIES}
+          >
+            Add body
+          </button>
+          <button type="button" onClick={resetBodies}>
+            Reset
+          </button>
+          <span className="physics-status" role="status">
+            {controlsWorld
+              ? "You control the simulation"
+              : "Watching shared motion"}
+          </span>
+        </div>
+
+        <div
+          ref={worldRef}
+          className="physics-world"
+          aria-label="Shared physics world"
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
+          {bodyIds.map((id, index) => (
+            <button
+              key={id}
+              id={"physics-" + id}
+              className="physics-body"
+              type="button"
+              data-body-id={id}
+              aria-label={"Physics body " + id}
+              onPointerDown={(event) => handlePointerDown(event, id)}
+              ref={(element) => {
+                if (element) bodyElementsRef.current.set(id, element);
+                else bodyElementsRef.current.delete(id);
+              }}
+            >
+              {index + 1}
+            </button>
+          ))}
+        </div>
+
+        <p className="physics-note">
+          The last person to interact controls the simulation.
+        </p>
+      </section>
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <PlayProvider initOptions={{ developmentMode: true }}>
+      <SharedPhysics />
+    </PlayProvider>
+  );
+}
+`;

--- a/apps/docs/src/components/playground/recipes/react/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/react/shared-audio-file.ts
@@ -1,0 +1,269 @@
+// ABOUTME: Provides the copy-paste React source for the shared audio-file example.
+// ABOUTME: Mirrors the vanilla recipe with local media playback and shared transport data.
+
+export const sharedAudioFileReactSource = `// ABOUTME: Keeps one audio file on a shared play, pause, and restart timeline.
+// ABOUTME: Loads and plays the media locally while PlayHTML syncs only transport data.
+import { useEffect, useRef, useState } from "react";
+import { PlayProvider, withSharedState } from "@playhtml/react";
+
+type TransportData = {
+  isPlaying: boolean;
+  startedAtMs: number;
+  positionMs: number;
+};
+
+const AUDIO_URL =
+  "https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3";
+
+function durationMs(audio: HTMLAudioElement | null): number {
+  return audio && Number.isFinite(audio.duration) ? audio.duration * 1000 : 2000;
+}
+
+function playbackPositionMs(
+  data: TransportData,
+  nowMs: number,
+  audio: HTMLAudioElement | null,
+): number {
+  const duration = durationMs(audio);
+  const elapsed = data.isPlaying ? nowMs - data.startedAtMs : data.positionMs;
+  return ((elapsed % duration) + duration) % duration;
+}
+
+const SharedAudioPlayer = withSharedState<TransportData>(
+  {
+    id: "shared-audio-player",
+    defaultData: {
+      isPlaying: false,
+      startedAtMs: 0,
+      positionMs: 0,
+    },
+  },
+  function SharedAudioPlayerView({ data, setData }) {
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+    const dataRef = useRef(data);
+    const audioEnabledRef = useRef(false);
+    const [positionMs, setPositionMs] = useState(0);
+    const [audioEnabled, setAudioEnabled] = useState(false);
+    const [status, setStatus] = useState(
+      "Enable audio in this window before playing.",
+    );
+
+    dataRef.current = data;
+
+    useEffect(() => {
+      let animationFrame = 0;
+      let cancelled = false;
+
+      const tick = () => {
+        const audio = audioRef.current;
+        const transport = dataRef.current;
+        const nowMs = Date.now();
+        const expectedMs = playbackPositionMs(transport, nowMs, audio);
+        setPositionMs(expectedMs);
+
+        if (audio && audioEnabledRef.current) {
+          const expectedSeconds = expectedMs / 1000;
+          if (Math.abs(audio.currentTime - expectedSeconds) > 0.25) {
+            audio.currentTime = expectedSeconds;
+          }
+
+          if (transport.isPlaying && audio.paused) {
+            void audio.play().catch(() => {
+              if (cancelled) return;
+              audioEnabledRef.current = false;
+              setAudioEnabled(false);
+              setStatus("Audio is blocked in this window. Enable it again.");
+            });
+          } else if (!transport.isPlaying && !audio.paused) {
+            audio.pause();
+          }
+        }
+
+        animationFrame = requestAnimationFrame(tick);
+      };
+
+      animationFrame = requestAnimationFrame(tick);
+      return () => {
+        cancelled = true;
+        cancelAnimationFrame(animationFrame);
+        audioRef.current?.pause();
+      };
+    }, []);
+
+    async function enableAudio() {
+      const audio = audioRef.current;
+      if (!audio) return;
+
+      try {
+        await audio.play();
+        audio.pause();
+        audioEnabledRef.current = true;
+        setAudioEnabled(true);
+        setStatus("This window can now play the shared file.");
+
+        if (dataRef.current.isPlaying) {
+          audio.currentTime =
+            playbackPositionMs(dataRef.current, Date.now(), audio) / 1000;
+          await audio.play();
+        }
+      } catch {
+        audioEnabledRef.current = false;
+        setAudioEnabled(false);
+        setStatus("The audio file could not play in this window.");
+      }
+    }
+
+    function togglePlayback() {
+      const nowMs = Date.now();
+      const position = playbackPositionMs(data, nowMs, audioRef.current);
+      setData((draft) => {
+        draft.isPlaying = !data.isPlaying;
+        draft.positionMs = position;
+        draft.startedAtMs = nowMs - position;
+      });
+    }
+
+    function restartPlayback() {
+      const nowMs = Date.now();
+      setData((draft) => {
+        draft.positionMs = 0;
+        draft.startedAtMs = nowMs;
+      });
+    }
+
+    const progress = (positionMs / durationMs(audioRef.current)) * 100;
+
+    return (
+      <section id="shared-audio-player" className="player">
+        <audio ref={audioRef} src={AUDIO_URL} preload="auto" loop />
+
+        <div className="file">
+          <span className="file-icon" aria-hidden="true">♪</span>
+          <span>t-rex-roar.mp3</span>
+        </div>
+
+        <div className="controls">
+          <button type="button" onClick={() => void enableAudio()}>
+            {audioEnabled ? "Audio enabled" : "Enable audio"}
+          </button>
+          <button className="primary" type="button" onClick={togglePlayback}>
+            {data.isPlaying ? "Pause for everyone" : "Play for everyone"}
+          </button>
+          <button type="button" onClick={restartPlayback}>Restart</button>
+        </div>
+
+        <div className="timeline">
+          <div className="timeline-head">
+            <strong>
+              {data.isPlaying ? "Playing for everyone" : "Paused for everyone"}
+            </strong>
+            <span>{(positionMs / 1000).toFixed(1)}s</span>
+          </div>
+          <div
+            className="track"
+            role="progressbar"
+            aria-label="Audio position"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(progress)}
+          >
+            <div className="progress" style={{ width: progress + "%" }} />
+          </div>
+        </div>
+        <p className="status" role="status">{status}</p>
+      </section>
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <PlayProvider initOptions={{ developmentMode: true }}>
+      <main>
+        <h1>Shared audio file</h1>
+        <p className="intro">
+          Every window plays the same file from the shared position.
+        </p>
+        <SharedAudioPlayer />
+      </main>
+
+      <style>{\`
+        :root {
+          color: #1c1c1c;
+          background: #f4efe5;
+          font-family: ui-sans-serif, system-ui, sans-serif;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; }
+        #root {
+          display: grid;
+          min-height: 100vh;
+          padding: 1.5rem;
+          place-items: center;
+        }
+        main { width: min(34rem, 100%); }
+        h1 {
+          margin: 0 0 0.5rem;
+          font-size: clamp(2rem, 8vw, 3.5rem);
+          line-height: 1;
+        }
+        .intro { margin: 0 0 1.25rem; color: #3b3b3b; line-height: 1.5; }
+        .player {
+          padding: 1.25rem;
+          border: 2px solid #1c1c1c;
+          background: #ebe4d5;
+          box-shadow: 5px 5px 0 #1c1c1c;
+        }
+        .file {
+          display: flex;
+          align-items: center;
+          gap: 0.75rem;
+          margin-bottom: 1rem;
+          padding: 0.75rem;
+          border: 1px solid #1c1c1c;
+          background: #f4efe5;
+          font-family: ui-monospace, monospace;
+          font-size: 0.82rem;
+        }
+        .file-icon { font-size: 1.5rem; }
+        .controls { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+        button {
+          padding: 0.65rem 0.9rem;
+          border: 2px solid #1c1c1c;
+          border-radius: 4px;
+          background: #f4efe5;
+          color: #1c1c1c;
+          box-shadow: 2px 2px 0 #1c1c1c;
+          cursor: pointer;
+          font: inherit;
+          font-weight: 700;
+        }
+        button:hover { background: #e8a63a; }
+        button:active { translate: 2px 2px; box-shadow: none; }
+        .primary { background: #274b9e; color: #f4efe5; }
+        .primary:hover { background: #1c3875; }
+        .timeline { margin-top: 1rem; }
+        .timeline-head {
+          display: flex;
+          justify-content: space-between;
+          gap: 1rem;
+          margin-bottom: 0.45rem;
+        }
+        .track {
+          height: 16px;
+          overflow: hidden;
+          border: 2px solid #1c1c1c;
+          background: #e0d8c6;
+        }
+        .progress { height: 100%; background: #274b9e; }
+        .status {
+          min-height: 1.4em;
+          margin: 0.8rem 0 0;
+          color: #6a6a66;
+          font-size: 0.9rem;
+        }
+      \`}</style>
+    </PlayProvider>
+  );
+}
+`;

--- a/apps/docs/src/components/playground/recipes/react/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/react/shared-audio-file.ts
@@ -155,7 +155,7 @@ const SharedAudioPlayer = withSharedState<TransportData>(
         <div className="timeline">
           <div className="timeline-head">
             <strong>
-              {data.isPlaying ? "Playing for everyone" : "Paused for everyone"}
+              {data.isPlaying ? "Playing" : "Paused"}
             </strong>
             <span>{(positionMs / 1000).toFixed(1)}s</span>
           </div>

--- a/apps/docs/src/components/playground/recipes/react/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/react/synchronized-sound.ts
@@ -1,0 +1,438 @@
+// ABOUTME: Provides the copy-paste React source for the synchronized-sound example.
+// ABOUTME: Mirrors event-driven cues and a shared generated-audio transport.
+
+export const synchronizedSoundReactSource = `// ABOUTME: Broadcasts one-shot tones and shares a generated loop transport.
+// ABOUTME: Keeps Web Audio permission and scheduling local to each browser.
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  PlayProvider,
+  usePlayContext,
+  withSharedState,
+} from "@playhtml/react";
+
+type TransportData = {
+  isPlaying: boolean;
+  startedAtMs: number;
+  positionMs: number;
+};
+
+const CUE_EVENT = "synchronized-sound-cue";
+const STEP_MS = 500;
+const LOOP_MS = 2000;
+const PATTERN = [261.63, 329.63, 392, 523.25];
+
+function loopPositionMs(data: TransportData, nowMs: number): number {
+  const elapsedMs = data.isPlaying
+    ? nowMs - data.startedAtMs
+    : data.positionMs;
+  return ((elapsedMs % LOOP_MS) + LOOP_MS) % LOOP_MS;
+}
+
+const SharedSound = withSharedState<TransportData>(
+  {
+    id: "sound-transport",
+    defaultData: {
+      isPlaying: false,
+      startedAtMs: 0,
+      positionMs: 0,
+    },
+  },
+  function SharedSoundView({ data, setData }) {
+    const {
+      dispatchPlayEvent,
+      registerPlayEventListener,
+      removePlayEventListener,
+    } = usePlayContext();
+    const dataRef = useRef(data);
+    const audioContextRef = useRef<AudioContext | null>(null);
+    const scheduledStartRef = useRef<number | null>(null);
+    const nextStepRef = useRef(0);
+    const patternGainsRef = useRef(new Set<GainNode>());
+    const [audioEnabled, setAudioEnabled] = useState(false);
+    const [audioStatus, setAudioStatus] = useState(
+      "Audio is off in this window.",
+    );
+    const [positionMs, setPositionMs] = useState(0);
+
+    dataRef.current = data;
+
+    const playTone = useCallback((
+      frequency: number,
+      startTime: number,
+      duration: number,
+      volume: number,
+      patternTone = false,
+    ) => {
+      const audioContext = audioContextRef.current;
+      if (!audioContext || audioContext.state !== "running") return;
+
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      const start = Math.max(audioContext.currentTime, startTime);
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(frequency, start);
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(volume, start + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      oscillator.connect(gain).connect(audioContext.destination);
+      oscillator.start(start);
+      oscillator.stop(start + duration + 0.02);
+
+      if (patternTone) patternGainsRef.current.add(gain);
+      oscillator.addEventListener("ended", () => {
+        patternGainsRef.current.delete(gain);
+        oscillator.disconnect();
+        gain.disconnect();
+      }, { once: true });
+    }, []);
+
+    const silencePattern = useCallback(() => {
+      const audioContext = audioContextRef.current;
+      if (!audioContext) return;
+
+      for (const gain of patternGainsRef.current) {
+        gain.gain.cancelScheduledValues(audioContext.currentTime);
+        gain.gain.setValueAtTime(0.0001, audioContext.currentTime);
+      }
+      patternGainsRef.current.clear();
+    }, []);
+
+    const playCue = useCallback(() => {
+      const audioContext = audioContextRef.current;
+      if (!audioContext || audioContext.state !== "running") {
+        setAudioStatus(
+          "A chime arrived. Enable audio to hear future sounds in this window.",
+        );
+        return;
+      }
+      playTone(880, audioContext.currentTime + 0.01, 0.28, 0.16);
+      setAudioStatus("Chime received in this window.");
+    }, [playTone]);
+
+    useEffect(() => {
+      const listenerId = registerPlayEventListener(CUE_EVENT, {
+        onEvent: playCue,
+      });
+      return () => removePlayEventListener(CUE_EVENT, listenerId);
+    }, [
+      playCue,
+      registerPlayEventListener,
+      removePlayEventListener,
+    ]);
+
+    const schedulePattern = useCallback((
+      transport: TransportData,
+      nowMs: number,
+    ) => {
+      const audioContext = audioContextRef.current;
+      if (
+        !audioContext ||
+        audioContext.state !== "running" ||
+        !transport.isPlaying
+      ) {
+        if (scheduledStartRef.current !== null) silencePattern();
+        scheduledStartRef.current = null;
+        return;
+      }
+
+      if (scheduledStartRef.current !== transport.startedAtMs) {
+        silencePattern();
+        scheduledStartRef.current = transport.startedAtMs;
+        const elapsedMs = Math.max(0, nowMs - transport.startedAtMs);
+        const currentStep = Math.floor(elapsedMs / STEP_MS);
+        playTone(
+          PATTERN[currentStep % PATTERN.length],
+          audioContext.currentTime + 0.01,
+          0.18,
+          0.09,
+          true,
+        );
+        nextStepRef.current = currentStep + 1;
+      }
+
+      const scheduleThroughMs = nowMs + 120;
+      let beatAtMs =
+        transport.startedAtMs + nextStepRef.current * STEP_MS;
+      while (beatAtMs <= scheduleThroughMs) {
+        if (beatAtMs >= nowMs - 20) {
+          const delaySeconds = Math.max(0, beatAtMs - nowMs) / 1000;
+          playTone(
+            PATTERN[nextStepRef.current % PATTERN.length],
+            audioContext.currentTime + delaySeconds,
+            0.18,
+            0.09,
+            true,
+          );
+        }
+        nextStepRef.current += 1;
+        beatAtMs =
+          transport.startedAtMs + nextStepRef.current * STEP_MS;
+      }
+    }, [playTone, silencePattern]);
+
+    useEffect(() => {
+      let animationFrame = 0;
+      const tick = () => {
+        const nowMs = Date.now();
+        const transport = dataRef.current;
+        setPositionMs(loopPositionMs(transport, nowMs));
+        schedulePattern(transport, nowMs);
+        animationFrame = requestAnimationFrame(tick);
+      };
+
+      animationFrame = requestAnimationFrame(tick);
+      return () => {
+        cancelAnimationFrame(animationFrame);
+        silencePattern();
+        void audioContextRef.current?.close();
+      };
+    }, [schedulePattern, silencePattern]);
+
+    async function enableAudio() {
+      const AudioContextClass =
+        window.AudioContext ||
+        (window as typeof window & {
+          webkitAudioContext?: typeof AudioContext;
+        }).webkitAudioContext;
+
+      if (!AudioContextClass) {
+        setAudioStatus("Web Audio is not available in this browser.");
+        return;
+      }
+
+      if (!audioContextRef.current) {
+        audioContextRef.current = new AudioContextClass();
+      }
+      await audioContextRef.current.resume();
+      scheduledStartRef.current = null;
+      setAudioEnabled(true);
+      setAudioStatus("Audio is enabled in this window.");
+    }
+
+    function toggleTransport() {
+      const nowMs = Date.now();
+      const position = loopPositionMs(data, nowMs);
+      setData((draft) => {
+        draft.isPlaying = !data.isPlaying;
+        draft.positionMs = position;
+        draft.startedAtMs = nowMs - position;
+      });
+    }
+
+    function restartTransport() {
+      const nowMs = Date.now();
+      setData((draft) => {
+        draft.positionMs = 0;
+        draft.startedAtMs = nowMs;
+      });
+    }
+
+    const activeStep = Math.floor(positionMs / STEP_MS) % PATTERN.length;
+
+    return (
+      <section id="sound-transport">
+        <div className="audio-unlock">
+          <button type="button" onClick={() => void enableAudio()}>
+            {audioEnabled ? "Audio enabled" : "Enable audio"}
+          </button>
+          <p>
+            <strong>Do this in every window.</strong> Browsers require a local
+            click before a page can make sound.
+          </p>
+        </div>
+
+        <div className="panel">
+          <p className="eyebrow">Transient event</p>
+          <h2>One-shot cue</h2>
+          <p className="panel-copy">
+            This chime plays once for everyone currently connected. It is not
+            replayed for late joiners.
+          </p>
+          <button
+            className="primary"
+            type="button"
+            onClick={() => dispatchPlayEvent({ type: CUE_EVENT })}
+          >
+            Send chime
+          </button>
+        </div>
+
+        <div className="panel">
+          <p className="eyebrow">Persistent shared data</p>
+          <h2>Four-beat loop</h2>
+          <p className="panel-copy">
+            Play, pause, and position are shared. Each window generates the
+            tones locally from the same timeline.
+          </p>
+          <div className="controls">
+            <button
+              className="primary"
+              type="button"
+              onClick={toggleTransport}
+            >
+              {data.isPlaying ? "Pause loop" : "Play loop"}
+            </button>
+            <button type="button" onClick={restartTransport}>Restart</button>
+          </div>
+          <div className="timeline">
+            <div className="timeline-head">
+              <strong>
+                {data.isPlaying ? "Playing for everyone" : "Paused for everyone"}
+              </strong>
+              <span className="time">
+                {(positionMs / 1000).toFixed(1)} / 2.0s
+              </span>
+            </div>
+            <div
+              className="track"
+              role="progressbar"
+              aria-label="Loop position"
+              aria-valuemin={0}
+              aria-valuemax={LOOP_MS}
+              aria-valuenow={Math.round(positionMs)}
+            >
+              <div
+                className="progress"
+                style={{ width: (positionMs / LOOP_MS) * 100 + "%" }}
+              />
+            </div>
+            <div className="steps" aria-hidden="true">
+              {["C", "E", "G", "C"].map((note, index) => (
+                <span
+                  className="step"
+                  data-active={index === activeStep}
+                  key={index}
+                >
+                  {note}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+        <p className="local-status" role="status">{audioStatus}</p>
+      </section>
+    );
+  },
+);
+
+export default function App() {
+  return (
+    <PlayProvider initOptions={{ developmentMode: true }}>
+      <main>
+        <h1>Synchronized sound</h1>
+        <p className="intro">
+          A one-shot cue reaches people who are here now. The loop stores a
+          shared timeline, so late joiners start on the current beat.
+        </p>
+        <SharedSound />
+      </main>
+
+      <style>{\`
+        :root {
+          color: #3d3833;
+          background: #f7f3ea;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+          font-synthesis: none;
+        }
+        * { box-sizing: border-box; }
+        body { margin: 0; }
+        #root { min-height: 100vh; padding: clamp(1rem, 5vw, 4rem); }
+        main { width: min(760px, 100%); margin: 0 auto; }
+        h1 {
+          margin: 0 0 1rem;
+          color: #274b9e;
+          font-size: clamp(2.4rem, 8vw, 5rem);
+          line-height: 0.95;
+        }
+        .intro { max-width: 62ch; font-size: 1.05rem; line-height: 1.5; }
+        .audio-unlock {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 0.75rem;
+          margin: 1.5rem 0;
+          padding: 1rem;
+          border: 2px solid #3d3833;
+          background: #ffe95c;
+          box-shadow: 5px 5px 0 #3d3833;
+        }
+        .audio-unlock p { margin: 0; flex: 1 1 260px; }
+        .panel {
+          margin-top: 1.25rem;
+          padding: clamp(1rem, 4vw, 2rem);
+          border: 2px solid #3d3833;
+          background: #fffdf8;
+          box-shadow: 7px 7px 0 #3d3833;
+        }
+        .eyebrow {
+          margin: 0;
+          color: #5e5751;
+          font-size: 0.75rem;
+          font-weight: 800;
+          letter-spacing: 0.12em;
+          text-transform: uppercase;
+        }
+        h2 { margin: 0.35rem 0 0.6rem; font-size: 1.45rem; }
+        .panel-copy { margin: 0 0 1rem; line-height: 1.5; }
+        button {
+          appearance: none;
+          padding: 0.7rem 1rem;
+          border: 2px solid #3d3833;
+          border-radius: 0;
+          background: #fff;
+          color: inherit;
+          box-shadow: 3px 3px 0 #3d3833;
+          cursor: pointer;
+          font: inherit;
+          font-weight: 750;
+        }
+        button:hover { background: #ffe95c; }
+        button:active {
+          translate: 2px 2px;
+          box-shadow: 1px 1px 0 #3d3833;
+        }
+        .primary { background: #274b9e; color: #fff; }
+        .primary:hover { background: #355fae; }
+        .controls { display: flex; flex-wrap: wrap; gap: 0.7rem; }
+        .timeline { margin-top: 1.25rem; }
+        .timeline-head {
+          display: flex;
+          align-items: baseline;
+          justify-content: space-between;
+          gap: 1rem;
+          margin-bottom: 0.5rem;
+        }
+        .time { font-variant-numeric: tabular-nums; font-weight: 750; }
+        .track {
+          height: 18px;
+          overflow: hidden;
+          border: 2px solid #3d3833;
+          background: #d9d3ca;
+        }
+        .progress { height: 100%; background: #274b9e; }
+        .steps {
+          display: grid;
+          grid-template-columns: repeat(4, 1fr);
+          gap: 0.4rem;
+          margin-top: 0.55rem;
+        }
+        .step {
+          display: grid;
+          height: 34px;
+          border: 2px solid #3d3833;
+          background: #fff;
+          place-items: center;
+          font-size: 0.78rem;
+          font-weight: 800;
+        }
+        .step[data-active="true"] { background: #ffe95c; }
+        .local-status {
+          min-height: 1.5em;
+          margin: 0.8rem 0 0;
+          color: #5e5751;
+        }
+      \`}</style>
+    </PlayProvider>
+  );
+}
+`;

--- a/apps/docs/src/components/playground/recipes/react/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/react/synchronized-sound.ts
@@ -277,7 +277,7 @@ const SharedSound = withSharedState<TransportData>(
           <div className="timeline">
             <div className="timeline-head">
               <strong>
-                {data.isPlaying ? "Playing for everyone" : "Paused for everyone"}
+                {data.isPlaying ? "Playing" : "Paused"}
               </strong>
               <span className="time">
                 {(positionMs / 1000).toFixed(1)} / 2.0s

--- a/apps/docs/src/components/playground/recipes/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/shared-audio-file.ts
@@ -150,7 +150,7 @@ export const sharedAudioFileRecipe: ExampleRecipe = {
       element.querySelector("[data-position]").textContent =
         (positionMs / 1000).toFixed(1) + "s";
       element.querySelector("[data-playback-state]").textContent =
-        data.isPlaying ? "Playing for everyone" : "Paused for everyone";
+        data.isPlaying ? "Playing" : "Paused";
       element.querySelector("[data-action='toggle']").textContent =
         data.isPlaying ? "Pause for everyone" : "Play for everyone";
     }

--- a/apps/docs/src/components/playground/recipes/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/shared-audio-file.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Defines the canonical shared audio-file recipe for docs and the playground.
 // ABOUTME: Synchronizes an HTML audio element with a small shared transport state.
 import type { ExampleRecipe } from "./types";
+import { sharedAudioFileReactSource } from "./react/shared-audio-file";
 
 export const sharedAudioFileRecipe: ExampleRecipe = {
   id: "shared-audio-file",
@@ -11,6 +12,10 @@ export const sharedAudioFileRecipe: ExampleRecipe = {
   capabilities: ["can-play"],
   difficulty: "intermediate",
   docsHref: "/docs/examples/shared-audio-file/",
+  react: {
+    install: "npm install playhtml @playhtml/react",
+    code: sharedAudioFileReactSource,
+  },
   html: `<!doctype html>
 <html lang="en">
 <head>

--- a/apps/docs/src/components/playground/recipes/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/shared-audio-file.ts
@@ -1,0 +1,244 @@
+// ABOUTME: Defines the canonical shared audio-file recipe for docs and the playground.
+// ABOUTME: Synchronizes an HTML audio element with a small shared transport state.
+import type { ExampleRecipe } from "./types";
+
+export const sharedAudioFileRecipe: ExampleRecipe = {
+  id: "shared-audio-file",
+  title: "Shared audio file",
+  description:
+    "Play, pause, and restart one audio file for everyone using a shared timeline.",
+  tags: ["audio", "audio file", "timeline", "late joiners"],
+  capabilities: ["can-play"],
+  difficulty: "intermediate",
+  docsHref: "/docs/examples/shared-audio-file/",
+  html: `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Shared audio file with playhtml</title>
+  <style>
+    :root {
+      color: #1c1c1c;
+      background: #f4efe5;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body { display: grid; min-height: 100vh; margin: 0; padding: 1.5rem; place-items: center; }
+    main { width: min(34rem, 100%); }
+    h1 { margin: 0 0 0.5rem; font-size: clamp(2rem, 8vw, 3.5rem); line-height: 1; }
+    .intro { margin: 0 0 1.25rem; color: #3b3b3b; line-height: 1.5; }
+    .player {
+      padding: 1.25rem;
+      border: 2px solid #1c1c1c;
+      background: #ebe4d5;
+      box-shadow: 5px 5px 0 #1c1c1c;
+    }
+    .file {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+      padding: 0.75rem;
+      border: 1px solid #1c1c1c;
+      background: #f4efe5;
+      font-family: ui-monospace, monospace;
+      font-size: 0.82rem;
+    }
+    .file-icon { font-size: 1.5rem; }
+    .controls { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+    button {
+      padding: 0.65rem 0.9rem;
+      border: 2px solid #1c1c1c;
+      border-radius: 4px;
+      background: #f4efe5;
+      color: #1c1c1c;
+      box-shadow: 2px 2px 0 #1c1c1c;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 700;
+    }
+    button:hover { background: #e8a63a; }
+    button:active { translate: 2px 2px; box-shadow: none; }
+    .primary { background: #274b9e; color: #f4efe5; }
+    .primary:hover { background: #1c3875; }
+    .timeline { margin-top: 1rem; }
+    .timeline-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 1rem;
+      margin-bottom: 0.45rem;
+    }
+    .track { height: 16px; overflow: hidden; border: 2px solid #1c1c1c; background: #e0d8c6; }
+    .progress { width: 0%; height: 100%; background: #274b9e; }
+    .status { min-height: 1.4em; margin: 0.8rem 0 0; color: #6a6a66; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Shared audio file</h1>
+    <p class="intro">Every window plays the same file from the shared position.</p>
+
+    <section id="shared-audio-player" class="player" can-play>
+      <audio
+        data-audio
+        src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3"
+        preload="auto"
+        loop
+      ></audio>
+
+      <div class="file">
+        <span class="file-icon" aria-hidden="true">♪</span>
+        <span>t-rex-roar.mp3</span>
+      </div>
+
+      <div class="controls">
+        <button type="button" data-action="enable-audio">Enable audio</button>
+        <button class="primary" type="button" data-action="toggle">Play for everyone</button>
+        <button type="button" data-action="restart">Restart</button>
+      </div>
+
+      <div class="timeline">
+        <div class="timeline-head">
+          <strong data-playback-state>Paused</strong>
+          <span data-position>0.0s</span>
+        </div>
+        <div
+          class="track"
+          role="progressbar"
+          aria-label="Audio position"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow="0"
+        >
+          <div class="progress" data-progress></div>
+        </div>
+      </div>
+      <p class="status" data-status role="status">Enable audio in this window before playing.</p>
+    </section>
+  </main>
+
+  <script type="module">
+    import { playhtml } from "playhtml";
+
+    const player = document.getElementById("shared-audio-player");
+    const audio = player.querySelector("[data-audio]");
+    let audioEnabled = false;
+
+    function durationMs() {
+      return Number.isFinite(audio.duration) ? audio.duration * 1000 : 2000;
+    }
+
+    function playbackPositionMs(data, nowMs) {
+      const duration = durationMs();
+      const elapsed = data.isPlaying ? nowMs - data.startedAtMs : data.positionMs;
+      return ((elapsed % duration) + duration) % duration;
+    }
+
+    function render(element, data, nowMs) {
+      const positionMs = playbackPositionMs(data, nowMs);
+      const progress = (positionMs / durationMs()) * 100;
+      element.querySelector("[data-progress]").style.width = progress + "%";
+      element
+        .querySelector("[role='progressbar']")
+        .setAttribute("aria-valuenow", String(Math.round(progress)));
+      element.querySelector("[data-position]").textContent =
+        (positionMs / 1000).toFixed(1) + "s";
+      element.querySelector("[data-playback-state]").textContent =
+        data.isPlaying ? "Playing for everyone" : "Paused for everyone";
+      element.querySelector("[data-action='toggle']").textContent =
+        data.isPlaying ? "Pause for everyone" : "Play for everyone";
+    }
+
+    function syncLocalAudio(data, nowMs) {
+      if (!audioEnabled) return;
+
+      const expectedSeconds = playbackPositionMs(data, nowMs) / 1000;
+      const driftSeconds = Math.abs(audio.currentTime - expectedSeconds);
+      if (driftSeconds > 0.25) audio.currentTime = expectedSeconds;
+
+      if (data.isPlaying && audio.paused) {
+        void audio.play().catch(() => {
+          audioEnabled = false;
+          player.querySelector("[data-status]").textContent =
+            "Audio is blocked in this window. Enable it again.";
+        });
+      } else if (!data.isPlaying && !audio.paused) {
+        audio.pause();
+      }
+    }
+
+    async function enableAudio(data) {
+      try {
+        await audio.play();
+        audio.pause();
+        audioEnabled = true;
+        player.querySelector("[data-action='enable-audio']").textContent =
+          "Audio enabled";
+        player.querySelector("[data-status]").textContent =
+          "This window can now play the shared file.";
+        syncLocalAudio(data, Date.now());
+      } catch {
+        player.querySelector("[data-status]").textContent =
+          "The audio file could not play in this window.";
+      }
+    }
+
+    player.defaultData = {
+      isPlaying: false,
+      startedAtMs: 0,
+      positionMs: 0,
+    };
+
+    player.updateElement = ({ element, data }) => {
+      render(element, data, Date.now());
+    };
+
+    player.onClick = (event, { data, setData }) => {
+      const action = event.target.closest("[data-action]")?.dataset.action;
+      if (!action) return;
+
+      if (action === "enable-audio") {
+        void enableAudio(data);
+        return;
+      }
+
+      const nowMs = Date.now();
+      if (action === "toggle") {
+        const positionMs = playbackPositionMs(data, nowMs);
+        setData((draft) => {
+          draft.isPlaying = !data.isPlaying;
+          draft.positionMs = positionMs;
+          draft.startedAtMs = nowMs - positionMs;
+        });
+      }
+
+      if (action === "restart") {
+        setData((draft) => {
+          draft.positionMs = 0;
+          draft.startedAtMs = nowMs;
+        });
+      }
+    };
+
+    player.onMount = ({ getData, getElement }) => {
+      let animationFrame = 0;
+      const tick = () => {
+        const data = getData();
+        const nowMs = Date.now();
+        render(getElement(), data, nowMs);
+        syncLocalAudio(data, nowMs);
+        animationFrame = requestAnimationFrame(tick);
+      };
+      animationFrame = requestAnimationFrame(tick);
+      return () => {
+        cancelAnimationFrame(animationFrame);
+        audio.pause();
+      };
+    };
+
+    await playhtml.init({ developmentMode: true });
+  </script>
+</body>
+</html>`,
+};

--- a/apps/docs/src/components/playground/recipes/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/synchronized-sound.ts
@@ -1,6 +1,7 @@
 // ABOUTME: Defines the canonical synchronized-sound recipe for docs and the playground.
 // ABOUTME: Demonstrates transient audio events and a persistent shared transport.
 import type { ExampleRecipe } from "./types";
+import { synchronizedSoundReactSource } from "./react/synchronized-sound";
 
 export const synchronizedSoundRecipe: ExampleRecipe = {
   id: "synchronized-sound",
@@ -11,6 +12,10 @@ export const synchronizedSoundRecipe: ExampleRecipe = {
   capabilities: ["can-play", "events"],
   difficulty: "advanced",
   docsHref: "/docs/examples/synchronized-sound/",
+  react: {
+    install: "npm install playhtml @playhtml/react",
+    code: synchronizedSoundReactSource,
+  },
   html: `<!doctype html>
 <html lang="en">
 <head>

--- a/apps/docs/src/components/playground/recipes/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/synchronized-sound.ts
@@ -1,0 +1,338 @@
+// ABOUTME: Defines the canonical synchronized-sound recipe for docs and the playground.
+// ABOUTME: Demonstrates transient audio events and a persistent shared transport.
+import type { ExampleRecipe } from "./types";
+
+export const synchronizedSoundRecipe: ExampleRecipe = {
+  id: "synchronized-sound",
+  title: "Synchronized sound",
+  description:
+    "Play one-shot sound cues for everyone, then share a play/pause timeline that catches up late joiners.",
+  tags: ["audio", "events", "timeline", "late joiners", "Web Audio"],
+  capabilities: ["can-play", "events"],
+  difficulty: "advanced",
+  docsHref: "/docs/examples/synchronized-sound/",
+  html: `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Synchronized sound with playhtml</title>
+  <style>
+    :root {
+      color: #3d3833;
+      background: #f7f3ea;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-synthesis: none;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; padding: clamp(1rem, 5vw, 4rem); }
+    main { width: min(760px, 100%); margin: 0 auto; }
+    h1 { color: #274b9e; font-size: clamp(2.4rem, 8vw, 5rem); line-height: 0.95; margin: 0 0 1rem; }
+    .intro { max-width: 62ch; font-size: 1.05rem; line-height: 1.5; }
+    .audio-unlock {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.75rem;
+      margin: 1.5rem 0;
+      padding: 1rem;
+      border: 2px solid #3d3833;
+      background: #ffe95c;
+      box-shadow: 5px 5px 0 #3d3833;
+    }
+    .audio-unlock p { margin: 0; flex: 1 1 260px; }
+    .panel {
+      margin-top: 1.25rem;
+      padding: clamp(1rem, 4vw, 2rem);
+      border: 2px solid #3d3833;
+      background: #fffdf8;
+      box-shadow: 7px 7px 0 #3d3833;
+    }
+    .eyebrow { margin: 0; color: #5e5751; font-size: 0.75rem; font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; }
+    h2 { margin: 0.35rem 0 0.6rem; font-size: 1.45rem; }
+    .panel-copy { margin: 0 0 1rem; line-height: 1.5; }
+    button {
+      appearance: none;
+      border: 2px solid #3d3833;
+      border-radius: 0;
+      background: #fff;
+      color: inherit;
+      cursor: pointer;
+      font: inherit;
+      font-weight: 750;
+      padding: 0.7rem 1rem;
+      box-shadow: 3px 3px 0 #3d3833;
+    }
+    button:hover { background: #ffe95c; }
+    button:active { translate: 2px 2px; box-shadow: 1px 1px 0 #3d3833; }
+    .primary { background: #274b9e; color: #fff; }
+    .primary:hover { background: #355fae; }
+    .controls { display: flex; flex-wrap: wrap; gap: 0.7rem; }
+    .timeline { margin-top: 1.25rem; }
+    .timeline-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; margin-bottom: 0.5rem; }
+    .time { font-variant-numeric: tabular-nums; font-weight: 750; }
+    .track { height: 18px; overflow: hidden; border: 2px solid #3d3833; background: #d9d3ca; }
+    .progress { width: 0%; height: 100%; background: #274b9e; }
+    .steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.4rem; margin-top: 0.55rem; }
+    .step { height: 34px; display: grid; place-items: center; border: 2px solid #3d3833; background: #fff; font-size: 0.78rem; font-weight: 800; }
+    .step[data-active="true"] { background: #ffe95c; }
+    .local-status { margin: 0.8rem 0 0; min-height: 1.5em; color: #5e5751; }
+    code { padding: 0.1rem 0.25rem; background: #eae5db; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Synchronized sound</h1>
+    <p class="intro">
+      A one-shot cue reaches people who are here now. The loop stores a shared
+      play/pause timeline, so people who arrive later join at the current beat.
+    </p>
+
+    <section id="sound-transport" can-play>
+      <div class="audio-unlock">
+        <button type="button" data-action="enable-audio">Enable audio</button>
+        <p><strong>Do this in every window.</strong> Browsers require a local click before a page can make sound.</p>
+      </div>
+
+      <div class="panel">
+        <p class="eyebrow">Transient event</p>
+        <h2>One-shot cue</h2>
+        <p class="panel-copy">This chime plays once for everyone currently connected. It is not replayed for late joiners.</p>
+        <button class="primary" type="button" data-action="send-cue">Send chime</button>
+      </div>
+
+      <div class="panel">
+        <p class="eyebrow">Persistent shared data</p>
+        <h2>Four-beat loop</h2>
+        <p class="panel-copy">Play, pause, and position are shared. Each window generates the tones locally from the same timeline.</p>
+        <div class="controls">
+          <button class="primary" type="button" data-action="toggle-transport">Play loop</button>
+          <button type="button" data-action="restart-transport">Restart</button>
+        </div>
+        <div class="timeline">
+          <div class="timeline-head">
+            <strong data-transport-state>Paused</strong>
+            <span class="time" data-position>0.0 / 2.0s</span>
+          </div>
+          <div class="track" role="progressbar" aria-label="Loop position" aria-valuemin="0" aria-valuemax="2000" aria-valuenow="0">
+            <div class="progress" data-progress></div>
+          </div>
+          <div class="steps" aria-hidden="true">
+            <span class="step" data-step="0">C</span>
+            <span class="step" data-step="1">E</span>
+            <span class="step" data-step="2">G</span>
+            <span class="step" data-step="3">C</span>
+          </div>
+        </div>
+      </div>
+      <p class="local-status" data-audio-status role="status">Audio is off in this window.</p>
+    </section>
+  </main>
+
+  <script type="module">
+    import { playhtml } from "playhtml";
+
+    const CUE_EVENT = "synchronized-sound-cue";
+    const STEP_MS = 500;
+    const LOOP_MS = 2000;
+    const PATTERN = [261.63, 329.63, 392.0, 523.25];
+    const soundTransport = document.getElementById("sound-transport");
+
+    let audioContext = null;
+    let scheduledTransportStart = null;
+    let nextStepToSchedule = 0;
+    const activePatternGains = new Set();
+
+    function loopPositionMs(data, nowMs) {
+      const elapsedMs = data.isPlaying
+        ? nowMs - data.startedAtMs
+        : data.positionMs;
+      return ((elapsedMs % LOOP_MS) + LOOP_MS) % LOOP_MS;
+    }
+
+    function setAudioStatus(message) {
+      soundTransport.querySelector("[data-audio-status]").textContent = message;
+    }
+
+    function playTone(frequency, startTime, duration, volume, patternTone = false) {
+      if (!audioContext || audioContext.state !== "running") return;
+      const oscillator = audioContext.createOscillator();
+      const gain = audioContext.createGain();
+      const start = Math.max(audioContext.currentTime, startTime);
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(frequency, start);
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(volume, start + 0.012);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+      oscillator.connect(gain).connect(audioContext.destination);
+      oscillator.start(start);
+      oscillator.stop(start + duration + 0.02);
+      if (patternTone) activePatternGains.add(gain);
+      oscillator.addEventListener("ended", () => {
+        activePatternGains.delete(gain);
+        oscillator.disconnect();
+        gain.disconnect();
+      }, { once: true });
+    }
+
+    function silencePattern() {
+      if (!audioContext) return;
+      for (const gain of activePatternGains) {
+        gain.gain.cancelScheduledValues(audioContext.currentTime);
+        gain.gain.setValueAtTime(0.0001, audioContext.currentTime);
+      }
+      activePatternGains.clear();
+    }
+
+    function playCue(payload) {
+      const frequency = Number(payload && payload.frequency) || 880;
+      if (!audioContext || audioContext.state !== "running") {
+        setAudioStatus("A chime arrived. Enable audio to hear future sounds in this window.");
+        return;
+      }
+      playTone(frequency, audioContext.currentTime + 0.01, 0.28, 0.16);
+      setAudioStatus("Chime received in this window.");
+    }
+
+    async function enableAudio() {
+      const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextClass) {
+        setAudioStatus("Web Audio is not available in this browser.");
+        return;
+      }
+      if (!audioContext) audioContext = new AudioContextClass();
+      await audioContext.resume();
+      document.querySelector("[data-action='enable-audio']").textContent = "Audio enabled";
+      setAudioStatus("Audio is enabled in this window.");
+      scheduledTransportStart = null;
+    }
+
+    function renderTimeline(element, data, nowMs) {
+      const positionMs = loopPositionMs(data, nowMs);
+      const progress = element.querySelector("[data-progress]");
+      const track = progress.parentElement;
+      const step = Math.floor(positionMs / STEP_MS) % PATTERN.length;
+      progress.style.width = String((positionMs / LOOP_MS) * 100) + "%";
+      track.setAttribute("aria-valuenow", String(Math.round(positionMs)));
+      element.querySelector("[data-position]").textContent = (positionMs / 1000).toFixed(1) + " / 2.0s";
+      element.querySelector("[data-transport-state]").textContent = data.isPlaying ? "Playing for everyone" : "Paused for everyone";
+      element.querySelector("[data-action='toggle-transport']").textContent = data.isPlaying ? "Pause loop" : "Play loop";
+      for (const marker of element.querySelectorAll("[data-step]")) {
+        marker.dataset.active = String(Number(marker.dataset.step) === step);
+      }
+    }
+
+    function schedulePattern(data, nowMs) {
+      if (!audioContext || audioContext.state !== "running" || !data.isPlaying) {
+        if (scheduledTransportStart !== null) silencePattern();
+        scheduledTransportStart = null;
+        return;
+      }
+
+      if (scheduledTransportStart !== data.startedAtMs) {
+        silencePattern();
+        scheduledTransportStart = data.startedAtMs;
+        const elapsedMs = Math.max(0, nowMs - data.startedAtMs);
+        const currentStep = Math.floor(elapsedMs / STEP_MS);
+        playTone(
+          PATTERN[currentStep % PATTERN.length],
+          audioContext.currentTime + 0.01,
+          0.18,
+          0.09,
+          true,
+        );
+        nextStepToSchedule = currentStep + 1;
+      }
+
+      const scheduleThroughMs = nowMs + 120;
+      let beatAtMs = data.startedAtMs + nextStepToSchedule * STEP_MS;
+      while (beatAtMs <= scheduleThroughMs) {
+        if (beatAtMs >= nowMs - 20) {
+          const delaySeconds = Math.max(0, beatAtMs - nowMs) / 1000;
+          playTone(
+            PATTERN[nextStepToSchedule % PATTERN.length],
+            audioContext.currentTime + delaySeconds,
+            0.18,
+            0.09,
+            true,
+          );
+        }
+        nextStepToSchedule += 1;
+        beatAtMs = data.startedAtMs + nextStepToSchedule * STEP_MS;
+      }
+    }
+
+    soundTransport.defaultData = {
+      isPlaying: false,
+      startedAtMs: 0,
+      positionMs: 0,
+    };
+
+    soundTransport.updateElement = ({ element, data }) => {
+      renderTimeline(element, data, Date.now());
+    };
+
+    soundTransport.onClick = (event, { data, setData }) => {
+      const button = event.target.closest("[data-action]");
+      if (!button) return;
+
+      if (button.dataset.action === "enable-audio") {
+        void enableAudio();
+        return;
+      }
+
+      if (button.dataset.action === "send-cue") {
+        playhtml.dispatchPlayEvent({
+          type: CUE_EVENT,
+          eventPayload: { frequency: 880 },
+        });
+        return;
+      }
+
+      const nowMs = Date.now();
+      if (button.dataset.action === "toggle-transport") {
+        const positionMs = loopPositionMs(data, nowMs);
+        setData((draft) => {
+          draft.isPlaying = !data.isPlaying;
+          draft.positionMs = positionMs;
+          draft.startedAtMs = nowMs - positionMs;
+        });
+      }
+
+      if (button.dataset.action === "restart-transport") {
+        setData((draft) => {
+          draft.positionMs = 0;
+          draft.startedAtMs = nowMs;
+        });
+      }
+    };
+
+    soundTransport.onMount = ({ getData, getElement }) => {
+      let animationFrame = 0;
+      const tick = () => {
+        const nowMs = Date.now();
+        const data = getData();
+        renderTimeline(getElement(), data, nowMs);
+        schedulePattern(data, nowMs);
+        animationFrame = requestAnimationFrame(tick);
+      };
+      animationFrame = requestAnimationFrame(tick);
+      return () => {
+        cancelAnimationFrame(animationFrame);
+        silencePattern();
+      };
+    };
+
+    await playhtml.init({
+      developmentMode: true,
+      events: {
+        [CUE_EVENT]: {
+          type: CUE_EVENT,
+          onEvent: playCue,
+        },
+      },
+    });
+  </script>
+</body>
+</html>`,
+};

--- a/apps/docs/src/components/playground/recipes/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/synchronized-sound.ts
@@ -7,7 +7,7 @@ export const synchronizedSoundRecipe: ExampleRecipe = {
   id: "synchronized-sound",
   title: "Synchronized sound",
   description:
-    "Play one-shot sound cues for everyone, then share a play/pause timeline that catches up late joiners.",
+    "Send a one-shot cue to everyone currently connected, or share a loop that late joiners can join.",
   tags: ["audio", "events", "timeline", "late joiners", "Web Audio"],
   capabilities: ["can-play", "events"],
   difficulty: "advanced",
@@ -220,7 +220,7 @@ export const synchronizedSoundRecipe: ExampleRecipe = {
       progress.style.width = String((positionMs / LOOP_MS) * 100) + "%";
       track.setAttribute("aria-valuenow", String(Math.round(positionMs)));
       element.querySelector("[data-position]").textContent = (positionMs / 1000).toFixed(1) + " / 2.0s";
-      element.querySelector("[data-transport-state]").textContent = data.isPlaying ? "Playing for everyone" : "Paused for everyone";
+      element.querySelector("[data-transport-state]").textContent = data.isPlaying ? "Playing" : "Paused";
       element.querySelector("[data-action='toggle-transport']").textContent = data.isPlaying ? "Pause loop" : "Play loop";
       for (const marker of element.querySelectorAll("[data-step]")) {
         marker.dataset.active = String(Number(marker.dataset.step) === step);

--- a/apps/docs/src/components/playground/recipes/types.ts
+++ b/apps/docs/src/components/playground/recipes/types.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Defines the metadata and source shared by docs examples and the playground.
+// ABOUTME: Keeps catalogue cards, example pages, and runnable recipes on one contract.
+
+export type ExampleDifficulty = "starter" | "intermediate" | "advanced";
+
+export type RunnableRecipe = {
+  id: string;
+  html: string;
+};
+
+export type ExampleRecipe = RunnableRecipe & {
+  title: string;
+  description: string;
+  tags: readonly string[];
+  capabilities: readonly string[];
+  difficulty: ExampleDifficulty;
+  docsHref: `/docs/examples/${string}/`;
+};
+
+export type ExampleRecipeSummary = Omit<ExampleRecipe, "html">;

--- a/apps/docs/src/components/playground/recipes/types.ts
+++ b/apps/docs/src/components/playground/recipes/types.ts
@@ -15,6 +15,10 @@ export type ExampleRecipe = RunnableRecipe & {
   capabilities: readonly string[];
   difficulty: ExampleDifficulty;
   docsHref: `/docs/examples/${string}/`;
+  react: {
+    install: string;
+    code: string;
+  };
 };
 
-export type ExampleRecipeSummary = Omit<ExampleRecipe, "html">;
+export type ExampleRecipeSummary = Omit<ExampleRecipe, "html" | "react">;

--- a/apps/docs/src/components/react/DocsScrollRail.tsx
+++ b/apps/docs/src/components/react/DocsScrollRail.tsx
@@ -1,3 +1,6 @@
+// ABOUTME: Renders collaborative reader positions on a document scroll rail.
+// ABOUTME: Marks article section headings without indexing interactive component content.
+
 import React, { useEffect, useRef, useState } from 'react';
 import { withSharedState } from '@playhtml/react';
 
@@ -27,7 +30,10 @@ function readCursorColor(): string {
 function computeSectionTicks(): SectionTick[] {
   if (typeof document === 'undefined') return [];
   const headings = document.querySelectorAll<HTMLElement>(
-    'main h2, main h3, article h2, article h3'
+    [
+      'main :is(h2, h3):not(:where(.not-content *))',
+      'article :is(h2, h3):not(:where(.not-content *))',
+    ].join(', ')
   );
   const docHeight = Math.max(1, document.documentElement.scrollHeight);
   const ticks: SectionTick[] = [];

--- a/apps/docs/src/content/docs/data/events.mdx
+++ b/apps/docs/src/content/docs/data/events.mdx
@@ -111,13 +111,13 @@ Keep the payload small and JSON-serializable. Events aren't a replacement for sh
 
 Click the hydrant. It dispatches a `"rain"` event, and clouds drift across the top of the page for anyone reading this page right now. Try it in two tabs.
 
-<div className="ph-demo-slot" data-label="EVENTS — rain">
+<div id="rain-event-demo" className="ph-demo-slot" data-label="EVENTS — rain">
   <RainSprinklerDemo client:only="react" />
 </div>
 
 Same primitive, different shape: each click below sends a short-lived emoji burst. No state, no persistence: exactly the "live reactions" pattern from video calls.
 
-<div className="ph-demo-slot" data-label="EVENTS — live reactions">
+<div id="live-reactions-demo" className="ph-demo-slot" data-label="EVENTS — live reactions">
   <LiveReactionsDemo client:only="react" />
 </div>
 

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -190,7 +190,7 @@ function Lobby() {
 
 ## Try it live
 
-<div className="ph-demo-slot" data-label="PRESENCE — online indicator">
+<div id="online-indicator-demo" className="ph-demo-slot" data-label="PRESENCE — online indicator">
   <OnlineIndicatorDemo client:only="react" />
 </div>
 

--- a/apps/docs/src/content/docs/examples/index.mdx
+++ b/apps/docs/src/content/docs/examples/index.mdx
@@ -1,0 +1,20 @@
+---
+title: "Examples"
+description: "Search runnable PlayHTML examples and finished sites made with PlayHTML."
+sidebar:
+  order: 1
+tableOfContents: false
+---
+
+import { ExampleCatalogue } from "../../../components/examples/ExampleCatalogue";
+import { exampleRecipeSummaries } from "../../../components/playground/recipes";
+
+Browse complete PlayHTML examples you can open, test, and remix. The Sites
+collection shows finished work made with PlayHTML and opens each project on its
+original URL.
+
+To test a collaborative example, open it in two browser contexts. Use a regular
+window and an incognito window, or use two different browsers, then follow the
+steps on the example page.
+
+<ExampleCatalogue examples={exampleRecipeSummaries} client:load />

--- a/apps/docs/src/content/docs/examples/index.mdx
+++ b/apps/docs/src/content/docs/examples/index.mdx
@@ -14,8 +14,8 @@ Recipes open on their own page and can be remixed in the playground. Docs demos
 jump to the guide that explains them. The Sites collection shows finished work
 made with PlayHTML and opens each project on its original URL.
 
-To test a collaborative example, open it in two browser contexts. Use a regular
-window and an incognito window, or use two different browsers, then follow the
-steps on the example page.
+To test a collaborative example, open it in two browser windows. Use a regular
+and private window, or use two different browsers. Then follow the steps on the
+example page.
 
 <ExampleCatalogue examples={catalogueExamples} client:load />

--- a/apps/docs/src/content/docs/examples/index.mdx
+++ b/apps/docs/src/content/docs/examples/index.mdx
@@ -7,14 +7,15 @@ tableOfContents: false
 ---
 
 import { ExampleCatalogue } from "../../../components/examples/ExampleCatalogue";
-import { exampleRecipeSummaries } from "../../../components/playground/recipes";
+import { catalogueExamples } from "../../../components/examples/examples";
 
-Browse complete PlayHTML examples you can open, test, and remix. The Sites
-collection shows finished work made with PlayHTML and opens each project on its
-original URL.
+Browse complete PlayHTML recipes and smaller live demos from across the docs.
+Recipes open on their own page and can be remixed in the playground. Docs demos
+jump to the guide that explains them. The Sites collection shows finished work
+made with PlayHTML and opens each project on its original URL.
 
 To test a collaborative example, open it in two browser contexts. Use a regular
 window and an incognito window, or use two different browsers, then follow the
 steps on the example page.
 
-<ExampleCatalogue examples={exampleRecipeSummaries} client:load />
+<ExampleCatalogue examples={catalogueExamples} client:load />

--- a/apps/docs/src/content/docs/examples/matter-physics.mdx
+++ b/apps/docs/src/content/docs/examples/matter-physics.mdx
@@ -1,0 +1,48 @@
+---
+title: "Shared Matter.js physics"
+description: "Run one small physics simulation and sync its bodies across browsers."
+sidebar:
+  order: 4
+---
+
+import { RecipeExample } from "@/components/playground/RecipeExample";
+import { matterPhysicsRecipe } from "@/components/playground/recipes/matter-physics";
+
+This example syncs a small Matter.js world across browsers. Use it when you want physics motion to persist without making every connected browser simulate and write the same bodies.
+
+<RecipeExample recipe={matterPhysicsRecipe} client:load />
+
+## What syncs
+
+Each body is stored under a stable key with three values: `x`, `y`, and `angle`. Dragging, adding, and resetting update that keyed shared data.
+
+The last person to interact becomes the simulation controller. Only that browser runs Matter.js and publishes transforms. Other browsers keep their bodies static and interpolate toward the latest shared positions.
+
+This is intentionally a small ownership rule. It makes the core synchronization pattern easy to inspect, but it does not support two people dragging separate bodies at the same time.
+
+## Why writes are bounded
+
+Physics engines render at about 60 frames per second. Writing shared data on every frame creates more updates than remote readers need.
+
+The example instead:
+
+- publishes at most once every 100 milliseconds;
+- skips position and angle changes below a small threshold;
+- clamps positions to the visible world before publishing;
+- writes body fields in place under their stable keys.
+
+All shared writes start from a user action or from the one browser currently controlling the simulation. `updateElement` only reads shared data and updates local targets.
+
+## Test it in two windows
+
+1. Open this page in a normal browser window.
+2. Click **Copy private-window link**, then open that exact URL in a private or incognito window. Keep both windows visible.
+3. Drag a body upward in the normal window and release it. The body should fall and settle in both windows.
+4. Click **Add body** in the private window. A new falling body should appear in both windows, and the private window now controls the simulation.
+5. Click **Reset** in either window. Both windows should return to the same three-body arrangement.
+
+If the windows do not match, confirm that both address bars contain the exact same example-page URL. A copied playground remix or a different path can use a different room.
+
+## Larger reference
+
+[Cinderblock Yard](/experiments/cinderblock/) extends the same idea into a larger working project with more bodies, selection tools, rotation and removal, sleeping, responsive scaling, and a more detailed ownership handoff. Start with this recipe before reading that implementation.

--- a/apps/docs/src/content/docs/examples/matter-physics.mdx
+++ b/apps/docs/src/content/docs/examples/matter-physics.mdx
@@ -23,7 +23,7 @@ The last person to interact becomes the simulation controller. Only that browser
 
 This is intentionally a small ownership rule. It makes the core synchronization pattern easy to inspect, but it does not support two people dragging separate bodies at the same time.
 
-## Why writes are bounded
+## Limit shared physics updates
 
 Physics engines render at about 60 frames per second. Writing shared data on every frame creates more updates than remote readers need.
 
@@ -46,6 +46,6 @@ All shared writes start from a user action or from the one browser currently con
 
 If the windows do not match, confirm that both address bars contain the exact same example-page URL. A copied playground remix or a different path can use a different room.
 
-## Larger reference
+## Compare with Cinderblock Yard
 
 [Cinderblock Yard](/experiments/cinderblock/) extends the same idea into a larger working project with more bodies, selection tools, rotation and removal, sleeping, responsive scaling, and a more detailed ownership handoff. Start with this recipe before reading that implementation.

--- a/apps/docs/src/content/docs/examples/matter-physics.mdx
+++ b/apps/docs/src/content/docs/examples/matter-physics.mdx
@@ -6,11 +6,14 @@ sidebar:
 ---
 
 import { RecipeExample } from "@/components/playground/RecipeExample";
+import RecipeCodeTabs from "@/components/playground/RecipeCodeTabs.astro";
 import { matterPhysicsRecipe } from "@/components/playground/recipes/matter-physics";
 
 This example syncs a small Matter.js world across browsers. Use it when you want physics motion to persist without making every connected browser simulate and write the same bodies.
 
 <RecipeExample recipe={matterPhysicsRecipe} client:load />
+
+<RecipeCodeTabs recipe={matterPhysicsRecipe} />
 
 ## What syncs
 

--- a/apps/docs/src/content/docs/examples/shared-audio-file.mdx
+++ b/apps/docs/src/content/docs/examples/shared-audio-file.mdx
@@ -1,0 +1,78 @@
+---
+title: "Shared audio file"
+description: "Keep an HTML audio file on the same play/pause timeline across browsers."
+sidebar:
+  order: 2
+---
+
+import { RecipeExample } from "@/components/playground/RecipeExample";
+import { sharedAudioFileRecipe } from "@/components/playground/recipes/shared-audio-file";
+
+This example keeps one HTML audio file on the same play/pause timeline across
+browsers. Start here when you already have an MP3, WAV, or other
+browser-supported audio file.
+
+<RecipeExample recipe={sharedAudioFileRecipe} client:load />
+
+## How it works
+
+The page uses a normal audio element:
+
+```html
+<audio src="/sounds/song.mp3" preload="auto" loop></audio>
+```
+
+PlayHTML shares only three transport values:
+
+```js
+{
+  isPlaying: false,
+  startedAtMs: 0,
+  positionMs: 0,
+}
+```
+
+Each browser loads the audio file itself. When someone presses **Play**, every
+browser calculates the current position from the shared start time and plays
+its local audio element from there.
+
+The example corrects the local audio position when it drifts by more than 250
+milliseconds. It keeps casual shared playback close, but it is not
+sample-accurate synchronization.
+
+## Enable audio in every window
+
+Browsers require a local interaction before a page can play sound. Click
+**Enable audio** once in every browser window.
+
+That permission cannot be shared. A play command still synchronizes while
+audio is locked, but the locked window stays silent until someone enables it
+there.
+
+## Use your own file
+
+Replace the `src` URL on the audio element:
+
+```html
+<audio src="/sounds/your-file.mp3" preload="auto" loop></audio>
+```
+
+Use a URL every browser can reach. The file does not pass through PlayHTML;
+each browser downloads it normally.
+
+## Test in two windows
+
+1. Click **Enable audio** in the normal browser window.
+2. Copy the private-window link and open it in a private or incognito window.
+3. Click **Enable audio** in the private window.
+4. Press **Play for everyone**. Both windows should play the same file from
+   nearly the same position.
+5. Pause or restart from either window. Both timelines should update.
+6. Start playback, wait a moment, and reload one window. Enable audio there
+   again; it should join at the current shared position.
+
+## Synthetic sounds and one-shot cues
+
+Use [Synchronized sound](/docs/examples/synchronized-sound/) when you need
+generated tones, one-shot events, or a custom scheduler instead of a normal
+audio file.

--- a/apps/docs/src/content/docs/examples/shared-audio-file.mdx
+++ b/apps/docs/src/content/docs/examples/shared-audio-file.mdx
@@ -6,6 +6,7 @@ sidebar:
 ---
 
 import { RecipeExample } from "@/components/playground/RecipeExample";
+import RecipeCodeTabs from "@/components/playground/RecipeCodeTabs.astro";
 import { sharedAudioFileRecipe } from "@/components/playground/recipes/shared-audio-file";
 
 This example keeps one HTML audio file on the same play/pause timeline across
@@ -13,6 +14,8 @@ browsers. Start here when you already have an MP3, WAV, or other
 browser-supported audio file.
 
 <RecipeExample recipe={sharedAudioFileRecipe} client:load />
+
+<RecipeCodeTabs recipe={sharedAudioFileRecipe} />
 
 ## How it works
 

--- a/apps/docs/src/content/docs/examples/shared-audio-file.mdx
+++ b/apps/docs/src/content/docs/examples/shared-audio-file.mdx
@@ -17,7 +17,7 @@ browser-supported audio file.
 
 <RecipeCodeTabs recipe={sharedAudioFileRecipe} />
 
-## How it works
+## Share the playback timeline
 
 The page uses a normal audio element:
 

--- a/apps/docs/src/content/docs/examples/synchronized-sound.mdx
+++ b/apps/docs/src/content/docs/examples/synchronized-sound.mdx
@@ -1,0 +1,74 @@
+---
+title: "Synchronized sound"
+description: "Broadcast one-shot audio cues and keep a shared play/pause timeline in sync."
+sidebar:
+  order: 3
+---
+
+import { RecipeExample } from "@/components/playground/RecipeExample";
+import { synchronizedSoundRecipe } from "@/components/playground/recipes/synchronized-sound";
+
+This advanced example shows two ways to coordinate generated sound with playhtml. Use an event for a sound that should happen once, or shared data for a generated loop that people need to join, pause, and resume.
+
+If you already have an MP3, WAV, or another audio file, start with [Shared audio file](/docs/examples/shared-audio-file/).
+
+<RecipeExample recipe={synchronizedSoundRecipe} client:load />
+
+## Choose the sound behavior
+
+| Behavior | PlayHTML primitive | Late joiners | Tradeoff |
+| --- | --- | --- | --- |
+| One-shot chime | Event | Do not hear an earlier chime | Good for reactions and effects, but it does not preserve history. |
+| Four-beat loop | Shared element data | Join at the current position | Preserves transport state, but each device still generates and schedules its own audio. |
+
+The example uses the Web Audio API to generate every tone in the browser. It does not download or stream an audio file.
+
+## Enable audio in every window
+
+Browsers block sound until a person interacts with the page. **Enable audio** creates and resumes a local `AudioContext`, so every open window must click it once.
+
+The audio-enabled setting is intentionally not shared. One person cannot grant another browser permission to make sound.
+
+## Send a one-shot cue
+
+**Send chime** dispatches a `synchronized-sound-cue` event. Everyone currently connected receives the event and generates the same short tone locally.
+
+The event is not stored. A person who opens the page after the click does not hear it. See [Events](/docs/data/events/) for the complete event API and other transient-signal examples.
+
+## Share a play/pause timeline
+
+The loop keeps only the transport state in shared data:
+
+```js
+{
+  isPlaying: false,
+  startedAtMs: 0,
+  positionMs: 0,
+}
+```
+
+When someone presses **Play loop**, the example stores a wall-clock start time. Every window calculates the current position from `Date.now() - startedAtMs`. Someone who joins late therefore starts on the current beat instead of beat one.
+
+The local scheduler looks ahead by a short interval and recalculates each upcoming beat from the shared start time. This corrects ordinary JavaScript timer drift instead of letting timing errors accumulate. It is appropriate for shared music controls and playful sound effects, but it is not sample-accurate audio networking: device clock differences and network delay can still produce a small offset.
+
+Shared writes happen only when a person presses **Play**, **Pause**, or **Restart**. The animation and audio-scheduling loop reads the current data without writing it back, so a remote update cannot start a self-triggering write loop. See [Data essentials](/docs/data/data-essentials/) for the shared-data rules used here.
+
+## Test in two windows
+
+Use the live example above so both windows join the room shown in its toolbar.
+
+1. Click **Enable audio** in the normal browser window.
+2. Click **Copy private-window link**. Open a private or incognito window and paste the copied URL.
+3. Click **Enable audio** in the private window too.
+4. Click **Send chime** in either window. Both windows should play one chime. Reloading the other window should not replay it.
+5. Click **Play loop**. Both windows should show the same highlighted beat and nearly the same position.
+6. Click **Pause loop** in the other window. Both timelines should stop at that shared position.
+7. Start the loop again, wait a few beats, then reload the private window. After clicking **Enable audio** again, it should jump to the current position and join the next beat instead of restarting from zero.
+
+If the controls synchronize but one window is silent, audio is still locked in that window. Click **Enable audio** there again.
+
+## Related
+
+- [Events](/docs/data/events/): broadcast transient signals that are not replayed.
+- [Data essentials](/docs/data/data-essentials/): choose between shared data, presence, local state, and events.
+- [Custom elements](/docs/custom-elements/): build a `can-play` element with your own data and event handlers.

--- a/apps/docs/src/content/docs/examples/synchronized-sound.mdx
+++ b/apps/docs/src/content/docs/examples/synchronized-sound.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Synchronized sound"
-description: "Broadcast one-shot audio cues and keep a shared play/pause timeline in sync."
+description: "Send one-shot audio cues to connected readers and keep a generated loop on the same timeline across browsers."
 sidebar:
   order: 3
 ---

--- a/apps/docs/src/content/docs/examples/synchronized-sound.mdx
+++ b/apps/docs/src/content/docs/examples/synchronized-sound.mdx
@@ -6,6 +6,7 @@ sidebar:
 ---
 
 import { RecipeExample } from "@/components/playground/RecipeExample";
+import RecipeCodeTabs from "@/components/playground/RecipeCodeTabs.astro";
 import { synchronizedSoundRecipe } from "@/components/playground/recipes/synchronized-sound";
 
 This advanced example shows two ways to coordinate generated sound with playhtml. Use an event for a sound that should happen once, or shared data for a generated loop that people need to join, pause, and resume.
@@ -13,6 +14,8 @@ This advanced example shows two ways to coordinate generated sound with playhtml
 If you already have an MP3, WAV, or another audio file, start with [Shared audio file](/docs/examples/shared-audio-file/).
 
 <RecipeExample recipe={synchronizedSoundRecipe} client:load />
+
+<RecipeCodeTabs recipe={synchronizedSoundRecipe} />
 
 ## Choose the sound behavior
 

--- a/apps/docs/src/styles/docs-extras.css
+++ b/apps/docs/src/styles/docs-extras.css
@@ -147,6 +147,10 @@ body {
   position: relative;
   min-height: 100vh;
 }
+
+body:has(#examples-catalogue-results) {
+  --sl-content-width: min(100%, 110rem);
+}
 body::before {
   content: "";
   position: fixed;
@@ -171,6 +175,10 @@ body > * {
   z-index: 1;
 }
 
+.content-panel + .content-panel {
+  border-top: 0;
+}
+
 /* ---------------------------------------------------------------------
    4. Typography
    --------------------------------------------------------------------- */
@@ -181,47 +189,50 @@ h3,
 h4,
 h5,
 h6,
-.sl-markdown-content :is(h1, h2, h3, h4, h5, h6) {
+.sl-markdown-content
+  :is(h1, h2, h3, h4, h5, h6):not(:where(.not-content *)) {
   font-family: var(--ph-font-display);
   font-weight: 700;
   letter-spacing: -0.015em;
   color: var(--ph-ink);
 }
 
-.sl-markdown-content h1 {
+.sl-markdown-content h1:not(:where(.not-content *)) {
   font-size: clamp(2.1rem, 1.4rem + 2.4vw, 3.1rem);
   font-weight: 800;
   letter-spacing: -0.02em;
 }
-.sl-markdown-content h2 {
+.sl-markdown-content h2:not(:where(.not-content *)) {
   font-size: clamp(1.55rem, 1.15rem + 1.4vw, 2.05rem);
   margin-top: 2.6rem;
   padding-top: 1.2rem;
   border-top: 1px solid var(--ph-hairline-soft);
 }
-.sl-markdown-content h3 {
+.sl-markdown-content h3:not(:where(.not-content *)) {
   font-size: 1.25rem;
   margin-top: 2rem;
 }
 
-.sl-markdown-content p,
-.sl-markdown-content li {
+.sl-markdown-content p:not(:where(.not-content *)),
+.sl-markdown-content li:not(:where(.not-content *)) {
   font-family: var(--ph-font-body);
   font-size: 1rem;
   line-height: 1.7;
   letter-spacing: 0.005em;
 }
-.sl-markdown-content p {
+.sl-markdown-content p:not(:where(.not-content *)) {
   max-width: 68ch;
 }
 
-.sl-markdown-content a:not(.sl-link-card, .sl-link-button) {
+.sl-markdown-content
+  a:not(.sl-link-card, .sl-link-button, :where(.not-content *)) {
   color: var(--ph-ultramarine-deep);
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
   transition: color var(--ph-motion-fast);
 }
-.sl-markdown-content a:not(.sl-link-card, .sl-link-button):hover {
+.sl-markdown-content
+  a:not(.sl-link-card, .sl-link-button, :where(.not-content *)):hover {
   color: var(--ph-ink);
   background: var(--ph-mustard-wash);
 }


### PR DESCRIPTION
## Summary

- add a searchable examples catalogue that combines runnable docs recipes, 16 embedded docs demos, and curated PlayHTML sites from Are.na
- add reusable recipe pages for shared audio-file, synchronized sound, and Matter.js physics examples
- provide complete copy-paste Vanilla HTML and React versions for every recipe in synced framework tabs
- render recipe source with the same dual-theme syntax highlighting and copy treatment as normal docs code fences
- send Vanilla HTML readers directly to the live playground for testing and remixing
- link smaller docs demos directly to the guide section that explains and runs them
- make collaborative testing explicit with shared-room links for normal and private browser windows
- align the catalogue, cards, controls, and responsive layout with the existing docs design system
- stack search and source controls into two rows when the docs content column is too narrow, while keeping all source buttons together
- validate shared room links and map Are.na author metadata from the live V3 response

## Why

The docs had useful examples spread across inline documentation, the playground, and a separate Are.na collection. This gives them one browsable entry point. Complete recipes are copy-pasteable in either Vanilla HTML or React; the Vanilla version remains runnable, testable across browser contexts, and remixable in the playground. Smaller docs demos jump directly to their live guide section.

## Validation

- `bun run test` from `apps/docs` — 40 tests passed
- `bun run build` from `apps/docs` — 31 pages built
- browser-verified `/docs/examples/` and all three recipe pages at desktop width
- verified recipe source in explicit light and dark themes, including dual Shiki token palettes, syntax highlighting, copy controls, and removal of filename labels
- verified the controls use the catalogue content width for their responsive breakpoint and preserve a single source-button row
- verified synced Vanilla HTML/React tab persistence across recipe pages, complete copy controls, and Vanilla-only playground handoff
- verified catalogue search/source filters, recipe versus docs-demo actions, author search, playground remix links, audio-file playback, synchronized sound controls, Matter.js interaction, responsive layout, and missing-image handling
- verified every newly indexed docs-demo link resolves to its intended target
- regression coverage for invalid room IDs, HTML-safe iframe serialization, React recipe syntax, stable element IDs, event cleanup, and shared-write boundaries

Visual evidence is attached in the PR conversation.