### PR TITLE
extension: button, svg-icon, and cursor scrap kinds

### DIFF
--- a/extension/src/__tests__/background-scraps.test.ts
+++ b/extension/src/__tests__/background-scraps.test.ts
@@ -1,10 +1,34 @@
 // ABOUTME: Verifies the background scrap query response used by extension rendering surfaces.
-// ABOUTME: Guards newest-first query limits and stored-event metadata mapping.
+// ABOUTME: Guards union mapping, stable render keys, query limits, ordering, and unknown kinds.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CollectionEvent } from "@playhtml/extension-types";
+import { hashScrapString, serializeScrapStyles } from "../collectors/scrapUtils";
 
 const originalDefineBackground = (globalThis as any).defineBackground;
+
+function createEvent(
+  id: string,
+  ts: number,
+  data: Record<string, unknown>,
+  domain: string | undefined = "example.com",
+): CollectionEvent {
+  return {
+    id,
+    type: "element",
+    ts,
+    data,
+    meta: {
+      pid: "pid",
+      sid: "sid",
+      url: `https://example.com/${id}`,
+      vw: 1024,
+      vh: 768,
+      tz: "America/Los_Angeles",
+    },
+    domain,
+  } as CollectionEvent;
+}
 
 describe("background scrap queries", () => {
   beforeEach(() => {
@@ -20,33 +44,54 @@ describe("background scrap queries", () => {
     }
   });
 
-  it("returns stored scraps with the default limit and rendering shape", async () => {
-    const event: CollectionEvent = {
-      id: "scrap-1",
-      type: "element",
-      ts: 1234,
-      data: {
-        kind: "image",
-        src: "https://cdn.example.com/image.jpg",
-        alt: "A found image",
-        naturalWidth: 1200,
-        naturalHeight: 800,
-        displayWidth: 300,
-        displayHeight: 200,
-        pageTitle: "Example page",
-        faviconUrl: "https://example.com/favicon.png",
-      },
-      meta: {
-        pid: "pid",
-        sid: "sid",
-        url: "https://example.com/page",
-        vw: 1024,
-        vh: 768,
-        tz: "America/Los_Angeles",
-      },
-      domain: "example.com",
+  it("maps every known scrap kind newest-first and skips unknown kinds", async () => {
+    const image = createEvent("image", 100, {
+      kind: "image",
+      src: "https://cdn.example.com/image.jpg",
+      alt: "A found image",
+      naturalWidth: 1200,
+      naturalHeight: 800,
+      displayWidth: 300,
+      displayHeight: 200,
+      pageTitle: "Image page",
+      faviconUrl: "https://example.com/favicon.png",
+    });
+    const buttonStyles = {
+      color: "rgb(1, 2, 3)",
+      backgroundColor: "rgb(4, 5, 6)",
     };
-    const queryByType = vi.fn().mockResolvedValue([event]);
+    const button = createEvent("button", 200, {
+      kind: "button",
+      text: "Keep this",
+      styles: buttonStyles,
+      innerSvg: "<svg/>",
+      pageTitle: "Button page",
+    });
+    const svg = createEvent("svg", 300, {
+      kind: "svg-icon",
+      markup: '<svg viewBox="0 0 24 24"/>',
+      width: 24,
+      height: 24,
+      pageTitle: "SVG page",
+    });
+    const cursor = createEvent("cursor", 400, {
+      kind: "cursor",
+      url: "data:image/png;base64,AAAA",
+      hotspotX: 2,
+      hotspotY: 3,
+      pageTitle: "Cursor page",
+    });
+    const unknown = createEvent("future", 500, {
+      kind: "future-kind",
+      pageTitle: "Future page",
+    }, undefined);
+    const queryByType = vi.fn().mockResolvedValue([
+      button,
+      unknown,
+      image,
+      cursor,
+      svg,
+    ]);
     const onMessageAddListener = vi.fn();
 
     vi.doMock("../storage/LocalEventStore", () => ({
@@ -93,18 +138,107 @@ describe("background scrap queries", () => {
 
     expect(queryByType).toHaveBeenCalledWith("element", { limit: 5000 });
     expect(response).toEqual({
-      scraps: [{
-        id: "scrap-1",
-        src: "https://cdn.example.com/image.jpg",
-        alt: "A found image",
-        pageTitle: "Example page",
-        faviconUrl: "https://example.com/favicon.png",
-        domain: "example.com",
-        pageUrl: "https://example.com/page",
-        ts: 1234,
-        naturalWidth: 1200,
-        naturalHeight: 800,
-      }],
+      scraps: [
+        {
+          id: "cursor",
+          key: "data:image/png;base64,AAAA",
+          kind: "cursor",
+          domain: "example.com",
+          pageUrl: "https://example.com/cursor",
+          ts: 400,
+          pageTitle: "Cursor page",
+          url: "data:image/png;base64,AAAA",
+          hotspotX: 2,
+          hotspotY: 3,
+        },
+        {
+          id: "svg",
+          key: hashScrapString('<svg viewBox="0 0 24 24"/>'),
+          kind: "svg-icon",
+          domain: "example.com",
+          pageUrl: "https://example.com/svg",
+          ts: 300,
+          pageTitle: "SVG page",
+          markup: '<svg viewBox="0 0 24 24"/>',
+          width: 24,
+          height: 24,
+        },
+        {
+          id: "button",
+          key: hashScrapString(
+            `Keep this\n${serializeScrapStyles(buttonStyles)}`,
+          ),
+          kind: "button",
+          domain: "example.com",
+          pageUrl: "https://example.com/button",
+          ts: 200,
+          pageTitle: "Button page",
+          text: "Keep this",
+          styles: buttonStyles,
+          innerSvg: "<svg/>",
+        },
+        {
+          id: "image",
+          key: "https://cdn.example.com/image.jpg",
+          kind: "image",
+          domain: "example.com",
+          pageUrl: "https://example.com/image",
+          ts: 100,
+          pageTitle: "Image page",
+          faviconUrl: "https://example.com/favicon.png",
+          src: "https://cdn.example.com/image.jpg",
+          alt: "A found image",
+          naturalWidth: 1200,
+          naturalHeight: 800,
+        },
+      ],
     });
+  });
+
+  it("passes an explicit query limit through unchanged", async () => {
+    const queryByType = vi.fn().mockResolvedValue([]);
+    const onMessageAddListener = vi.fn();
+
+    vi.doMock("../storage/LocalEventStore", () => ({
+      LocalEventStore: vi.fn(() => ({ queryByType })),
+    }));
+    vi.doMock("../storage/sync", () => ({ uploadEvents: vi.fn() }));
+    vi.doMock("../storage/restore", () => ({ fetchEventsByPid: vi.fn() }));
+    vi.doMock("webextension-polyfill", () => ({
+      default: {
+        storage: {
+          local: {
+            get: vi.fn().mockResolvedValue({}),
+            set: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        runtime: {
+          onInstalled: { addListener: vi.fn() },
+          onMessage: { addListener: onMessageAddListener },
+          getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+        },
+        tabs: {
+          create: vi.fn().mockResolvedValue(undefined),
+          query: vi.fn().mockResolvedValue([]),
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        alarms: {
+          create: vi.fn(),
+          onAlarm: { addListener: vi.fn() },
+        },
+      },
+    }));
+    (globalThis as any).defineBackground = (setup: () => void) => {
+      setup();
+      return setup;
+    };
+
+    await import("../entrypoints/background");
+    const listener = onMessageAddListener.mock.calls[0][0];
+    await new Promise((resolve) => {
+      listener({ type: "GET_SCRAPS", options: { limit: 25 } }, {}, resolve);
+    });
+
+    expect(queryByType).toHaveBeenCalledWith("element", { limit: 25 });
   });
 });

--- a/extension/src/collectors/ScrapCollector.ts
+++ b/extension/src/collectors/ScrapCollector.ts
@@ -1,26 +1,97 @@
-// ABOUTME: Captures visible page images as locally stored internet scraps.
-// ABOUTME: Filters unusable image sources and bounds collection on image-heavy pages.
+// ABOUTME: Captures visible images, controls, icons, and cursor artwork as internet scraps.
+// ABOUTME: Applies per-kind filtering, visibility timing, sanitization, and page-session limits.
 
 import { BaseCollector } from "./BaseCollector";
-import type { ScrapEventData } from "./types";
+import { getScrapKey, serializeSvg } from "./scrapUtils";
+import type {
+  ButtonScrapData,
+  CursorScrapData,
+  ScrapEventData,
+  SvgIconScrapData,
+} from "./types";
 import { getFaviconUrl } from "../utils/pageMetadata";
 
-const MIN_DISPLAY_SIZE = 80;
-const MIN_NATURAL_SIZE = 50;
+const MIN_IMAGE_DISPLAY_SIZE = 80;
+const MIN_IMAGE_NATURAL_SIZE = 50;
+const MIN_BUTTON_WIDTH = 40;
+const MIN_BUTTON_HEIGHT = 20;
+const MAX_BUTTON_WIDTH = 480;
+const MAX_BUTTON_HEIGHT = 160;
+const MIN_BUTTON_TEXT_LENGTH = 1;
+const MAX_BUTTON_TEXT_LENGTH = 60;
+const MIN_SVG_SIZE = 12;
+const MAX_SVG_SIZE = 400;
 const VISIBILITY_DELAY_MS = 1000;
-const MAX_SCRAPS_PER_PAGE = 50;
+const CURSOR_CHECK_INTERVAL_MS = 500;
+const MAX_IMAGES_PER_PAGE = 50;
+const MAX_BUTTONS_PER_PAGE = 20;
+const MAX_SVG_ICONS_PER_PAGE = 20;
+const MAX_SVG_MARKUP_BYTES = 20 * 1024;
+const MAX_BUTTON_SVG_BYTES = 8 * 1024;
+const BUTTON_SELECTOR =
+  'button, input[type="submit"], input[type="button"], [role="button"]';
+const GRADIENT_PATTERN =
+  /^(?:repeating-)?(?:linear|radial|conic)-gradient\(/i;
+const CURSOR_URL_PATTERN =
+  /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*?))\s*\)\s*(?:([+-]?(?:\d+(?:\.\d*)?|\.\d+))\s+([+-]?(?:\d+(?:\.\d*)?|\.\d+)))?/i;
+
+const BUTTON_STYLE_PROPERTIES = [
+  "backgroundColor",
+  "color",
+  "borderRadius",
+  "paddingTop",
+  "paddingRight",
+  "paddingBottom",
+  "paddingLeft",
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "letterSpacing",
+  "textTransform",
+  "boxShadow",
+] as const;
+
+const BUTTON_BORDER_PROPERTIES = [
+  "borderTopWidth",
+  "borderTopStyle",
+  "borderTopColor",
+  "borderRightWidth",
+  "borderRightStyle",
+  "borderRightColor",
+  "borderBottomWidth",
+  "borderBottomStyle",
+  "borderBottomColor",
+  "borderLeftWidth",
+  "borderLeftStyle",
+  "borderLeftColor",
+] as const;
+
+interface CursorImage {
+  url: string;
+  hotspotX?: number;
+  hotspotY?: number;
+}
 
 export class ScrapCollector extends BaseCollector<ScrapEventData> {
   readonly type = "element" as const;
-  readonly description = "Captures visible images as local internet scraps";
+  readonly description = "Captures visible page objects as local internet scraps";
 
   private intersectionObserver?: IntersectionObserver;
   private mutationObserver?: MutationObserver;
-  private visibilityTimers = new Map<HTMLImageElement, number>();
+  private visibilityTimers = new Map<Element, number>();
   private observedImages = new Set<HTMLImageElement>();
+  private observedButtons = new Set<Element>();
+  private observedSvgIcons = new Set<SVGSVGElement>();
   private loadHandlers = new Map<HTMLImageElement, () => void>();
-  private seenSources = new Set<string>();
-  private captureCount = 0;
+  private seenImageSources = new Set<string>();
+  private seenButtonKeys = new Set<string>();
+  private seenSvgKeys = new Set<string>();
+  private seenCursorUrls = new Set<string>();
+  private imageCaptureCount = 0;
+  private buttonCaptureCount = 0;
+  private svgCaptureCount = 0;
+  private lastCursorCheckAt = Number.NEGATIVE_INFINITY;
 
   start(): void {
     this.intersectionObserver = new IntersectionObserver(
@@ -29,19 +100,20 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     );
 
     document.querySelectorAll("img").forEach((image) => {
-      this.observeCandidate(image);
+      this.observeImageCandidate(image);
+    });
+    document.querySelectorAll(BUTTON_SELECTOR).forEach((button) => {
+      this.observeButtonCandidate(button);
+    });
+    document.querySelectorAll("svg").forEach((svg) => {
+      this.observeSvgCandidate(svg as SVGSVGElement);
     });
 
     this.mutationObserver = new MutationObserver((mutations) => {
       for (const mutation of mutations) {
         for (const node of mutation.addedNodes) {
-          if (!(node instanceof HTMLElement)) continue;
-          if (node instanceof HTMLImageElement) {
-            this.observeCandidate(node);
-          }
-          node.querySelectorAll("img").forEach((image) => {
-            this.observeCandidate(image);
-          });
+          if (!(node instanceof Element)) continue;
+          this.discoverCandidates(node);
         }
       }
     });
@@ -52,6 +124,10 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
         subtree: true,
       });
     }
+
+    document.addEventListener("mouseover", this.handleMouseover, {
+      passive: true,
+    });
   }
 
   stop(): void {
@@ -59,6 +135,7 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     this.mutationObserver?.disconnect();
     this.intersectionObserver = undefined;
     this.mutationObserver = undefined;
+    document.removeEventListener("mouseover", this.handleMouseover);
 
     for (const timer of this.visibilityTimers.values()) {
       clearTimeout(timer);
@@ -70,13 +147,43 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     }
     this.loadHandlers.clear();
     this.observedImages.clear();
-    this.seenSources.clear();
-    this.captureCount = 0;
+    this.observedButtons.clear();
+    this.observedSvgIcons.clear();
+    this.seenImageSources.clear();
+    this.seenButtonKeys.clear();
+    this.seenSvgKeys.clear();
+    this.seenCursorUrls.clear();
+    this.imageCaptureCount = 0;
+    this.buttonCaptureCount = 0;
+    this.svgCaptureCount = 0;
+    this.lastCursorCheckAt = Number.NEGATIVE_INFINITY;
   }
 
-  private observeCandidate(image: HTMLImageElement): void {
+  private discoverCandidates(node: Element): void {
+    if (node instanceof HTMLImageElement) {
+      this.observeImageCandidate(node);
+    }
+    if (node.matches(BUTTON_SELECTOR)) {
+      this.observeButtonCandidate(node);
+    }
+    if (node instanceof SVGSVGElement) {
+      this.observeSvgCandidate(node);
+    }
+
+    node.querySelectorAll("img").forEach((image) => {
+      this.observeImageCandidate(image);
+    });
+    node.querySelectorAll(BUTTON_SELECTOR).forEach((button) => {
+      this.observeButtonCandidate(button);
+    });
+    node.querySelectorAll("svg").forEach((svg) => {
+      this.observeSvgCandidate(svg as SVGSVGElement);
+    });
+  }
+
+  private observeImageCandidate(image: HTMLImageElement): void {
     if (
-      this.captureCount >= MAX_SCRAPS_PER_PAGE ||
+      this.imageCaptureCount >= MAX_IMAGES_PER_PAGE ||
       this.observedImages.has(image) ||
       this.loadHandlers.has(image)
     ) {
@@ -87,7 +194,7 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
       const handleLoad = () => {
         this.loadHandlers.delete(image);
         if (this.enabled) {
-          this.observeCandidate(image);
+          this.observeImageCandidate(image);
         }
       };
       this.loadHandlers.set(image, handleLoad);
@@ -99,50 +206,97 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     this.intersectionObserver?.observe(image);
   }
 
+  private observeButtonCandidate(button: Element): void {
+    if (
+      this.buttonCaptureCount >= MAX_BUTTONS_PER_PAGE ||
+      this.observedButtons.has(button)
+    ) {
+      return;
+    }
+    this.observedButtons.add(button);
+    this.intersectionObserver?.observe(button);
+  }
+
+  private observeSvgCandidate(svg: SVGSVGElement): void {
+    if (
+      this.svgCaptureCount >= MAX_SVG_ICONS_PER_PAGE ||
+      this.observedSvgIcons.has(svg) ||
+      svg.closest(BUTTON_SELECTOR)
+    ) {
+      return;
+    }
+    this.observedSvgIcons.add(svg);
+    this.intersectionObserver?.observe(svg);
+  }
+
   private handleIntersections(entries: IntersectionObserverEntry[]): void {
     for (const entry of entries) {
-      const image = entry.target as HTMLImageElement;
+      const candidate = entry.target;
       const isVisible = entry.isIntersecting && entry.intersectionRatio >= 0.5;
 
       if (!isVisible) {
-        this.clearVisibilityTimer(image);
+        this.clearVisibilityTimer(candidate);
         continue;
       }
-      if (this.visibilityTimers.has(image)) continue;
+      if (this.visibilityTimers.has(candidate)) continue;
 
       const timer = window.setTimeout(() => {
-        this.visibilityTimers.delete(image);
-        this.capture(image);
-        this.intersectionObserver?.unobserve(image);
-        this.observedImages.delete(image);
+        this.visibilityTimers.delete(candidate);
+        this.captureCandidate(candidate);
+        this.intersectionObserver?.unobserve(candidate);
+        this.observedImages.delete(candidate as HTMLImageElement);
+        this.observedButtons.delete(candidate);
+        this.observedSvgIcons.delete(candidate as SVGSVGElement);
       }, VISIBILITY_DELAY_MS);
-      this.visibilityTimers.set(image, timer);
+      this.visibilityTimers.set(candidate, timer);
     }
   }
 
-  private clearVisibilityTimer(image: HTMLImageElement): void {
-    const timer = this.visibilityTimers.get(image);
+  private clearVisibilityTimer(candidate: Element): void {
+    const timer = this.visibilityTimers.get(candidate);
     if (timer === undefined) return;
     clearTimeout(timer);
-    this.visibilityTimers.delete(image);
+    this.visibilityTimers.delete(candidate);
   }
 
-  private capture(image: HTMLImageElement): void {
-    if (!this.enabled || this.captureCount >= MAX_SCRAPS_PER_PAGE) return;
+  private captureCandidate(candidate: Element): void {
+    if (this.observedImages.has(candidate as HTMLImageElement)) {
+      this.captureImage(candidate as HTMLImageElement);
+      return;
+    }
+    if (this.observedButtons.has(candidate)) {
+      this.captureButton(candidate);
+      return;
+    }
+    if (this.observedSvgIcons.has(candidate as SVGSVGElement)) {
+      this.captureSvgIcon(candidate as SVGSVGElement);
+    }
+  }
+
+  private captureImage(image: HTMLImageElement): void {
+    if (!this.enabled || this.imageCaptureCount >= MAX_IMAGES_PER_PAGE) return;
 
     const src = image.currentSrc || image.src;
     if (!src || src.startsWith("data:") || src.startsWith("blob:")) return;
-    if (this.seenSources.has(src)) return;
+    if (this.seenImageSources.has(src)) return;
 
     const bounds = image.getBoundingClientRect();
-    if (bounds.width < MIN_DISPLAY_SIZE || bounds.height < MIN_DISPLAY_SIZE) return;
-    if (image.naturalWidth < MIN_NATURAL_SIZE || image.naturalHeight < MIN_NATURAL_SIZE) {
+    if (
+      bounds.width < MIN_IMAGE_DISPLAY_SIZE ||
+      bounds.height < MIN_IMAGE_DISPLAY_SIZE
+    ) {
+      return;
+    }
+    if (
+      image.naturalWidth < MIN_IMAGE_NATURAL_SIZE ||
+      image.naturalHeight < MIN_IMAGE_NATURAL_SIZE
+    ) {
       return;
     }
 
     const faviconUrl = getFaviconUrl();
-    this.seenSources.add(src);
-    this.captureCount++;
+    this.seenImageSources.add(src);
+    this.imageCaptureCount++;
     this.emit({
       kind: "image",
       src,
@@ -155,22 +309,224 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
       ...(faviconUrl ? { faviconUrl } : {}),
     });
 
-    if (this.captureCount >= MAX_SCRAPS_PER_PAGE) {
-      this.stopObservingCandidates();
+    if (this.imageCaptureCount >= MAX_IMAGES_PER_PAGE) {
+      this.stopObservingImages();
     }
   }
 
-  private stopObservingCandidates(): void {
-    this.intersectionObserver?.disconnect();
-    this.mutationObserver?.disconnect();
-    for (const timer of this.visibilityTimers.values()) {
-      clearTimeout(timer);
+  private captureButton(button: Element): void {
+    if (!this.enabled || this.buttonCaptureCount >= MAX_BUTTONS_PER_PAGE) return;
+
+    const bounds = button.getBoundingClientRect();
+    if (
+      bounds.width < MIN_BUTTON_WIDTH ||
+      bounds.width > MAX_BUTTON_WIDTH ||
+      bounds.height < MIN_BUTTON_HEIGHT ||
+      bounds.height > MAX_BUTTON_HEIGHT
+    ) {
+      return;
     }
-    this.visibilityTimers.clear();
+
+    const inlineSvg = button.querySelector("svg");
+    const text = this.getButtonText(button);
+    if (
+      (!inlineSvg && text.length < MIN_BUTTON_TEXT_LENGTH) ||
+      text.length > MAX_BUTTON_TEXT_LENGTH
+    ) {
+      return;
+    }
+
+    const computedStyle = getComputedStyle(button);
+    const styles = this.pickButtonStyles(computedStyle);
+    const innerSvg = inlineSvg
+      ? this.serializeButtonSvg(inlineSvg as SVGSVGElement)
+      : undefined;
+    if (!text && !innerSvg) return;
+
+    const faviconUrl = getFaviconUrl();
+    const data: ButtonScrapData = {
+      kind: "button",
+      text,
+      styles,
+      ...(innerSvg ? { innerSvg } : {}),
+      pageTitle: document.title,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    };
+    const key = getScrapKey(data);
+    if (this.seenButtonKeys.has(key)) return;
+
+    this.seenButtonKeys.add(key);
+    this.buttonCaptureCount++;
+    this.emit(data);
+
+    if (this.buttonCaptureCount >= MAX_BUTTONS_PER_PAGE) {
+      this.stopObservingButtons();
+    }
+  }
+
+  private getButtonText(button: Element): string {
+    const rawText =
+      button instanceof HTMLInputElement
+        ? button.getAttribute("value") ?? ""
+        : "innerText" in button && typeof button.innerText === "string"
+          ? button.innerText
+          : button.textContent ?? "";
+    return rawText.replace(/\s+/g, " ").trim();
+  }
+
+  private pickButtonStyles(computedStyle: CSSStyleDeclaration): Record<string, string> {
+    const styles: Record<string, string> = {};
+    for (const property of BUTTON_STYLE_PROPERTIES) {
+      const value = computedStyle[property];
+      if (value) styles[property] = value;
+    }
+
+    if (computedStyle.border) {
+      styles.border = computedStyle.border;
+    } else {
+      for (const property of BUTTON_BORDER_PROPERTIES) {
+        const value = computedStyle[property];
+        if (value) styles[property] = value;
+      }
+    }
+
+    if (GRADIENT_PATTERN.test(computedStyle.backgroundImage.trim())) {
+      styles.backgroundImage = computedStyle.backgroundImage;
+    }
+    return styles;
+  }
+
+  private serializeButtonSvg(svg: SVGSVGElement): string | undefined {
+    const bounds = svg.getBoundingClientRect();
+    if (bounds.width <= 0 || bounds.height <= 0) return undefined;
+    return serializeSvg(svg, {
+      width: bounds.width,
+      height: bounds.height,
+      color: getComputedStyle(svg).color,
+      maxBytes: MAX_BUTTON_SVG_BYTES,
+    });
+  }
+
+  private captureSvgIcon(svg: SVGSVGElement): void {
+    if (
+      !this.enabled ||
+      this.svgCaptureCount >= MAX_SVG_ICONS_PER_PAGE ||
+      svg.closest(BUTTON_SELECTOR)
+    ) {
+      return;
+    }
+
+    const bounds = svg.getBoundingClientRect();
+    if (
+      bounds.width < MIN_SVG_SIZE ||
+      bounds.width > MAX_SVG_SIZE ||
+      bounds.height < MIN_SVG_SIZE ||
+      bounds.height > MAX_SVG_SIZE
+    ) {
+      return;
+    }
+
+    const markup = serializeSvg(svg, {
+      width: bounds.width,
+      height: bounds.height,
+      color: getComputedStyle(svg).color,
+      maxBytes: MAX_SVG_MARKUP_BYTES,
+    });
+    if (!markup) return;
+
+    const faviconUrl = getFaviconUrl();
+    const data: SvgIconScrapData = {
+      kind: "svg-icon",
+      markup,
+      width: bounds.width,
+      height: bounds.height,
+      pageTitle: document.title,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    };
+    const key = getScrapKey(data);
+    if (this.seenSvgKeys.has(key)) return;
+
+    this.seenSvgKeys.add(key);
+    this.svgCaptureCount++;
+    this.emit(data);
+
+    if (this.svgCaptureCount >= MAX_SVG_ICONS_PER_PAGE) {
+      this.stopObservingSvgIcons();
+    }
+  }
+
+  private handleMouseover = (event: MouseEvent): void => {
+    if (!this.enabled || !(event.target instanceof Element)) return;
+    const now = Date.now();
+    if (now - this.lastCursorCheckAt < CURSOR_CHECK_INTERVAL_MS) return;
+    this.lastCursorCheckAt = now;
+
+    const cursorImage = this.parseCursorImage(getComputedStyle(event.target).cursor);
+    if (
+      !cursorImage ||
+      cursorImage.url.startsWith("blob:") ||
+      this.seenCursorUrls.has(cursorImage.url)
+    ) {
+      return;
+    }
+
+    const faviconUrl = getFaviconUrl();
+    const data: CursorScrapData = {
+      kind: "cursor",
+      url: cursorImage.url,
+      ...(cursorImage.hotspotX !== undefined
+        ? { hotspotX: cursorImage.hotspotX }
+        : {}),
+      ...(cursorImage.hotspotY !== undefined
+        ? { hotspotY: cursorImage.hotspotY }
+        : {}),
+      pageTitle: document.title,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    };
+    this.seenCursorUrls.add(getScrapKey(data));
+    this.emit(data);
+  };
+
+  private parseCursorImage(cursor: string): CursorImage | undefined {
+    const match = CURSOR_URL_PATTERN.exec(cursor);
+    if (!match) return undefined;
+    const url = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (!url) return undefined;
+
+    const hotspotX = match[4] === undefined ? undefined : Number(match[4]);
+    const hotspotY = match[5] === undefined ? undefined : Number(match[5]);
+    return {
+      url,
+      ...(hotspotX !== undefined ? { hotspotX } : {}),
+      ...(hotspotY !== undefined ? { hotspotY } : {}),
+    };
+  }
+
+  private stopObservingImages(): void {
+    for (const image of this.observedImages) {
+      this.clearVisibilityTimer(image);
+      this.intersectionObserver?.unobserve(image);
+    }
     for (const [image, handler] of this.loadHandlers) {
       image.removeEventListener("load", handler);
     }
     this.loadHandlers.clear();
     this.observedImages.clear();
+  }
+
+  private stopObservingButtons(): void {
+    for (const button of this.observedButtons) {
+      this.clearVisibilityTimer(button);
+      this.intersectionObserver?.unobserve(button);
+    }
+    this.observedButtons.clear();
+  }
+
+  private stopObservingSvgIcons(): void {
+    for (const svg of this.observedSvgIcons) {
+      this.clearVisibilityTimer(svg);
+      this.intersectionObserver?.unobserve(svg);
+    }
+    this.observedSvgIcons.clear();
   }
 }

--- a/extension/src/collectors/__tests__/ScrapCollector.test.ts
+++ b/extension/src/collectors/__tests__/ScrapCollector.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Tests image scrap capture rules, visibility timing, and collection limits.
-// ABOUTME: Exercises ScrapCollector against DOM images with controlled intersection events.
+// ABOUTME: Tests internet scrap capture rules, visibility timing, sanitization, and limits.
+// ABOUTME: Exercises image, button, SVG icon, and cursor pipelines against real DOM nodes.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScrapCollector } from "../ScrapCollector";
@@ -37,14 +37,27 @@ class IntersectionObserverMock {
   }
 }
 
-interface ImageOptions {
+interface ElementSize {
+  width?: number;
+  height?: number;
+}
+
+interface ImageOptions extends ElementSize {
   src: string;
   alt?: string;
   naturalWidth?: number;
   naturalHeight?: number;
-  displayWidth?: number;
-  displayHeight?: number;
   complete?: boolean;
+}
+
+function setRenderedSize(
+  element: Element,
+  { width = 160, height = 120 }: ElementSize = {},
+): void {
+  vi.spyOn(element, "getBoundingClientRect").mockReturnValue({
+    width,
+    height,
+  } as DOMRect);
 }
 
 function createImage({
@@ -52,8 +65,8 @@ function createImage({
   alt = "",
   naturalWidth = 200,
   naturalHeight = 150,
-  displayWidth = 160,
-  displayHeight = 120,
+  width = 160,
+  height = 120,
   complete = true,
 }: ImageOptions): HTMLImageElement {
   const image = document.createElement("img");
@@ -64,12 +77,46 @@ function createImage({
     naturalWidth: { value: naturalWidth, configurable: true },
     naturalHeight: { value: naturalHeight, configurable: true },
   });
-  vi.spyOn(image, "getBoundingClientRect").mockReturnValue({
-    width: displayWidth,
-    height: displayHeight,
-  } as DOMRect);
+  setRenderedSize(image, { width, height });
   document.body.appendChild(image);
   return image;
+}
+
+interface ButtonOptions extends ElementSize {
+  text?: string;
+  value?: string;
+  role?: boolean;
+}
+
+function createButton({
+  text = "Keep this",
+  value,
+  role = false,
+  width = 160,
+  height = 40,
+}: ButtonOptions = {}): HTMLElement {
+  const element = value === undefined
+    ? document.createElement(role ? "div" : "button")
+    : document.createElement("input");
+  if (element instanceof HTMLInputElement) {
+    element.type = "button";
+    element.setAttribute("value", value ?? "");
+  } else {
+    element.textContent = text;
+  }
+  if (role) element.setAttribute("role", "button");
+  setRenderedSize(element, { width, height });
+  document.body.appendChild(element);
+  return element;
+}
+
+function createSvg(
+  { width = 24, height = 24 }: ElementSize = {},
+): SVGSVGElement {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  setRenderedSize(svg, { width, height });
+  document.body.appendChild(svg);
+  return svg;
 }
 
 describe("ScrapCollector", () => {
@@ -83,6 +130,25 @@ describe("ScrapCollector", () => {
     document.head.innerHTML = "";
     document.body.innerHTML = "";
     document.title = "A page worth keeping";
+    vi.stubGlobal("getComputedStyle", (element: Element) => ({
+      backgroundColor: element.getAttribute("data-background") ?? "rgb(20, 30, 40)",
+      backgroundImage: element.getAttribute("data-background-image") ?? "none",
+      color: element.getAttribute("data-color") ?? "rgb(10, 20, 30)",
+      border: "1px solid rgb(1, 2, 3)",
+      borderRadius: "4px",
+      paddingTop: "4px",
+      paddingRight: "8px",
+      paddingBottom: "4px",
+      paddingLeft: "8px",
+      fontFamily: "sans-serif",
+      fontSize: "14px",
+      fontWeight: "400",
+      fontStyle: "normal",
+      letterSpacing: "normal",
+      textTransform: "none",
+      boxShadow: "none",
+      cursor: element.getAttribute("data-cursor") ?? "auto",
+    } as CSSStyleDeclaration));
     emitCallback = vi.fn();
     collector = new ScrapCollector();
     collector.setEmitCallback(emitCallback);
@@ -100,15 +166,21 @@ describe("ScrapCollector", () => {
     return IntersectionObserverMock.instances[0];
   }
 
-  function showForCapture(images: HTMLImageElement[]): void {
-    observer().trigger(images);
+  function showForCapture(elements: Element[]): void {
+    observer().trigger(elements);
     vi.advanceTimersByTime(1000);
   }
 
-  it("filters images below the displayed or natural size minimums", () => {
+  function emitted(kind: ScrapEventData["kind"]): ScrapEventData[] {
+    return emitCallback.mock.calls
+      .map(([data]) => data as ScrapEventData)
+      .filter((data) => data.kind === kind);
+  }
+
+  it("keeps the existing image filters and dimensions", () => {
     const smallDisplay = createImage({
       src: "https://example.com/small-display.jpg",
-      displayWidth: 79,
+      width: 79,
     });
     const smallNatural = createImage({
       src: "https://example.com/small-natural.jpg",
@@ -118,52 +190,51 @@ describe("ScrapCollector", () => {
       src: "https://example.com/minimum.jpg",
       naturalWidth: 50,
       naturalHeight: 50,
-      displayWidth: 80,
-      displayHeight: 80,
+      width: 80,
+      height: 80,
     });
-
-    collector.enable();
-    showForCapture([smallDisplay, smallNatural, minimumSize]);
-
-    expect(emitCallback).toHaveBeenCalledOnce();
-    expect((emitCallback.mock.calls[0][0] as ScrapEventData).src).toBe(
-      "https://example.com/minimum.jpg",
-    );
-  });
-
-  it("skips data and blob image sources", () => {
     const dataImage = createImage({ src: "data:image/png;base64,test" });
     const blobImage = createImage({ src: "blob:https://example.com/image" });
 
     collector.enable();
-    showForCapture([dataImage, blobImage]);
+    showForCapture([
+      smallDisplay,
+      smallNatural,
+      minimumSize,
+      dataImage,
+      blobImage,
+    ]);
 
-    expect(emitCallback).not.toHaveBeenCalled();
+    expect(emitted("image")).toEqual([expect.objectContaining({
+      kind: "image",
+      src: "https://example.com/minimum.jpg",
+      naturalWidth: 50,
+      naturalHeight: 50,
+      displayWidth: 80,
+      displayHeight: 80,
+    })]);
   });
 
-  it("captures each resolved source once per page session", () => {
+  it("captures each image source once and stops images at fifty", () => {
     const first = createImage({ src: "https://cdn.example.com/shared.jpg" });
     const second = createImage({ src: "https://cdn.example.com/shared.jpg" });
-
-    collector.enable();
-    showForCapture([first, second]);
-
-    expect(emitCallback).toHaveBeenCalledOnce();
-  });
-
-  it("stops at fifty captures on an image-heavy page", () => {
-    const images = Array.from({ length: 51 }, (_, index) =>
+    const images = Array.from({ length: 50 }, (_, index) =>
       createImage({ src: `https://example.com/image-${index}.jpg` }),
     );
 
     collector.enable();
-    showForCapture(images);
+    showForCapture([first, second, ...images]);
 
-    expect(emitCallback).toHaveBeenCalledTimes(50);
-    expect(observer().disconnect).toHaveBeenCalled();
+    expect(emitted("image")).toHaveLength(50);
+    expect(observer().observed.has(images[49])).toBe(false);
+
+    const button = createButton();
+    return Promise.resolve().then(() => {
+      expect(observer().observed.has(button)).toBe(true);
+    });
   });
 
-  it("emits the image dimensions and page metadata", () => {
+  it("emits image page metadata after a continuous visible second", () => {
     const favicon = document.createElement("link");
     favicon.rel = "icon";
     favicon.href = "https://example.com/favicon.png";
@@ -173,13 +244,18 @@ describe("ScrapCollector", () => {
       alt: "Sunlight through a window",
       naturalWidth: 1200,
       naturalHeight: 800,
-      displayWidth: 300,
-      displayHeight: 200,
+      width: 300,
+      height: 200,
     });
 
     collector.enable();
-    showForCapture([image]);
+    observer().trigger([image], 0.5);
+    vi.advanceTimersByTime(999);
+    observer().trigger([image], 0.4);
+    vi.advanceTimersByTime(1);
+    expect(emitCallback).not.toHaveBeenCalled();
 
+    showForCapture([image]);
     expect(emitCallback).toHaveBeenCalledWith({
       kind: "image",
       src: "https://example.com/feature.jpg",
@@ -213,21 +289,344 @@ describe("ScrapCollector", () => {
     expect(observer().observed.has(image)).toBe(true);
 
     showForCapture([image]);
-    expect(emitCallback).toHaveBeenCalledOnce();
+    expect(emitted("image")).toHaveLength(1);
   });
 
-  it("requires one continuous second at fifty percent visibility", () => {
-    const image = createImage({ src: "https://example.com/brief.jpg" });
+  it("filters button text and displayed-size bounds", () => {
+    const noText = createButton({ text: "" });
+    const tooLong = createButton({ text: "x".repeat(61) });
+    const tooNarrow = createButton({ text: "Narrow", width: 39 });
+    const tooShort = createButton({ text: "Short", height: 19 });
+    const tooWide = createButton({ text: "Wide", width: 481 });
+    const tooTall = createButton({ text: "Tall", height: 161 });
+    const minimum = createButton({ text: "M", width: 40, height: 20 });
+    const maximum = createButton({
+      text: "x".repeat(60),
+      width: 480,
+      height: 160,
+    });
 
     collector.enable();
-    observer().trigger([image], 0.5);
-    vi.advanceTimersByTime(999);
-    observer().trigger([image], 0.4);
-    vi.advanceTimersByTime(1);
-    expect(emitCallback).not.toHaveBeenCalled();
+    showForCapture([
+      noText,
+      tooLong,
+      tooNarrow,
+      tooShort,
+      tooWide,
+      tooTall,
+      minimum,
+      maximum,
+    ]);
 
-    observer().trigger([image], 0.5);
-    vi.advanceTimersByTime(1000);
-    expect(emitCallback).toHaveBeenCalledOnce();
+    expect(emitted("button").map((data) => data.kind === "button" && data.text))
+      .toEqual(["M", "x".repeat(60)]);
+  });
+
+  it("uses input value labels and reconstructs a safe style subset", () => {
+    const input = createButton({ value: "Submit form" });
+    input.setAttribute(
+      "data-background-image",
+      "linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))",
+    );
+    const remoteBackground = createButton({ text: "Remote background" });
+    remoteBackground.setAttribute(
+      "data-background-image",
+      'url("https://example.com/button.png")',
+    );
+
+    collector.enable();
+    showForCapture([input, remoteBackground]);
+
+    const buttons = emitted("button");
+    expect(buttons[0]).toMatchObject({
+      kind: "button",
+      text: "Submit form",
+      styles: {
+        backgroundColor: "rgb(20, 30, 40)",
+        backgroundImage: "linear-gradient(rgb(1, 2, 3), rgb(4, 5, 6))",
+        color: "rgb(10, 20, 30)",
+        border: "1px solid rgb(1, 2, 3)",
+      },
+    });
+    expect(buttons[1]).toMatchObject({
+      kind: "button",
+      text: "Remote background",
+    });
+    expect(
+      buttons[1].kind === "button" && buttons[1].styles.backgroundImage,
+    ).toBeUndefined();
+  });
+
+  it("deduplicates reconstructed buttons and caps them at twenty", () => {
+    const duplicateOne = createButton({ text: "Same button" });
+    const duplicateTwo = createButton({ text: "Same button" });
+    const uniqueButtons = Array.from({ length: 20 }, (_, index) =>
+      createButton({ text: `Button ${index}` }),
+    );
+
+    collector.enable();
+    showForCapture([duplicateOne, duplicateTwo, ...uniqueButtons]);
+
+    expect(emitted("button")).toHaveLength(20);
+    expect(
+      emitted("button").filter(
+        (data) => data.kind === "button" && data.text === "Same button",
+      ),
+    ).toHaveLength(1);
+    expect(observer().observed.has(uniqueButtons[19])).toBe(false);
+  });
+
+  it("discovers added submit and role buttons through DOM mutations", async () => {
+    collector.enable();
+    const submit = document.createElement("input");
+    submit.type = "submit";
+    submit.setAttribute("value", "Send");
+    setRenderedSize(submit, { width: 80, height: 32 });
+    const roleButton = createButton({ text: "Open", role: true });
+    document.body.appendChild(submit);
+
+    await Promise.resolve();
+    expect(observer().observed.has(submit)).toBe(true);
+    expect(observer().observed.has(roleButton)).toBe(true);
+
+    showForCapture([submit, roleButton]);
+    expect(emitted("button").map(
+      (data) => data.kind === "button" && data.text,
+    )).toEqual(["Send", "Open"]);
+  });
+
+  it("excludes button-owned SVG icons and captures icon-only buttons safely", () => {
+    const button = createButton({ text: "" });
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("onclick", "alert(1)");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M0 0h10v10z");
+    svg.appendChild(path);
+    setRenderedSize(svg, { width: 24, height: 24 });
+    button.appendChild(svg);
+
+    collector.enable();
+    expect(observer().observed.has(button)).toBe(true);
+    expect(observer().observed.has(svg)).toBe(false);
+    showForCapture([button]);
+
+    const scraps = emitted("button");
+    expect(scraps).toHaveLength(1);
+    expect(scraps[0]).toMatchObject({ kind: "button", text: "" });
+    expect(scraps[0].kind === "button" && scraps[0].innerSvg).toContain("<svg");
+    expect(scraps[0].kind === "button" && scraps[0].innerSvg).not.toContain(
+      "onclick",
+    );
+  });
+
+  it("omits oversized inline SVG markup from text buttons", () => {
+    const button = createButton({ text: "Text survives" });
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", `M0 0${"h1".repeat(5 * 1024)}`);
+    svg.appendChild(path);
+    setRenderedSize(svg, { width: 24, height: 24 });
+    button.appendChild(svg);
+
+    collector.enable();
+    showForCapture([button]);
+
+    const buttons = emitted("button");
+    expect(buttons).toEqual([expect.objectContaining({
+      kind: "button",
+      text: "Text survives",
+    })]);
+    const buttonScrap = buttons[0];
+    expect(buttonScrap.kind).toBe("button");
+    if (buttonScrap.kind !== "button") {
+      throw new Error("Expected a button scrap");
+    }
+    expect(buttonScrap.innerSvg).toBeUndefined();
+  });
+
+  it("skips SVG icons with unresolvable use references or oversized markup", () => {
+    const unresolved = createSvg();
+    const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+    use.setAttribute("href", "#missing");
+    unresolved.appendChild(use);
+    const oversized = createSvg();
+    const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    text.textContent = "x".repeat(21 * 1024);
+    oversized.appendChild(text);
+    const tooSmall = createSvg({ width: 11, height: 24 });
+    const tooLarge = createSvg({ width: 401, height: 24 });
+
+    collector.enable();
+    showForCapture([unresolved, oversized, tooSmall, tooLarge]);
+
+    expect(emitted("svg-icon")).toHaveLength(0);
+  });
+
+  it("embeds in-document references used by captured SVG icons", () => {
+    const definitions = createSvg({ width: 0, height: 0 });
+    const symbol = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "symbol",
+    );
+    symbol.id = "saved-shape";
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "M0 0h8v8z");
+    symbol.appendChild(path);
+    definitions.appendChild(symbol);
+
+    const svg = createSvg();
+    const use = document.createElementNS("http://www.w3.org/2000/svg", "use");
+    use.setAttribute("href", "#saved-shape");
+    svg.appendChild(use);
+
+    collector.enable();
+    showForCapture([svg]);
+
+    const scraps = emitted("svg-icon");
+    expect(scraps).toHaveLength(1);
+    const markup = scraps[0].kind === "svg-icon" ? scraps[0].markup : "";
+    expect(markup).toContain('id="saved-shape"');
+    expect(markup).toContain('d="M0 0h8v8z"');
+    expect(markup).toContain('href="#saved-shape"');
+  });
+
+  it("sanitizes SVG icons and bakes currentColor into their markup", () => {
+    const svg = createSvg({ width: 32, height: 36 });
+    svg.setAttribute("data-color", "rgb(12, 34, 56)");
+    svg.setAttribute("onload", "alert(1)");
+    const script = document.createElementNS("http://www.w3.org/2000/svg", "script");
+    script.textContent = "alert(1)";
+    const foreignObject = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "foreignObject",
+    );
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("fill", "currentColor");
+    path.setAttribute("stroke", "currentColor");
+    path.setAttribute("onclick", "alert(1)");
+    path.setAttribute("d", "M0 0h10v10z");
+    const image = document.createElementNS("http://www.w3.org/2000/svg", "image");
+    image.setAttribute("href", "https://example.com/tracker.png");
+    svg.append(script, foreignObject, path, image);
+
+    collector.enable();
+    showForCapture([svg]);
+
+    const scraps = emitted("svg-icon");
+    expect(scraps).toHaveLength(1);
+    const markup = scraps[0].kind === "svg-icon" ? scraps[0].markup : "";
+    expect(markup).toContain('width="32"');
+    expect(markup).toContain('height="36"');
+    expect(markup).toContain('viewBox="0 0 32 36"');
+    expect(markup).toContain('fill="rgb(12, 34, 56)"');
+    expect(markup).toContain('stroke="rgb(12, 34, 56)"');
+    expect(markup).not.toMatch(
+      /currentColor|script|foreignObject|onload|onclick|tracker\.png/i,
+    );
+  });
+
+  it("deduplicates serialized SVG icons and caps them at twenty", () => {
+    const duplicateOne = createSvg();
+    const duplicateTwo = createSvg();
+    for (const svg of [duplicateOne, duplicateTwo]) {
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", "M0 0h1v1z");
+      svg.appendChild(path);
+    }
+    const uniqueIcons = Array.from({ length: 20 }, (_, index) => {
+      const svg = createSvg();
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", `M${index + 1} 0h1v1z`);
+      svg.appendChild(path);
+      return svg;
+    });
+
+    collector.enable();
+    showForCapture([duplicateOne, duplicateTwo, ...uniqueIcons]);
+
+    expect(emitted("svg-icon")).toHaveLength(20);
+    const duplicateMarkup = emitted("svg-icon").filter(
+      (data) =>
+        data.kind === "svg-icon" && data.markup.includes("M0 0h1v1z"),
+    );
+    expect(duplicateMarkup).toHaveLength(1);
+    expect(observer().observed.has(uniqueIcons[19])).toBe(false);
+  });
+
+  it("captures cursor URLs and hotspots while ignoring fallback-only cursors", () => {
+    const fallback = document.createElement("div");
+    fallback.setAttribute("data-cursor", "pointer");
+    const custom = document.createElement("div");
+    custom.setAttribute(
+      "data-cursor",
+      'url("https://example.com/cursor.cur") 4 7, url("fallback.cur"), pointer',
+    );
+    document.body.append(fallback, custom);
+
+    collector.enable();
+    fallback.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(500);
+    custom.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(emitted("cursor")).toEqual([expect.objectContaining({
+      kind: "cursor",
+      url: "https://example.com/cursor.cur",
+      hotspotX: 4,
+      hotspotY: 7,
+    })]);
+  });
+
+  it("allows data cursors, skips blob cursors, and deduplicates by URL", () => {
+    const blob = document.createElement("div");
+    blob.setAttribute(
+      "data-cursor",
+      'url("blob:https://example.com/cursor") 1 2, auto',
+    );
+    const dataFirst = document.createElement("div");
+    dataFirst.setAttribute(
+      "data-cursor",
+      'url("data:image/png;base64,AAAA") 3 5, auto',
+    );
+    const dataSecond = document.createElement("div");
+    dataSecond.setAttribute(
+      "data-cursor",
+      'url("data:image/png;base64,AAAA") 9 9, pointer',
+    );
+    document.body.append(blob, dataFirst, dataSecond);
+
+    collector.enable();
+    blob.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(500);
+    dataFirst.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    vi.advanceTimersByTime(500);
+    dataSecond.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+
+    expect(emitted("cursor")).toEqual([expect.objectContaining({
+      kind: "cursor",
+      url: "data:image/png;base64,AAAA",
+      hotspotX: 3,
+      hotspotY: 5,
+    })]);
+  });
+
+  it("throttles cursor style checks to one every five hundred milliseconds", () => {
+    const first = document.createElement("div");
+    first.setAttribute("data-cursor", 'url("https://example.com/one.cur"), auto');
+    const second = document.createElement("div");
+    second.setAttribute("data-cursor", 'url("https://example.com/two.cur"), auto');
+    document.body.append(first, second);
+
+    collector.enable();
+    first.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    expect(emitted("cursor")).toHaveLength(1);
+
+    vi.advanceTimersByTime(499);
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    expect(emitted("cursor")).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    second.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    expect(emitted("cursor")).toHaveLength(2);
   });
 });

--- a/extension/src/collectors/scrapUtils.ts
+++ b/extension/src/collectors/scrapUtils.ts
@@ -1,0 +1,247 @@
+// ABOUTME: Builds stable identities for locally captured internet scraps.
+// ABOUTME: Sanitizes inline SVG markup before it reaches extension rendering surfaces.
+
+import type { ScrapEventData } from "./types";
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
+const ALLOWED_SVG_ELEMENTS = new Set([
+  "circle",
+  "clippath",
+  "defs",
+  "desc",
+  "ellipse",
+  "feblend",
+  "fecolormatrix",
+  "fecomponenttransfer",
+  "fecomposite",
+  "feconvolvematrix",
+  "fediffuselighting",
+  "fedisplacementmap",
+  "fedistantlight",
+  "fedropshadow",
+  "feflood",
+  "fefunca",
+  "fefuncb",
+  "fefuncg",
+  "fefuncr",
+  "fegaussianblur",
+  "femerge",
+  "femergenode",
+  "femorphology",
+  "feoffset",
+  "fepointlight",
+  "fespecularlighting",
+  "fespotlight",
+  "fetile",
+  "feturbulence",
+  "filter",
+  "g",
+  "lineargradient",
+  "line",
+  "marker",
+  "mask",
+  "path",
+  "pattern",
+  "polygon",
+  "polyline",
+  "radialgradient",
+  "rect",
+  "stop",
+  "svg",
+  "symbol",
+  "text",
+  "textpath",
+  "title",
+  "tspan",
+  "use",
+]);
+
+export function hashScrapString(value: string): string {
+  let hash = 5381;
+  for (let index = 0; index < value.length; index++) {
+    hash = ((hash << 5) + hash) ^ value.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function serializeScrapStyles(styles: Record<string, string>): string {
+  return Object.keys(styles)
+    .sort()
+    .map((property) => `${property}:${styles[property]}`)
+    .join(";");
+}
+
+export function getScrapKey(data: ScrapEventData): string {
+  switch (data.kind) {
+    case "image":
+      return data.src;
+    case "button":
+      return hashScrapString(`${data.text}\n${serializeScrapStyles(data.styles)}`);
+    case "svg-icon":
+      return hashScrapString(data.markup);
+    case "cursor":
+      return data.url;
+  }
+}
+
+function getUseReference(use: SVGUseElement): string | null {
+  return (
+    use.getAttribute("href") ??
+    use.getAttributeNS(XLINK_NAMESPACE, "href") ??
+    use.getAttribute("xlink:href")
+  );
+}
+
+function hasElementWithId(root: SVGSVGElement, id: string): boolean {
+  return Array.from(root.querySelectorAll("[id]")).some(
+    (element) => element.getAttribute("id") === id,
+  );
+}
+
+function resolveUseReferences(svg: SVGSVGElement): boolean {
+  const resolvedIds = new Set<string>();
+
+  for (let pass = 0; pass < 100; pass++) {
+    const unresolvedUse = Array.from(svg.querySelectorAll("use")).find((use) => {
+      const href = getUseReference(use as SVGUseElement);
+      return href !== null && href.startsWith("#") && !hasElementWithId(svg, href.slice(1));
+    });
+
+    if (!unresolvedUse) break;
+    const href = getUseReference(unresolvedUse as SVGUseElement);
+    if (!href || !href.startsWith("#") || href.length === 1) return false;
+
+    const id = href.slice(1);
+    if (resolvedIds.has(id)) return false;
+    const referenced = document.getElementById(id);
+    if (!referenced || !(referenced instanceof SVGElement)) return false;
+
+    let defs = svg.querySelector(":scope > defs");
+    if (!defs) {
+      defs = document.createElementNS(SVG_NAMESPACE, "defs");
+      svg.prepend(defs);
+    }
+    defs.appendChild(referenced.cloneNode(true));
+    resolvedIds.add(id);
+  }
+
+  return Array.from(svg.querySelectorAll("use")).every((use) => {
+    const href = getUseReference(use as SVGUseElement);
+    return Boolean(
+      href &&
+      href.startsWith("#") &&
+      href.length > 1 &&
+      hasElementWithId(svg, href.slice(1)),
+    );
+  });
+}
+
+function referencesExternalResource(element: Element): boolean {
+  if (element.localName.toLowerCase() === "image") return true;
+
+  for (const attribute of Array.from(element.attributes)) {
+    const name = attribute.name.toLowerCase();
+    const value = attribute.value.trim();
+    if (
+      (name === "href" || name === "xlink:href" || name === "src") &&
+      !value.startsWith("#")
+    ) {
+      return true;
+    }
+    if (/url\(\s*(['"]?)(?!#)[^)]+\1\s*\)/i.test(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sanitizeSvgTree(svg: SVGSVGElement): boolean {
+  if (
+    !ALLOWED_SVG_ELEMENTS.has(svg.localName.toLowerCase()) ||
+    referencesExternalResource(svg)
+  ) {
+    return false;
+  }
+
+  for (const element of Array.from(svg.querySelectorAll("*"))) {
+    const name = element.localName.toLowerCase();
+    if (!ALLOWED_SVG_ELEMENTS.has(name) || referencesExternalResource(element)) {
+      element.remove();
+      continue;
+    }
+
+    for (const attribute of Array.from(element.attributes)) {
+      const name = attribute.name.toLowerCase();
+      const value = attribute.value;
+      if (
+        name.startsWith("on") ||
+        /javascript\s*:/i.test(value) ||
+        name === "srcdoc"
+      ) {
+        element.removeAttributeNode(attribute);
+      }
+    }
+  }
+
+  for (const attribute of Array.from(svg.attributes)) {
+    const name = attribute.name.toLowerCase();
+    if (
+      name.startsWith("on") ||
+      /javascript\s*:/i.test(attribute.value) ||
+      name === "srcdoc"
+    ) {
+      svg.removeAttributeNode(attribute);
+    }
+  }
+
+  return true;
+}
+
+function bakeCurrentColor(svg: SVGSVGElement, color: string): void {
+  let usesFill = false;
+  let usesStroke = false;
+
+  for (const element of [svg, ...Array.from(svg.querySelectorAll("*"))]) {
+    for (const attribute of Array.from(element.attributes)) {
+      if (!/currentcolor/i.test(attribute.value)) continue;
+      if (attribute.name.toLowerCase() === "fill") usesFill = true;
+      if (attribute.name.toLowerCase() === "stroke") usesStroke = true;
+      element.setAttribute(
+        attribute.name,
+        attribute.value.replace(/currentcolor/gi, color),
+      );
+    }
+  }
+
+  if (usesFill) svg.setAttribute("fill", color);
+  if (usesStroke) svg.setAttribute("stroke", color);
+}
+
+export interface SerializeSvgOptions {
+  width: number;
+  height: number;
+  color: string;
+  maxBytes: number;
+}
+
+export function serializeSvg(
+  source: SVGSVGElement,
+  { width, height, color, maxBytes }: SerializeSvgOptions,
+): string | undefined {
+  const svg = source.cloneNode(true) as SVGSVGElement;
+  if (!resolveUseReferences(svg)) return undefined;
+
+  bakeCurrentColor(svg, color);
+  if (!sanitizeSvgTree(svg)) return undefined;
+
+  svg.setAttribute("width", String(width));
+  svg.setAttribute("height", String(height));
+  if (!svg.hasAttribute("viewBox")) {
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  }
+
+  const markup = new XMLSerializer().serializeToString(svg);
+  if (new TextEncoder().encode(markup).byteLength > maxBytes) return undefined;
+  return markup;
+}

--- a/extension/src/collectors/types.ts
+++ b/extension/src/collectors/types.ts
@@ -119,10 +119,38 @@ export interface ImageScrapData {
   faviconUrl?: string;
 }
 
-// Discriminated union over the object kinds the scrap collector captures
-// (future kinds: button, input, svg-icon, ...). Sound is a separate event
-// type with its own collection pipeline, not a scrap kind.
-export type ScrapEventData = ImageScrapData;
+export interface ButtonScrapData {
+  kind: "button";
+  text: string;
+  styles: Record<string, string>;
+  innerSvg?: string;
+  pageTitle: string;
+  faviconUrl?: string;
+}
+
+export interface SvgIconScrapData {
+  kind: "svg-icon";
+  markup: string;
+  width: number;
+  height: number;
+  pageTitle: string;
+  faviconUrl?: string;
+}
+
+export interface CursorScrapData {
+  kind: "cursor";
+  url: string;
+  hotspotX?: number;
+  hotspotY?: number;
+  pageTitle: string;
+  faviconUrl?: string;
+}
+
+export type ScrapEventData =
+  | ImageScrapData
+  | ButtonScrapData
+  | SvgIconScrapData
+  | CursorScrapData;
 
 /**
  * Collector configuration

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -7,6 +7,7 @@ import { uploadEvents } from '../storage/sync'
 import { fetchEventsByPid } from '../storage/restore'
 import type { CollectionEvent } from '@playhtml/extension-types'
 import type { ScrapEventData } from '../collectors/types'
+import { getScrapKey } from '../collectors/scrapUtils'
 import {
   ensurePlayerIdentity,
   getPlayerProfile,
@@ -32,17 +33,104 @@ import {
 } from '../milestones/milestones'
 import { getSessionId } from '../storage/participant'
 
-export interface ScrapRecord {
+interface ScrapRecordBase {
   id: string
-  src: string
-  alt?: string
-  pageTitle: string
-  faviconUrl?: string
+  key: string
   domain: string
   pageUrl: string
   ts: number
-  naturalWidth: number
-  naturalHeight: number
+  pageTitle: string
+  faviconUrl?: string
+}
+
+export type ScrapRecord = ScrapRecordBase & (
+  | {
+      kind: "image"
+      src: string
+      alt?: string
+      naturalWidth: number
+      naturalHeight: number
+    }
+  | {
+      kind: "button"
+      text: string
+      styles: Record<string, string>
+      innerSvg?: string
+    }
+  | {
+      kind: "svg-icon"
+      markup: string
+      width: number
+      height: number
+    }
+  | {
+      kind: "cursor"
+      url: string
+      hotspotX?: number
+      hotspotY?: number
+    }
+)
+
+function toScrapRecord(event: CollectionEvent): ScrapRecord | undefined {
+  const kind = (event.data as { kind?: unknown } | null)?.kind
+  if (
+    kind !== "image" &&
+    kind !== "button" &&
+    kind !== "svg-icon" &&
+    kind !== "cursor"
+  ) {
+    return undefined
+  }
+  if (!event.domain) {
+    throw new Error(`Scrap event ${event.id} is missing its domain`)
+  }
+
+  const data = event.data as ScrapEventData
+  const base: ScrapRecordBase = {
+    id: event.id,
+    key: getScrapKey(data),
+    domain: event.domain,
+    pageUrl: event.meta.url,
+    ts: event.ts,
+    pageTitle: data.pageTitle,
+    ...(data.faviconUrl ? { faviconUrl: data.faviconUrl } : {}),
+  }
+
+  switch (data.kind) {
+    case "image":
+      return {
+        ...base,
+        kind: data.kind,
+        src: data.src,
+        ...(data.alt ? { alt: data.alt } : {}),
+        naturalWidth: data.naturalWidth,
+        naturalHeight: data.naturalHeight,
+      }
+    case "button":
+      return {
+        ...base,
+        kind: data.kind,
+        text: data.text,
+        styles: data.styles,
+        ...(data.innerSvg ? { innerSvg: data.innerSvg } : {}),
+      }
+    case "svg-icon":
+      return {
+        ...base,
+        kind: data.kind,
+        markup: data.markup,
+        width: data.width,
+        height: data.height,
+      }
+    case "cursor":
+      return {
+        ...base,
+        kind: data.kind,
+        url: data.url,
+        ...(data.hotspotX !== undefined ? { hotspotX: data.hotspotX } : {}),
+        ...(data.hotspotY !== undefined ? { hotspotY: data.hotspotY } : {}),
+      }
+  }
 }
 
 const store = new LocalEventStore()
@@ -381,25 +469,12 @@ export default defineBackground(() => {
     if (message.type === 'GET_SCRAPS') {
       const limit = (message.options?.limit ?? 5000) as number
       store.queryByType('element', { limit })
-        .then((events) => events.flatMap((event): ScrapRecord[] => {
-          if (!event.domain) {
-            throw new Error(`Scrap event ${event.id} is missing its domain`)
-          }
-          const data = event.data as ScrapEventData
-          if (data.kind !== 'image') return []
-          return [{
-            id: event.id,
-            src: data.src,
-            ...(data.alt ? { alt: data.alt } : {}),
-            pageTitle: data.pageTitle,
-            ...(data.faviconUrl ? { faviconUrl: data.faviconUrl } : {}),
-            domain: event.domain,
-            pageUrl: event.meta.url,
-            ts: event.ts,
-            naturalWidth: data.naturalWidth,
-            naturalHeight: data.naturalHeight,
-          }]
-        }))
+        .then((events) => events
+          .sort((first, second) => second.ts - first.ts)
+          .flatMap((event): ScrapRecord[] => {
+            const scrap = toScrapRecord(event)
+            return scrap ? [scrap] : []
+          }))
         .then((scraps) => reply({ scraps }))
         .catch((e) => {
           console.error('[Background] GET_SCRAPS error:', e)

--- a/extension/src/entrypoints/scraps/scraps.tsx
+++ b/extension/src/entrypoints/scraps/scraps.tsx
@@ -9,36 +9,97 @@ import {
   type ScrapItem,
 } from "@movement/components/ScrapCollage";
 
-interface ScrapRecord {
+interface ScrapRecordBase {
   id: string;
-  src: string;
-  alt?: string;
+  key: string;
   pageTitle: string;
   faviconUrl?: string;
   domain: string;
   pageUrl: string;
   ts: number;
-  naturalWidth: number;
-  naturalHeight: number;
 }
+
+type ScrapRecord = ScrapRecordBase &
+  (
+    | {
+        kind: "image";
+        src: string;
+        alt?: string;
+        naturalWidth: number;
+        naturalHeight: number;
+      }
+    | {
+        kind: "button";
+        text: string;
+        styles: Record<string, string>;
+        innerSvg?: string;
+      }
+    | {
+        kind: "svg-icon";
+        markup: string;
+        width: number;
+        height: number;
+      }
+    | {
+        kind: "cursor";
+        url: string;
+        hotspotX?: number;
+        hotspotY?: number;
+      }
+  );
 
 interface ScrapsResponse {
   scraps: ScrapRecord[];
 }
 
 function toScrapItem(record: ScrapRecord): ScrapItem {
-  return {
+  const base = {
     id: record.id,
-    src: record.src,
-    ...(record.alt ? { alt: record.alt } : {}),
+    key: record.key,
     pageTitle: record.pageTitle,
-    ...(record.faviconUrl ? { faviconUrl: record.faviconUrl } : {}),
+    ...(record.faviconUrl !== undefined
+      ? { faviconUrl: record.faviconUrl }
+      : {}),
     domain: record.domain,
     pageUrl: record.pageUrl,
     ts: record.ts,
-    naturalWidth: record.naturalWidth,
-    naturalHeight: record.naturalHeight,
   };
+
+  switch (record.kind) {
+    case "image":
+      return {
+        ...base,
+        kind: record.kind,
+        src: record.src,
+        ...(record.alt !== undefined ? { alt: record.alt } : {}),
+        naturalWidth: record.naturalWidth,
+        naturalHeight: record.naturalHeight,
+      };
+    case "button":
+      return {
+        ...base,
+        kind: record.kind,
+        text: record.text,
+        styles: record.styles,
+        ...(record.innerSvg !== undefined ? { innerSvg: record.innerSvg } : {}),
+      };
+    case "svg-icon":
+      return {
+        ...base,
+        kind: record.kind,
+        markup: record.markup,
+        width: record.width,
+        height: record.height,
+      };
+    case "cursor":
+      return {
+        ...base,
+        kind: record.kind,
+        url: record.url,
+        ...(record.hotspotX !== undefined ? { hotspotX: record.hotspotX } : {}),
+        ...(record.hotspotY !== undefined ? { hotspotY: record.hotspotY } : {}),
+      };
+  }
 }
 
 const centeredMessageStyle: React.CSSProperties = {

--- a/extension/src/entrypoints/scraps/scraps.tsx
+++ b/extension/src/entrypoints/scraps/scraps.tsx
@@ -268,7 +268,7 @@ export function ScrapsPage() {
             zIndex: 2,
           }}
         >
-          <ScrapCollage items={items} seed={seed} />
+          <ScrapCollage items={items} seed={seed} showKindFilter={true} />
         </div>
       )}
 

--- a/extension/website/scraps-grid/index.html
+++ b/extension/website/scraps-grid/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!-- ABOUTME: Hosts the playable grid inventory prototype for synthetic internet scraps. -->
+<!-- ABOUTME: Serves at /scraps-grid/ as a network-free visual and interaction study. -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>scrap cabinet</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Martian+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@1,8..60,200&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./scraps-grid.tsx"></script>
+  </body>
+</html>

--- a/extension/website/scraps-grid/scraps-grid.tsx
+++ b/extension/website/scraps-grid/scraps-grid.tsx
@@ -1,0 +1,1039 @@
+// ABOUTME: Arranges mixed internet scraps in a draggable warm-paper grid inventory.
+// ABOUTME: Sizes each scrap by kind and image proportions, with rotation and overflow packing.
+
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createRoot } from "react-dom/client";
+import type { ScrapItem } from "@movement/components/ScrapCollage";
+import { buildItems } from "../scraps-preview/demoScraps";
+
+const GRID_COLUMNS = 16;
+const GRID_ROWS = 9;
+// Cells cap at 56px and shrink to keep the full board inside the viewport.
+const CELL_SIZE = Math.max(
+  36,
+  Math.min(56, Math.floor((window.innerWidth - 150) / GRID_COLUMNS)),
+);
+const IMAGE_LARGE_TIER_DIVISOR = 3;
+
+interface Footprint {
+  cols: number;
+  rows: number;
+}
+
+interface GridPosition {
+  col: number;
+  row: number;
+}
+
+interface InventoryPlacement {
+  footprint: Footprint;
+  position: GridPosition | null;
+}
+
+type PlacementMap = Record<string, InventoryPlacement>;
+
+interface DragTarget extends GridPosition {
+  valid: boolean;
+}
+
+interface DragState {
+  itemId: string;
+  origin: InventoryPlacement;
+  footprint: Footprint;
+  pointerX: number;
+  pointerY: number;
+  grabOffsetX: number;
+  grabOffsetY: number;
+  target: DragTarget | null;
+}
+
+interface FittedButtonProps {
+  item: Extract<ScrapItem, { kind: "button" }>;
+}
+
+interface ScrapContentProps {
+  item: ScrapItem;
+}
+
+interface InventoryCardProps {
+  item: ScrapItem;
+  footprint: Footprint;
+  className?: string;
+  onPointerDown?: (event: React.PointerEvent<HTMLDivElement>) => void;
+  style?: React.CSSProperties;
+  showTooltip?: boolean;
+}
+
+const PAGE_STYLES = `
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    min-height: 100vh;
+    background: #faf7f2;
+    color: #3d3833;
+  }
+
+  .scrap-page {
+    position: relative;
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+    align-items: center;
+    padding: 78px 24px 28px;
+    background:
+      radial-gradient(circle at 18% 20%, rgba(196, 114, 78, 0.035), transparent 26%),
+      radial-gradient(circle at 78% 68%, rgba(74, 154, 138, 0.035), transparent 28%),
+      #faf7f2;
+  }
+
+  .wordmark {
+    position: absolute;
+    top: 14px;
+    left: 20px;
+    z-index: 20;
+    font-family: "Source Serif 4", Georgia, serif;
+    font-size: 20px;
+    font-style: italic;
+    font-weight: 200;
+    pointer-events: none;
+  }
+
+  .page-header {
+    position: absolute;
+    top: 14px;
+    left: 50%;
+    z-index: 20;
+    width: max-content;
+    text-align: center;
+    transform: translateX(-50%);
+    pointer-events: none;
+  }
+
+  .page-header h1 {
+    margin: 0;
+    font-family: "Martian Mono", monospace;
+    font-size: 15px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+  }
+
+  .page-header p {
+    margin: 5px 0 0;
+    color: #827a72;
+    font-family: "Martian Mono", monospace;
+    font-size: 9px;
+  }
+
+  .cabinet {
+    display: flex;
+    width: ${GRID_COLUMNS * CELL_SIZE + 16}px;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .inventory-frame {
+    position: relative;
+    padding: 8px;
+    border: 1px solid #8d7054;
+    background: #a88969;
+    box-shadow:
+      0 14px 32px rgba(74, 55, 38, 0.14),
+      inset 0 0 0 2px rgba(255, 249, 238, 0.25),
+      inset 0 0 0 5px rgba(102, 74, 50, 0.12);
+  }
+
+  .inventory-board {
+    position: relative;
+    width: ${GRID_COLUMNS * CELL_SIZE}px;
+    height: ${GRID_ROWS * CELL_SIZE}px;
+    background: #f5f0e8;
+    touch-action: none;
+  }
+
+  .inventory-slots {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    grid-template-columns: repeat(${GRID_COLUMNS}, ${CELL_SIZE}px);
+    grid-template-rows: repeat(${GRID_ROWS}, ${CELL_SIZE}px);
+  }
+
+  .inventory-slot {
+    border-right: 1px solid #d8d0c0;
+    border-bottom: 1px solid #d8d0c0;
+    box-shadow:
+      inset 1px 1px 3px rgba(99, 78, 56, 0.035),
+      inset -1px -1px 2px rgba(255, 255, 255, 0.45);
+  }
+
+  .inventory-slot:nth-child(${GRID_COLUMNS}n) {
+    border-right: 0;
+  }
+
+  .inventory-slot:nth-last-child(-n + ${GRID_COLUMNS}) {
+    border-bottom: 0;
+  }
+
+  .inventory-card {
+    position: absolute;
+    z-index: 4;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(128, 102, 73, 0.28);
+    border-radius: 3px;
+    background:
+      linear-gradient(145deg, rgba(255, 253, 248, 0.7), rgba(225, 212, 192, 0.25)),
+      #f2eadf;
+    box-shadow:
+      0 2px 5px rgba(79, 57, 38, 0.08),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.38);
+    cursor: grab;
+    touch-action: none;
+    transition:
+      filter 130ms ease,
+      box-shadow 130ms ease,
+      transform 130ms ease;
+  }
+
+  .inventory-card:hover {
+    z-index: 7;
+    filter: saturate(1.04);
+    box-shadow:
+      0 5px 12px rgba(79, 57, 38, 0.13),
+      inset 0 0 0 1px rgba(255, 255, 255, 0.46);
+  }
+
+  .inventory-card--reserved {
+    z-index: 2;
+    border-style: dashed;
+    background: rgba(224, 214, 198, 0.2);
+    box-shadow: inset 0 0 9px rgba(112, 86, 61, 0.07);
+    cursor: default;
+  }
+
+  .inventory-card--ghost {
+    position: fixed;
+    z-index: 100;
+    cursor: grabbing;
+    pointer-events: none;
+    transform: scale(1.04);
+    transform-origin: center;
+    filter: drop-shadow(0 14px 10px rgba(61, 56, 51, 0.24));
+  }
+
+  .drop-target {
+    position: absolute;
+    z-index: 6;
+    border: 2px solid;
+    border-radius: 4px;
+    pointer-events: none;
+  }
+
+  .drop-target--valid {
+    border-color: rgba(74, 154, 138, 0.82);
+    background: rgba(74, 154, 138, 0.2);
+    box-shadow: inset 0 0 12px rgba(74, 154, 138, 0.18);
+  }
+
+  .drop-target--invalid {
+    border-color: rgba(196, 114, 78, 0.88);
+    background: rgba(196, 114, 78, 0.2);
+    box-shadow: inset 0 0 12px rgba(196, 114, 78, 0.18);
+  }
+
+  .scrap-content {
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .scrap-content--image {
+    display: block;
+    padding: 7px;
+    object-fit: contain;
+  }
+
+  .scrap-content--button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 6px;
+  }
+
+  .scrap-button {
+    flex: 0 0 auto;
+    transform-origin: center;
+  }
+
+  .scrap-button__icon {
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+    flex: 0 0 auto;
+    margin-right: 0.45em;
+  }
+
+  .scrap-button__icon > svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .scrap-content--svg {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 9px;
+  }
+
+  .scrap-content--svg > svg {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .scrap-content--cursor {
+    display: block;
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+    image-rendering: pixelated;
+  }
+
+  .scrap-tooltip {
+    position: absolute;
+    left: 4px;
+    bottom: calc(100% + 6px);
+    z-index: 30;
+    width: max-content;
+    max-width: 280px;
+    overflow: hidden;
+    padding: 6px 8px;
+    border: 1px solid rgba(61, 56, 51, 0.16);
+    border-radius: 3px;
+    background: rgba(250, 247, 242, 0.97);
+    box-shadow: 0 5px 14px rgba(61, 56, 51, 0.12);
+    color: #5c554e;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+    line-height: 1.35;
+    opacity: 0;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transform: translateY(3px);
+    transition:
+      opacity 100ms ease,
+      transform 100ms ease;
+  }
+
+  .inventory-card:hover .scrap-tooltip,
+  .overflow-item:hover .scrap-tooltip {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .overflow-section {
+    margin-top: 12px;
+  }
+
+  .overflow-label {
+    margin: 0 0 6px 2px;
+    color: #8a8279;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .overflow-shelf {
+    display: flex;
+    min-height: 68px;
+    align-items: center;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 6px 8px;
+    border: 1px solid #c8b9a5;
+    background:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.34), transparent 42%),
+      #e9dfd0;
+    box-shadow:
+      inset 0 4px 8px rgba(103, 77, 50, 0.06),
+      inset 0 -2px 0 rgba(137, 104, 72, 0.16);
+  }
+
+  .overflow-item {
+    position: relative;
+    display: flex;
+    height: 54px;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(128, 102, 73, 0.28);
+    border-radius: 3px;
+    background: #f2eadf;
+    box-shadow: 0 2px 5px rgba(79, 57, 38, 0.09);
+    cursor: grab;
+    touch-action: none;
+  }
+
+  .overflow-item .scrap-content--image {
+    padding: 4px;
+  }
+
+  .footprint-size {
+    position: absolute;
+    right: 3px;
+    bottom: 2px;
+    color: #8a8279;
+    font-family: "Martian Mono", monospace;
+    font-size: 6px;
+    pointer-events: none;
+  }
+
+  .overflow-empty {
+    color: #958b80;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+  }
+
+  .hud {
+    display: flex;
+    justify-content: center;
+    gap: 7px;
+    margin-top: 10px;
+  }
+
+  .hud-chip {
+    padding: 6px 8px;
+    border: 1px solid #d8d0c0;
+    border-radius: 2px;
+    background: rgba(245, 240, 232, 0.78);
+    color: #756c63;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+    line-height: 1;
+  }
+`;
+
+function imageArea(item: Extract<ScrapItem, { kind: "image" }>): number {
+  return item.naturalWidth * item.naturalHeight;
+}
+
+function getFootprints(items: ScrapItem[]): Record<string, Footprint> {
+  const images = items.filter(
+    (item): item is Extract<ScrapItem, { kind: "image" }> =>
+      item.kind === "image",
+  );
+  const largeImageCount = Math.ceil(
+    images.length / IMAGE_LARGE_TIER_DIVISOR,
+  );
+  const largeImageIds = new Set(
+    images
+      .slice()
+      .sort((a, b) => imageArea(b) - imageArea(a))
+      .slice(0, largeImageCount)
+      .map((item) => item.id),
+  );
+
+  return Object.fromEntries(
+    items.map((item): [string, Footprint] => {
+      switch (item.kind) {
+        case "image": {
+          const aspectRatio = item.naturalWidth / item.naturalHeight;
+          let footprint =
+            aspectRatio > 1.4
+              ? { cols: 3, rows: 2 }
+              : aspectRatio < 0.7
+                ? { cols: 2, rows: 3 }
+                : { cols: 2, rows: 2 };
+
+          if (largeImageIds.has(item.id)) {
+            footprint = {
+              cols: Math.min(4, footprint.cols + 1),
+              rows: Math.min(3, footprint.rows + 1),
+            };
+          }
+          return [item.id, footprint];
+        }
+        case "button":
+          return [
+            item.id,
+            {
+              cols: Math.max(
+                2,
+                Math.ceil((10 * item.text.length + 30) / CELL_SIZE),
+              ),
+              rows: 1,
+            },
+          ];
+        case "svg-icon":
+        case "cursor":
+          return [item.id, { cols: 1, rows: 1 }];
+      }
+    }),
+  );
+}
+
+function fitsInCells(
+  occupied: boolean[][],
+  position: GridPosition,
+  footprint: Footprint,
+): boolean {
+  if (
+    position.col < 0 ||
+    position.row < 0 ||
+    position.col + footprint.cols > GRID_COLUMNS ||
+    position.row + footprint.rows > GRID_ROWS
+  ) {
+    return false;
+  }
+
+  for (let row = position.row; row < position.row + footprint.rows; row += 1) {
+    for (
+      let col = position.col;
+      col < position.col + footprint.cols;
+      col += 1
+    ) {
+      if (occupied[row][col]) return false;
+    }
+  }
+  return true;
+}
+
+function markCells(
+  occupied: boolean[][],
+  position: GridPosition,
+  footprint: Footprint,
+): void {
+  for (let row = position.row; row < position.row + footprint.rows; row += 1) {
+    for (
+      let col = position.col;
+      col < position.col + footprint.cols;
+      col += 1
+    ) {
+      occupied[row][col] = true;
+    }
+  }
+}
+
+function packItems(
+  items: ScrapItem[],
+  footprints: Record<string, Footprint>,
+): PlacementMap {
+  const occupied = Array.from({ length: GRID_ROWS }, () =>
+    Array.from({ length: GRID_COLUMNS }, () => false),
+  );
+  const sortedItems = items
+    .map((item, index) => ({ item, index }))
+    .sort((a, b) => {
+      const aFootprint = footprints[a.item.id];
+      const bFootprint = footprints[b.item.id];
+      const areaDifference =
+        bFootprint.cols * bFootprint.rows -
+        aFootprint.cols * aFootprint.rows;
+      return areaDifference || a.index - b.index;
+    });
+  const placements: PlacementMap = {};
+
+  for (const { item } of sortedItems) {
+    const footprint = footprints[item.id];
+    let position: GridPosition | null = null;
+
+    search: for (
+      let row = 0;
+      row <= GRID_ROWS - footprint.rows;
+      row += 1
+    ) {
+      for (
+        let col = 0;
+        col <= GRID_COLUMNS - footprint.cols;
+        col += 1
+      ) {
+        const candidate = { col, row };
+        if (!fitsInCells(occupied, candidate, footprint)) continue;
+        position = candidate;
+        break search;
+      }
+    }
+
+    if (position) markCells(occupied, position, footprint);
+    placements[item.id] = { footprint, position };
+  }
+
+  return placements;
+}
+
+function occupiedByOtherItems(
+  placements: PlacementMap,
+  draggedItemId: string,
+): boolean[][] {
+  const occupied = Array.from({ length: GRID_ROWS }, () =>
+    Array.from({ length: GRID_COLUMNS }, () => false),
+  );
+
+  for (const [itemId, placement] of Object.entries(placements)) {
+    if (itemId === draggedItemId || !placement.position) continue;
+    markCells(occupied, placement.position, placement.footprint);
+  }
+  return occupied;
+}
+
+function calculateTarget(
+  board: HTMLDivElement | null,
+  placements: PlacementMap,
+  drag: Pick<
+    DragState,
+    | "itemId"
+    | "footprint"
+    | "pointerX"
+    | "pointerY"
+    | "grabOffsetX"
+    | "grabOffsetY"
+  >,
+): DragTarget | null {
+  if (!board) return null;
+  const boardBounds = board.getBoundingClientRect();
+  const position = {
+    col: Math.round(
+      (drag.pointerX - drag.grabOffsetX - boardBounds.left) / CELL_SIZE,
+    ),
+    row: Math.round(
+      (drag.pointerY - drag.grabOffsetY - boardBounds.top) / CELL_SIZE,
+    ),
+  };
+  const occupied = occupiedByOtherItems(placements, drag.itemId);
+
+  return {
+    ...position,
+    valid: fitsInCells(occupied, position, drag.footprint),
+  };
+}
+
+function FittedButton({ item }: FittedButtonProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLSpanElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const button = buttonRef.current;
+    if (!container || !button) return;
+
+    const fitButton = () => {
+      const availableWidth = container.clientWidth;
+      const buttonWidth = button.scrollWidth;
+      setScale(
+        buttonWidth > 0 ? Math.min(1, availableWidth / buttonWidth) : 1,
+      );
+    };
+
+    fitButton();
+    const observer = new ResizeObserver(fitButton);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [item]);
+
+  return (
+    <div ref={containerRef} className="scrap-content scrap-content--button">
+      <span
+        ref={buttonRef}
+        className="scrap-button"
+        style={{
+          ...(item.styles as React.CSSProperties),
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          whiteSpace: "nowrap",
+          transform: `scale(${scale})`,
+        }}
+      >
+        {item.innerSvg && (
+          <span
+            className="scrap-button__icon"
+            aria-hidden="true"
+            dangerouslySetInnerHTML={{ __html: item.innerSvg }}
+          />
+        )}
+        {item.text}
+      </span>
+    </div>
+  );
+}
+
+function ScrapContent({ item }: ScrapContentProps) {
+  switch (item.kind) {
+    case "image":
+      return (
+        <img
+          className="scrap-content scrap-content--image"
+          src={item.src}
+          alt={item.alt ?? ""}
+          draggable={false}
+        />
+      );
+    case "button":
+      return <FittedButton item={item} />;
+    case "svg-icon":
+      return (
+        <div
+          className="scrap-content scrap-content--svg"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: item.markup }}
+        />
+      );
+    case "cursor":
+      return (
+        <img
+          className="scrap-content--cursor"
+          src={item.url}
+          alt=""
+          draggable={false}
+        />
+      );
+  }
+}
+
+function InventoryCard({
+  item,
+  footprint,
+  className = "",
+  onPointerDown,
+  style,
+  showTooltip = true,
+}: InventoryCardProps) {
+  return (
+    <div
+      className={`inventory-card ${className}`}
+      onPointerDown={onPointerDown}
+      style={style}
+    >
+      <ScrapContent item={item} />
+      {showTooltip && (
+        <span className="scrap-tooltip">
+          {item.pageTitle} · {item.domain}
+        </span>
+      )}
+      <span className="footprint-size">
+        {footprint.cols}×{footprint.rows}
+      </span>
+    </div>
+  );
+}
+
+function cardPositionStyle(
+  position: GridPosition,
+  footprint: Footprint,
+): React.CSSProperties {
+  return {
+    left: position.col * CELL_SIZE + 2,
+    top: position.row * CELL_SIZE + 2,
+    width: footprint.cols * CELL_SIZE - 4,
+    height: footprint.rows * CELL_SIZE - 4,
+  };
+}
+
+function ScrapCabinet() {
+  const items = useMemo(() => buildItems(), []);
+  const itemsById = useMemo(
+    () => new Map(items.map((item) => [item.id, item])),
+    [items],
+  );
+  const footprints = useMemo(() => getFootprints(items), [items]);
+  const [placements, setPlacements] = useState<PlacementMap>(() =>
+    packItems(items, footprints),
+  );
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const boardRef = useRef<HTMLDivElement>(null);
+
+  const startDrag = (
+    event: React.PointerEvent<HTMLDivElement>,
+    itemId: string,
+  ) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    const placement = placements[itemId];
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const width = placement.footprint.cols * CELL_SIZE;
+    const height = placement.footprint.rows * CELL_SIZE;
+    const horizontalRatio =
+      bounds.width > 0 ? (event.clientX - bounds.left) / bounds.width : 0.5;
+    const verticalRatio =
+      bounds.height > 0 ? (event.clientY - bounds.top) / bounds.height : 0.5;
+    const initialDrag = {
+      itemId,
+      origin: {
+        footprint: { ...placement.footprint },
+        position: placement.position ? { ...placement.position } : null,
+      },
+      footprint: { ...placement.footprint },
+      pointerX: event.clientX,
+      pointerY: event.clientY,
+      grabOffsetX: horizontalRatio * width,
+      grabOffsetY: verticalRatio * height,
+      target: null,
+    };
+
+    setDrag({
+      ...initialDrag,
+      target: calculateTarget(boardRef.current, placements, initialDrag),
+    });
+  };
+
+  useEffect(() => {
+    if (!drag) return;
+
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = "none";
+
+    const moveDrag = (event: PointerEvent) => {
+      setDrag((current) => {
+        if (!current) return null;
+        const moved = {
+          ...current,
+          pointerX: event.clientX,
+          pointerY: event.clientY,
+        };
+        return {
+          ...moved,
+          target: calculateTarget(boardRef.current, placements, moved),
+        };
+      });
+    };
+
+    const finishDrag = () => {
+      setDrag((current) => {
+        if (current?.target?.valid) {
+          setPlacements((existing) => ({
+            ...existing,
+            [current.itemId]: {
+              footprint: current.footprint,
+              position: {
+                col: current.target?.col ?? 0,
+                row: current.target?.row ?? 0,
+              },
+            },
+          }));
+        }
+        return null;
+      });
+    };
+
+    const cancelDrag = () => setDrag(null);
+
+    const rotateDrag = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== "r") return;
+      event.preventDefault();
+      setDrag((current) => {
+        if (!current || current.footprint.rows === 1) return current;
+        const footprint = {
+          cols: current.footprint.rows,
+          rows: current.footprint.cols,
+        };
+        const grabOffsetX =
+          (current.grabOffsetX / (current.footprint.cols * CELL_SIZE)) *
+          footprint.cols *
+          CELL_SIZE;
+        const grabOffsetY =
+          (current.grabOffsetY / (current.footprint.rows * CELL_SIZE)) *
+          footprint.rows *
+          CELL_SIZE;
+        const rotated = {
+          ...current,
+          footprint,
+          grabOffsetX,
+          grabOffsetY,
+        };
+        return {
+          ...rotated,
+          target: calculateTarget(boardRef.current, placements, rotated),
+        };
+      });
+    };
+
+    window.addEventListener("pointermove", moveDrag);
+    window.addEventListener("pointerup", finishDrag);
+    window.addEventListener("pointercancel", cancelDrag);
+    window.addEventListener("keydown", rotateDrag);
+    return () => {
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener("pointermove", moveDrag);
+      window.removeEventListener("pointerup", finishDrag);
+      window.removeEventListener("pointercancel", cancelDrag);
+      window.removeEventListener("keydown", rotateDrag);
+    };
+  }, [drag?.itemId, placements]);
+
+  const overflowItems = items.filter(
+    (item) => placements[item.id].position === null,
+  );
+  const usedCells = Object.values(placements).reduce(
+    (total, placement) =>
+      total +
+      (placement.position
+        ? placement.footprint.cols * placement.footprint.rows
+        : 0),
+    0,
+  );
+  const kindCounts = items.reduce(
+    (counts, item) => {
+      counts[item.kind] += 1;
+      return counts;
+    },
+    { image: 0, button: 0, "svg-icon": 0, cursor: 0 },
+  );
+
+  return (
+    <main className="scrap-page">
+      <style>{PAGE_STYLES}</style>
+      <span className="wordmark">we were online</span>
+      <header className="page-header">
+        <h1>scrap cabinet</h1>
+        <p>drag to rearrange · press r while dragging to rotate</p>
+      </header>
+
+      <section className="cabinet" aria-label="Scrap cabinet inventory">
+        <div className="inventory-frame">
+          <div ref={boardRef} className="inventory-board">
+            <div className="inventory-slots" aria-hidden="true">
+              {Array.from(
+                { length: GRID_COLUMNS * GRID_ROWS },
+                (_, index) => (
+                  <span key={index} className="inventory-slot" />
+                ),
+              )}
+            </div>
+
+            {items.map((item) => {
+              const placement = placements[item.id];
+              if (!placement.position || drag?.itemId === item.id) return null;
+              return (
+                <InventoryCard
+                  key={item.id}
+                  item={item}
+                  footprint={placement.footprint}
+                  onPointerDown={(event) => startDrag(event, item.id)}
+                  style={cardPositionStyle(
+                    placement.position,
+                    placement.footprint,
+                  )}
+                />
+              );
+            })}
+
+            {drag?.origin.position && (
+              <div
+                className="inventory-card inventory-card--reserved"
+                style={cardPositionStyle(
+                  drag.origin.position,
+                  drag.origin.footprint,
+                )}
+              />
+            )}
+
+            {drag?.target && (
+              <div
+                className={`drop-target ${
+                  drag.target.valid
+                    ? "drop-target--valid"
+                    : "drop-target--invalid"
+                }`}
+                style={{
+                  left: drag.target.col * CELL_SIZE,
+                  top: drag.target.row * CELL_SIZE,
+                  width: drag.footprint.cols * CELL_SIZE,
+                  height: drag.footprint.rows * CELL_SIZE,
+                }}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="overflow-section">
+          <p className="overflow-label">overflow shelf</p>
+          <div className="overflow-shelf">
+            {overflowItems.length === 0 && (
+              <span className="overflow-empty">all scraps packed</span>
+            )}
+            {overflowItems.map((item) => {
+              const placement = placements[item.id];
+              if (drag?.itemId === item.id) {
+                return (
+                  <span
+                    key={item.id}
+                    className="overflow-empty"
+                    style={{ width: 54, textAlign: "center" }}
+                  >
+                    reserved
+                  </span>
+                );
+              }
+              return (
+                <InventoryCard
+                  key={item.id}
+                  item={item}
+                  footprint={placement.footprint}
+                  className="overflow-item"
+                  onPointerDown={(event) => startDrag(event, item.id)}
+                  style={{
+                    position: "relative",
+                    width: Math.min(
+                      168,
+                      Math.max(CELL_SIZE, placement.footprint.cols * CELL_SIZE),
+                    ),
+                    height: 54,
+                  }}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="hud">
+          <span className="hud-chip">
+            images {kindCounts.image} · buttons {kindCounts.button} · icons{" "}
+            {kindCounts["svg-icon"]} · cursors {kindCounts.cursor}
+          </span>
+          <span className="hud-chip">
+            cells used {usedCells}/{GRID_COLUMNS * GRID_ROWS}
+          </span>
+        </div>
+      </section>
+
+      {drag &&
+        (() => {
+          const item = itemsById.get(drag.itemId);
+          if (!item) return null;
+          return (
+            <InventoryCard
+              item={item}
+              footprint={drag.footprint}
+              className="inventory-card--ghost"
+              showTooltip={false}
+              style={{
+                left: drag.pointerX - drag.grabOffsetX + 2,
+                top: drag.pointerY - drag.grabOffsetY + 2,
+                width: drag.footprint.cols * CELL_SIZE - 4,
+                height: drag.footprint.rows * CELL_SIZE - 4,
+              }}
+            />
+          );
+        })()}
+    </main>
+  );
+}
+
+const container = document.getElementById("reactContent");
+if (container) {
+  createRoot(container).render(<ScrapCabinet />);
+}

--- a/extension/website/scraps-pile/index.html
+++ b/extension/website/scraps-pile/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<!-- ABOUTME: Full-viewport preview shell for the interactive scrap crate prototype. -->
+<!-- ABOUTME: Serves the physics-driven inventory experiment at /scraps-pile/. -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>scrap crate</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Martian+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@1,8..60,200&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./scraps-pile.tsx"></script>
+  </body>
+</html>

--- a/extension/website/scraps-pile/scraps-pile.tsx
+++ b/extension/website/scraps-pile/scraps-pile.tsx
@@ -1,0 +1,1191 @@
+// ABOUTME: Builds a throwable physics pile from synthetic image, button, icon, and cursor scraps.
+// ABOUTME: Renders an open crate with tunable circle collisions, gravity, rotation, and spring dragging.
+
+import React, { useEffect, useMemo, useRef } from "react";
+import { createRoot } from "react-dom/client";
+import type { ScrapItem } from "@movement/components/ScrapCollage";
+import { buildItems } from "../scraps-preview/demoScraps";
+
+const PHYSICS = {
+  gravity: 2200,
+  velocityDamping: 0.995,
+  angularDamping: 0.992,
+  restitution: 0.15,
+  spawnIntervalMs: 80,
+  sleepVelocity: 18,
+  sleepAngularVelocity: 0.06,
+  sleepDistance: 2,
+  sleepAngle: 0.03,
+  sleepFrames: 24,
+  spinImpactVelocity: 90,
+  collisionSlop: 0.5,
+  positionCorrection: 0.8,
+  supportTolerance: 1,
+  contactDamping: 0.86,
+  relaxationIterations: 3,
+  dragSpring: 92,
+  dragDamping: 0.82,
+  maxTimeStep: 1 / 30,
+} as const;
+
+const IMAGE_LONG_EDGES = [90, 130, 170] as const;
+const CURSOR_SIZE = 40;
+const WALL_FRICTION = 0.84;
+const FLOOR_FRICTION = 0.9;
+const MAX_THROW_SPEED = 2400;
+// Below this, a crate measurement is treated as a transient mid-layout
+// report rather than the real bounds (see the resize handler in
+// ScrapsPilePage). The crate's CSS min-height/min-width keep it well above
+// this at all real layout sizes.
+const MIN_CRATE_DIMENSION = 100;
+
+interface ScrapLayout {
+  item: ScrapItem;
+  width: number;
+  height: number;
+  radius: number;
+  spawnOrder: number;
+}
+
+interface Body extends ScrapLayout {
+  x: number;
+  y: number;
+  velocityX: number;
+  velocityY: number;
+  angle: number;
+  angularVelocity: number;
+  spawnAt: number;
+  active: boolean;
+  sleeping: boolean;
+  stillFrames: number;
+  onFloor: boolean;
+  supported: boolean;
+  restX: number;
+  restY: number;
+  restAngle: number;
+  zIndex: number;
+}
+
+interface CrateBounds {
+  width: number;
+  height: number;
+}
+
+interface DragState {
+  body: Body;
+  pointerId: number;
+  targetX: number;
+  targetY: number;
+  pointerVelocityX: number;
+  pointerVelocityY: number;
+  lastPointerX: number;
+  lastPointerY: number;
+  lastPointerTime: number;
+  element: HTMLDivElement;
+}
+
+function clamp(minimum: number, maximum: number, value: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function seededRandom(key: string, salt: number): number {
+  let value = hashString(`${key}:${salt}`);
+  value += 0x6d2b79f5;
+  value = Math.imul(value ^ (value >>> 15), value | 1);
+  value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+  return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+}
+
+function imageDimensions(
+  item: Extract<ScrapItem, { kind: "image" }>,
+  longEdge: number,
+): { width: number; height: number } {
+  const naturalLongEdge = Math.max(item.naturalWidth, item.naturalHeight);
+  if (naturalLongEdge <= 0) return { width: longEdge, height: longEdge };
+
+  return {
+    width: longEdge * (item.naturalWidth / naturalLongEdge),
+    height: longEdge * (item.naturalHeight / naturalLongEdge),
+  };
+}
+
+function buildLayouts(items: ScrapItem[]): ScrapLayout[] {
+  const imageAreas = items
+    .filter(
+      (item): item is Extract<ScrapItem, { kind: "image" }> =>
+        item.kind === "image",
+    )
+    .map((item) => item.naturalWidth * item.naturalHeight)
+    .sort((left, right) => left - right);
+  const lowerArea = imageAreas[Math.floor((imageAreas.length - 1) / 3)] ?? 0;
+  const upperArea =
+    imageAreas[Math.floor(((imageAreas.length - 1) * 2) / 3)] ?? 0;
+
+  return items
+    .map((item) => {
+      switch (item.kind) {
+        case "image": {
+          const area = item.naturalWidth * item.naturalHeight;
+          const tier = area <= lowerArea ? 0 : area <= upperArea ? 1 : 2;
+          const dimensions = imageDimensions(item, IMAGE_LONG_EDGES[tier]);
+          return {
+            item,
+            ...dimensions,
+            radius: Math.max(dimensions.width, dimensions.height) * 0.42,
+            spawnOrder: seededRandom(item.key, 1),
+          };
+        }
+        case "button": {
+          const width = clamp(80, 230, item.text.trim().length * 10 + 30);
+          return {
+            item,
+            width,
+            height: 40,
+            radius: (width / 2) * 0.75,
+            spawnOrder: seededRandom(item.key, 1),
+          };
+        }
+        case "svg-icon": {
+          const longEdge = 48 + seededRandom(item.key, 2) * 24;
+          const naturalLongEdge = Math.max(item.width, item.height);
+          const width = longEdge * (item.width / naturalLongEdge);
+          const height = longEdge * (item.height / naturalLongEdge);
+          return {
+            item,
+            width,
+            height,
+            radius: longEdge * 0.45,
+            spawnOrder: seededRandom(item.key, 1),
+          };
+        }
+        case "cursor":
+          return {
+            item,
+            width: CURSOR_SIZE,
+            height: CURSOR_SIZE,
+            radius: CURSOR_SIZE / 2,
+            spawnOrder: seededRandom(item.key, 1),
+          };
+      }
+    })
+    .sort((left, right) => left.spawnOrder - right.spawnOrder);
+}
+
+function createBodies(
+  layouts: ScrapLayout[],
+  bounds: CrateBounds,
+  startTime: number,
+): Body[] {
+  return layouts.map((layout, index) => {
+    const usableWidth = Math.max(0, bounds.width - layout.radius * 2);
+    const x = layout.radius + usableWidth * seededRandom(layout.item.key, 3);
+    const y = -layout.radius - seededRandom(layout.item.key, 4) * 52;
+    const angle = (seededRandom(layout.item.key, 6) - 0.5) * 0.65;
+    return {
+      ...layout,
+      x,
+      y,
+      velocityX: (seededRandom(layout.item.key, 5) - 0.5) * 90,
+      velocityY: 0,
+      angle,
+      angularVelocity: (seededRandom(layout.item.key, 7) - 0.5) * 1.3,
+      spawnAt: startTime + index * PHYSICS.spawnIntervalMs,
+      active: false,
+      sleeping: false,
+      stillFrames: 0,
+      onFloor: false,
+      supported: false,
+      restX: x,
+      restY: y,
+      restAngle: angle,
+      zIndex: index + 1,
+    };
+  });
+}
+
+function wakeBody(body: Body): void {
+  body.sleeping = false;
+  body.stillFrames = 0;
+  body.restX = body.x;
+  body.restY = body.y;
+  body.restAngle = body.angle;
+}
+
+// Re-anchors a body to the current crate bounds after a resize. Always
+// recomputes x from the body's spawn seed against the CURRENT width rather
+// than scaling the previous x by a ratio: ratio-scaling compounds across
+// repeated resizes (and degenerates to 0 if a transient mid-layout
+// measurement reports width 0), which is how bodies ended up permanently
+// clustered against the left wall. Wakes the body and re-anchors its rest
+// snapshot so the positional sleep criterion doesn't instantly re-sleep it
+// at a position that's now stale.
+function reflowBody(body: Body, bounds: CrateBounds, heightRatio: number): void {
+  const usableWidth = Math.max(0, bounds.width - body.radius * 2);
+  body.x = body.radius + usableWidth * seededRandom(body.item.key, 3);
+  // Bodies that haven't landed yet stay airborne (renormalized against the
+  // new height); landed bodies get rescaled so the pile keeps its relative
+  // vertical position instead of jumping to the new floor instantly.
+  if (Number.isFinite(heightRatio)) body.y *= heightRatio;
+  constrainBody(body, bounds, false);
+  wakeBody(body);
+}
+
+function constrainBody(
+  body: Body,
+  bounds: CrateBounds,
+  applyResponse: boolean,
+): void {
+  const minimumX = body.radius;
+  const maximumX = Math.max(minimumX, bounds.width - body.radius);
+  const maximumY = Math.max(body.radius, bounds.height - body.radius);
+
+  if (body.x < minimumX) {
+    body.x = minimumX;
+    if (applyResponse && !body.sleeping && body.velocityX < 0) {
+      body.velocityX = -body.velocityX * PHYSICS.restitution;
+      body.velocityY *= WALL_FRICTION;
+    }
+  } else if (body.x > maximumX) {
+    body.x = maximumX;
+    if (applyResponse && !body.sleeping && body.velocityX > 0) {
+      body.velocityX = -body.velocityX * PHYSICS.restitution;
+      body.velocityY *= WALL_FRICTION;
+    }
+  }
+
+  if (body.y > maximumY) {
+    body.y = maximumY;
+    if (applyResponse && !body.sleeping && body.velocityY > 0) {
+      body.velocityY = -body.velocityY * PHYSICS.restitution;
+      body.velocityX *= FLOOR_FRICTION;
+    }
+  }
+}
+
+function resolveCollision(
+  first: Body,
+  second: Body,
+  applyImpulse: boolean,
+  grabbedBody: Body | undefined,
+): void {
+  if (!first.active || !second.active) return;
+
+  const differenceX = second.x - first.x;
+  const differenceY = second.y - first.y;
+  const minimumDistance = first.radius + second.radius;
+  const distanceSquared = differenceX * differenceX + differenceY * differenceY;
+  if (distanceSquared >= minimumDistance * minimumDistance) return;
+
+  const distance = Math.sqrt(distanceSquared);
+  const normalX = distance > 0.001 ? differenceX / distance : 1;
+  const normalY = distance > 0.001 ? differenceY / distance : 0;
+  const overlap = minimumDistance - Math.max(distance, 0.001);
+  const relativeVelocityX = second.velocityX - first.velocityX;
+  const relativeVelocityY = second.velocityY - first.velocityY;
+  const normalVelocity =
+    relativeVelocityX * normalX + relativeVelocityY * normalY;
+
+  if (
+    applyImpulse &&
+    normalVelocity < 0 &&
+    (normalVelocity < -PHYSICS.spinImpactVelocity ||
+      first === grabbedBody ||
+      second === grabbedBody)
+  ) {
+    wakeBody(first);
+    wakeBody(second);
+  }
+
+  const firstInverseMass = first.sleeping
+    ? 0
+    : (first === grabbedBody ? 0.08 : 1) / (first.radius * first.radius);
+  const secondInverseMass = second.sleeping
+    ? 0
+    : (second === grabbedBody ? 0.08 : 1) / (second.radius * second.radius);
+  const totalInverseMass = firstInverseMass + secondInverseMass;
+  const correction =
+    Math.max(0, overlap - PHYSICS.collisionSlop) * PHYSICS.positionCorrection;
+
+  if (totalInverseMass > 0 && correction > 0) {
+    first.x -= normalX * correction * (firstInverseMass / totalInverseMass);
+    first.y -= normalY * correction * (firstInverseMass / totalInverseMass);
+    second.x += normalX * correction * (secondInverseMass / totalInverseMass);
+    second.y += normalY * correction * (secondInverseMass / totalInverseMass);
+  }
+
+  if (!applyImpulse || normalVelocity >= 0 || totalInverseMass === 0) return;
+
+  // Restitution slop: resting contacts get a fully inelastic response, so the
+  // pile can come to rest instead of absorbing a micro-bounce every frame.
+  const restitution =
+    normalVelocity < -PHYSICS.spinImpactVelocity ? PHYSICS.restitution : 0;
+  const impulse = (-(1 + restitution) * normalVelocity) / totalInverseMass;
+
+  if (firstInverseMass > 0) {
+    first.velocityX -= impulse * firstInverseMass * normalX;
+    first.velocityY -= impulse * firstInverseMass * normalY;
+  }
+  if (secondInverseMass > 0) {
+    second.velocityX += impulse * secondInverseMass * normalX;
+    second.velocityY += impulse * secondInverseMass * normalY;
+  }
+
+  if (normalVelocity < -PHYSICS.spinImpactVelocity) {
+    const tangentVelocity =
+      relativeVelocityX * -normalY + relativeVelocityY * normalX;
+    if (firstInverseMass > 0) {
+      first.angularVelocity -=
+        (tangentVelocity / Math.max(1, first.radius)) * 0.08;
+    }
+    if (secondInverseMass > 0) {
+      second.angularVelocity +=
+        (tangentVelocity / Math.max(1, second.radius)) * 0.08;
+    }
+  }
+}
+
+function updateSupport(bodies: Body[], bounds: CrateBounds): void {
+  for (const body of bodies) {
+    body.onFloor =
+      body.active &&
+      body.y >= bounds.height - body.radius - PHYSICS.supportTolerance;
+    body.supported = false;
+  }
+
+  let supportChanged = true;
+  while (supportChanged) {
+    supportChanged = false;
+    for (let firstIndex = 0; firstIndex < bodies.length; firstIndex += 1) {
+      const first = bodies[firstIndex];
+      if (!first.active) continue;
+
+      for (
+        let secondIndex = firstIndex + 1;
+        secondIndex < bodies.length;
+        secondIndex += 1
+      ) {
+        const second = bodies[secondIndex];
+        if (!second.active) continue;
+
+        const differenceX = second.x - first.x;
+        const differenceY = second.y - first.y;
+        const contactDistance =
+          first.radius + second.radius + PHYSICS.supportTolerance;
+        const distanceSquared =
+          differenceX * differenceX + differenceY * differenceY;
+        if (distanceSquared > contactDistance * contactDistance) continue;
+
+        const distance = Math.sqrt(distanceSquared);
+        const normalY = distance > 0.001 ? differenceY / distance : 0;
+        if (
+          normalY > 0.35 &&
+          !first.supported &&
+          (second.onFloor || second.supported)
+        ) {
+          first.supported = true;
+          supportChanged = true;
+        } else if (
+          normalY < -0.35 &&
+          !second.supported &&
+          (first.onFloor || first.supported)
+        ) {
+          second.supported = true;
+          supportChanged = true;
+        }
+      }
+    }
+  }
+}
+
+function updateBodyElement(
+  body: Body,
+  element: HTMLDivElement | undefined,
+  grabbedBody: Body | undefined,
+): void {
+  if (!element) return;
+
+  element.style.visibility = body.active ? "visible" : "hidden";
+  if (!body.active) return;
+
+  const left = body.x - body.width / 2;
+  const top = body.y - body.height / 2;
+  element.style.transform = `translate3d(${left}px, ${top}px, 0) rotate(${body.angle}rad)`;
+  element.style.zIndex = String(body === grabbedBody ? 2000 : body.zIndex);
+  element.style.setProperty("--counter-rotation", `${-body.angle}rad`);
+  element.classList.toggle("is-grabbed", body === grabbedBody);
+}
+
+function ScrapContent({ item }: { item: ScrapItem }) {
+  switch (item.kind) {
+    case "image":
+      return (
+        <img
+          className="scrap-crate__image"
+          src={item.src}
+          alt={item.alt ?? ""}
+          draggable={false}
+        />
+      );
+    case "button":
+      return (
+        <span
+          className="scrap-crate__button"
+          style={item.styles as React.CSSProperties}
+        >
+          {item.innerSvg && (
+            <span
+              className="scrap-crate__button-icon"
+              aria-hidden="true"
+              dangerouslySetInnerHTML={{ __html: item.innerSvg }}
+            />
+          )}
+          {item.text}
+        </span>
+      );
+    case "svg-icon":
+      return (
+        <span
+          className="scrap-crate__svg"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: item.markup }}
+        />
+      );
+    case "cursor":
+      return (
+        <img
+          className="scrap-crate__cursor"
+          src={item.url}
+          alt=""
+          draggable={false}
+        />
+      );
+  }
+}
+
+const PAGE_STYLES = `
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body,
+  #reactContent {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  body {
+    background: #faf7f2;
+    color: #3d3833;
+    user-select: none;
+  }
+
+  .scrap-page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    min-height: 560px;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 18% 14%, rgba(138, 106, 58, 0.04), transparent 28%),
+      #faf7f2;
+  }
+
+  .scrap-page__wordmark {
+    position: absolute;
+    top: 14px;
+    left: 20px;
+    z-index: 20;
+    font-family: "Source Serif 4", Georgia, serif;
+    font-size: 20px;
+    font-style: italic;
+    font-weight: 200;
+    pointer-events: none;
+  }
+
+  .scrap-page__header {
+    position: absolute;
+    top: 14px;
+    left: 50%;
+    z-index: 20;
+    width: min(560px, calc(100vw - 260px));
+    text-align: center;
+    transform: translateX(-50%);
+    pointer-events: none;
+  }
+
+  .scrap-page__title {
+    margin: 0;
+    font-family: "Martian Mono", monospace;
+    font-size: 15px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+  }
+
+  .scrap-page__subtitle {
+    margin: 5px 0 0;
+    color: #827a72;
+    font-family: "Martian Mono", monospace;
+    font-size: 9px;
+    line-height: 1.5;
+  }
+
+  .scrap-crate {
+    position: absolute;
+    top: 92px;
+    left: 50%;
+    width: min(78vw, 1180px);
+    height: min(62vh, 700px);
+    min-height: 390px;
+    padding: 13px 18px 26px;
+    border: 3px solid #664925;
+    border-radius: 5px 5px 9px 9px;
+    background: #8a6a3a;
+    box-shadow:
+      0 18px 38px rgba(83, 57, 24, 0.18),
+      inset 0 2px 0 rgba(255, 245, 221, 0.2),
+      inset 0 -8px 14px rgba(72, 47, 19, 0.2);
+    transform: translateX(-50%);
+  }
+
+  .scrap-crate::before {
+    position: absolute;
+    top: 9px;
+    right: 11px;
+    bottom: 21px;
+    left: 11px;
+    z-index: 1;
+    border: 7px solid #73542d;
+    border-top-width: 9px;
+    box-shadow:
+      inset 12px 0 16px rgba(92, 63, 29, 0.14),
+      inset -12px 0 16px rgba(92, 63, 29, 0.14);
+    content: "";
+    pointer-events: none;
+  }
+
+  .scrap-crate__interior {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    height: 100%;
+    background:
+      repeating-linear-gradient(
+        5deg,
+        rgba(116, 88, 52, 0.025) 0,
+        rgba(116, 88, 52, 0.025) 1px,
+        transparent 1px,
+        transparent 8px
+      ),
+      #f5f0e8;
+    box-shadow:
+      inset 0 12px 16px rgba(94, 65, 31, 0.12),
+      inset 10px 0 13px rgba(94, 65, 31, 0.08),
+      inset -10px 0 13px rgba(94, 65, 31, 0.08);
+    touch-action: none;
+  }
+
+  .scrap-crate__front {
+    position: absolute;
+    right: -3px;
+    bottom: -3px;
+    left: -3px;
+    z-index: 1000;
+    height: 46px;
+    border: 3px solid #664925;
+    border-radius: 0 0 8px 8px;
+    background:
+      linear-gradient(180deg, rgba(255, 240, 207, 0.12), transparent 38%),
+      #806033;
+    box-shadow:
+      0 8px 16px rgba(83, 57, 24, 0.16),
+      inset 0 -5px 8px rgba(72, 47, 19, 0.16);
+    pointer-events: none;
+  }
+
+  .scrap-crate__hud {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    display: flex;
+    gap: 7px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    transform: translate(-50%, -50%);
+  }
+
+  .scrap-crate__chip {
+    padding: 4px 7px 3px;
+    border: 1px solid rgba(76, 51, 24, 0.34);
+    border-radius: 2px;
+    background: #e9ddc8;
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.28);
+    color: #574328;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .scrap-crate__body {
+    --counter-rotation: 0rad;
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    visibility: hidden;
+    border: 0;
+    background: transparent;
+    cursor: grab;
+    outline: none;
+    transform-origin: center;
+    will-change: transform;
+  }
+
+  .scrap-crate__body:focus-visible {
+    filter: drop-shadow(0 0 0.35rem rgba(91, 141, 184, 0.8));
+  }
+
+  .scrap-crate__body.is-grabbed {
+    cursor: grabbing;
+    filter: drop-shadow(0 13px 10px rgba(61, 56, 51, 0.28));
+  }
+
+  .scrap-crate__body.is-grabbed > .scrap-crate__content {
+    transform: scale(1.07);
+  }
+
+  .scrap-crate__content {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    transition: transform 110ms ease;
+  }
+
+  .scrap-crate__image {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    pointer-events: none;
+  }
+
+  .scrap-crate__button {
+    display: inline-flex !important;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  .scrap-crate__button-icon {
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+    flex: 0 0 auto;
+    margin-right: 0.45em;
+    pointer-events: none;
+  }
+
+  .scrap-crate__button-icon > svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .scrap-crate__svg {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .scrap-crate__svg > svg {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+  }
+
+  .scrap-crate__cursor {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    image-rendering: pixelated;
+    pointer-events: none;
+  }
+
+  .scrap-crate__label {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    z-index: 10;
+    width: max-content;
+    max-width: 260px;
+    padding: 6px 8px 5px;
+    overflow: hidden;
+    border: 1px solid rgba(91, 68, 39, 0.28);
+    border-radius: 2px;
+    background: rgba(245, 240, 232, 0.98);
+    box-shadow: 0 5px 12px rgba(61, 56, 51, 0.15);
+    color: #574c40;
+    font-family: "Martian Mono", monospace;
+    font-size: 8px;
+    line-height: 1.3;
+    opacity: 0;
+    pointer-events: none;
+    text-overflow: ellipsis;
+    transform:
+      translateX(-50%)
+      rotate(var(--counter-rotation))
+      translateY(3px);
+    transition: opacity 100ms ease, transform 100ms ease;
+    white-space: nowrap;
+  }
+
+  .scrap-crate__body:not(.is-grabbed):hover .scrap-crate__label {
+    opacity: 1;
+    transform:
+      translateX(-50%)
+      rotate(var(--counter-rotation))
+      translateY(0);
+  }
+
+  @media (max-width: 760px) {
+    .scrap-page__wordmark {
+      left: 14px;
+      font-size: 17px;
+    }
+
+    .scrap-page__header {
+      top: 50px;
+      width: calc(100vw - 30px);
+    }
+
+    .scrap-crate {
+      top: 102px;
+      width: calc(100vw - 28px);
+      height: calc(100vh - 128px);
+      min-height: 390px;
+    }
+
+    .scrap-crate__hud {
+      gap: 3px;
+    }
+
+    .scrap-crate__chip {
+      padding-right: 4px;
+      padding-left: 4px;
+      font-size: 7px;
+    }
+  }
+`;
+
+export function ScrapsPilePage() {
+  const items = useMemo(() => buildItems(), []);
+  const layouts = useMemo(() => buildLayouts(items), [items]);
+  const crateRef = useRef<HTMLDivElement>(null);
+  const bodyElements = useRef(new Map<string, HTMLDivElement>());
+  const bodiesRef = useRef<Body[]>([]);
+  const boundsRef = useRef<CrateBounds>({ width: 0, height: 0 });
+  const dragRef = useRef<DragState | undefined>(undefined);
+  const nextZIndex = useRef(layouts.length + 1);
+
+  const counts = useMemo(
+    () => ({
+      images: items.filter((item) => item.kind === "image").length,
+      buttons: items.filter((item) => item.kind === "button").length,
+      icons: items.filter((item) => item.kind === "svg-icon").length,
+      cursors: items.filter((item) => item.kind === "cursor").length,
+    }),
+    [items],
+  );
+
+  useEffect(() => {
+    const crate = crateRef.current;
+    if (!crate) return;
+
+    const resize = () => {
+      const previousBounds = boundsRef.current;
+      const rect = crate.getBoundingClientRect();
+      // The crate always has a nonzero laid-out size (CSS min-height/min-width
+      // guarantee this). A 0x0 (or otherwise degenerate) measurement is a
+      // transient mid-layout report from the ResizeObserver, not the real
+      // bounds -- reflowing bodies against it would collapse every spawn x to
+      // that body's own radius, piling everything against the left wall.
+      // Ignore it and wait for a real measurement instead.
+      if (rect.width < MIN_CRATE_DIMENSION || rect.height < MIN_CRATE_DIMENSION) {
+        return;
+      }
+      const nextBounds = { width: rect.width, height: rect.height };
+      boundsRef.current = nextBounds;
+
+      if (bodiesRef.current.length === 0) {
+        bodiesRef.current = createBodies(
+          layouts,
+          nextBounds,
+          performance.now() + 180,
+        );
+        return;
+      }
+
+      const widthChanged =
+        Math.abs(nextBounds.width - previousBounds.width) > 2;
+      const heightChanged =
+        Math.abs(nextBounds.height - previousBounds.height) > 2;
+      if (!widthChanged && !heightChanged) return;
+
+      const heightRatio =
+        previousBounds.height > 0
+          ? nextBounds.height / previousBounds.height
+          : 1;
+      const grabbedBody = dragRef.current?.body;
+      for (const body of bodiesRef.current) {
+        if (body === grabbedBody) continue;
+        reflowBody(body, nextBounds, heightRatio);
+      }
+    };
+
+    resize();
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(crate);
+
+    let animationFrame = 0;
+    let previousTime = performance.now();
+
+    const animate = (time: number) => {
+      const elapsed = Math.min(
+        Math.max(0, (time - previousTime) / 1000),
+        PHYSICS.maxTimeStep,
+      );
+      previousTime = time;
+      const bounds = boundsRef.current;
+      const bodies = bodiesRef.current;
+      const drag = dragRef.current;
+      const grabbedBody = drag?.body;
+
+      for (const body of bodies) {
+        if (!body.active && time >= body.spawnAt) {
+          body.active = true;
+          wakeBody(body);
+        }
+      }
+
+      const substeps = Math.max(1, Math.ceil(elapsed / (1 / 120)));
+      const stepElapsed = elapsed / substeps;
+      const stepScale = stepElapsed * 60;
+      const velocityDamping = Math.pow(PHYSICS.velocityDamping, stepScale);
+      const angularDamping = Math.pow(PHYSICS.angularDamping, stepScale);
+      const springDamping = Math.pow(PHYSICS.dragDamping, stepScale);
+
+      for (let substep = 0; substep < substeps; substep += 1) {
+        for (const body of bodies) {
+          if (!body.active || body.sleeping) continue;
+
+          body.velocityY += PHYSICS.gravity * stepElapsed;
+          body.velocityX *= velocityDamping;
+          body.velocityY *= velocityDamping;
+          body.angularVelocity *= angularDamping;
+
+          if (body === grabbedBody && drag) {
+            body.velocityX +=
+              (drag.targetX - body.x) * PHYSICS.dragSpring * stepElapsed;
+            body.velocityY +=
+              (drag.targetY - body.y) * PHYSICS.dragSpring * stepElapsed;
+            body.velocityX *= springDamping;
+            body.velocityY *= springDamping;
+          }
+
+          body.x += body.velocityX * stepElapsed;
+          body.y += body.velocityY * stepElapsed;
+          body.angle += body.angularVelocity * stepElapsed;
+          constrainBody(body, bounds, true);
+        }
+
+        for (
+          let iteration = 0;
+          iteration < PHYSICS.relaxationIterations;
+          iteration += 1
+        ) {
+          for (
+            let firstIndex = 0;
+            firstIndex < bodies.length;
+            firstIndex += 1
+          ) {
+            for (
+              let secondIndex = firstIndex + 1;
+              secondIndex < bodies.length;
+              secondIndex += 1
+            ) {
+              resolveCollision(
+                bodies[firstIndex],
+                bodies[secondIndex],
+                iteration === 0,
+                grabbedBody,
+              );
+            }
+          }
+          for (const body of bodies) {
+            if (body.active) constrainBody(body, bounds, false);
+          }
+        }
+      }
+
+      updateSupport(bodies, bounds);
+
+      const contactDamping = Math.pow(PHYSICS.contactDamping, elapsed * 60);
+      for (const body of bodies) {
+        if (
+          body.active &&
+          !body.sleeping &&
+          body !== grabbedBody &&
+          (body.onFloor || body.supported)
+        ) {
+          body.velocityX *= contactDamping;
+          body.angularVelocity *= contactDamping;
+          // A body pinned in place by neighbors can still accumulate runaway
+          // spin from repeated tangential impulses; brake it hard.
+          const pinnedDrift = Math.hypot(
+            body.x - body.restX,
+            body.y - body.restY,
+          );
+          if (pinnedDrift < 1 && Math.abs(body.angularVelocity) > 1.5) {
+            body.angularVelocity *= 0.8;
+          }
+        }
+        if (body.active && body.sleeping && !body.onFloor && !body.supported) {
+          wakeBody(body);
+        }
+      }
+
+      for (const body of bodies) {
+        if (body.active && body !== grabbedBody && !body.sleeping) {
+          const restDrift = Math.hypot(
+            body.x - body.restX,
+            body.y - body.restY,
+          );
+          const restTurn = Math.abs(body.angle - body.restAngle);
+          const linearSpeed = Math.hypot(body.velocityX, body.velocityY);
+          if (
+            (body.onFloor || body.supported) &&
+            linearSpeed < PHYSICS.sleepVelocity &&
+            Math.abs(body.angularVelocity) < PHYSICS.sleepAngularVelocity &&
+            restDrift < PHYSICS.sleepDistance &&
+            restTurn < PHYSICS.sleepAngle
+          ) {
+            body.stillFrames += 1;
+            if (body.stillFrames >= PHYSICS.sleepFrames) {
+              body.velocityX = 0;
+              body.velocityY = 0;
+              body.angularVelocity = 0;
+              body.sleeping = true;
+            }
+          } else {
+            body.restX = body.x;
+            body.restY = body.y;
+            body.restAngle = body.angle;
+            body.stillFrames = 0;
+          }
+        }
+
+        updateBodyElement(
+          body,
+          bodyElements.current.get(body.item.id),
+          grabbedBody,
+        );
+      }
+
+      scheduleFrame();
+    };
+
+    let timeoutHandle = 0;
+    let nextTick = 0;
+    let pendingTick = 0;
+    let stopped = false;
+    const scheduleFrame = () => {
+      if (stopped) return;
+      const tickId = nextTick + 1;
+      nextTick = tickId;
+      pendingTick = tickId;
+      const frameHandle = requestAnimationFrame((time) => tick(tickId, time));
+      animationFrame = frameHandle;
+      timeoutHandle = window.setTimeout(() => {
+        cancelAnimationFrame(frameHandle);
+        tick(tickId, performance.now());
+      }, 40);
+    };
+    const tick = (tickId: number, time: number) => {
+      if (stopped || tickId !== pendingTick) return;
+      pendingTick = 0;
+      window.clearTimeout(timeoutHandle);
+      animate(time);
+    };
+
+    scheduleFrame();
+    return () => {
+      stopped = true;
+      pendingTick = 0;
+      resizeObserver.disconnect();
+      cancelAnimationFrame(animationFrame);
+      window.clearTimeout(timeoutHandle);
+    };
+  }, [layouts]);
+
+  const pointerPosition = (event: React.PointerEvent<HTMLDivElement>) => {
+    const crate = crateRef.current;
+    if (!crate) return;
+    const rect = crate.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  };
+
+  const grabBody = (
+    event: React.PointerEvent<HTMLDivElement>,
+    itemId: string,
+  ) => {
+    const position = pointerPosition(event);
+    const body = bodiesRef.current.find(
+      (candidate) => candidate.item.id === itemId,
+    );
+    if (!position || !body || !body.active) return;
+
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    wakeBody(body);
+    body.zIndex = nextZIndex.current;
+    nextZIndex.current += 1;
+    dragRef.current = {
+      body,
+      pointerId: event.pointerId,
+      targetX: position.x,
+      targetY: position.y,
+      pointerVelocityX: 0,
+      pointerVelocityY: 0,
+      lastPointerX: position.x,
+      lastPointerY: position.y,
+      lastPointerTime: event.timeStamp,
+      element: event.currentTarget,
+    };
+  };
+
+  const moveGrabbedBody = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    const position = pointerPosition(event);
+    if (!drag || drag.pointerId !== event.pointerId || !position) return;
+
+    const elapsed = Math.max(8, event.timeStamp - drag.lastPointerTime) / 1000;
+    const instantVelocityX = (position.x - drag.lastPointerX) / elapsed;
+    const instantVelocityY = (position.y - drag.lastPointerY) / elapsed;
+    drag.pointerVelocityX =
+      drag.pointerVelocityX * 0.35 + instantVelocityX * 0.65;
+    drag.pointerVelocityY =
+      drag.pointerVelocityY * 0.35 + instantVelocityY * 0.65;
+    drag.targetX = position.x;
+    drag.targetY = position.y;
+    drag.lastPointerX = position.x;
+    drag.lastPointerY = position.y;
+    drag.lastPointerTime = event.timeStamp;
+  };
+
+  const releaseBody = (event: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+
+    wakeBody(drag.body);
+    drag.body.velocityX = clamp(
+      -MAX_THROW_SPEED,
+      MAX_THROW_SPEED,
+      drag.pointerVelocityX,
+    );
+    drag.body.velocityY = clamp(
+      -MAX_THROW_SPEED,
+      MAX_THROW_SPEED,
+      drag.pointerVelocityY,
+    );
+    drag.body.angularVelocity +=
+      (drag.body.velocityX / Math.max(1, drag.body.radius)) * 0.16;
+    drag.element.classList.remove("is-grabbed");
+    dragRef.current = undefined;
+  };
+
+  return (
+    <main className="scrap-page">
+      <style>{PAGE_STYLES}</style>
+      <span className="scrap-page__wordmark">we were online</span>
+      <header className="scrap-page__header">
+        <h1 className="scrap-page__title">scrap crate</h1>
+        <p className="scrap-page__subtitle">
+          grab a piece of the internet and toss it back in
+        </p>
+      </header>
+      <section className="scrap-crate" aria-label="Interactive scrap crate">
+        <div ref={crateRef} className="scrap-crate__interior">
+          {layouts.map((layout) => (
+            <div
+              key={layout.item.id}
+              ref={(element) => {
+                if (element) {
+                  bodyElements.current.set(layout.item.id, element);
+                } else {
+                  bodyElements.current.delete(layout.item.id);
+                }
+              }}
+              className="scrap-crate__body"
+              style={{ width: layout.width, height: layout.height }}
+              role="button"
+              tabIndex={0}
+              aria-label={`${layout.item.pageTitle} from ${layout.item.domain}`}
+              onPointerDown={(event) => grabBody(event, layout.item.id)}
+              onPointerMove={moveGrabbedBody}
+              onPointerUp={releaseBody}
+              onPointerCancel={releaseBody}
+            >
+              <span className="scrap-crate__content">
+                <ScrapContent item={layout.item} />
+              </span>
+              <span className="scrap-crate__label">
+                {layout.item.pageTitle} · {layout.item.domain}
+              </span>
+            </div>
+          ))}
+        </div>
+        <div className="scrap-crate__front">
+          <ul className="scrap-crate__hud" aria-label="Scrap counts">
+            <li className="scrap-crate__chip">images {counts.images}</li>
+            <li className="scrap-crate__chip">buttons {counts.buttons}</li>
+            <li className="scrap-crate__chip">icons {counts.icons}</li>
+            <li className="scrap-crate__chip">cursors {counts.cursors}</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+const container = document.getElementById("reactContent");
+if (container) {
+  createRoot(container).render(<ScrapsPilePage />);
+}

--- a/extension/website/scraps-preview/demoScraps.ts
+++ b/extension/website/scraps-preview/demoScraps.ts
@@ -1,0 +1,424 @@
+// ABOUTME: Synthetic scrap demo data (images, buttons, svg icons, cursors) for preview pages.
+// ABOUTME: Network-free ScrapItem fixtures shared by the collage and inventory prototypes.
+
+import type { ScrapItem } from "@movement/components/ScrapCollage";
+
+export const DAY_MS = 86_400_000;
+export const NOW = 1_784_000_000_000;
+
+export function svgDataUri(markup: string): string {
+  return `data:image/svg+xml;utf8,${encodeURIComponent(markup)}`;
+}
+
+interface FakeImage {
+  name: string;
+  domain: string;
+  pageTitle: string;
+  markup: string;
+  naturalWidth: number;
+  naturalHeight: number;
+}
+
+const FAKE_IMAGES: FakeImage[] = [
+  {
+    name: "pear",
+    domain: "orchard.example",
+    pageTitle: "Heirloom pears, ranked",
+    naturalWidth: 480,
+    naturalHeight: 640,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 64"><path d="M24 8c2 8 12 12 12 28a12 12 0 0 1-24 0C12 20 22 16 24 8z" fill="#a8c66c"/><path d="M24 8c1-3 3-5 6-6" stroke="#6b4f2a" stroke-width="2" fill="none"/></svg>',
+  },
+  {
+    name: "bottle",
+    domain: "orchard.example",
+    pageTitle: "Cellar notes",
+    naturalWidth: 300,
+    naturalHeight: 900,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 90"><path d="M12 4h6v18c6 4 8 10 8 18v42a6 6 0 0 1-6 6H10a6 6 0 0 1-6-6V40c0-8 2-14 8-18z" fill="#3d5a48"/><rect x="6" y="48" width="18" height="20" fill="#e8e0cf"/></svg>',
+  },
+  {
+    name: "boot",
+    domain: "fleamarket.example",
+    pageTitle: "Saturday finds",
+    naturalWidth: 640,
+    naturalHeight: 520,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 52"><path d="M14 4h18v22c8 2 22 6 26 16v6H8V8a4 4 0 0 1 6-4z" fill="#7a4a2b"/><path d="M8 42h50v6H8z" fill="#3d3833"/><path d="M18 8h10M18 14h10M18 20h10" stroke="#c9a227" stroke-width="2"/></svg>',
+  },
+  {
+    name: "fish",
+    domain: "fleamarket.example",
+    pageTitle: "Tin toys",
+    naturalWidth: 800,
+    naturalHeight: 420,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 42"><path d="M8 21C20 6 44 4 60 14l12-8-4 15 4 15-12-8C44 38 20 36 8 21z" fill="#5b8db8"/><circle cx="54" cy="18" r="3" fill="#22333b"/><path d="M30 12c4 6 4 12 0 18" stroke="#3d6a8f" stroke-width="2" fill="none"/></svg>',
+  },
+  {
+    name: "teapot",
+    domain: "kitchenalia.example",
+    pageTitle: "Grandmother's teapot pattern",
+    naturalWidth: 700,
+    naturalHeight: 560,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 70 56"><path d="M18 20h30a14 14 0 0 1 0 28H24a14 14 0 0 1-6-28z" fill="#c4724e"/><path d="M48 26c8 0 14 4 14 10-4 2-8 2-12 0" fill="#c4724e"/><path d="M22 20c0-8 6-12 12-12s12 4 12 12" stroke="#8a4a2e" stroke-width="3" fill="none"/><circle cx="34" cy="8" r="3" fill="#8a4a2e"/></svg>',
+  },
+  {
+    name: "moth",
+    domain: "nightgarden.example",
+    pageTitle: "Moths of the porch light",
+    naturalWidth: 620,
+    naturalHeight: 460,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 62 46"><path d="M31 20C24 8 10 4 4 10c-2 10 10 18 24 18z" fill="#d4b85c"/><path d="M31 20c7-12 21-16 27-10 2 10-10 18-24 18z" fill="#d4b85c"/><path d="M31 20c-5 6-12 14-8 22 4 2 8-2 8-8 0 6 4 10 8 8 4-8-3-16-8-22z" fill="#b89a3e"/><ellipse cx="31" cy="20" rx="3" ry="8" fill="#5c4a1e"/></svg>',
+  },
+  {
+    name: "chair",
+    domain: "auctionhouse.example",
+    pageTitle: "Lot 44: bentwood chair",
+    naturalWidth: 420,
+    naturalHeight: 760,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 76"><path d="M8 4c10-4 16-4 26 0l-4 28H12z" fill="none" stroke="#6b4f2a" stroke-width="4"/><rect x="8" y="32" width="26" height="6" fill="#8a6a3a"/><path d="M10 38v34M32 38v34M12 54h18" stroke="#6b4f2a" stroke-width="4"/></svg>',
+  },
+  {
+    name: "radio",
+    domain: "auctionhouse.example",
+    pageTitle: "Lot 12: valve radio",
+    naturalWidth: 760,
+    naturalHeight: 500,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 50"><rect x="4" y="10" width="68" height="36" rx="8" fill="#7a4a2b"/><circle cx="24" cy="28" r="10" fill="#e8e0cf"/><rect x="42" y="20" width="22" height="16" rx="3" fill="#c9a227"/><path d="M8 10L40 2" stroke="#3d3833" stroke-width="2"/></svg>',
+  },
+  {
+    name: "shell",
+    domain: "tidepool.example",
+    pageTitle: "Low tide inventory",
+    naturalWidth: 500,
+    naturalHeight: 440,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 44"><path d="M25 42C10 42 4 30 6 18c8-16 30-16 38 0 2 12-4 24-19 24z" fill="#e0b8a0"/><path d="M25 42V6M15 40L20 8M35 40L30 8M9 32l8-20M41 32l-8-20" stroke="#a97c5e" stroke-width="2" fill="none"/></svg>',
+  },
+  {
+    name: "clock",
+    domain: "tidepool.example",
+    pageTitle: "Harbor master's office",
+    naturalWidth: 520,
+    naturalHeight: 520,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 52 52"><circle cx="26" cy="26" r="22" fill="#e8e0cf" stroke="#3d3833" stroke-width="4"/><path d="M26 12v14l10 6" stroke="#3d3833" stroke-width="3" fill="none"/><circle cx="26" cy="26" r="2" fill="#c4724e"/></svg>',
+  },
+  {
+    name: "mushroom",
+    domain: "nightgarden.example",
+    pageTitle: "After the rain",
+    naturalWidth: 460,
+    naturalHeight: 500,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46 50"><path d="M23 4C10 4 2 14 4 24h38c2-10-6-20-19-20z" fill="#c0392b"/><circle cx="14" cy="14" r="3" fill="#f2e8dc"/><circle cx="28" cy="10" r="2.5" fill="#f2e8dc"/><circle cx="34" cy="18" r="2" fill="#f2e8dc"/><path d="M17 24h12l-2 20a8 8 0 0 1-8 0z" fill="#efe3d0"/></svg>',
+  },
+  {
+    name: "kettle-stamp",
+    domain: "kitchenalia.example",
+    pageTitle: "Enamelware catalog scan",
+    naturalWidth: 900,
+    naturalHeight: 620,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 90 62"><rect x="2" y="2" width="86" height="58" fill="#f2ead8" stroke="#b0a488" stroke-dasharray="4 3" stroke-width="2"/><path d="M30 22h30a12 12 0 0 1 0 24H32a12 12 0 0 1-2-24z" fill="#4a9a8a"/><path d="M60 28c6 0 10 3 10 7-3 2-6 1-9 0" fill="#4a9a8a"/><path d="M34 22c0-6 5-9 11-9s11 3 11 9" stroke="#2f6b5f" stroke-width="3" fill="none"/><text x="45" y="56" font-family="monospace" font-size="6" fill="#8a8279" text-anchor="middle">NO. 7 ENAMEL KETTLE</text></svg>',
+  },
+];
+
+const BUTTONS: Array<{
+  text: string;
+  domain: string;
+  pageTitle: string;
+  styles: Record<string, string>;
+}> = [
+  {
+    text: "Subscribe",
+    domain: "videotube.example",
+    pageTitle: "moss time-lapse, 3 hours",
+    styles: {
+      backgroundColor: "rgb(204, 0, 0)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none rgb(255, 255, 255)",
+      borderRadius: "18px",
+      padding: "8px 16px",
+      fontFamily: "Roboto, Arial, sans-serif",
+      fontSize: "14px",
+      fontWeight: "500",
+    },
+  },
+  {
+    text: "Follow",
+    domain: "birdsite.example",
+    pageTitle: "@tidepoolwatcher",
+    styles: {
+      backgroundColor: "rgb(15, 20, 25)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none",
+      borderRadius: "9999px",
+      padding: "6px 16px",
+      fontFamily: "system-ui, sans-serif",
+      fontSize: "14px",
+      fontWeight: "700",
+    },
+  },
+  {
+    text: "Download Now",
+    domain: "sharewarehill.example",
+    pageTitle: "WinAmp skins archive",
+    styles: {
+      backgroundColor: "rgb(212, 208, 200)",
+      color: "rgb(0, 0, 0)",
+      border: "2px outset rgb(255, 255, 255)",
+      borderRadius: "0px",
+      padding: "4px 12px",
+      fontFamily: "Tahoma, sans-serif",
+      fontSize: "12px",
+      fontWeight: "400",
+    },
+  },
+  {
+    text: "Sign up free",
+    domain: "saasland.example",
+    pageTitle: "The last productivity app",
+    styles: {
+      backgroundImage: "linear-gradient(135deg, rgb(99, 102, 241), rgb(168, 85, 247))",
+      backgroundColor: "rgb(99, 102, 241)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none",
+      borderRadius: "10px",
+      padding: "12px 24px",
+      fontFamily: "Inter, sans-serif",
+      fontSize: "15px",
+      fontWeight: "600",
+      boxShadow: "rgba(99, 102, 241, 0.4) 0px 8px 20px 0px",
+    },
+  },
+  {
+    text: "Add to cart",
+    domain: "megastore.example",
+    pageTitle: "Cast iron kettle, 2qt",
+    styles: {
+      backgroundColor: "rgb(255, 216, 20)",
+      color: "rgb(15, 17, 17)",
+      border: "1px solid rgb(252, 210, 0)",
+      borderRadius: "20px",
+      padding: "8px 20px",
+      fontFamily: "Arial, sans-serif",
+      fontSize: "13px",
+      fontWeight: "400",
+    },
+  },
+  {
+    text: "Learn more",
+    domain: "saasland.example",
+    pageTitle: "Pricing",
+    styles: {
+      backgroundColor: "rgba(0, 0, 0, 0)",
+      color: "rgb(91, 141, 184)",
+      border: "1.5px solid rgb(91, 141, 184)",
+      borderRadius: "6px",
+      padding: "9px 18px",
+      fontFamily: "Georgia, serif",
+      fontSize: "14px",
+      fontWeight: "400",
+      fontStyle: "italic",
+    },
+  },
+  {
+    text: "JOIN SERVER",
+    domain: "chathaven.example",
+    pageTitle: "the moss appreciation zone",
+    styles: {
+      backgroundColor: "rgb(88, 101, 242)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none",
+      borderRadius: "3px",
+      padding: "10px 22px",
+      fontFamily: "'gg sans', sans-serif",
+      fontSize: "13px",
+      fontWeight: "600",
+      textTransform: "uppercase",
+      letterSpacing: "0.5px",
+    },
+  },
+  {
+    text: "I'm Feeling Lucky",
+    domain: "searchbox.example",
+    pageTitle: "Search",
+    styles: {
+      backgroundColor: "rgb(248, 249, 250)",
+      color: "rgb(60, 64, 67)",
+      border: "1px solid rgb(248, 249, 250)",
+      borderRadius: "4px",
+      padding: "8px 16px",
+      fontFamily: "Arial, sans-serif",
+      fontSize: "13px",
+      fontWeight: "400",
+    },
+  },
+];
+
+const SVG_ICONS: Array<{
+  name: string;
+  domain: string;
+  pageTitle: string;
+  width: number;
+  height: number;
+  markup: string;
+}> = [
+  {
+    name: "heart",
+    domain: "birdsite.example",
+    pageTitle: "@tidepoolwatcher",
+    width: 24,
+    height: 24,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 21C5 14 2 10 2 7a5 5 0 0 1 10-1 5 5 0 0 1 10 1c0 3-3 7-10 14z" fill="#e0245e"/></svg>',
+  },
+  {
+    name: "star",
+    domain: "codeforge.example",
+    pageTitle: "tiny-collage-engine",
+    width: 20,
+    height: 20,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20"><path d="M10 1l2.6 5.6 6.4.8-4.7 4.3 1.2 6.3L10 15l-5.5 3 1.2-6.3L1 7.4l6.4-.8z" fill="#d4b85c" stroke="#b89a3e" stroke-width="1"/></svg>',
+  },
+  {
+    name: "rss",
+    domain: "webring.example",
+    pageTitle: "sites of the old web",
+    width: 28,
+    height: 28,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><rect width="28" height="28" rx="5" fill="#f26522"/><circle cx="7" cy="21" r="3" fill="#fff"/><path d="M4 12a12 12 0 0 1 12 12h-4a8 8 0 0 0-8-8zM4 4a20 20 0 0 1 20 20h-4A16 16 0 0 0 4 8z" fill="#fff"/></svg>',
+  },
+  {
+    name: "paper-plane",
+    domain: "chathaven.example",
+    pageTitle: "the moss appreciation zone",
+    width: 24,
+    height: 24,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M2 12L22 2l-6 20-5-7z" fill="#5b8db8"/><path d="M11 15l11-13-14 11z" fill="#3d6a8f"/></svg>',
+  },
+  {
+    name: "gear",
+    domain: "saasland.example",
+    pageTitle: "Settings",
+    width: 22,
+    height: 22,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 22 22"><path d="M11 1l1.5 3.2 3.5-.6 1 3.4 3.4 1-.6 3.5L23 13l-2.2 2.5.6 3.5-3.4 1-1 3.4-3.5-.6L11 25z" fill="none"/><circle cx="11" cy="11" r="9" fill="#8a8279"/><circle cx="11" cy="11" r="4" fill="#f5f0e8"/><path d="M11 0v4M11 18v4M0 11h4M18 11h4M3 3l3 3M16 16l3 3M19 3l-3 3M6 16l-3 3" stroke="#8a8279" stroke-width="2.5"/></svg>',
+  },
+  {
+    name: "flame",
+    domain: "forumpit.example",
+    pageTitle: "hottest takes of 2004",
+    width: 20,
+    height: 26,
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="26" viewBox="0 0 20 26"><path d="M10 0c2 5 8 8 8 15a8 8 0 0 1-16 0C2 10 8 6 10 0z" fill="#c4724e"/><path d="M10 10c1 3 4 4 4 8a4 4 0 0 1-8 0c0-4 3-5 4-8z" fill="#d4b85c"/></svg>',
+  },
+];
+
+const CURSORS: Array<{
+  name: string;
+  domain: string;
+  pageTitle: string;
+  markup: string;
+}> = [
+  {
+    name: "sword",
+    domain: "guildhall.example",
+    pageTitle: "browser MMO of your dreams",
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path d="M4 4l16 14 3-3L9 1z" fill="#b0b8c0" stroke="#5a6470" stroke-width="1"/><path d="M20 18l4 4-2 2-4-4z" fill="#7a4a2b"/><path d="M25 21l4 4-4 4-4-4z" fill="#c9a227"/></svg>',
+  },
+  {
+    name: "wand",
+    domain: "sparkleshop.example",
+    pageTitle: "cursors for your homepage",
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><path d="M3 29L20 12l-1-1L2 28z" fill="#8a6a3a"/><path d="M24 2l1.5 4.5L30 8l-4.5 1.5L24 14l-1.5-4.5L18 8l4.5-1.5z" fill="#d4b85c"/><circle cx="14" cy="18" r="1.5" fill="#e8d48a"/><circle cx="27" cy="16" r="1" fill="#e8d48a"/></svg>',
+  },
+  {
+    name: "crab",
+    domain: "tidepool.example",
+    pageTitle: "Low tide inventory",
+    markup:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32"><ellipse cx="16" cy="20" rx="9" ry="7" fill="#c0392b"/><circle cx="12" cy="16" r="1.5" fill="#22333b"/><circle cx="20" cy="16" r="1.5" fill="#22333b"/><path d="M7 18C3 16 2 12 4 9c3 1 5 4 5 7zM25 18c4-2 5-6 3-9-3 1-5 4-5 7z" fill="#c0392b"/><path d="M6 24l-4 3M9 27l-3 4M26 24l4 3M23 27l3 4" stroke="#8a2a1e" stroke-width="2"/></svg>',
+  },
+];
+
+export function buildItems(): ScrapItem[] {
+  const items: ScrapItem[] = [];
+
+  FAKE_IMAGES.forEach((image, index) => {
+    const src = svgDataUri(image.markup);
+    items.push({
+      id: `img-${image.name}`,
+      key: src,
+      kind: "image",
+      src,
+      alt: image.name,
+      naturalWidth: image.naturalWidth,
+      naturalHeight: image.naturalHeight,
+      pageTitle: image.pageTitle,
+      domain: image.domain,
+      pageUrl: `https://${image.domain}/`,
+      ts: NOW - index * 6 * 60 * 60 * 1000,
+    });
+  });
+
+  BUTTONS.forEach((button, index) => {
+    items.push({
+      id: `btn-${index}`,
+      key: `btn-${button.domain}-${button.text}`,
+      kind: "button",
+      text: button.text,
+      styles: button.styles,
+      pageTitle: button.pageTitle,
+      domain: button.domain,
+      pageUrl: `https://${button.domain}/`,
+      ts: NOW - (index + 2) * 5 * 60 * 60 * 1000,
+    });
+  });
+
+  SVG_ICONS.forEach((icon, index) => {
+    items.push({
+      id: `svg-${icon.name}`,
+      key: `svg-${icon.name}`,
+      kind: "svg-icon",
+      markup: icon.markup,
+      width: icon.width,
+      height: icon.height,
+      pageTitle: icon.pageTitle,
+      domain: icon.domain,
+      pageUrl: `https://${icon.domain}/`,
+      ts: NOW - (index + 1) * 7 * 60 * 60 * 1000,
+    });
+  });
+
+  CURSORS.forEach((cursor, index) => {
+    items.push({
+      id: `cur-${cursor.name}`,
+      key: svgDataUri(cursor.markup),
+      kind: "cursor",
+      url: svgDataUri(cursor.markup),
+      hotspotX: 2,
+      hotspotY: 2,
+      pageTitle: cursor.pageTitle,
+      domain: cursor.domain,
+      pageUrl: `https://${cursor.domain}/`,
+      ts: NOW - (index + 3) * 9 * 60 * 60 * 1000,
+    });
+  });
+
+  return items;
+}

--- a/extension/website/scraps-preview/index.html
+++ b/extension/website/scraps-preview/index.html
@@ -1,0 +1,27 @@
+<!-- ABOUTME: Demo page rendering ScrapCollage with synthetic scraps of every kind. -->
+<!-- ABOUTME: Serves at /scraps-preview/ for network-free visual checks of the collage. -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>internet scraps preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Martian+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@1,8..60,200&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./scraps-preview.tsx"></script>
+  </body>
+</html>

--- a/extension/website/scraps-preview/scraps-preview.tsx
+++ b/extension/website/scraps-preview/scraps-preview.tsx
@@ -1,0 +1,85 @@
+// ABOUTME: Renders ScrapCollage with synthetic image, button, svg-icon, and cursor scraps.
+// ABOUTME: Network-free demo data for visually checking mixed-media collage rendering.
+
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { ScrapCollage } from "@movement/components/ScrapCollage";
+import { buildItems, DAY_MS, NOW } from "./demoScraps";
+
+function PreviewPage() {
+  const seed = Math.floor(NOW / DAY_MS);
+
+  return (
+    <main
+      style={{
+        position: "relative",
+        width: "100vw",
+        height: "100vh",
+        overflow: "hidden",
+        background: "#faf9f6",
+        color: "#3d3833",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          top: 14,
+          left: 20,
+          zIndex: 4,
+          fontFamily: "'Source Serif 4', Georgia, serif",
+          fontSize: 20,
+          fontStyle: "italic",
+          fontWeight: 200,
+          pointerEvents: "none",
+        }}
+      >
+        we were online
+      </span>
+      <header
+        style={{
+          position: "absolute",
+          top: 14,
+          left: "50%",
+          zIndex: 4,
+          textAlign: "center",
+          transform: "translateX(-50%)",
+          pointerEvents: "none",
+        }}
+      >
+        <h1
+          style={{
+            margin: 0,
+            fontFamily: '"Martian Mono", monospace',
+            fontSize: 15,
+            fontWeight: 500,
+            letterSpacing: "0.04em",
+          }}
+        >
+          internet scraps (preview data)
+        </h1>
+        <p
+          style={{
+            margin: "5px 0 0",
+            color: "#827a72",
+            fontFamily: '"Martian Mono", monospace',
+            fontSize: 9,
+          }}
+        >
+          synthetic scraps: images, buttons, icons, cursors
+        </p>
+      </header>
+      <div style={{ position: "absolute", inset: "74px 20px 18px", zIndex: 2 }}>
+        <ScrapCollage
+          items={buildItems()}
+          seed={seed}
+          showKindFilter={true}
+        />
+      </div>
+    </main>
+  );
+}
+
+const container = document.getElementById("reactContent");
+if (container) {
+  createRoot(container).render(<PreviewPage />);
+}

--- a/extension/website/shared/components/ScrapCollage.tsx
+++ b/extension/website/shared/components/ScrapCollage.tsx
@@ -4,18 +4,44 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { hashString, seededRandom } from "../utils/styleUtils";
 
-export interface ScrapItem {
+interface ScrapItemBase {
   id: string;
-  src: string;
-  alt?: string;
+  key: string;
   pageTitle: string;
   faviconUrl?: string;
   domain: string;
   pageUrl: string;
   ts: number;
-  naturalWidth: number;
-  naturalHeight: number;
 }
+
+export type ScrapItem = ScrapItemBase &
+  (
+    | {
+        kind: "image";
+        src: string;
+        alt?: string;
+        naturalWidth: number;
+        naturalHeight: number;
+      }
+    | {
+        kind: "button";
+        text: string;
+        styles: Record<string, string>;
+        innerSvg?: string;
+      }
+    | {
+        kind: "svg-icon";
+        markup: string;
+        width: number;
+        height: number;
+      }
+    | {
+        kind: "cursor";
+        url: string;
+        hotspotX?: number;
+        hotspotY?: number;
+      }
+  );
 
 interface CurateScrapsOptions {
   perDomainCap?: number;
@@ -45,20 +71,26 @@ interface ScrapLayout {
 const DEFAULT_PER_DOMAIN_CAP = 4;
 const DEFAULT_TARGET_COUNT = 200;
 const LONG_EDGE_BY_TIER = [96, 152, 208] as const;
+const CURSOR_TILE_SIZE = 48;
 
 function naturalArea(item: ScrapItem): number {
-  return item.naturalWidth * item.naturalHeight;
+  switch (item.kind) {
+    case "image":
+      return item.naturalWidth * item.naturalHeight;
+    case "button":
+      return estimateButtonWidth(item.text) * 40;
+    case "svg-icon":
+      return item.width * item.height;
+    case "cursor":
+      return CURSOR_TILE_SIZE * CURSOR_TILE_SIZE;
+  }
 }
 
 function itemOrder(item: ScrapItem, seed: number): number {
-  return seededRandom(seed + hashString(item.src));
+  return seededRandom(seed + hashString(item.key));
 }
 
-function compareDomainScraps(
-  a: ScrapItem,
-  b: ScrapItem,
-  seed: number,
-): number {
+function compareDomainScraps(a: ScrapItem, b: ScrapItem, seed: number): number {
   const areaDifference = naturalArea(b) - naturalArea(a);
   if (areaDifference !== 0) return areaDifference;
 
@@ -68,7 +100,7 @@ function compareDomainScraps(
   const seededDifference = itemOrder(a, seed) - itemOrder(b, seed);
   if (seededDifference !== 0) return seededDifference;
 
-  return a.src.localeCompare(b.src);
+  return a.key.localeCompare(b.key);
 }
 
 export function curateScraps(
@@ -85,16 +117,16 @@ export function curateScraps(
   );
   if (perDomainCap === 0 || targetCount === 0) return [];
 
-  const newestBySrc = new Map<string, ScrapItem>();
+  const newestByKey = new Map<string, ScrapItem>();
   for (const item of items) {
-    const current = newestBySrc.get(item.src);
+    const current = newestByKey.get(item.key);
     if (!current || item.ts > current.ts) {
-      newestBySrc.set(item.src, item);
+      newestByKey.set(item.key, item);
     }
   }
 
   const scrapsByDomain = new Map<string, ScrapItem[]>();
-  for (const item of newestBySrc.values()) {
+  for (const item of newestByKey.values()) {
     const domainScraps = scrapsByDomain.get(item.domain);
     if (domainScraps) {
       domainScraps.push(item);
@@ -147,6 +179,68 @@ function formatCollectedDate(timestamp: number): string {
   }).format(timestamp);
 }
 
+function clamp(minimum: number, maximum: number, value: number): number {
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+function estimateButtonWidth(text: string): number {
+  return clamp(100, 240, 48 + text.trim().length * 8);
+}
+
+function imageSize(
+  item: Extract<ScrapItem, { kind: "image" }>,
+  tier: number,
+  itemSeed: number,
+): { width: number; height: number } {
+  const longEdge =
+    LONG_EDGE_BY_TIER[tier] * (0.92 + seededRandom(itemSeed, 1) * 0.16);
+  const naturalLongEdge = Math.max(item.naturalWidth, item.naturalHeight);
+  if (naturalLongEdge <= 0) return { width: 0, height: 0 };
+
+  return {
+    width: longEdge * (item.naturalWidth / naturalLongEdge),
+    height: longEdge * (item.naturalHeight / naturalLongEdge),
+  };
+}
+
+function svgIconSize(
+  item: Extract<ScrapItem, { kind: "svg-icon" }>,
+  itemSeed: number,
+): { width: number; height: number } {
+  if (item.width <= 0 || item.height <= 0) return { width: 0, height: 0 };
+
+  const longEdge = 56 + seededRandom(itemSeed, 1) * 40;
+  const aspect = item.width / item.height;
+  if (aspect >= 1) {
+    return {
+      width: longEdge,
+      height: longEdge / clamp(1, 2, aspect),
+    };
+  }
+
+  return {
+    width: longEdge * clamp(0.5, 1, aspect),
+    height: longEdge,
+  };
+}
+
+function itemSize(
+  item: ScrapItem,
+  tier: number,
+  itemSeed: number,
+): { width: number; height: number } {
+  switch (item.kind) {
+    case "image":
+      return imageSize(item, tier, itemSeed);
+    case "button":
+      return { width: estimateButtonWidth(item.text), height: 40 };
+    case "svg-icon":
+      return svgIconSize(item, itemSeed);
+    case "cursor":
+      return { width: CURSOR_TILE_SIZE, height: CURSOR_TILE_SIZE };
+  }
+}
+
 function buildLayout(
   items: ScrapItem[],
   width: number,
@@ -155,7 +249,13 @@ function buildLayout(
 ): ScrapLayout[] {
   if (items.length === 0 || width === 0 || height === 0) return [];
 
-  const sortedAreas = items.map(naturalArea).sort((a, b) => a - b);
+  const sortedAreas = items
+    .filter(
+      (item): item is Extract<ScrapItem, { kind: "image" }> =>
+        item.kind === "image",
+    )
+    .map(naturalArea)
+    .sort((a, b) => a - b);
   const lowerArea = sortedAreas[Math.floor((sortedAreas.length - 1) / 3)];
   const upperArea = sortedAreas[Math.floor(((sortedAreas.length - 1) * 2) / 3)];
   const aspectRatio = width / height;
@@ -169,28 +269,37 @@ function buildLayout(
 
   return items.map((item, index) => {
     const area = naturalArea(item);
-    const tier = area <= lowerArea ? 0 : area <= upperArea ? 1 : 2;
-    const itemSeed = seed + hashString(item.src);
-    const longEdge =
-      LONG_EDGE_BY_TIER[tier] * (0.92 + seededRandom(itemSeed, 1) * 0.16);
-    const naturalLongEdge = Math.max(item.naturalWidth, item.naturalHeight);
-    const imageWidth = longEdge * (item.naturalWidth / naturalLongEdge);
-    const imageHeight = longEdge * (item.naturalHeight / naturalLongEdge);
+    const tier =
+      item.kind !== "image" || area <= lowerArea
+        ? 0
+        : area <= upperArea
+          ? 1
+          : 2;
+    const itemSeed = seed + hashString(item.key);
+    const itemDimensions = itemSize(item, tier, itemSeed);
     const column = index % columnCount;
     const row = Math.floor(index / columnCount);
     const jitterX = (seededRandom(itemSeed, 2) - 0.5) * cellWidth * 0.6;
     const jitterY = (seededRandom(itemSeed, 3) - 0.5) * cellHeight * 0.6;
-    const unclampedX = (column + 0.5) * cellWidth + jitterX - imageWidth / 2;
-    const unclampedY = (row + 0.5) * cellHeight + jitterY - imageHeight / 2;
-    const x = Math.max(4, Math.min(width - imageWidth - 4, unclampedX));
-    const y = Math.max(4, Math.min(height - imageHeight - 4, unclampedY));
+    const unclampedX =
+      (column + 0.5) * cellWidth + jitterX - itemDimensions.width / 2;
+    const unclampedY =
+      (row + 0.5) * cellHeight + jitterY - itemDimensions.height / 2;
+    const x = Math.max(
+      4,
+      Math.min(width - itemDimensions.width - 4, unclampedX),
+    );
+    const y = Math.max(
+      4,
+      Math.min(height - itemDimensions.height - 4, unclampedY),
+    );
 
     return {
       item,
       x,
       y,
-      width: imageWidth,
-      height: imageHeight,
+      width: itemDimensions.width,
+      height: itemDimensions.height,
       rotation: seededRandom(itemSeed, 4) * 12 - 6,
       zIndex: Math.floor(seededRandom(itemSeed, 5) * 80) + 1,
       cardAbove: y > height * 0.58,
@@ -225,6 +334,56 @@ const COLLAGE_STYLES = `
     height: 100%;
     display: block;
     object-fit: contain;
+  }
+
+  .scrap-collage__button {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .scrap-collage__button-icon {
+    display: inline-flex;
+    width: 1em;
+    height: 1em;
+    flex: 0 0 auto;
+    margin-right: 0.45em;
+    pointer-events: none;
+  }
+
+  .scrap-collage__button-icon > svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  .scrap-collage__svg {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+  }
+
+  .scrap-collage__svg > svg {
+    max-width: 100%;
+    max-height: 100%;
+    display: block;
+  }
+
+  .scrap-collage__cursor {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 32px;
+    height: 32px;
+    display: block;
+    object-fit: contain;
+    image-rendering: pixelated;
+    pointer-events: none;
+    transform: translate(-50%, -50%);
   }
 
   .scrap-collage__provenance {
@@ -285,6 +444,100 @@ const COLLAGE_STYLES = `
   }
 `;
 
+function scrapTitle(item: ScrapItem): string {
+  if (item.pageTitle.trim()) return item.pageTitle;
+
+  switch (item.kind) {
+    case "image":
+      return item.alt?.trim() || "image";
+    case "button":
+      return item.text.trim() || "button";
+    case "svg-icon":
+      return "icon";
+    case "cursor":
+      return "cursor";
+  }
+}
+
+function isRenderableScrap(item: ScrapItem): boolean {
+  switch (item.kind) {
+    case "image":
+      return (
+        item.src.trim().length > 0 &&
+        item.naturalWidth > 0 &&
+        item.naturalHeight > 0
+      );
+    case "button":
+      return Boolean(item.text.trim() || item.innerSvg?.trim());
+    case "svg-icon":
+      return Boolean(item.markup.trim() && item.width > 0 && item.height > 0);
+    case "cursor":
+      return item.url.trim().length > 0;
+  }
+}
+
+interface ScrapContentProps {
+  item: ScrapItem;
+  onError: () => void;
+}
+
+function ScrapContent({ item, onError }: ScrapContentProps) {
+  switch (item.kind) {
+    case "image":
+      return (
+        <img
+          className="scrap-collage__image"
+          src={item.src}
+          alt={item.alt ?? ""}
+          loading="lazy"
+          draggable={false}
+          onError={onError}
+        />
+      );
+    case "button":
+      return (
+        <span
+          className="scrap-collage__button"
+          style={{
+            ...(item.styles as React.CSSProperties),
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {item.innerSvg && (
+            <span
+              className="scrap-collage__button-icon"
+              aria-hidden="true"
+              dangerouslySetInnerHTML={{ __html: item.innerSvg }}
+            />
+          )}
+          {item.text}
+        </span>
+      );
+    case "svg-icon":
+      return (
+        <div
+          className="scrap-collage__svg"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{ __html: item.markup }}
+        />
+      );
+    case "cursor":
+      return (
+        <img
+          className="scrap-collage__cursor"
+          src={item.url}
+          alt=""
+          loading="lazy"
+          draggable={false}
+          onError={onError}
+        />
+      );
+  }
+}
+
 export function ScrapCollage({
   items,
   seed,
@@ -305,13 +558,7 @@ export function ScrapCollage({
     [items, perDomainCap, seed, targetCount],
   );
   const layout = useMemo(
-    () =>
-      buildLayout(
-        curated,
-        containerSize.width,
-        containerSize.height,
-        seed,
-      ),
+    () => buildLayout(curated, containerSize.width, containerSize.height, seed),
     [containerSize.height, containerSize.width, curated, seed],
   );
 
@@ -330,11 +577,11 @@ export function ScrapCollage({
     return () => observer.disconnect();
   }, []);
 
-  const removeScrap = (src: string) => {
+  const removeScrap = (key: string) => {
     setFailedScraps((current) => {
-      if (current.has(src)) return current;
+      if (current.has(key)) return current;
       const next = new Set(current);
-      next.add(src);
+      next.add(key);
       return next;
     });
   };
@@ -355,7 +602,12 @@ export function ScrapCollage({
     >
       <style>{COLLAGE_STYLES}</style>
       {layout.map((scrap) => {
-        if (failedScraps.has(scrap.item.src)) return null;
+        if (
+          failedScraps.has(scrap.item.key) ||
+          !isRenderableScrap(scrap.item)
+        ) {
+          return null;
+        }
 
         const faviconFailed = failedFavicons.has(scrap.item.domain);
         const faviconSrc =
@@ -369,24 +621,21 @@ export function ScrapCollage({
           zIndex: scrap.zIndex,
           "--scrap-rotation": `${scrap.rotation}deg`,
         } as React.CSSProperties & { "--scrap-rotation": string };
+        const title = scrapTitle(scrap.item);
 
         return (
           <a
-            key={scrap.item.src}
+            key={scrap.item.key}
             className="scrap-collage__tile"
             href={scrap.item.pageUrl}
             target="_blank"
             rel="noopener noreferrer"
-            aria-label={`Open source page for ${scrap.item.pageTitle}`}
+            aria-label={`Open source page for ${title}`}
             style={tileStyle}
           >
-            <img
-              className="scrap-collage__image"
-              src={scrap.item.src}
-              alt={scrap.item.alt ?? ""}
-              loading="lazy"
-              draggable={false}
-              onError={() => removeScrap(scrap.item.src)}
+            <ScrapContent
+              item={scrap.item}
+              onError={() => removeScrap(scrap.item.key)}
             />
             <div
               className="scrap-collage__provenance"
@@ -413,11 +662,9 @@ export function ScrapCollage({
                 />
               )}
               <span className="scrap-collage__details">
-                <span className="scrap-collage__title">
-                  {scrap.item.pageTitle}
-                </span>
+                <span className="scrap-collage__title">{title}</span>
                 <span className="scrap-collage__metadata">
-                  {scrap.item.domain}
+                  {scrap.item.kind} · {scrap.item.domain}
                   <br />
                   collected {formatCollectedDate(scrap.item.ts)}
                 </span>

--- a/extension/website/shared/components/ScrapCollage.tsx
+++ b/extension/website/shared/components/ScrapCollage.tsx
@@ -54,6 +54,7 @@ interface ScrapCollageProps {
   seed: number;
   targetCount?: number;
   perDomainCap?: number;
+  showKindFilter?: boolean;
 }
 
 interface ScrapLayout {
@@ -72,6 +73,15 @@ const DEFAULT_PER_DOMAIN_CAP = 4;
 const DEFAULT_TARGET_COUNT = 200;
 const LONG_EDGE_BY_TIER = [96, 152, 208] as const;
 const CURSOR_TILE_SIZE = 48;
+const SCRAP_KIND_OPTIONS = [
+  { kind: "image", label: "images" },
+  { kind: "button", label: "buttons" },
+  { kind: "svg-icon", label: "icons" },
+  { kind: "cursor", label: "cursors" },
+] as const;
+
+type ScrapKind = ScrapItem["kind"];
+type ScrapKindFilter = "all" | ScrapKind;
 
 function naturalArea(item: ScrapItem): number {
   switch (item.kind) {
@@ -309,6 +319,66 @@ function buildLayout(
 }
 
 const COLLAGE_STYLES = `
+  .scrap-collage__filters {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    max-width: calc(100% - 24px);
+    pointer-events: auto;
+    transform: translateX(-50%);
+  }
+
+  .scrap-collage__filter {
+    appearance: none;
+    padding: 4px 10px;
+    border: 1px solid rgba(61, 56, 51, 0.18);
+    border-radius: 999px;
+    background: #f5f0e8;
+    color: #3d3833;
+    cursor: pointer;
+    font-family: "Martian Mono", monospace;
+    font-size: 9px;
+    line-height: 1.4;
+    white-space: nowrap;
+    transition:
+      transform 140ms ease,
+      box-shadow 140ms ease,
+      border-color 140ms ease,
+      background-color 140ms ease,
+      color 140ms ease;
+  }
+
+  .scrap-collage__filter-count {
+    color: #8a8279;
+  }
+
+  .scrap-collage__filter[aria-pressed="true"] {
+    border-color: #4a9a8a;
+    background: rgba(74, 154, 138, 0.1);
+    color: #4a9a8a;
+  }
+
+  .scrap-collage__filter[aria-pressed="true"] .scrap-collage__filter-count {
+    color: #4a9a8a;
+  }
+
+  .scrap-collage__filter:hover,
+  .scrap-collage__filter:focus-visible {
+    border-color: #4a9a8a;
+    box-shadow: 0 5px 10px rgba(61, 56, 51, 0.14);
+    transform: translateY(-2px);
+  }
+
+  .scrap-collage__filter:focus-visible {
+    outline: 2px solid rgba(74, 154, 138, 0.45);
+    outline-offset: 2px;
+  }
+
   .scrap-collage__tile {
     position: absolute;
     display: block;
@@ -543,9 +613,12 @@ export function ScrapCollage({
   seed,
   targetCount,
   perDomainCap,
+  showKindFilter = false,
 }: ScrapCollageProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
+  const [selectedKind, setSelectedKind] =
+    useState<ScrapKindFilter>("all");
   const [failedScraps, setFailedScraps] = useState<Set<string>>(
     () => new Set(),
   );
@@ -553,14 +626,39 @@ export function ScrapCollage({
     () => new Set(),
   );
 
+  const kindCounts = useMemo(() => {
+    const counts: Record<ScrapKind, number> = {
+      image: 0,
+      button: 0,
+      "svg-icon": 0,
+      cursor: 0,
+    };
+    for (const item of items) {
+      counts[item.kind] += 1;
+    }
+    return counts;
+  }, [items]);
+  const filteredItems = useMemo(
+    () =>
+      selectedKind === "all"
+        ? items
+        : items.filter((item) => item.kind === selectedKind),
+    [items, selectedKind],
+  );
   const curated = useMemo(
-    () => curateScraps(items, { seed, targetCount, perDomainCap }),
-    [items, perDomainCap, seed, targetCount],
+    () => curateScraps(filteredItems, { seed, targetCount, perDomainCap }),
+    [filteredItems, perDomainCap, seed, targetCount],
   );
   const layout = useMemo(
     () => buildLayout(curated, containerSize.width, containerSize.height, seed),
     [containerSize.height, containerSize.width, curated, seed],
   );
+
+  useEffect(() => {
+    if (selectedKind !== "all" && kindCounts[selectedKind] === 0) {
+      setSelectedKind("all");
+    }
+  }, [kindCounts, selectedKind]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -601,6 +699,35 @@ export function ScrapCollage({
       style={{ position: "relative", width: "100%", height: "100%" }}
     >
       <style>{COLLAGE_STYLES}</style>
+      {showKindFilter && (
+        <div className="scrap-collage__filters" aria-label="Filter scraps">
+          <button
+            type="button"
+            className="scrap-collage__filter"
+            aria-pressed={selectedKind === "all"}
+            onClick={() => setSelectedKind("all")}
+          >
+            all{" "}
+            <span className="scrap-collage__filter-count">{items.length}</span>
+          </button>
+          {SCRAP_KIND_OPTIONS.map(({ kind, label }) =>
+            kindCounts[kind] > 0 ? (
+              <button
+                key={kind}
+                type="button"
+                className="scrap-collage__filter"
+                aria-pressed={selectedKind === kind}
+                onClick={() => setSelectedKind(kind)}
+              >
+                {label}{" "}
+                <span className="scrap-collage__filter-count">
+                  {kindCounts[kind]}
+                </span>
+              </button>
+            ) : null,
+          )}
+        </div>
+      )}
       {layout.map((scrap) => {
         if (
           failedScraps.has(scrap.item.key) ||

--- a/extension/website/shared/components/ScrapCollage.tsx
+++ b/extension/website/shared/components/ScrapCollage.tsx
@@ -251,6 +251,70 @@ function itemSize(
   }
 }
 
+function tierBounds(items: ScrapItem[]): { lowerArea: number; upperArea: number } {
+  const sortedAreas = items
+    .filter(
+      (item): item is Extract<ScrapItem, { kind: "image" }> =>
+        item.kind === "image",
+    )
+    .map(naturalArea)
+    .sort((a, b) => a - b);
+  return {
+    lowerArea: sortedAreas[Math.floor((sortedAreas.length - 1) / 3)],
+    upperArea: sortedAreas[Math.floor(((sortedAreas.length - 1) * 2) / 3)],
+  };
+}
+
+function tierForItem(
+  item: ScrapItem,
+  lowerArea: number,
+  upperArea: number,
+): number {
+  const area = naturalArea(item);
+  return item.kind !== "image" || area <= lowerArea
+    ? 0
+    : area <= upperArea
+      ? 1
+      : 2;
+}
+
+/**
+ * Field height for "everything" mode: the container's fixed width is kept,
+ * but there's no fixed height to fit into, so rows are derived from the tile
+ * count instead of the field being clamped to the container. Column count
+ * uses the same sqrt-of-area formula as the fit-to-container layout,
+ * treating the container's own (measured) height as the reference aspect
+ * ratio so column width stays visually consistent between the two modes.
+ * Row height is the actual average tile height (via the same size-tier
+ * logic buildLayout uses), not a placeholder square cell, so the estimate
+ * tracks the real mix of image/button/icon/cursor tile sizes.
+ */
+function computeEverythingFieldHeight(
+  items: ScrapItem[],
+  width: number,
+  referenceHeight: number,
+  seed: number,
+): number {
+  if (items.length === 0 || width === 0 || referenceHeight === 0) return 0;
+
+  const aspectRatio = width / referenceHeight;
+  const columnCount = Math.max(
+    1,
+    Math.ceil(Math.sqrt(items.length * aspectRatio)),
+  );
+  const rowCount = Math.ceil(items.length / columnCount);
+
+  const { lowerArea, upperArea } = tierBounds(items);
+  const averageCellHeight =
+    items.reduce((sum, item) => {
+      const tier = tierForItem(item, lowerArea, upperArea);
+      const itemSeed = seed + hashString(item.key);
+      return sum + itemSize(item, tier, itemSeed).height;
+    }, 0) / items.length;
+
+  return rowCount * averageCellHeight;
+}
+
 function buildLayout(
   items: ScrapItem[],
   width: number,
@@ -259,15 +323,7 @@ function buildLayout(
 ): ScrapLayout[] {
   if (items.length === 0 || width === 0 || height === 0) return [];
 
-  const sortedAreas = items
-    .filter(
-      (item): item is Extract<ScrapItem, { kind: "image" }> =>
-        item.kind === "image",
-    )
-    .map(naturalArea)
-    .sort((a, b) => a - b);
-  const lowerArea = sortedAreas[Math.floor((sortedAreas.length - 1) / 3)];
-  const upperArea = sortedAreas[Math.floor(((sortedAreas.length - 1) * 2) / 3)];
+  const { lowerArea, upperArea } = tierBounds(items);
   const aspectRatio = width / height;
   const columnCount = Math.max(
     1,
@@ -278,13 +334,7 @@ function buildLayout(
   const cellHeight = height / rowCount;
 
   return items.map((item, index) => {
-    const area = naturalArea(item);
-    const tier =
-      item.kind !== "image" || area <= lowerArea
-        ? 0
-        : area <= upperArea
-          ? 1
-          : 2;
+    const tier = tierForItem(item, lowerArea, upperArea);
     const itemSeed = seed + hashString(item.key);
     const itemDimensions = itemSize(item, tier, itemSeed);
     const column = index % columnCount;
@@ -377,6 +427,38 @@ const COLLAGE_STYLES = `
   .scrap-collage__filter:focus-visible {
     outline: 2px solid rgba(74, 154, 138, 0.45);
     outline-offset: 2px;
+  }
+
+  .scrap-collage__filter--everything[aria-pressed="true"] {
+    border-color: #c4724e;
+    background: rgba(196, 114, 78, 0.1);
+    color: #c4724e;
+  }
+
+  .scrap-collage__filter--everything[aria-pressed="true"] .scrap-collage__filter-count {
+    color: #c4724e;
+  }
+
+  .scrap-collage__filter--everything:hover,
+  .scrap-collage__filter--everything:focus-visible {
+    border-color: #c4724e;
+  }
+
+  .scrap-collage__filter--everything:focus-visible {
+    outline-color: rgba(196, 114, 78, 0.45);
+  }
+
+  .scrap-collage__scroll {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 100%;
+  }
+
+  .scrap-collage__field {
+    position: relative;
+    width: 100%;
   }
 
   .scrap-collage__tile {
@@ -619,6 +701,7 @@ export function ScrapCollage({
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
   const [selectedKind, setSelectedKind] =
     useState<ScrapKindFilter>("all");
+  const [everythingMode, setEverythingMode] = useState(false);
   const [failedScraps, setFailedScraps] = useState<Set<string>>(
     () => new Set(),
   );
@@ -645,13 +728,40 @@ export function ScrapCollage({
         : items.filter((item) => item.kind === selectedKind),
     [items, selectedKind],
   );
+  const everythingScraps = useMemo(
+    () =>
+      curateScraps(filteredItems, {
+        seed,
+        perDomainCap: Infinity,
+        targetCount: Infinity,
+      }),
+    [filteredItems, seed],
+  );
   const curated = useMemo(
-    () => curateScraps(filteredItems, { seed, targetCount, perDomainCap }),
-    [filteredItems, perDomainCap, seed, targetCount],
+    () =>
+      everythingMode
+        ? everythingScraps
+        : curateScraps(filteredItems, { seed, targetCount, perDomainCap }),
+    [everythingMode, everythingScraps, filteredItems, perDomainCap, seed, targetCount],
+  );
+  const fieldHeight = useMemo(
+    () =>
+      everythingMode
+        ? Math.max(
+            containerSize.height,
+            computeEverythingFieldHeight(
+              curated,
+              containerSize.width,
+              containerSize.height,
+              seed,
+            ),
+          )
+        : containerSize.height,
+    [containerSize.height, containerSize.width, curated, everythingMode, seed],
   );
   const layout = useMemo(
-    () => buildLayout(curated, containerSize.width, containerSize.height, seed),
-    [containerSize.height, containerSize.width, curated, seed],
+    () => buildLayout(curated, containerSize.width, fieldHeight, seed),
+    [containerSize.width, curated, fieldHeight, seed],
   );
 
   useEffect(() => {
@@ -693,6 +803,76 @@ export function ScrapCollage({
     });
   };
 
+  const tiles = layout.map((scrap) => {
+    if (failedScraps.has(scrap.item.key) || !isRenderableScrap(scrap.item)) {
+      return null;
+    }
+
+    const faviconFailed = failedFavicons.has(scrap.item.domain);
+    const faviconSrc =
+      scrap.item.faviconUrl ||
+      `https://www.google.com/s2/favicons?domain=${encodeURIComponent(scrap.item.domain)}&sz=32`;
+    const tileStyle = {
+      left: scrap.x,
+      top: scrap.y,
+      width: scrap.width,
+      height: scrap.height,
+      zIndex: scrap.zIndex,
+      "--scrap-rotation": `${scrap.rotation}deg`,
+    } as React.CSSProperties & { "--scrap-rotation": string };
+    const title = scrapTitle(scrap.item);
+
+    return (
+      <a
+        key={scrap.item.key}
+        className="scrap-collage__tile"
+        href={scrap.item.pageUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Open source page for ${title}`}
+        style={tileStyle}
+      >
+        <ScrapContent
+          item={scrap.item}
+          onError={() => removeScrap(scrap.item.key)}
+        />
+        <div
+          className="scrap-collage__provenance"
+          style={{
+            ...(scrap.cardAbove
+              ? { bottom: "calc(100% + 10px)" }
+              : { top: "calc(100% + 10px)" }),
+            ...(scrap.cardRightAligned ? { right: 0 } : { left: 0 }),
+          }}
+        >
+          {faviconFailed ? (
+            <span
+              className="scrap-collage__favicon"
+              style={{
+                backgroundColor: placeholderColor(scrap.item.domain),
+              }}
+            />
+          ) : (
+            <img
+              className="scrap-collage__favicon"
+              src={faviconSrc}
+              alt=""
+              onError={() => markFaviconFailed(scrap.item.domain)}
+            />
+          )}
+          <span className="scrap-collage__details">
+            <span className="scrap-collage__title">{title}</span>
+            <span className="scrap-collage__metadata">
+              {scrap.item.kind} · {scrap.item.domain}
+              <br />
+              collected {formatCollectedDate(scrap.item.ts)}
+            </span>
+          </span>
+        </div>
+      </a>
+    );
+  });
+
   return (
     <div
       ref={containerRef}
@@ -726,80 +906,31 @@ export function ScrapCollage({
               </button>
             ) : null,
           )}
+          <button
+            type="button"
+            className="scrap-collage__filter scrap-collage__filter--everything"
+            aria-pressed={everythingMode}
+            onClick={() => setEverythingMode((current) => !current)}
+          >
+            everything{" "}
+            <span className="scrap-collage__filter-count">
+              {everythingScraps.length}
+            </span>
+          </button>
         </div>
       )}
-      {layout.map((scrap) => {
-        if (
-          failedScraps.has(scrap.item.key) ||
-          !isRenderableScrap(scrap.item)
-        ) {
-          return null;
-        }
-
-        const faviconFailed = failedFavicons.has(scrap.item.domain);
-        const faviconSrc =
-          scrap.item.faviconUrl ||
-          `https://www.google.com/s2/favicons?domain=${encodeURIComponent(scrap.item.domain)}&sz=32`;
-        const tileStyle = {
-          left: scrap.x,
-          top: scrap.y,
-          width: scrap.width,
-          height: scrap.height,
-          zIndex: scrap.zIndex,
-          "--scrap-rotation": `${scrap.rotation}deg`,
-        } as React.CSSProperties & { "--scrap-rotation": string };
-        const title = scrapTitle(scrap.item);
-
-        return (
-          <a
-            key={scrap.item.key}
-            className="scrap-collage__tile"
-            href={scrap.item.pageUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`Open source page for ${title}`}
-            style={tileStyle}
+      {everythingMode ? (
+        <div className="scrap-collage__scroll">
+          <div
+            className="scrap-collage__field"
+            style={{ height: fieldHeight }}
           >
-            <ScrapContent
-              item={scrap.item}
-              onError={() => removeScrap(scrap.item.key)}
-            />
-            <div
-              className="scrap-collage__provenance"
-              style={{
-                ...(scrap.cardAbove
-                  ? { bottom: "calc(100% + 10px)" }
-                  : { top: "calc(100% + 10px)" }),
-                ...(scrap.cardRightAligned ? { right: 0 } : { left: 0 }),
-              }}
-            >
-              {faviconFailed ? (
-                <span
-                  className="scrap-collage__favicon"
-                  style={{
-                    backgroundColor: placeholderColor(scrap.item.domain),
-                  }}
-                />
-              ) : (
-                <img
-                  className="scrap-collage__favicon"
-                  src={faviconSrc}
-                  alt=""
-                  onError={() => markFaviconFailed(scrap.item.domain)}
-                />
-              )}
-              <span className="scrap-collage__details">
-                <span className="scrap-collage__title">{title}</span>
-                <span className="scrap-collage__metadata">
-                  {scrap.item.kind} · {scrap.item.domain}
-                  <br />
-                  collected {formatCollectedDate(scrap.item.ts)}
-                </span>
-              </span>
-            </div>
-          </a>
-        );
-      })}
+            {tiles}
+          </div>
+        </div>
+      ) : (
+        tiles
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Stacked on #323. Extends internet scraps with three new object kinds — all riding the existing `element` event type's payload union, so **zero changes to `@playhtml/extension-types`** (no changeset, no worker bump; this is the payoff of the kind-discriminant design).

- **`button`** — semantic candidates only (`<button>`, `input[type=submit|button]`, `[role=button]`), same visibility gate as images, per-page cap 20. Captured by **reconstruction** (label text + allowlisted computed-style subset + optional sanitized inner svg), never raw outerHTML — captured markup renders in a privileged extension page, so arbitrary HTML replay is off the table. Gradient backgrounds kept, `url(...)` backgrounds never.
- **`svg-icon`** — inline `<svg>` (excluding those inside button candidates), 12–400px, per-page cap 20. Serialized with in-document `<use>` refs inlined (external/unresolvable → skip), `currentColor` baked to computed values, run through an allowlist sanitizer (elements whitelist, external-resource rejection incl. `url()` in any attribute, `on*`/`javascript:` stripping), 20KB cap.
- **`cursor`** — passive 500ms-throttled mouseover sampling of computed `cursor: url(...)` + hotspot. `data:` URIs allowed (self-contained cursors never rot), `blob:` skipped, uncapped — rare finds.

`GET_SCRAPS` now returns a discriminated union with a per-kind `key` (src / style-hash / markup-hash / url) used for both capture-time and render-time dedup. The collage renders per-kind tiles: buttons as styled `<span>`s (native button UA styling can't fight the captured look), icons via sanitized markup, cursors as tiny pixelated tiles; provenance cards gain a kind label.

Consumption affordances (equipping cursors via the satchel, placing scraps) are deliberately NOT in this PR — affordances derive from `kind` at consumption time per the plan.

## Verification

- 424/424 extension tests (new coverage: button text/size filters + input labels, svg sanitizer strips + `use` resolution + byte cap, cursor parsing/throttle/dedup, union mapping + keys)
- Typecheck: exactly the 40 pre-existing baseline errors, none referencing changed files; website tsconfig clean
- Chrome production build succeeds
- Sanitizer hand-reviewed: allowlist-based, resolve-then-sanitize ordering, cycle-guarded `use` resolution, external-URL rejection across attribute values

## Notes

- No `PENDING.md` bullet (ships dark behind the same `FLAGS.SCRAPS` / dev-toggle gate — per the release-notes rule).
- No docs/starter changes needed: no public core-package API touched.
- Retarget this PR to `main` after #323 merges.