### PR TITLE
Fix MovementCanvas audio crackling and live sound

### DIFF
--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -162,6 +162,14 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const soundFramesRef = useRef<TrailSoundFrame[]>([]);
     const soundTrailIndicesRef = useRef<Map<string, number>>(new Map());
     const nextSoundTrailIndexRef = useRef(0);
+    const retiredSoundTrailIndicesRef = useRef<number[]>([]);
+    const queueSoundTrailRetirement = (trailId: string) => {
+      const soundTrailIndex = soundTrailIndicesRef.current.get(trailId);
+      if (soundTrailIndex !== undefined) {
+        retiredSoundTrailIndicesRef.current.push(soundTrailIndex);
+      }
+      soundTrailIndicesRef.current.delete(trailId);
+    };
 
     const spawnedClickKeysByTrailRef = useRef<Map<string, Set<string>>>(
       new Map(),
@@ -207,6 +215,13 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
 
     useEffect(() => {
       keptRef.current = kept;
+      if (retiredSoundTrailIndicesRef.current.length > 0) {
+        const trailIndices = retiredSoundTrailIndicesRef.current;
+        retiredSoundTrailIndicesRef.current = [];
+        for (const trailIndex of trailIndices) {
+          soundEngineRef.current?.retireTrail(trailIndex);
+        }
+      }
       if (removedIdsRef.current.length > 0) {
         const ids = removedIdsRef.current;
         removedIdsRef.current = [];
@@ -253,7 +268,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             // Fully faded — drop, and report so its events can be freed.
             removedIdsRef.current.push(id);
             spawnedClickKeysByTrailRef.current.delete(id);
-            soundTrailIndicesRef.current.delete(id);
+            queueSoundTrailRetirement(id);
           }
         }
         // Brand-new live trails not already in `kept`.
@@ -301,7 +316,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               changed = true;
               removedIdsRef.current.push(tid);
               spawnedClickKeysByTrailRef.current.delete(tid);
-              soundTrailIndicesRef.current.delete(tid);
+              queueSoundTrailRetirement(tid);
             }
           }
           return changed ? next : prev;
@@ -309,6 +324,15 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       }, 1000);
       return () => window.clearInterval(id);
     }, []);
+
+    useEffect(
+      () => () => {
+        for (const trailIndex of soundTrailIndicesRef.current.values()) {
+          soundEngineRef.current?.retireTrail(trailIndex);
+        }
+      },
+      [],
+    );
 
     // Per-trail imperative handles, keyed by stable trail id.
     const trailHandles = useRef<Map<string, ImperativeTrailHandle>>(new Map());
@@ -387,6 +411,14 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       const runFrame = (perfNow: number) => {
         if (frozenRef.current) {
           pauseDrawClock(perfNow);
+          soundEngineRef.current?.tick(
+            getDrawClockTime(
+              perfNow,
+              pausedAccumMsRef.current,
+              pauseStartedAtRef.current,
+            ),
+            [],
+          );
           return;
         }
         resumeDrawClock(perfNow);

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -3,6 +3,8 @@
 
 import React, { useEffect, useRef, useState, memo } from "react";
 import type { TrailState } from "../types";
+import type { SoundEngine } from "../sound/SoundEngine";
+import type { TrailSoundFrame } from "../sound/types";
 import { getTrailRenderer } from "../styles/trailRenderers";
 import { RippleEffect, type RippleSettings } from "./ClickRipple";
 import {
@@ -54,6 +56,30 @@ export function getDrawClockTime(
   return (pauseStartedAt ?? performanceNow) - pausedAccumMs;
 }
 
+export function createLiveSoundFrame(
+  trailIndex: number,
+  trailState: TrailState,
+  cursorPosition: { x: number; y: number },
+  trailProgress: number,
+): TrailSoundFrame {
+  const points = trailState.trail.points;
+  const cursorPointIndex = Math.min(
+    Math.floor((points.length - 1) * trailProgress),
+    points.length - 1,
+  );
+  return {
+    trailIndex,
+    x: cursorPosition.x,
+    y: cursorPosition.y,
+    prevX: cursorPosition.x,
+    prevY: cursorPosition.y,
+    cursorType: points[cursorPointIndex]?.cursor,
+    progress: trailProgress,
+    color: trailState.trail.color,
+    isNewlyActive: false,
+  };
+}
+
 /** Tiny deterministic hash of a string to a small int, for per-trail variation. */
 function hashKey(key: string): number {
   let h = 0;
@@ -75,6 +101,7 @@ interface LiveTrailsProps {
   trailStates: TrailState[];
   frozen?: boolean;
   showClickRipples?: boolean;
+  soundEngine?: SoundEngine | null;
   /** Called with trail ids once they have fully faded out and been removed, so
    * the owner can free their accumulated events. */
   onTrailsRemoved?: (ids: string[]) => void;
@@ -91,6 +118,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     trailStates,
     frozen = false,
     showClickRipples = false,
+    soundEngine = null,
     onTrailsRemoved,
     settings,
   }) => {
@@ -126,6 +154,14 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       showClickRipplesRef.current = showClickRipples;
       if (!showClickRipples) setActiveClickEffects([]);
     }, [showClickRipples]);
+
+    const soundEngineRef = useRef(soundEngine);
+    useEffect(() => {
+      soundEngineRef.current = soundEngine;
+    }, [soundEngine]);
+    const soundFramesRef = useRef<TrailSoundFrame[]>([]);
+    const soundTrailIndicesRef = useRef<Map<string, number>>(new Map());
+    const nextSoundTrailIndexRef = useRef(0);
 
     const spawnedClickKeysByTrailRef = useRef<Map<string, Set<string>>>(
       new Map(),
@@ -217,6 +253,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             // Fully faded — drop, and report so its events can be freed.
             removedIdsRef.current.push(id);
             spawnedClickKeysByTrailRef.current.delete(id);
+            soundTrailIndicesRef.current.delete(id);
           }
         }
         // Brand-new live trails not already in `kept`.
