### PR TITLE
React: bind shared-state setters to registered elements

### DIFF
--- a/.changeset/calm-react-bindings.md
+++ b/.changeset/calm-react-bindings.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Prevent React elements from writing through another element's handler. React now rebinds elements when their ID, data source, capability, or shared permission changes.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "test": "vitest run --no-typecheck",
+    "test": "vitest run --no-typecheck && vitest run --no-typecheck --config vitest.integration.config.ts",
     "test:watch": "vitest --no-typecheck"
   },
   "publishConfig": {

--- a/packages/react/src/__tests__/binding.integration.test.tsx
+++ b/packages/react/src/__tests__/binding.integration.test.tsx
@@ -1,0 +1,62 @@
+// ABOUTME: Tests React element binding lifecycle against the real playhtml core.
+// ABOUTME: Verifies data-source changes remove handlers created after asynchronous ID assignment.
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { playhtml, resetPlayHTML, TagType } from "playhtml";
+import { withSharedState } from "../index";
+
+describe("CanPlayElement binding lifecycle", () => {
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    await playhtml.init({});
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+  });
+
+  it("removes the previous data-source handler after core assigns a DOM id", async () => {
+    const SharedElement = withSharedState(
+      ({ dataSource }: { dataSource: string }) => ({
+        dataSource,
+        defaultData: { count: 0 },
+        standalone: true,
+      }),
+      ({ data }) => <div>{data.count}</div>,
+    );
+
+    const { container, rerender, unmount } = render(
+      <SharedElement dataSource="/first#first-source" />,
+    );
+    const element = container.querySelector("[can-play]") as HTMLElement;
+
+    await waitFor(() => {
+      expect(
+        playhtml.elementHandlers.get(TagType.CanPlay)?.get("first-source")
+          ?.element,
+      ).toBe(element);
+    });
+    expect(element.id).not.toBe("");
+
+    rerender(<SharedElement dataSource="/second#second-source" />);
+
+    await waitFor(() => {
+      expect(
+        playhtml.elementHandlers.get(TagType.CanPlay)?.get("second-source")
+          ?.element,
+      ).toBe(element);
+    });
+    expect(
+      playhtml.elementHandlers.get(TagType.CanPlay)?.has("first-source"),
+    ).toBe(false);
+
+    unmount();
+  });
+});

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -592,6 +592,139 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect(removeIds).toEqual(["first-id"]);
   });
 
