### PR TITLE
chore: migrate hasSynced consumers to isLoading

### DIFF
--- a/website/components/ExperimentsArchive.tsx
+++ b/website/components/ExperimentsArchive.tsx
@@ -362,7 +362,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
       cursors,
       dispatchPlayEvent,
       getMyPlayerIdentity,
-      hasSynced,
+      isLoading,
       registerPlayEventListener,
       removePlayEventListener,
     } = useContext(PlayContext);
@@ -512,7 +512,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
 
     useEffect(() => {
       if (
-        !hasSynced ||
+        isLoading ||
         !registerPlayEventListener ||
         !removePlayEventListener
       ) {
@@ -541,7 +541,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
         removePlayEventListener(RandomExperimentEventType, listenerId);
       };
     }, [
-      hasSynced,
+      isLoading,
       getMyPlayerIdentity,
       registerPlayEventListener,
       removePlayEventListener,
@@ -581,7 +581,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
       (event: MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
 
-        if (!hasSynced) return;
+        if (isLoading) return;
 
         const availableExperiments = experiments.filter(
           (experiment) => experiment.href,
@@ -612,7 +612,7 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
           eventPayload: payload,
         });
       },
-      [dispatchPlayEvent, getMyPlayerIdentity, hasSynced, myColor],
+      [dispatchPlayEvent, getMyPlayerIdentity, isLoading, myColor],
     );
 
     return (
@@ -671,10 +671,10 @@ const ExperimentsArchiveContent = withSharedState<ExperimentsArchiveData>(
           </span>
           <button
             type="button"
-            disabled={!hasSynced}
+            disabled={isLoading}
             onClick={handleRandomExperiment}
           >
-            {hasSynced ? "random experiment" : "syncing..."}
+            {!isLoading ? "random experiment" : "syncing..."}
           </button>
         </div>
       </section>

--- a/website/experiments/6/6.tsx
+++ b/website/experiments/6/6.tsx
@@ -216,7 +216,7 @@ const Main = withSharedState(
     id: "screen-symphony-2",
   },
   ({ data, setData, setMyAwareness }) => {
-    const { hasSynced } = usePlayContext();
+    const { isLoading } = usePlayContext();
     const [currentSize, setCurrentSize] = useState({ width: 0, height: 0 });
     const [isResizing, setIsResizing] = useState(false);
     const [zoom, setZoom] = useState(1);
@@ -241,7 +241,7 @@ const Main = withSharedState(
       setMyAwareness({ currentSize: sizeKey });
 
       // Only register this device once after sync is complete
-      if (hasSynced) {
+      if (!isLoading) {
         const localStorageKey = `screen-symphony-${sizeKey}`;
         const hasVisited = localStorage.getItem(localStorageKey);
 
@@ -273,7 +273,7 @@ const Main = withSharedState(
           localStorage.setItem(localStorageKey, timestamp.toString());
         }
       }
-    }, [hasSynced]);
+    }, [isLoading]);
 
     // Handle resize events with debouncing (update current size but don't re-register)
     useEffect(() => {

--- a/website/experiments/7/7.tsx
+++ b/website/experiments/7/7.tsx
@@ -308,7 +308,7 @@ const Main = withSharedState(
     id: "stellar-connections",
   },
   ({ data, setData, awareness, setMyAwareness }) => {
-    const { hasSynced, configureCursors, getMyPlayerIdentity, cursors } =
+    const { isLoading, configureCursors, getMyPlayerIdentity, cursors } =
       usePlayContext();
     const [proximityUsers, setProximityUsers] = useState<Set<string>>(
       new Set()
@@ -421,7 +421,7 @@ const Main = withSharedState(
         setMyAwareness({ activeHandHold: handHold });
 
         // Create or brighten star
-        if (hasSynced) {
+        if (!isLoading) {
           setData((draft) => {
             const starId = pairId;
             const otherColor = otherPlayer.playerStyle.colorPalette[0];
@@ -459,7 +459,7 @@ const Main = withSharedState(
           });
         }
       },
-      [hasSynced, setData, setMyAwareness, triggerStarAnimation]
+      [isLoading, setData, setMyAwareness, triggerStarAnimation]
     );
 
     const handleProximityLeft = useCallback(

--- a/website/experiments/9/drunk-cursor.tsx
+++ b/website/experiments/9/drunk-cursor.tsx
@@ -73,7 +73,7 @@ const DrunkCursorController = withSharedState(
     const lastInterferenceTimeRef = useRef(0);
     const lastUpdateTimeRef = useRef(0); // Track last mousemove time for wobble detection
     const wobblePhaseRef = useRef({ x: 0, y: 0, lastResetX: 0, lastResetY: 0 }); // Track wobble phase for smooth/jerk pattern
-    const { hasSynced, cursors, getMyPlayerIdentity } = useContext(PlayContext);
+    const { isLoading, cursors, getMyPlayerIdentity } = useContext(PlayContext);
     const myStableId = getMyPlayerIdentity()?.publicKey ?? null;
     const drunkDecayIntervalRef = useRef<number | null>(null);
     const cursorPresences = useCursorPresences();
@@ -89,7 +89,7 @@ const DrunkCursorController = withSharedState(
 
     // Override playhtml's document cursor style - hide it since we render our own
     useEffect(() => {
-      if (!hasSynced) return;
+      if (isLoading) return;
 
       const overrideCursor = () => {
         document.documentElement.style.cursor = "none";
@@ -97,7 +97,7 @@ const DrunkCursorController = withSharedState(
 
       // Override immediately and set up observer to keep it overridden
       overrideCursor();
-    }, [hasSynced]);
+    }, [isLoading]);
 
     // Get my user ID (stable ID)
     const getMyUserId = useCallback((): string | null => {
@@ -121,7 +121,7 @@ const DrunkCursorController = withSharedState(
 
     // Track own cursor movements
     useEffect(() => {
-      if (!hasSynced) return;
+      if (isLoading) return;
 
       let lastUpdateTime = 0;
       const THROTTLE_MS = 1000 / 60; // 60fps for mouse position updates
@@ -312,12 +312,12 @@ const DrunkCursorController = withSharedState(
       return () => {
         document.removeEventListener("mousemove", handleMove);
       };
-    }, [hasSynced, getMyUserId, drunkLevel]);
+    }, [isLoading, getMyUserId, drunkLevel]);
 
     // Smooth interpolation of cursor position (runs continuously)
     // Also handles wobble for other users' cursors
     useEffect(() => {
-      if (!hasSynced) return;
+      if (isLoading) return;
 
       const smoothStep = () => {
         // Update own cursor position
@@ -488,7 +488,7 @@ const DrunkCursorController = withSharedState(
           cancelAnimationFrame(animationFrameRef.current);
         }
       };
-    }, [hasSynced, drunkLevel, getUserDrunkLevel]);
+    }, [isLoading, drunkLevel, getUserDrunkLevel]);
 
     // Drunk level decay over time - use a single interval that runs continuously
     useEffect(() => {
@@ -742,7 +742,7 @@ const DrunkCursorController = withSharedState(
 
     // Collaborative: when anyone drinks, all clients play sound and start local animation
     useEffect(() => {
-      if (!hasSynced || !registerPlayEventListener || !removePlayEventListener)
+      if (isLoading || !registerPlayEventListener || !removePlayEventListener)
         return;
       const listenerId = registerPlayEventListener("drunk-cursor-drink", {
         onEvent: (payload: unknown) => {
@@ -780,7 +780,7 @@ const DrunkCursorController = withSharedState(
       });
       return () => removePlayEventListener("drunk-cursor-drink", listenerId);
     }, [
-      hasSynced,
+      isLoading,
       registerPlayEventListener,
       removePlayEventListener,
       getMyUserId,
@@ -790,7 +790,7 @@ const DrunkCursorController = withSharedState(
     // Click handler: only update shared state and dispatch event; animation is started by event listener
     const handleDrink = useCallback(
       (drinkIndex: number) => {
-        if (!hasSynced || !dispatchPlayEvent) return;
+        if (isLoading || !dispatchPlayEvent) return;
         if (animatingSlotData[drinkIndex] != null) return;
         const consumedType = data?.drinkTypes?.[drinkIndex] ?? "beer";
         const nextType = Math.random() < WATER_SPAWN_CHANCE ? "water" : "beer";
@@ -809,7 +809,7 @@ const DrunkCursorController = withSharedState(
         });
       },
       [
-        hasSynced,
+        isLoading,
         dispatchPlayEvent,
         animatingSlotData,
         data?.drinkTypes,

--- a/website/experiments/two/two.tsx
+++ b/website/experiments/two/two.tsx
@@ -32,7 +32,7 @@ const CursorController = withSharedState(
     };
     const userCursorIsGif = userCursor && userCursor.endsWith(".gif");
     const [cursorLocation, setCursorLocation] = useState({ x: 0, y: 0 });
-    const { dispatchPlayEvent, hasSynced } = useContext(PlayContext);
+    const { dispatchPlayEvent, isLoading } = useContext(PlayContext);
 
     useEffect(() => {
       // TODO: doesn't handle scroll
@@ -61,7 +61,7 @@ const CursorController = withSharedState(
         document.removeEventListener("mousemove", move);
         document.removeEventListener("click", click);
       };
-    }, [hasSynced]);
+    }, [isLoading]);
     useEffect(() => {
       if (cursors.length === 0 || userCursor) return;
 

--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -1118,12 +1118,12 @@ const FridgeWordsContent = withSharedState(
       currentZoom,
       currentPan,
     } = props;
-    const { hasSynced } = useContext(PlayContext);
+    const { isLoading } = useContext(PlayContext);
     const { search } = useLocation();
     const params = new URLSearchParams(search);
     const isAdmin = params.get("admin") !== null;
 
-    return !hasSynced ? (
+    return isLoading ? (
       <div
         className="loading"
         style={{

--- a/website/test/react-test.tsx
+++ b/website/test/react-test.tsx
@@ -51,7 +51,7 @@ const Candle = withSharedState(
 
 // Loading State Test Component
 const LoadingStateTest = () => {
-  const { hasSynced } = usePlayContext();
+  const { isLoading } = usePlayContext();
 
   return (
     <div
@@ -60,7 +60,7 @@ const LoadingStateTest = () => {
       <h3>Enhanced Loading State Tests</h3>
       <p style={{ marginBottom: "20px" }}>
         Sync Status:{" "}
-        <strong>{hasSynced ? "✅ Synced" : "⏳ Loading..."}</strong>
+        <strong>{!isLoading ? "✅ Synced" : "⏳ Loading..."}</strong>
       </p>
 
       <div


### PR DESCRIPTION
## Summary

Migrates all in-repo consumers of the deprecated React context field `hasSynced` to its replacement `isLoading` (`hasSynced === !isLoading`). 7 files, 30 references, all in `website/`.

The deprecated field itself stays in `PlayProvider` until the next major — this sweep makes its eventual removal a one-line change. Part of the simplification arc tracked in #289 (see `internal-docs/2026-07-24-simplification-audit.md`, Bucket 4).

## Verification

- `bun run build-site` passes
- Zero `hasSynced` references remain outside `packages/react` (only the field's own declaration/plumbing)

No changeset — no `packages/` changes.