@@ -264,6 +301,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               changed = true;
               removedIdsRef.current.push(tid);
               spawnedClickKeysByTrailRef.current.delete(tid);
+              soundTrailIndicesRef.current.delete(tid);
             }
           }
           return changed ? next : prev;
@@ -358,6 +396,9 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         const trailOpacity = trailOpacityRef.current;
         const strokeWidth = strokeWidthRef.current;
         const drawMap = drawRef.current;
+        const soundEngine = soundEngineRef.current;
+        const soundFrames = soundFramesRef.current;
+        soundFrames.length = 0;
 
         const present = new Set<string>();
 
@@ -441,6 +482,27 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             progress,
           );
 
+          const activelyTracing =
+            result &&
+            !caughtUp &&
+            !draw.settled &&
+            entry.departedAt === null;
+          if (soundEngine && activelyTracing) {
+            let soundTrailIndex = soundTrailIndicesRef.current.get(key);
+            if (soundTrailIndex === undefined) {
+              soundTrailIndex = nextSoundTrailIndexRef.current++;
+              soundTrailIndicesRef.current.set(key, soundTrailIndex);
+            }
+            soundFrames.push(
+              createLiveSoundFrame(
+                soundTrailIndex,
+                ts,
+                result.cursorPosition,
+                result.trailProgress,
+              ),
+            );
+          }
+
           if (result && showClickRipplesRef.current) {
             let spawnedClickKeys = spawnedClickKeysByTrailRef.current.get(key);
             if (!spawnedClickKeys) {
@@ -456,6 +518,15 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               Date.now(),
             );
             if (effects.length > 0) {
+              if (soundEngine) {
+                for (const effect of effects) {
+                  soundEngine.triggerClick({
+                    x: effect.x,
+                    y: effect.y,
+                    holdDuration: effect.holdDuration,
+                  });
+                }
+              }
               setActiveClickEffects((active) => [...active, ...effects]);
             }
           }
@@ -486,6 +557,8 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             cursorHandle?.hide();
           }
         }