+  it("removes the previous binding when dataSource changes but its element id does not", () => {
+    const setupSources: Array<string | null> = [];
+    const removeSources: Array<string | null> = [];
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation((element) => {
+      setupSources.push((element as HTMLElement).getAttribute("data-source"));
+    });
+    vi.spyOn(playhtml, "removePlayElement").mockImplementation((element) => {
+      removeSources.push(
+        (element as HTMLElement).getAttribute("data-source"),
+      );
+    });
+
+    const SharedElement = withSharedState(
+      ({ dataSource }: { dataSource: string }) => ({
+        dataSource,
+        defaultData: { count: 0 },
+      }),
+      ({ data }) => <div>{data.count}</div>,
+    );
+
+    const { rerender } = render(
+      <SharedElement dataSource="/first#source-id" />,
+    );
+
+    rerender(<SharedElement dataSource="/second#source-id" />);
+
+    expect(setupSources).toEqual([
+      "/first#source-id",
+      "/second#source-id",
+    ]);
+    expect(removeSources).toEqual(["/first#source-id"]);
+  });
+
+  it("rebinds the element when its shared permission changes", () => {
+    const setupPermissions: Array<string | null> = [];
+    const removePermissions: Array<string | null> = [];
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation((element) => {
+      setupPermissions.push((element as HTMLElement).getAttribute("shared"));
+    });
+    vi.spyOn(playhtml, "removePlayElement").mockImplementation((element) => {
+      removePermissions.push(
+        (element as HTMLElement).getAttribute("shared"),
+      );
+    });
+
+    const SharedElement = withSharedState(
+      ({ permission }: { permission: string }) => ({
+        id: "shared-source",
+        shared: permission,
+        defaultData: { count: 0 },
+      }),
+      ({ data }) => <div>{data.count}</div>,
+    );
+
+    const { rerender } = render(
+      <SharedElement permission="read-write" />,
+    );
+
+    rerender(<SharedElement permission="read-only" />);
+
+    expect(setupPermissions).toEqual(["read-write", "read-only"]);
+    expect(removePermissions).toEqual(["read-write"]);
+  });
+
+  it("does not write through a handler owned by another element", () => {
+    const otherElement = document.createElement("div");
+    const otherSetData = vi.fn();
+    const elementHandlers = new Map([
+      [
+        TagType.CanPlay,
+        new Map([
+          [
+            "duplicate-id",
+            { element: otherElement, setData: otherSetData },
+          ],
+        ]),
+      ],
+    ]);
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation(() => {});
+    vi.spyOn(playhtml, "removePlayElement").mockImplementation(() => {});
+    vi.spyOn(playhtml, "elementHandlers", "get").mockReturnValue(
+      elementHandlers as typeof playhtml.elementHandlers,
+    );
+
+    const SharedElement = withSharedState(
+      { id: "duplicate-id", defaultData: { count: 0 } },
+      ({ setData }) => (
+        <button onClick={() => setData({ count: 1 })}>update</button>
+      ),
+    );
+
+    const { getByRole } = render(<SharedElement />);
+    fireEvent.click(getByRole("button"));
+
+    expect(otherSetData).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "No handler registered for this element duplicate-id",
+      ),
+    );
+  });
+
+  it("binds writes after core assigns an element id", () => {
+    const setData = vi.fn();
+    const elementHandlers = new Map([
+      [TagType.CanPlay, new Map()],
+    ]);
+    vi.spyOn(playhtml, "setupPlayElement").mockImplementation(() => {});
+    vi.spyOn(playhtml, "removePlayElement").mockImplementation(() => {});
+    vi.spyOn(playhtml, "elementHandlers", "get").mockReturnValue(
+      elementHandlers as typeof playhtml.elementHandlers,
+    );
+
+    const SharedElement = withSharedState(
+      { defaultData: { count: 0 } },
+      ({ setData: updateData }) => (
+        <button onClick={() => updateData({ count: 1 })}>update</button>
+      ),
+    );
+
+    const { getByRole } = render(<SharedElement />);
+    const element = getByRole("button");
+    element.id = "generated-id";
+    elementHandlers.get(TagType.CanPlay)!.set("generated-id", {
+      element,
+      setData,
+    });
+
+    fireEvent.click(element);
+
+    expect(setData).toHaveBeenCalledWith({ count: 1 });
+  });
+
   it("reports the data-source binding id when id conflict uses dataSource", () => {
     const SharedElement = withSharedState(
       {
@@ -663,7 +796,7 @@ describe("CanPlayElement with built-in capabilities", () => {
   it("increments ReactiveOrb clicks through the current shared data", () => {
     const setData = vi.fn();
     const elementHandlers = new Map([
-      [TagType.CanPlay, new Map([["orb-test", { setData }]])],
+      [TagType.CanPlay, new Map()],
     ]);
     vi.spyOn(playhtml, "setupPlayElement").mockImplementation(() => {});
     vi.spyOn(playhtml, "removePlayElement").mockImplementation(() => {});
@@ -674,8 +807,13 @@ describe("CanPlayElement with built-in capabilities", () => {
     const { container } = render(
       <ReactiveOrb id="orb-test" className="orb-test" />,
     );
+    const element = container.querySelector("#orb-test") as HTMLElement;
+    elementHandlers.get(TagType.CanPlay)!.set("orb-test", {
+      element,
+      setData,
+    });
 
-    fireEvent.click(container.querySelector("#orb-test") as HTMLElement);
+    fireEvent.click(element);
 
     expect(setData).toHaveBeenCalledTimes(1);
     const update = setData.mock.calls[0][0];

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -95,6 +95,8 @@ type ElementBinding = {
   effectiveId: string;
   domId: string;
   dataSource: string | null;
+  shared: string | null;
+  tags: string;
 };
 
 function getDataSourceElementId(dataSource?: string): string | undefined {
@@ -103,7 +105,10 @@ function getDataSourceElementId(dataSource?: string): string | undefined {
   return elementId || undefined;
 }
 
-function getElementBinding(element: HTMLElement): ElementBinding | undefined {
+function getElementBinding(
+  element: HTMLElement,
+  tags: string[],
+): ElementBinding | undefined {
   const effectiveId = getIdForElement(element);
   if (!effectiveId) return undefined;
 
@@ -111,7 +116,21 @@ function getElementBinding(element: HTMLElement): ElementBinding | undefined {
     effectiveId,
     domId: element.id,
     dataSource: element.getAttribute("data-source"),
+    shared: element.getAttribute("shared"),
+    tags: [...tags].sort().join(" "),
   };
+}
+
+function isSameElementBinding(
+  first: ElementBinding,
+  second: ElementBinding,
+): boolean {
+  return (
+    first.effectiveId === second.effectiveId &&
+    first.dataSource === second.dataSource &&
+    first.shared === second.shared &&
+    first.tags === second.tags
+  );
 }
 
 function withElementBinding(
@@ -121,12 +140,18 @@ function withElementBinding(
 ) {
   const currentId = element.id;
   const currentDataSource = element.getAttribute("data-source");
+  const currentShared = element.getAttribute("shared");
 
   element.id = binding.domId;
   if (binding.dataSource === null) {
     element.removeAttribute("data-source");
   } else {
     element.setAttribute("data-source", binding.dataSource);
+  }
+  if (binding.shared === null) {
+    element.removeAttribute("shared");
+  } else {
+    element.setAttribute("shared", binding.shared);
   }
 
   try {
@@ -137,6 +162,11 @@ function withElementBinding(
       element.removeAttribute("data-source");
     } else {
       element.setAttribute("data-source", currentDataSource);
+    }
+    if (currentShared === null) {
+      element.removeAttribute("shared");
+    } else {
+      element.setAttribute("shared", currentShared);
     }
   }
 }
@@ -298,6 +328,32 @@ export function CanPlayElement<T extends object, V = any>({
     capabilityUpdateElementAwareness?.(handlerData);
   };
 
+  const bindingTags = Object.keys(computedTagInfo);
+  const getRegisteredHandler = () => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    const currentBinding = getElementBinding(element, bindingTags);
+    if (!currentBinding) return undefined;
+
+    const registeredBinding = registeredBindingRef.current;
+    if (
+      registeredBinding &&
+      !isSameElementBinding(registeredBinding, currentBinding)
+    ) return undefined;
+
+    const currentHandler = getCurrentElementHandler(
+      primaryTag,
+      currentBinding.effectiveId,
+    );
+    if (!currentHandler || currentHandler.element !== element) {
+      return undefined;
+    }
+
+    registeredBindingRef.current = currentBinding;
+    return currentHandler;
+  };
+
   useEffect(() => {
     if (ref.current) {
       const element = ref.current;
@@ -329,22 +385,24 @@ export function CanPlayElement<T extends object, V = any>({
 
       // Setup the element, which will handle data-source discovery if needed
       try {
-        const currentBinding = getElementBinding(element);
+        const currentBinding = getElementBinding(element, bindingTags);
         const registeredBinding = registeredBindingRef.current;
         if (
           registeredBinding &&
-          currentBinding &&
-          registeredBinding.effectiveId !== currentBinding.effectiveId
+          (!currentBinding ||
+            !isSameElementBinding(registeredBinding, currentBinding))
         ) {
           withElementBinding(element, registeredBinding, () => {
             playhtml.removePlayElement(element);
           });
+          registeredBindingRef.current = undefined;
         }
 
         playhtml.setupPlayElement(element, {
           ignoreIfAlreadySetup: true,
         });
-        registeredBindingRef.current = currentBinding;
+        const bindingAfterSetup = getElementBinding(element, bindingTags);
+        registeredBindingRef.current = bindingAfterSetup;
       } catch (error) {
         console.warn("[@playhtml/react] Failed to setup play element:", error);
 
@@ -366,6 +424,7 @@ export function CanPlayElement<T extends object, V = any>({
     return () => {
       if (!mountedElement || !playhtml.elementHandlers) return;
       playhtml.removePlayElement(mountedElement);
+      registeredBindingRef.current = undefined;
     };
   }, []);
   const renderedChildren = children({
@@ -389,23 +448,17 @@ export function CanPlayElement<T extends object, V = any>({
         );
         return;
       }
-      const handler = getCurrentElementHandler(primaryTag, effectiveId);
+      const handler = getRegisteredHandler();
       if (!handler) {
         console.warn(
-          `[@playhtml/react] No handler found for element ${effectiveId}`,
+          `[@playhtml/react] No handler registered for this element ${effectiveId}`,
         );
         return;
       }
       handler.setData(newData);
     },
     setMyAwareness: (newLocalAwareness) => {
-      const effectiveId = ref.current
-        ? getIdForElement(ref.current as unknown as HTMLElement)
-        : undefined;
-      if (!effectiveId) return;
-      getCurrentElementHandler(primaryTag, effectiveId)?.setMyAwareness(
-        newLocalAwareness,
-      );
+      getRegisteredHandler()?.setMyAwareness(newLocalAwareness);
     },
     myAwareness,
     ref,

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -142,7 +142,8 @@ function withElementBinding(
   const currentDataSource = element.getAttribute("data-source");
   const currentShared = element.getAttribute("shared");
 
-  element.id = binding.domId;
+  // Core can assign the DOM ID after React captures the binding.
+  element.id = binding.domId || currentId;
   if (binding.dataSource === null) {
     element.removeAttribute("data-source");
   } else {

--- a/packages/react/src/utils.tsx
+++ b/packages/react/src/utils.tsx
@@ -34,7 +34,9 @@ export type ReactElementInitializer<T = object, V = any> = Omit<
 } & PlayableChildren<T, V>;
 
 export function getCurrentElementHandler(tag: TagType | string, id: string) {
-  return playhtml.elementHandlers?.get(tag)?.get(id);
+  const handlers = playhtml.elementHandlers;
+  if (!(handlers instanceof Map)) return undefined;
+  return handlers.get(tag)?.get(id);
 }
 
 function isDOMElement(element: React.ReactElement): boolean {

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -10,7 +10,11 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/__tests__/setup.ts"],
-    exclude: ["node_modules/**", "dist/**"],
+    exclude: [
+      "node_modules/**",
+      "dist/**",
+      "src/**/__tests__/*.integration.test.tsx",
+    ],
   },
   resolve: {
     alias: {

--- a/packages/react/vitest.integration.config.ts
+++ b/packages/react/vitest.integration.config.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Configures React integration tests to exercise the real playhtml core.
+// ABOUTME: Uses deterministic provider fakes while preserving production binding behavior.
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["../playhtml/vitest.setup.ts"],
+    include: ["src/**/__tests__/*.integration.test.tsx"],
+    exclude: ["node_modules/**", "dist/**"],
+  },
+  resolve: {
+    alias: {
+      playhtml: path.resolve(__dirname, "../playhtml/src/index.ts"),
+      "@playhtml/common": path.resolve(__dirname, "../common/src/index.ts"),
+      "react/jsx-runtime": path.resolve(
+        __dirname,
+        "../../node_modules/react/jsx-runtime",
+      ),
+      "react/jsx-dev-runtime": path.resolve(
+        __dirname,
+        "../../node_modules/react/jsx-dev-runtime",
+      ),
+      "react-dom/test-utils": path.resolve(
+        __dirname,
+        "../../node_modules/react-dom/test-utils",
+      ),
+      "react-dom/client": path.resolve(
+        __dirname,
+        "../../node_modules/react-dom/client",
+      ),
+      "react-dom": path.resolve(__dirname, "../../node_modules/react-dom"),
+      react: path.resolve(__dirname, "../../node_modules/react"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Bind React shared-state writes and awareness updates to the handler owned by the mounted DOM element.
- Re-register elements when their ID, data source, capability tags, or shared permission changes.
- Preserve lazy binding for IDs assigned during core setup.
- Remove the previous data-source handler when core assigns a DOM ID asynchronously.

## Root cause

React resolved handlers by capability tag and effective ID without confirming that the handler belonged to the mounted DOM element. With duplicate IDs, the element that failed registration could write through the registered element's handler. The binding effect also did not track every property that changes registration identity, so a mounted element could retain a stale binding after a prop change.

Data-source-only elements expose a second lifecycle edge. React records the binding before core finishes assigning its generated DOM ID. Cleanup restored the recorded empty ID, which caused core removal to return before unregistering the previous handler.

## Impact

`setData` and awareness updates now no-op unless the current handler owns the mounted element. React removes and recreates registrations when the binding identity changes. Cleanup preserves a DOM ID assigned by core so the previous data-source handler and observer are removed before the new source registers.

## Verification

- `bun build-packages`
- `bun run --cwd packages/react test` (49 unit tests and 1 real-core integration test passed)
- `bun run --cwd packages/react build`
- `git diff --check`

## Documentation and templates

No public documentation or starter-template changes are needed. This fixes internal React binding lifecycle behavior without changing the public React or core API.

## Screenshots

Not applicable. This is a nonvisual package behavior fix.