+
+        soundEngine?.tick(clockMs, soundFrames);
 
         // Prune draw tracking for trails that left so the map can't grow.
         if (drawMap.size > present.size) {

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1564,6 +1564,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               trailStates={trailStates}
               frozen={paused}
               showClickRipples={!showClicks}
+              soundEngine={paused || !soundEnabled ? null : soundEngineReady}
               onTrailsRemoved={handleTrailsRemoved}
               settings={trailAnimationSettings}
             />

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1564,7 +1564,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               trailStates={trailStates}
               frozen={paused}
               showClickRipples={!showClicks}
-              soundEngine={paused || !soundEnabled ? null : soundEngineReady}
+              soundEngine={!soundEnabled ? null : soundEngineReady}
               onTrailsRemoved={handleTrailsRemoved}
               settings={trailAnimationSettings}
             />

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -178,6 +178,7 @@ describe("LiveTrails sound", () => {
     const soundEngine = {
       tick: vi.fn(),
       triggerClick: vi.fn(),
+      retireTrail: vi.fn(),
     } as unknown as SoundEngine;
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -204,7 +205,22 @@ describe("LiveTrails sound", () => {
       }),
     ]);
 
+    await act(async () => {
+      root.render(
+        React.createElement(LiveTrails, {
+          trailStates: [state],
+          frozen: true,
+          soundEngine,
+          settings: DEFAULT_SETTINGS,
+        }),
+      );
+    });
+    act(() => scheduledFrames.shift()?.(1700));
+
+    expect(soundEngine.tick).toHaveBeenLastCalledWith(1700, []);
+
     await act(async () => root.unmount());
+    expect(soundEngine.retireTrail).toHaveBeenCalledWith(0);
     container.remove();
     vi.unstubAllGlobals();
     delete testGlobal.IS_REACT_ACT_ENVIRONMENT;

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -1,9 +1,17 @@
 // ABOUTME: Tests click spawning and lifecycle timing for the live cursor-trail renderer.
 // ABOUTME: Covers one-shot effects and clock pauses while the document is hidden.
 
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import type { TrailState } from "../../types";
-import { getDrawClockTime } from "../LiveTrails";
+import type { SoundEngine } from "../../sound/SoundEngine";
+import { DEFAULT_SETTINGS } from "../settingsDefaults";
+import {
+  createLiveSoundFrame,
+  getDrawClockTime,
+  LiveTrails,
+} from "../LiveTrails";
 import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
@@ -124,5 +132,81 @@ describe("getDrawClockTime", () => {
 
   it("resumes from the same lifecycle time after accounting for the pause", () => {
     expect(getDrawClockTime(30_000, 22_000, null)).toBe(8_000);
+  });
+});
+
+describe("createLiveSoundFrame", () => {
+  it("maps the live draw head to the current cursor instrument", () => {
+    const state = trailState();
+    state.trail.points[0].cursor = "pointer";
+    state.trail.points[1].cursor = "text";
+
+    expect(
+      createLiveSoundFrame(7, state, { x: 75, y: 80 }, 1),
+    ).toEqual({
+      trailIndex: 7,
+      x: 75,
+      y: 80,
+      prevX: 75,
+      prevY: 80,
+      cursorType: "text",
+      progress: 1,
+      color: "#123456",
+      isNewlyActive: false,
+    });
+  });
+});
+
+describe("LiveTrails sound", () => {
+  it("feeds active live draw heads to the sound engine", async () => {
+    const testGlobal = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    const scheduledFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        scheduledFrames.push(callback);
+        return scheduledFrames.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const state = trailState();
+    state.trail.points[0].cursor = "pointer";
+    const soundEngine = {
+      tick: vi.fn(),
+      triggerClick: vi.fn(),
+    } as unknown as SoundEngine;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(LiveTrails, {
+          trailStates: [state],
+          soundEngine,
+          settings: DEFAULT_SETTINGS,
+        }),
+      );
+    });
+
+    act(() => scheduledFrames.shift()?.(1000));
+    act(() => scheduledFrames.shift()?.(1600));
+
+    expect(soundEngine.tick).toHaveBeenLastCalledWith(1600, [
+      expect.objectContaining({
+        trailIndex: 0,
+        cursorType: "pointer",
+        progress: 0.6,
+      }),
+    ]);
+
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
   });
 });

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -14,6 +14,9 @@ import { getInstrument, CLICK_BELL } from "./instruments";
 /** Minimum time between note changes for a single voice (ms) */
 const MIN_NOTE_INTERVAL_MS = 80;
 
+/** Duration of cursor-instrument timbre crossfades (seconds). */
+const OSCILLATOR_CROSSFADE_SECONDS = 0.03;
+
 /** Minimum velocity to trigger any sound (pixels per frame at ~60fps) */
 const SILENCE_VELOCITY_THRESHOLD = 0.05;
 
@@ -52,8 +55,10 @@ const PERCUSSIVE_CURSOR_TYPES = new Set(["text"]);
 /** Per-trail voice state */
 interface Voice {
   oscillator: OscillatorNode | null;
+  oscillatorLevel: GainNode | null;
   /** Fifth oscillator for chord voicing mode */
   fifthOscillator: OscillatorNode | null;
+  fifthOscillatorLevel: GainNode | null;
   gainNode: GainNode;
   /** Separate gain for the fifth so we can enable/disable it */
   fifthGainNode: GainNode | null;
@@ -470,7 +475,10 @@ export class SoundEngine {
 
     const pan = ctx.createStereoPanner();
 
-    osc.connect(filter);
+    const oscillatorLevel = ctx.createGain();
+    oscillatorLevel.gain.setValueAtTime(1, now);
+    osc.connect(oscillatorLevel);
+    oscillatorLevel.connect(filter);
     filter.connect(gain);
     gain.connect(pan);
     pan.connect(this.masterGain!);
@@ -488,19 +496,18 @@ export class SoundEngine {
       now,
     );
 
-    fifthOsc.connect(filter); // Share the same filter chain
-    fifthOsc.start(now);
-
-    // Route fifth gain separately so we can control its level
-    // Actually, the fifth goes through the same filter -> gain -> pan chain
-    // but we control its presence via fifthGain before the filter
-    fifthOsc.disconnect();
-    fifthOsc.connect(fifthGain);
+    const fifthOscillatorLevel = ctx.createGain();
+    fifthOscillatorLevel.gain.setValueAtTime(1, now);
+    fifthOsc.connect(fifthOscillatorLevel);
+    fifthOscillatorLevel.connect(fifthGain);
     fifthGain.connect(filter);
+    fifthOsc.start(now);
 
     return {
       oscillator: osc,
+      oscillatorLevel,
       fifthOscillator: fifthOsc,
+      fifthOscillatorLevel,
       gainNode: gain,
       fifthGainNode: fifthGain,
       filterNode: filter,
@@ -559,29 +566,71 @@ export class SoundEngine {
     );
     voice.filterNode.Q.linearRampToValueAtTime(instrument.filterQ, now + 0.1);
 
-    if (voice.oscillator && voice.oscillator.type !== instrument.oscillatorType) {
-      const oldOsc = voice.oscillator;
-      const newOsc = this.ctx.createOscillator();
-      newOsc.type = instrument.oscillatorType;
-      newOsc.frequency.value = voice.currentFrequency || 220;
-      newOsc.connect(voice.filterNode);
-      newOsc.start(this.ctx.currentTime);
-      oldOsc.stop(this.ctx.currentTime + 0.05);
-      voice.oscillator = newOsc;
+    if (
+      voice.oscillator &&
+      voice.oscillatorLevel &&
+      voice.oscillator.type !== instrument.oscillatorType
+    ) {
+      const primary = this.crossfadeOscillator(
+        voice.oscillator,
+        voice.oscillatorLevel,
+        voice.filterNode,
+        instrument.oscillatorType,
+        voice.currentFrequency || 220,
+      );
+      voice.oscillator = primary.oscillator;
+      voice.oscillatorLevel = primary.level;
 
-      // Also update the fifth oscillator type to match
-      if (voice.fifthOscillator && voice.fifthGainNode) {
-        const oldFifth = voice.fifthOscillator;
-        const newFifth = this.ctx.createOscillator();
-        newFifth.type = instrument.oscillatorType;
-        newFifth.frequency.value = (voice.currentFrequency || 220) * 1.5;
-        newFifth.connect(voice.fifthGainNode);
-        voice.fifthGainNode.connect(voice.filterNode);
-        newFifth.start(this.ctx.currentTime);
-        oldFifth.stop(this.ctx.currentTime + 0.05);
-        voice.fifthOscillator = newFifth;
+      if (
+        voice.fifthOscillator &&
+        voice.fifthOscillatorLevel &&
+        voice.fifthGainNode
+      ) {
+        const fifth = this.crossfadeOscillator(
+          voice.fifthOscillator,
+          voice.fifthOscillatorLevel,
+          voice.fifthGainNode,
+          instrument.oscillatorType,
+          (voice.currentFrequency || 220) * 1.5,
+        );
+        voice.fifthOscillator = fifth.oscillator;
+        voice.fifthOscillatorLevel = fifth.level;
       }
     }
+  }
+
+  private crossfadeOscillator(
+    oscillator: OscillatorNode,
+    level: GainNode,
+    destination: AudioNode,
+    oscillatorType: OscillatorType,
+    frequency: number,
+  ): { oscillator: OscillatorNode; level: GainNode } {
+    const ctx = this.ctx!;
+    const now = ctx.currentTime;
+    const currentOscillator = ctx.createOscillator();
+    const currentLevel = ctx.createGain();
+
+    currentOscillator.type = oscillatorType;
+    currentOscillator.frequency.value = frequency;
+    currentLevel.gain.setValueAtTime(0, now);
+    currentOscillator.connect(currentLevel);
+    currentLevel.connect(destination);
+    currentOscillator.start(now);
+
+    this.holdParam(level.gain, now);
+    level.gain.linearRampToValueAtTime(
+      0,
+      now + OSCILLATOR_CROSSFADE_SECONDS,
+    );
+    currentLevel.gain.linearRampToValueAtTime(
+      1,
+      now + OSCILLATOR_CROSSFADE_SECONDS,
+    );
+    oscillator.onended = () => level.disconnect();
+    oscillator.stop(now + OSCILLATOR_CROSSFADE_SECONDS);
+
+    return { oscillator: currentOscillator, level: currentLevel };
   }
 
   private fadeVoice(voice: Voice, duration: number): void {

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -238,7 +238,7 @@ export class SoundEngine {
 
       let voice = this.voices.get(frame.trailIndex);
 
-      if (!voice) {
+      if (!voice || !voice.oscillator) {
         voice = this.createVoice(instrument);
         this.voices.set(frame.trailIndex, voice);
       }

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -658,6 +658,59 @@ export class SoundEngine {
     }
   }
 
+  /** Permanently remove a trail's audio graph and cached motion state. */
+  retireTrail(trailIndex: number): void {
+    const voice = this.voices.get(trailIndex);
+    if (voice) {
+      const disconnect = () => this.disconnectVoice(voice);
+      let disconnectWhenStopped = false;
+      if (this.ctx && voice.oscillator) {
+        const now = this.ctx.currentTime;
+        this.holdParam(voice.gainNode.gain, now);
+        voice.gainNode.gain.linearRampToValueAtTime(0, now + 0.03);
+        voice.oscillator.onended = disconnect;
+        try {
+          voice.oscillator.stop(now + 0.04);
+          disconnectWhenStopped = true;
+        } catch { /* already stopped */ }
+      }
+      if (voice.oscillator) {
+        voice.oscillator = null;
+      }
+      if (voice.fifthOscillator) {
+        try {
+          voice.fifthOscillator.stop(
+            this.ctx ? this.ctx.currentTime + 0.04 : undefined,
+          );
+        } catch { /* already stopped */ }
+        voice.fifthOscillator = null;
+      }
+      if (!disconnectWhenStopped) {
+        disconnect();
+      }
+      this.voices.delete(trailIndex);
+    }
+    this.prevPositions.delete(trailIndex);
+    this.trailPaths.delete(trailIndex);
+    for (const key of this.crossingCooldowns.keys()) {
+      if (
+        key.startsWith(`${trailIndex}-path-`) ||
+        key.endsWith(`-path-${trailIndex}`)
+      ) {
+        this.crossingCooldowns.delete(key);
+      }
+    }
+  }
+
+  private disconnectVoice(voice: Voice): void {
+    voice.oscillatorLevel?.disconnect();
+    voice.fifthOscillatorLevel?.disconnect();
+    voice.fifthGainNode?.disconnect();
+    voice.filterNode.disconnect();
+    voice.gainNode.disconnect();
+    voice.panNode.disconnect();
+  }
+
   setVolume(volume: number): void {
     this.baseVolume = Math.max(0, Math.min(1, volume));
     this.updateMasterGainForPolyphony(this.lastActiveTrailCount);

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -56,6 +56,7 @@ class TestOscillatorNode extends TestAudioNode {
   frequency = new TestAudioParam();
   startTimes: number[] = [];
   stopTimes: Array<number | undefined> = [];
+  onended: (() => void) | null = null;
 
   start(time = 0): void {
     this.startTimes.push(time);
@@ -276,5 +277,61 @@ describe("SoundEngine cursor instruments", () => {
     expect(context.oscillators).toHaveLength(4);
     expect(context.oscillators[2].startTimes).toEqual([context.currentTime]);
     expect(context.oscillators[3].startTimes).toEqual([context.currentTime]);
+  });
+
+  it("retires all state for a finished live trail", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+    engine.setConfig({ crossingDissonance: true });
+
+    engine.tick(0, [
+      {
+        trailIndex: 7,
+        x: 0,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0,
+        color: "#000",
+        isNewlyActive: true,
+      },
+    ]);
+    engine.tick(100, [
+      {
+        trailIndex: 7,
+        x: 10,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.5,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const primaryLevel = context.oscillators[0].connections[0];
+    const state = engine as unknown as {
+      voices: Map<number, unknown>;
+      prevPositions: Map<number, unknown>;
+      trailPaths: Map<number, unknown>;
+      crossingCooldowns: Map<string, number>;
+    };
+    state.crossingCooldowns.set("7-path-2", 100);
+    state.crossingCooldowns.set("2-path-7", 100);
+
+    engine.retireTrail(7);
+
+    expect(state.voices.has(7)).toBe(false);
+    expect(state.prevPositions.has(7)).toBe(false);
+    expect(state.trailPaths.has(7)).toBe(false);
+    expect(state.crossingCooldowns).toEqual(new Map());
+    expect(primaryLevel.connections).not.toEqual([]);
+
+    context.oscillators[0].onended?.();
+
+    expect(primaryLevel.connections).toEqual([]);
   });
 });

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -226,4 +226,55 @@ describe("SoundEngine cursor instruments", () => {
       );
     }
   });
+
+  it("recreates a released voice when a live trail resumes", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+
+    engine.tick(0, [
+      {
+        trailIndex: 0,
+        x: 0,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0,
+        color: "#000",
+        isNewlyActive: true,
+      },
+    ]);
+    engine.tick(100, [
+      {
+        trailIndex: 0,
+        x: 10,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.5,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+    engine.tick(200, []);
+    engine.tick(300, [
+      {
+        trailIndex: 0,
+        x: 20,
+        y: 0,
+        prevX: 10,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.6,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    expect(context.oscillators).toHaveLength(4);
+    expect(context.oscillators[2].startTimes).toEqual([context.currentTime]);
+    expect(context.oscillators[3].startTimes).toEqual([context.currentTime]);
+  });
 });

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -1,0 +1,229 @@
+// ABOUTME: Tests audio-graph transitions in the movement visualization sound engine.
+// ABOUTME: Verifies cursor timbre changes crossfade without stacking full-level oscillators.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SoundEngine } from "../SoundEngine";
+
+type ParamEvent = {
+  method: "cancelAndHold" | "exponentialRamp" | "linearRamp" | "set";
+  value?: number;
+  time: number;
+};
+
+class TestAudioParam {
+  value = 0;
+  events: ParamEvent[] = [];
+
+  cancelAndHoldAtTime(time: number): void {
+    this.events.push({ method: "cancelAndHold", time });
+  }
+
+  cancelScheduledValues(): void {}
+
+  exponentialRampToValueAtTime(value: number, time: number): void {
+    this.events.push({ method: "exponentialRamp", value, time });
+  }
+
+  linearRampToValueAtTime(value: number, time: number): void {
+    this.events.push({ method: "linearRamp", value, time });
+  }
+
+  setValueAtTime(value: number, time: number): void {
+    this.value = value;
+    this.events.push({ method: "set", value, time });
+  }
+}
+
+class TestAudioNode {
+  connections: TestAudioNode[] = [];
+
+  connect(destination: TestAudioNode): TestAudioNode {
+    this.connections.push(destination);
+    return destination;
+  }
+
+  disconnect(): void {
+    this.connections = [];
+  }
+}
+
+class TestGainNode extends TestAudioNode {
+  gain = new TestAudioParam();
+}
+
+class TestOscillatorNode extends TestAudioNode {
+  type: OscillatorType = "sine";
+  frequency = new TestAudioParam();
+  startTimes: number[] = [];
+  stopTimes: Array<number | undefined> = [];
+
+  start(time = 0): void {
+    this.startTimes.push(time);
+  }
+
+  stop(time?: number): void {
+    this.stopTimes.push(time);
+  }
+}
+
+class TestBiquadFilterNode extends TestAudioNode {
+  type: BiquadFilterType = "lowpass";
+  frequency = new TestAudioParam();
+  Q = new TestAudioParam();
+}
+
+class TestStereoPannerNode extends TestAudioNode {
+  pan = new TestAudioParam();
+}
+
+class TestDynamicsCompressorNode extends TestAudioNode {
+  threshold = new TestAudioParam();
+  knee = new TestAudioParam();
+  ratio = new TestAudioParam();
+  attack = new TestAudioParam();
+  release = new TestAudioParam();
+}
+
+class TestConvolverNode extends TestAudioNode {
+  buffer: AudioBuffer | null = null;
+}
+
+class TestAudioContext {
+  currentTime = 1;
+  destination = new TestAudioNode();
+  sampleRate = 100;
+  state: AudioContextState = "running";
+  oscillators: TestOscillatorNode[] = [];
+
+  createBiquadFilter(): BiquadFilterNode {
+    return new TestBiquadFilterNode() as unknown as BiquadFilterNode;
+  }
+
+  createBuffer(_channels: number, length: number): AudioBuffer {
+    return {
+      getChannelData: () => new Float32Array(length),
+    } as unknown as AudioBuffer;
+  }
+
+  createConvolver(): ConvolverNode {
+    return new TestConvolverNode() as unknown as ConvolverNode;
+  }
+
+  createDynamicsCompressor(): DynamicsCompressorNode {
+    return new TestDynamicsCompressorNode() as unknown as DynamicsCompressorNode;
+  }
+
+  createGain(): GainNode {
+    return new TestGainNode() as unknown as GainNode;
+  }
+
+  createOscillator(): OscillatorNode {
+    const oscillator = new TestOscillatorNode();
+    this.oscillators.push(oscillator);
+    return oscillator as unknown as OscillatorNode;
+  }
+
+  createStereoPanner(): StereoPannerNode {
+    return new TestStereoPannerNode() as unknown as StereoPannerNode;
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  resume(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const originalAudioContext = globalThis.AudioContext;
+let context: TestAudioContext;
+
+beforeEach(() => {
+  context = new TestAudioContext();
+  globalThis.AudioContext = class {
+    constructor() {
+      return context;
+    }
+  } as unknown as typeof AudioContext;
+});
+
+afterEach(() => {
+  globalThis.AudioContext = originalAudioContext;
+});
+
+describe("SoundEngine cursor instruments", () => {
+  it("crossfades both oscillators when the cursor timbre changes", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+    engine.setConfig({ cursorInstruments: true, chordVoicing: true });
+
+    engine.tick(0, [
+      {
+        trailIndex: 0,
+        x: 0,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0,
+        color: "#000",
+        isNewlyActive: true,
+      },
+    ]);
+    engine.tick(100, [
+      {
+        trailIndex: 0,
+        x: 10,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.1,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const previousPrimary = context.oscillators[0];
+    const previousFifth = context.oscillators[1];
+
+    engine.tick(200, [
+      {
+        trailIndex: 0,
+        x: 20,
+        y: 0,
+        prevX: 10,
+        prevY: 0,
+        cursorType: "auto",
+        progress: 0.2,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const currentPrimary = context.oscillators[2];
+    const currentFifth = context.oscillators[3];
+    const previousPrimaryLevel = previousPrimary.connections[0];
+    const previousFifthLevel = previousFifth.connections[0];
+    const currentPrimaryLevel = currentPrimary.connections[0];
+    const currentFifthLevel = currentFifth.connections[0];
+
+    for (const level of [previousPrimaryLevel, previousFifthLevel]) {
+      expect(level).toBeInstanceOf(TestGainNode);
+      expect((level as TestGainNode).gain.events).toContainEqual(
+        expect.objectContaining({ method: "linearRamp", value: 0 }),
+      );
+    }
+    for (const level of [currentPrimaryLevel, currentFifthLevel]) {
+      expect(level).toBeInstanceOf(TestGainNode);
+      expect((level as TestGainNode).gain.events).toContainEqual(
+        expect.objectContaining({ method: "set", value: 0 }),
+      );
+      expect((level as TestGainNode).gain.events).toContainEqual(
+        expect.objectContaining({ method: "linearRamp", value: 1 }),
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Crossfade oscillator changes so cursor instrument transitions do not crackle.
- Feed live cursor trails and click effects into the existing sound engine.
- Release live voices when playback pauses.
- Disconnect and delete per-trail audio state when a live trail is removed.

## Root cause

Archive playback changed oscillator waveforms immediately while voices were audible, which produced discontinuities in the signal. The live trail renderer did not send its draw frames or click effects to the sound engine. It also detached the engine while paused without releasing active voices and retained audio state after live trails expired.

## Verification

- `../../node_modules/.bin/vitest run --environment jsdom shared` (52 tests)
- `../../node_modules/.bin/tsc --noEmit`
- `bun run build`
- Verified sound enable, pause, and resume on the real `/portrait/` route with no console errors.