### PR TITLE
playhtml: make register the vanilla custom element API

### DIFF
--- a/.changeset/calm-views-register.md
+++ b/.changeset/calm-views-register.md
@@ -3,4 +3,4 @@
 "@playhtml/common": patch
 ---
 
-Route programmatic element and capability registration through the standard setup paths. Registered initializers now bind without being copied onto DOM elements, while React's property-based `can-play` setup remains supported.
+Make `playhtml.register(id, initializer)` the recommended vanilla API for custom elements using either `updateElement` or `view`. Registered initializers now bind through the standard setup path without being copied onto DOM elements, while direct element-property configuration remains supported for compatibility.

--- a/.changeset/calm-views-register.md
+++ b/.changeset/calm-views-register.md
@@ -1,0 +1,6 @@
+---
+"playhtml": patch
+"@playhtml/common": patch
+---
+
+Route programmatic element and capability registration through the standard setup paths. Registered initializers now bind without being copied onto DOM elements, while React's property-based `can-play` setup remains supported.

--- a/.changeset/calm-views-register.md
+++ b/.changeset/calm-views-register.md
@@ -3,4 +3,4 @@
 "@playhtml/common": patch
 ---
 
-Make `playhtml.register(id, initializer)` the recommended vanilla API for custom elements using either `updateElement` or `view`. Registered initializers now bind through the standard setup path without being copied onto DOM elements, while direct element-property configuration remains supported for compatibility.
+Make `playhtml.register(elementOrId, initializer)` the recommended vanilla API for custom elements using either `updateElement` or `view`. Callers can pass an existing HTML element or register by id before the element exists. Registered initializers bind through the standard setup path without being copied onto DOM elements, while direct element-property configuration remains supported for compatibility.

--- a/apps/docs/src/components/playground/recipes/__tests__/basic-recipes.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/basic-recipes.test.ts
@@ -67,28 +67,44 @@ describe("basic canonical recipes", () => {
     );
   });
 
-  it("configures can-play elements before initialization", () => {
+  it("registers can-play elements before initialization", () => {
     for (const recipe of [sharedCounterRecipe, sharedGuestbookRecipe]) {
+      const registerIndex = recipe.html.indexOf("playhtml.register(");
       const initIndex = recipe.html.indexOf("await playhtml.init");
-      expect(recipe.html.indexOf(".defaultData")).toBeLessThan(initIndex);
-      expect(recipe.html.indexOf(".updateElement")).toBeLessThan(initIndex);
+      expect(registerIndex).toBeGreaterThan(-1);
+      expect(registerIndex).toBeLessThan(initIndex);
+      expect(recipe.html.indexOf("defaultData:", registerIndex)).toBeLessThan(
+        initIndex,
+      );
+      expect(recipe.html.indexOf("updateElement:", registerIndex)).toBeLessThan(
+        initIndex,
+      );
     }
   });
 
   it("writes counter and guestbook data only from user handlers", () => {
+    const counterRegister = sharedCounterRecipe.html.indexOf(
+      'playhtml.register("ph-docs-counter", {',
+    );
     const counterUpdate = sharedCounterRecipe.html.indexOf(
-      "counter.updateElement",
+      "updateElement:",
+      counterRegister,
     );
     const counterInit = sharedCounterRecipe.html.indexOf("await playhtml.init");
     expect(
       sharedCounterRecipe.html.slice(counterUpdate, counterInit),
     ).not.toContain("setData(");
 
+    const guestbookRegister = sharedGuestbookRecipe.html.indexOf(
+      "playhtml.register(guestbook, {",
+    );
     const guestbookUpdate = sharedGuestbookRecipe.html.indexOf(
-      "guestbook.updateElement",
+      "updateElement:",
+      guestbookRegister,
     );
     const guestbookClick = sharedGuestbookRecipe.html.indexOf(
-      "guestbook.onClick",
+      "onClick:",
+      guestbookRegister,
     );
     expect(
       sharedGuestbookRecipe.html.slice(guestbookUpdate, guestbookClick),
@@ -96,7 +112,7 @@ describe("basic canonical recipes", () => {
     expect(
       sharedGuestbookRecipe.html.slice(
         guestbookClick,
-        sharedGuestbookRecipe.html.indexOf("guestbook.onMount"),
+        sharedGuestbookRecipe.html.indexOf("onMount:", guestbookRegister),
       ),
     ).toContain("setData(");
     expect(sharedGuestbookRecipe.html).toContain(

--- a/apps/docs/src/components/playground/recipes/__tests__/matter-physics.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/matter-physics.test.ts
@@ -11,19 +11,19 @@ describe("matter physics recipe", () => {
       "/docs/examples/matter-physics/",
     );
     expect(matterPhysicsRecipe.html).toMatch(/^<!doctype html>/);
-    expect(matterPhysicsRecipe.html).toContain(
-      'id="physics-world" can-play',
-    );
+    expect(matterPhysicsRecipe.html).toContain('id="physics-world"');
     expect(matterPhysicsRecipe.html).toContain(
       'from "https://esm.sh/matter-js@0.20.0"',
     );
   });
 
-  it("configures the can-play element before initialization", () => {
+  it("registers the element before initialization", () => {
     const source = matterPhysicsRecipe.html;
-    const configPosition = source.indexOf("worldElement.defaultData =");
-    const updatePosition = source.indexOf("worldElement.updateElement =");
-    const mountPosition = source.indexOf("worldElement.onMount =");
+    const configPosition = source.indexOf(
+      'playhtml.register("physics-world", {',
+    );
+    const updatePosition = source.indexOf("updateElement:", configPosition);
+    const mountPosition = source.indexOf("onMount:", configPosition);
     const initPosition = source.indexOf("await playhtml.init(");
 
     expect(configPosition).toBeGreaterThan(-1);
@@ -34,6 +34,9 @@ describe("matter physics recipe", () => {
 
   it("uses one controller and bounded, throttled keyed writes", () => {
     const source = matterPhysicsRecipe.html;
+    const registerPosition = source.indexOf(
+      'playhtml.register("physics-world", {',
+    );
 
     expect(source).toContain("const SYNC_INTERVAL_MS = 100;");
     expect(source).toContain("draft.controllerId !== CLIENT_ID");
@@ -42,8 +45,8 @@ describe("matter physics recipe", () => {
     expect(source).toContain("resetLocalBodies();");
 
     const updateBody = source.slice(
-      source.indexOf("worldElement.updateElement ="),
-      source.indexOf("worldElement.onMount ="),
+      source.indexOf("updateElement:", registerPosition),
+      source.indexOf("onMount:", registerPosition),
     );
     expect(updateBody).not.toContain("setData");
   });

--- a/apps/docs/src/components/playground/recipes/__tests__/shared-audio-file.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/shared-audio-file.test.ts
@@ -10,27 +10,36 @@ describe("sharedAudioFileRecipe", () => {
       "/docs/examples/shared-audio-file/",
     );
     expect(sharedAudioFileRecipe.html).toContain(
-      'id="shared-audio-player" class="player" can-play',
+      'id="shared-audio-player" class="player"',
     );
     expect(sharedAudioFileRecipe.html).toContain("<audio");
     expect(sharedAudioFileRecipe.html).toContain("t-rex-roar.mp3");
   });
 
-  it("configures the element before playhtml initializes", () => {
+  it("registers the element before playhtml initializes", () => {
     const source = sharedAudioFileRecipe.html;
+    const registerIndex = source.indexOf(
+      'playhtml.register("shared-audio-player", {',
+    );
     const initIndex = source.indexOf("await playhtml.init");
 
-    expect(source.indexOf("player.defaultData")).toBeLessThan(initIndex);
-    expect(source.indexOf("player.updateElement")).toBeLessThan(initIndex);
-    expect(source.indexOf("player.onClick")).toBeLessThan(initIndex);
-    expect(source.indexOf("player.onMount")).toBeLessThan(initIndex);
+    expect(registerIndex).toBeGreaterThan(-1);
+    expect(registerIndex).toBeLessThan(initIndex);
+    expect(source.indexOf("updateElement:", registerIndex)).toBeLessThan(
+      initIndex,
+    );
+    expect(source.indexOf("onClick:", registerIndex)).toBeLessThan(initIndex);
+    expect(source.indexOf("onMount:", registerIndex)).toBeLessThan(initIndex);
   });
 
   it("writes shared data only from explicit controls", () => {
     const source = sharedAudioFileRecipe.html;
-    const updateStart = source.indexOf("player.updateElement");
-    const clickStart = source.indexOf("player.onClick");
-    const mountStart = source.indexOf("player.onMount");
+    const registerStart = source.indexOf(
+      'playhtml.register("shared-audio-player", {',
+    );
+    const updateStart = source.indexOf("updateElement:", registerStart);
+    const clickStart = source.indexOf("onClick:", registerStart);
+    const mountStart = source.indexOf("onMount:", registerStart);
     const initStart = source.indexOf("await playhtml.init");
 
     expect(source.slice(updateStart, clickStart)).not.toContain("setData(");

--- a/apps/docs/src/components/playground/recipes/__tests__/synchronized-sound.test.ts
+++ b/apps/docs/src/components/playground/recipes/__tests__/synchronized-sound.test.ts
@@ -10,21 +10,23 @@ describe("synchronizedSoundRecipe", () => {
       "/docs/examples/synchronized-sound/",
     );
     expect(synchronizedSoundRecipe.html).toContain("<!doctype html>");
-    expect(synchronizedSoundRecipe.html).toContain(
-      'id="sound-transport" can-play',
-    );
+    expect(synchronizedSoundRecipe.html).toContain('id="sound-transport"');
   });
 
-  it("configures the stable element before playhtml initializes", () => {
+  it("registers the stable element before playhtml initializes", () => {
     const source = synchronizedSoundRecipe.html;
+    const registerIndex = source.indexOf(
+      'playhtml.register("sound-transport", {',
+    );
     const initIndex = source.indexOf("await playhtml.init");
 
-    expect(source.indexOf("soundTransport.defaultData")).toBeLessThan(initIndex);
-    expect(source.indexOf("soundTransport.updateElement")).toBeLessThan(
+    expect(registerIndex).toBeGreaterThan(-1);
+    expect(registerIndex).toBeLessThan(initIndex);
+    expect(source.indexOf("updateElement:", registerIndex)).toBeLessThan(
       initIndex,
     );
-    expect(source.indexOf("soundTransport.onClick")).toBeLessThan(initIndex);
-    expect(source.indexOf("soundTransport.onMount")).toBeLessThan(initIndex);
+    expect(source.indexOf("onClick:", registerIndex)).toBeLessThan(initIndex);
+    expect(source.indexOf("onMount:", registerIndex)).toBeLessThan(initIndex);
   });
 
   it("uses an event for cues and shared wall-clock data for the transport", () => {
@@ -40,9 +42,12 @@ describe("synchronizedSoundRecipe", () => {
 
   it("never writes shared data from render or scheduling callbacks", () => {
     const source = synchronizedSoundRecipe.html;
-    const updateStart = source.indexOf("soundTransport.updateElement");
-    const clickStart = source.indexOf("soundTransport.onClick");
-    const mountStart = source.indexOf("soundTransport.onMount");
+    const registerStart = source.indexOf(
+      'playhtml.register("sound-transport", {',
+    );
+    const updateStart = source.indexOf("updateElement:", registerStart);
+    const clickStart = source.indexOf("onClick:", registerStart);
+    const mountStart = source.indexOf("onMount:", registerStart);
     const initStart = source.indexOf("await playhtml.init");
 
     expect(source.slice(updateStart, clickStart)).not.toContain("setData(");

--- a/apps/docs/src/components/playground/recipes/matter-physics.ts
+++ b/apps/docs/src/components/playground/recipes/matter-physics.ts
@@ -171,7 +171,7 @@ export const matterPhysicsRecipe: ExampleRecipe = {
       <span id="physics-status" role="status">Joining room…</span>
     </div>
 
-    <div id="physics-world" can-play aria-label="Shared physics world"></div>
+    <div id="physics-world" aria-label="Shared physics world"></div>
     <p class="note">The last person to interact controls the simulation.</p>
   </main>
 
@@ -481,16 +481,18 @@ export const matterPhysicsRecipe: ExampleRecipe = {
       requestAnimationFrame(animate);
     }
 
-    worldElement.defaultData = {
-      controllerId: "",
-      bodies: structuredClone(INITIAL_BODIES),
-    };
-    worldElement.updateElement = ({ data }) => applySharedState(data);
-    worldElement.onMount = (context) => {
-      getData = context.getData;
-      setData = context.setData;
-      statusElement.textContent = "Watching shared motion";
-    };
+    playhtml.register("physics-world", {
+      defaultData: {
+        controllerId: "",
+        bodies: structuredClone(INITIAL_BODIES),
+      },
+      updateElement: ({ data }) => applySharedState(data),
+      onMount: (context) => {
+        getData = context.getData;
+        setData = context.setData;
+        statusElement.textContent = "Watching shared motion";
+      },
+    });
 
     worldElement.addEventListener("pointerdown", handlePointerDown);
     worldElement.addEventListener("pointermove", handlePointerMove);

--- a/apps/docs/src/components/playground/recipes/shared-audio-file.ts
+++ b/apps/docs/src/components/playground/recipes/shared-audio-file.ts
@@ -84,7 +84,7 @@ export const sharedAudioFileRecipe: ExampleRecipe = {
     <h1>Shared audio file</h1>
     <p class="intro">Every window plays the same file from the shared position.</p>
 
-    <section id="shared-audio-player" class="player" can-play>
+    <section id="shared-audio-player" class="player">
       <audio
         data-audio
         src="https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3"
@@ -189,58 +189,57 @@ export const sharedAudioFileRecipe: ExampleRecipe = {
       }
     }
 
-    player.defaultData = {
-      isPlaying: false,
-      startedAtMs: 0,
-      positionMs: 0,
-    };
+    playhtml.register("shared-audio-player", {
+      defaultData: {
+        isPlaying: false,
+        startedAtMs: 0,
+        positionMs: 0,
+      },
+      updateElement: ({ element, data }) => {
+        render(element, data, Date.now());
+      },
+      onClick: (event, { data, setData }) => {
+        const action = event.target.closest("[data-action]")?.dataset.action;
+        if (!action) return;
 
-    player.updateElement = ({ element, data }) => {
-      render(element, data, Date.now());
-    };
+        if (action === "enable-audio") {
+          void enableAudio(data);
+          return;
+        }
 
-    player.onClick = (event, { data, setData }) => {
-      const action = event.target.closest("[data-action]")?.dataset.action;
-      if (!action) return;
-
-      if (action === "enable-audio") {
-        void enableAudio(data);
-        return;
-      }
-
-      const nowMs = Date.now();
-      if (action === "toggle") {
-        const positionMs = playbackPositionMs(data, nowMs);
-        setData((draft) => {
-          draft.isPlaying = !data.isPlaying;
-          draft.positionMs = positionMs;
-          draft.startedAtMs = nowMs - positionMs;
-        });
-      }
-
-      if (action === "restart") {
-        setData((draft) => {
-          draft.positionMs = 0;
-          draft.startedAtMs = nowMs;
-        });
-      }
-    };
-
-    player.onMount = ({ getData, getElement }) => {
-      let animationFrame = 0;
-      const tick = () => {
-        const data = getData();
         const nowMs = Date.now();
-        render(getElement(), data, nowMs);
-        syncLocalAudio(data, nowMs);
+        if (action === "toggle") {
+          const positionMs = playbackPositionMs(data, nowMs);
+          setData((draft) => {
+            draft.isPlaying = !data.isPlaying;
+            draft.positionMs = positionMs;
+            draft.startedAtMs = nowMs - positionMs;
+          });
+        }
+
+        if (action === "restart") {
+          setData((draft) => {
+            draft.positionMs = 0;
+            draft.startedAtMs = nowMs;
+          });
+        }
+      },
+      onMount: ({ getData, getElement }) => {
+        let animationFrame = 0;
+        const tick = () => {
+          const data = getData();
+          const nowMs = Date.now();
+          render(getElement(), data, nowMs);
+          syncLocalAudio(data, nowMs);
+          animationFrame = requestAnimationFrame(tick);
+        };
         animationFrame = requestAnimationFrame(tick);
-      };
-      animationFrame = requestAnimationFrame(tick);
-      return () => {
-        cancelAnimationFrame(animationFrame);
-        audio.pause();
-      };
-    };
+        return () => {
+          cancelAnimationFrame(animationFrame);
+          audio.pause();
+        };
+      },
+    });
 
     await playhtml.init({ developmentMode: true });
   </script>

--- a/apps/docs/src/components/playground/recipes/shared-state-basics.ts
+++ b/apps/docs/src/components/playground/recipes/shared-state-basics.ts
@@ -56,24 +56,23 @@ export const sharedCounterRecipe: ExampleRecipe = {
       id="ph-docs-counter"
       class="counter"
       type="button"
-      can-play
       aria-label="Increment the shared counter"
     >
       <span aria-hidden="true">❤️</span>
       <span class="count" data-count>0</span>
     </button>
   </main>`,
-    script: `    const counter = document.getElementById("ph-docs-counter");
-
-    counter.defaultData = { count: 0 };
-    counter.onClick = (_event, { setData }) => {
-      setData((draft) => {
-        draft.count += 1;
-      });
-    };
-    counter.updateElement = ({ element, data }) => {
-      element.querySelector("[data-count]").textContent = String(data.count);
-    };`,
+    script: `    playhtml.register("ph-docs-counter", {
+      defaultData: { count: 0 },
+      onClick: (_event, { setData }) => {
+        setData((draft) => {
+          draft.count += 1;
+        });
+      },
+      updateElement: ({ element, data }) => {
+        element.querySelector("[data-count]").textContent = String(data.count);
+      },
+    });`,
   }),
 };
 
@@ -133,7 +132,7 @@ export const sharedGuestbookRecipe: ExampleRecipe = {
     body: `  <main>
     <h1>Shared guestbook</h1>
     <p class="intro">Add a short note. The latest 20 entries remain for everyone.</p>
-    <section id="ph-cap-docs-guestbook" class="guestbook" can-play>
+    <section id="ph-cap-docs-guestbook" class="guestbook">
       <form data-form>
         <label>
           Prompt
@@ -166,67 +165,69 @@ export const sharedGuestbookRecipe: ExampleRecipe = {
       );
     }
 
-    guestbook.defaultData = { entries: [] };
-    guestbook.updateElement = ({ element, data }) => {
-      const list = element.querySelector("[data-entries]");
-      const entries = [...data.entries].reverse();
-      list.replaceChildren(
-        ...(entries.length
-          ? entries.map((entry) => {
-              const item = document.createElement("li");
-              const prompt = document.createElement("strong");
-              const text = document.createElement("span");
-              prompt.textContent = prompts[entry.prompt];
-              text.textContent = entry.text;
-              item.append(prompt, text);
-              return item;
-            })
-          : [Object.assign(document.createElement("li"), {
-              className: "empty",
-              textContent: "No entries yet.",
-            })]),
-      );
-    };
-    guestbook.onClick = (event, { setData }) => {
-      if (!event.target.closest("[data-submit]")) {
-        return;
-      }
-      event.preventDefault();
-
-      const form = guestbook.querySelector("[data-form]");
-      const prompt = form.elements.prompt;
-      const text = form.elements.text;
-      const value = text.value.trim().slice(0, 140);
-      if (!value || isProfane(value)) {
-        text.value = "";
-        return;
-      }
-
-      setData((draft) => {
-        draft.entries.push({
-          id: crypto.randomUUID(),
-          prompt: prompt.value,
-          text: value,
-          at: Date.now(),
-        });
-        if (draft.entries.length > MAX_ENTRIES) {
-          draft.entries.splice(0, draft.entries.length - MAX_ENTRIES);
+    playhtml.register(guestbook, {
+      defaultData: { entries: [] },
+      updateElement: ({ element, data }) => {
+        const list = element.querySelector("[data-entries]");
+        const entries = [...data.entries].reverse();
+        list.replaceChildren(
+          ...(entries.length
+            ? entries.map((entry) => {
+                const item = document.createElement("li");
+                const prompt = document.createElement("strong");
+                const text = document.createElement("span");
+                prompt.textContent = prompts[entry.prompt];
+                text.textContent = entry.text;
+                item.append(prompt, text);
+                return item;
+              })
+            : [Object.assign(document.createElement("li"), {
+                className: "empty",
+                textContent: "No entries yet.",
+              })]),
+        );
+      },
+      onClick: (event, { setData }) => {
+        if (!event.target.closest("[data-submit]")) {
+          return;
         }
-      });
-      text.value = "";
-    };
-    guestbook.onMount = ({ getElement }) => {
-      const form = getElement().querySelector("[data-form]");
-      const prompt = form.elements.prompt;
-      const text = form.elements.text;
-      const updatePlaceholder = () => {
-        text.placeholder = prompts[prompt.value];
-      };
+        event.preventDefault();
 
-      prompt.addEventListener("change", updatePlaceholder);
-      return () => {
-        prompt.removeEventListener("change", updatePlaceholder);
-      };
-    };`,
+        const form = guestbook.querySelector("[data-form]");
+        const prompt = form.elements.prompt;
+        const text = form.elements.text;
+        const value = text.value.trim().slice(0, 140);
+        if (!value || isProfane(value)) {
+          text.value = "";
+          return;
+        }
+
+        setData((draft) => {
+          draft.entries.push({
+            id: crypto.randomUUID(),
+            prompt: prompt.value,
+            text: value,
+            at: Date.now(),
+          });
+          if (draft.entries.length > MAX_ENTRIES) {
+            draft.entries.splice(0, draft.entries.length - MAX_ENTRIES);
+          }
+        });
+        text.value = "";
+      },
+      onMount: ({ getElement }) => {
+        const form = getElement().querySelector("[data-form]");
+        const prompt = form.elements.prompt;
+        const text = form.elements.text;
+        const updatePlaceholder = () => {
+          text.placeholder = prompts[prompt.value];
+        };
+
+        prompt.addEventListener("change", updatePlaceholder);
+        return () => {
+          prompt.removeEventListener("change", updatePlaceholder);
+        };
+      },
+    });`,
   }),
 };

--- a/apps/docs/src/components/playground/recipes/synchronized-sound.ts
+++ b/apps/docs/src/components/playground/recipes/synchronized-sound.ts
@@ -93,7 +93,7 @@ export const synchronizedSoundRecipe: ExampleRecipe = {
       play/pause timeline, so people who arrive later join at the current beat.
     </p>
 
-    <section id="sound-transport" can-play>
+    <section id="sound-transport">
       <div class="audio-unlock">
         <button type="button" data-action="enable-audio">Enable audio</button>
         <p><strong>Do this in every window.</strong> Browsers require a local click before a page can make sound.</p>
@@ -267,66 +267,65 @@ export const synchronizedSoundRecipe: ExampleRecipe = {
       }
     }
 
-    soundTransport.defaultData = {
-      isPlaying: false,
-      startedAtMs: 0,
-      positionMs: 0,
-    };
+    playhtml.register("sound-transport", {
+      defaultData: {
+        isPlaying: false,
+        startedAtMs: 0,
+        positionMs: 0,
+      },
+      updateElement: ({ element, data }) => {
+        renderTimeline(element, data, Date.now());
+      },
+      onClick: (event, { data, setData }) => {
+        const button = event.target.closest("[data-action]");
+        if (!button) return;
 
-    soundTransport.updateElement = ({ element, data }) => {
-      renderTimeline(element, data, Date.now());
-    };
+        if (button.dataset.action === "enable-audio") {
+          void enableAudio();
+          return;
+        }
 
-    soundTransport.onClick = (event, { data, setData }) => {
-      const button = event.target.closest("[data-action]");
-      if (!button) return;
+        if (button.dataset.action === "send-cue") {
+          playhtml.dispatchPlayEvent({
+            type: CUE_EVENT,
+            eventPayload: { frequency: 880 },
+          });
+          return;
+        }
 
-      if (button.dataset.action === "enable-audio") {
-        void enableAudio();
-        return;
-      }
-
-      if (button.dataset.action === "send-cue") {
-        playhtml.dispatchPlayEvent({
-          type: CUE_EVENT,
-          eventPayload: { frequency: 880 },
-        });
-        return;
-      }
-
-      const nowMs = Date.now();
-      if (button.dataset.action === "toggle-transport") {
-        const positionMs = loopPositionMs(data, nowMs);
-        setData((draft) => {
-          draft.isPlaying = !data.isPlaying;
-          draft.positionMs = positionMs;
-          draft.startedAtMs = nowMs - positionMs;
-        });
-      }
-
-      if (button.dataset.action === "restart-transport") {
-        setData((draft) => {
-          draft.positionMs = 0;
-          draft.startedAtMs = nowMs;
-        });
-      }
-    };
-
-    soundTransport.onMount = ({ getData, getElement }) => {
-      let animationFrame = 0;
-      const tick = () => {
         const nowMs = Date.now();
-        const data = getData();
-        renderTimeline(getElement(), data, nowMs);
-        schedulePattern(data, nowMs);
+        if (button.dataset.action === "toggle-transport") {
+          const positionMs = loopPositionMs(data, nowMs);
+          setData((draft) => {
+            draft.isPlaying = !data.isPlaying;
+            draft.positionMs = positionMs;
+            draft.startedAtMs = nowMs - positionMs;
+          });
+        }
+
+        if (button.dataset.action === "restart-transport") {
+          setData((draft) => {
+            draft.positionMs = 0;
+            draft.startedAtMs = nowMs;
+          });
+        }
+      },
+      onMount: ({ getData, getElement }) => {
+        let animationFrame = 0;
+        const tick = () => {
+          const nowMs = Date.now();
+          const data = getData();
+          renderTimeline(getElement(), data, nowMs);
+          schedulePattern(data, nowMs);
+          animationFrame = requestAnimationFrame(tick);
+        };
         animationFrame = requestAnimationFrame(tick);
-      };
-      animationFrame = requestAnimationFrame(tick);
-      return () => {
-        cancelAnimationFrame(animationFrame);
-        silencePattern();
-      };
-    };
+        return () => {
+          cancelAnimationFrame(animationFrame);
+          silencePattern();
+        };
+      },
+    });
 
     await playhtml.init({
       developmentMode: true,

--- a/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
+++ b/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
@@ -37,22 +37,22 @@ playhtml.setupPlayElement(el, { ignoreIfAlreadySetup: true });
 
 To re-walk the whole DOM (e.g. after injecting a chunk of server-rendered HTML), call `playhtml.setupPlayElements()`, the same pass `init()` runs.
 
-For a one-off custom element, call `register` with its future id. The registration can come before or after the element:
+For a one-off custom element that already exists, pass the element and its initializer to `register`:
 
 ```js
-playhtml.register("note-42", {
+const note = document.createElement("div");
+note.id = "note-42";
+document.body.appendChild(note);
+
+playhtml.register(note, {
   defaultData: { text: "" },
   updateElement: ({ element, data }) => {
     element.textContent = data.text;
   },
 });
-
-const note = document.createElement("div");
-note.id = "note-42";
-document.body.appendChild(note);
 ```
 
-playhtml binds the custom element when both the registration and DOM node exist. Do not call `setupPlayElement` for this path.
+This preserves the `setupPlayElement(element)` call shape while keeping the initializer in one object. You can also call `register("note-42", initializer)` before the element exists. Do not call `setupPlayElement` for either custom-element path.
 
 ### Cleaning up
 

--- a/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
+++ b/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Dynamic elements"
-description: "Register runtime-created nodes with setupPlayElement, and share state across many-of-a-kind elements with selector-id."
+description: "Bind runtime-created custom and capability elements, then share state across many-of-a-kind elements with selector-id."
 sidebar:
   order: 3
 ---
@@ -18,7 +18,7 @@ This page covers both.
 
 <Tabs syncKey="framework">
   <TabItem label="Vanilla HTML">
-When you add a playhtml element to the DOM yourself, call `setupPlayElement` to register it:
+For a built-in or defined capability, call `setupPlayElement` after adding the element:
 
 ```js
 const el = document.createElement("div");
@@ -36,6 +36,23 @@ playhtml.setupPlayElement(el, { ignoreIfAlreadySetup: true });
 ```
 
 To re-walk the whole DOM (e.g. after injecting a chunk of server-rendered HTML), call `playhtml.setupPlayElements()`, the same pass `init()` runs.
+
+For a one-off custom element, call `register` with its future id. The registration can come before or after the element:
+
+```js
+playhtml.register("note-42", {
+  defaultData: { text: "" },
+  updateElement: ({ element, data }) => {
+    element.textContent = data.text;
+  },
+});
+
+const note = document.createElement("div");
+note.id = "note-42";
+document.body.appendChild(note);
+```
+
+playhtml binds the custom element when both the registration and DOM node exist. Do not call `setupPlayElement` for this path.
 
 ### Cleaning up
 

--- a/apps/docs/src/content/docs/custom-elements.mdx
+++ b/apps/docs/src/content/docs/custom-elements.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Custom elements"
-description: "Build your own collaborative element: can-mirror for syncing existing DOM, the imperative can-play API, and the experimental reactive view API. Vanilla and React paths, each in their own section."
+description: "Build custom collaborative elements with can-mirror, register, updateElement, view, or React shared state."
 sidebar:
   order: 5
 ---
@@ -116,26 +116,35 @@ If a mirrored child also has its own playhtml capability, keep giving it a stabl
 
 ### can-play
 
-You give the element a `defaultData`, handlers like `onClick`, and an `updateElement` callback that writes the DOM from the current `data`. Set those properties on the element **before `playhtml.init()` runs**. playhtml syncs the data and calls `updateElement` whenever it changes — locally or from another tab.
+Register an element with its starting data, event handlers, and renderer in one initializer object. `playhtml.register(id, initializer)` works before or after `playhtml.init()`, and before or after the element exists. playhtml syncs the data and calls `updateElement` whenever it changes.
 
-The [Element API reference](/docs/reference/element-api/#initializer) has the full annotated property list — **`ctx`** is defined once at the top.
+The [Element API reference](/docs/reference/element-api/#initializer) lists every initializer field and callback context.
 
-Most capability tags can share the same element. Each tag keeps its own data and behavior, so an element can be both custom and draggable with `<img can-play can-move id="candle">`. Watch out for style conflicts: two capabilities can still fight if they write the same CSS property. For example, `can-move` and `can-spin` both update `transform`, so the last update wins instead of combining translate and rotate automatically.
+:::note[Existing property-based elements]
+Direct assignments such as `element.defaultData = …` and `element.updateElement = …` remain supported for compatibility. Use `register` for new vanilla elements.
+:::
+
+Most capabilities can share the same element. Each keeps its own data and behavior, so a registered element can also carry `can-move`. Watch out for style conflicts: two capabilities can still fight if they write the same CSS property. For example, `can-move` and `can-spin` both update `transform`, so the last update wins instead of combining translate and rotate.
 
 #### A click counter
 
 ```html
-<div id="counter" can-play></div>
+<div id="counter"></div>
 
 <script type="module">
   import { playhtml } from "playhtml";
 
-  const el = document.getElementById("counter");
-  el.defaultData = { count: 0 };
-  el.onClick = (_e, { setData }) => setData((d) => { d.count += 1; });
-  el.updateElement = ({ element, data }) => {
-    element.textContent = `${data.count}`;
-  };
+  playhtml.register("counter", {
+    defaultData: { count: 0 },
+    onClick: (_event, { setData }) => {
+      setData((data) => {
+        data.count += 1;
+      });
+    },
+    updateElement: ({ element, data }) => {
+      element.textContent = String(data.count);
+    },
+  });
 
   playhtml.init();
 </script>
@@ -163,18 +172,23 @@ Most capability tags can share the same element. Each tag keeps its own data and
 `updateElement` runs on every change, so the simplest pattern is "read `data`, set a class or style."
 
 ```html
-<button id="switch" can-play>off</button>
+<button id="switch">off</button>
 
 <script type="module">
   import { playhtml } from "playhtml";
 
-  const el = document.getElementById("switch");
-  el.defaultData = { on: false };
-  el.onClick = (_e, { setData }) => setData((d) => { d.on = !d.on; });
-  el.updateElement = ({ element, data }) => {
-    element.classList.toggle("on", data.on);
-    element.textContent = data.on ? "on" : "off";
-  };
+  playhtml.register("switch", {
+    defaultData: { on: false },
+    onClick: (_event, { setData }) => {
+      setData((data) => {
+        data.on = !data.on;
+      });
+    },
+    updateElement: ({ element, data }) => {
+      element.classList.toggle("on", data.on);
+      element.textContent = data.on ? "on" : "off";
+    },
+  });
 
   playhtml.init();
 </script>
@@ -195,23 +209,24 @@ Most capability tags can share the same element. Each tag keeps its own data and
 `myDefaultAwareness` seeds a per-user ephemeral value; `setMyAwareness` broadcasts it; `updateElementAwareness` renders everyone's. Awareness does **not** persist — it's "who's here right now."
 
 ```html
-<div id="online" can-play></div>
+<div id="online"></div>
 
 <script type="module">
   import { playhtml } from "playhtml";
 
-  const el = document.getElementById("online");
-  el.myDefaultAwareness = "#2563eb";
-  el.updateElementAwareness = ({ element, awareness }) => {
-    element.replaceChildren(
-      ...awareness.map((color) => {
-        const dot = document.createElement("span");
-        dot.className = "dot";
-        dot.style.background = color;
-        return dot;
-      }),
-    );
-  };
+  playhtml.register("online", {
+    myDefaultAwareness: "#2563eb",
+    updateElementAwareness: ({ element, awareness }) => {
+      element.replaceChildren(
+        ...awareness.map((color) => {
+          const dot = document.createElement("span");
+          dot.className = "dot";
+          dot.style.background = color;
+          return dot;
+        }),
+      );
+    },
+  });
 
   playhtml.init();
 </script>
@@ -229,15 +244,21 @@ Most capability tags can share the same element. Each tag keeps its own data and
 
 #### Reset shortcut
 
-Set `resetShortcut` so shift-clicking (or ctrl/alt/meta) resets the element to its `defaultData` for everyone:
+Put `resetShortcut` in the initializer so shift-clicking (or ctrl/alt/meta) resets the element to its `defaultData` for everyone:
 
 ```js
-el.resetShortcut = "shiftKey";
+playhtml.register("counter", {
+  defaultData: { count: 0 },
+  resetShortcut: "shiftKey",
+  updateElement: ({ element, data }) => {
+    element.textContent = String(data.count);
+  },
+});
 ```
 
 #### Dynamically-added elements
 
-`playhtml.init()` scans the DOM once. For elements you add later, call `playhtml.setupPlayElement(el)` after inserting them (and use [`selector-id`](/docs/advanced/dynamic-elements/) for many-of-a-kind elements). See [Dynamic elements](/docs/advanced/dynamic-elements/).
+`register` can run before the element exists and binds it when it appears. For dynamically added built-in or defined capabilities, call `playhtml.setupPlayElement(element)` after insertion. Use [`selector-id`](/docs/advanced/dynamic-elements/) for many-of-a-kind elements.
 
 :::note[Lists and data-driven UIs get verbose here]
 With `updateElement` you hand-build and diff the DOM yourself, which is painful for lists, chat, and anything computed from a collection. That's exactly what the [reactive view API](#reactive-view-api-experimental) below is for.
@@ -246,11 +267,10 @@ With `updateElement` you hand-build and diff the DOM yourself, which is painful 
 ### Reactive view API (experimental)
 
 <Aside type="caution" title="Experimental">
-  `playhtml.register` / `playhtml.define` and the `view` render function are new
-  and **experimental** — the surface may change in a future minor release based
-  on feedback. The imperative `can-play` API above keeps working unchanged, and
-  React's `withSharedState` is **stable**. Trying the view API? Tell us how it
-  goes in [#95](https://github.com/spencerc99/playhtml/issues/95).
+  The `view` renderer and lit-html helpers are experimental. `register`,
+  `define`, handles, and the imperative `updateElement` renderer are supported.
+  Trying `view`? Tell us how it goes in
+  [#95](https://github.com/spencerc99/playhtml/issues/95).
 </Aside>
 
 Instead of hand-writing DOM updates in `updateElement`, you can register a **`view`**: a pure function from state to a [lit-html](https://lit.dev/docs/libraries/standalone-templates/) template. playhtml patches only what changed when the data updates. It's the vanilla equivalent of what React's `withSharedState` already gives you.
@@ -264,7 +284,7 @@ import { playhtml, html, svg, repeat, classMap, styleMap, nothing } from "playht
 The element is an empty mount point; everything you see is rendered from state. `register` is callable before or after `init()` and before or after the element exists.
 
 ```html
-<div id="counter" can-play></div>
+<div id="counter"></div>
 
 <script type="module">
   import { playhtml, html } from "playhtml";
@@ -607,7 +627,7 @@ const Chats = withSharedState(
 ## Reference
 
 - Every `ElementInitializer` property: [Element API (`can-play`)](/docs/reference/element-api/)
-- Vanilla view API: [`register` / `define` / `view`](/docs/reference/view-api/)
+- Vanilla registration API: [`register` / `define` / `view`](/docs/reference/view-api/)
 - The `playhtml` object (setup, events, page data): [playhtml client](/docs/reference/playhtml-client/)
 - Presence & identity: [reference](/docs/reference/presence/)
 - React: [`@playhtml/react` API](/docs/reference/react-api/)

--- a/apps/docs/src/content/docs/custom-elements.mdx
+++ b/apps/docs/src/content/docs/custom-elements.mdx
@@ -362,7 +362,7 @@ form.addEventListener("submit", (e) => {
 
 #### Reusing the element many times: `define`
 
-`playhtml.define(name, init)` registers a capability under an attribute, so every `[name]` element gets it (including ones added later).
+`playhtml.define(name, init)` registers a capability under an attribute. Matching elements already on the page bind immediately, as do matching descendants rendered by a registered view. Call `setupPlayElement(element)` for other elements added after initialization.
 
 ```html
 <div id="note-1" can-note data-color="yellow"></div>

--- a/apps/docs/src/content/docs/custom-elements.mdx
+++ b/apps/docs/src/content/docs/custom-elements.mdx
@@ -116,7 +116,7 @@ If a mirrored child also has its own playhtml capability, keep giving it a stabl
 
 ### can-play
 
-Register an element with its starting data, event handlers, and renderer in one initializer object. `playhtml.register(id, initializer)` works before or after `playhtml.init()`, and before or after the element exists. playhtml syncs the data and calls `updateElement` whenever it changes.
+Register an element with its starting data, event handlers, and renderer in one initializer object. Pass the element itself when you already have it, or pass its id before it exists. Both `playhtml.register(element, initializer)` and `playhtml.register(id, initializer)` work before or after `playhtml.init()`. playhtml syncs the data and calls `updateElement` whenever it changes.
 
 The [Element API reference](/docs/reference/element-api/#initializer) lists every initializer field and callback context.
 

--- a/apps/docs/src/content/docs/data/data-essentials.md
+++ b/apps/docs/src/content/docs/data/data-essentials.md
@@ -154,9 +154,15 @@ Syncing on every `mousemove` or `scroll` will flood the socket and eat your Part
 **Use built-in handlers.** `onDrag`, `onMount` already debounce:
 
 ```js
-element.onDrag = (e, { setData }) => {
-  setData({ x: e.clientX, y: e.clientY });
-};
+playhtml.register("draggable", {
+  defaultData: { x: 0, y: 0 },
+  onDrag: (event, { setData }) => {
+    setData({ x: event.clientX, y: event.clientY });
+  },
+  updateElement: ({ element, data }) => {
+    element.style.translate = `${data.x}px ${data.y}px`;
+  },
+});
 ```
 
 **Debounce yourself** when you need your own event:

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -122,21 +122,26 @@ There's no partial/merge update for a channel. When you call `setMyPresence`, yo
 
 Use page-level presence when the signal belongs to the room: online status, cursor position, lobby readiness, or a typing indicator that several parts of the page may read. Use element awareness when the signal only matters for one playhtml element, like "who has joined this widget" or "which color is this reader contributing here".
 
-In vanilla `can-play`, element awareness appears on the element handler data:
+In vanilla HTML, put element awareness in the initializer passed to `register`:
 
 ```html
-<button can-play id="presence-count">0 readers here</button>
+<button id="presence-count">0 readers here</button>
 
-<script>
-  const element = document.getElementById("presence-count");
-  element.myDefaultAwareness = { color: "#3b82f6" };
-  element.onClick = (_event, { setMyAwareness }) => {
-    setMyAwareness({ color: "#f97316" });
-  };
-  element.updateElementAwareness = ({ element, awareness }) => {
-    const label = awareness.length === 1 ? "reader" : "readers";
-    element.textContent = `${awareness.length} ${label} here`;
-  };
+<script type="module">
+  import { playhtml } from "playhtml";
+
+  playhtml.register("presence-count", {
+    myDefaultAwareness: { color: "#3b82f6" },
+    onClick: (_event, { setMyAwareness }) => {
+      setMyAwareness({ color: "#f97316" });
+    },
+    updateElementAwareness: ({ element, awareness }) => {
+      const label = awareness.length === 1 ? "reader" : "readers";
+      element.textContent = `${awareness.length} ${label} here`;
+    },
+  });
+
+  playhtml.init();
 </script>
 ```
 

--- a/apps/docs/src/content/docs/examples/shared-counter.mdx
+++ b/apps/docs/src/content/docs/examples/shared-counter.mdx
@@ -18,14 +18,21 @@ current count so concurrent clicks merge without replacing newer values.
 
 ## Increment from the click handler
 
-Write from the user event:
+Pass the click handler and renderer in one registered initializer. Write shared
+data only from the user event:
 
 ```js
-counter.onClick = (_event, { setData }) => {
-  setData((draft) => {
-    draft.count += 1;
-  });
-};
+playhtml.register("ph-docs-counter", {
+  defaultData: { count: 0 },
+  onClick: (_event, { setData }) => {
+    setData((draft) => {
+      draft.count += 1;
+    });
+  },
+  updateElement: ({ element, data }) => {
+    element.querySelector("[data-count]").textContent = String(data.count);
+  },
+});
 ```
 
 Don't rebuild the value from rendered text. The rendered value may be behind a
@@ -33,13 +40,8 @@ remote update.
 
 ## Render the current count
 
-`updateElement` reads shared data without writing it:
-
-```js
-counter.updateElement = ({ element, data }) => {
-  element.querySelector("[data-count]").textContent = String(data.count);
-};
-```
+`updateElement` in the registered initializer reads shared data without writing
+it. playhtml calls it after initialization and whenever the shared count changes.
 
 See [Data essentials](/docs/data/data-essentials/) for mutator and replacement
 writes.

--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -51,14 +51,14 @@ playhtml makes HTML elements collaborative and real-time. Here's what you need t
 
 CRITICAL REQUIREMENTS:
 - All elements MUST have a unique `id` attribute
-- Vanilla HTML: register a custom element with playhtml.register(id, { defaultData, view })
+- Vanilla HTML: register a custom element with `playhtml.register(id, initializer)`
 - React: Components must be wrapped in <PlayProvider>
 
 SETUP — Vanilla HTML (custom element with register + view):
-Put an empty mount point in the HTML, then register a `view` that renders it from
-state. `register` can be called before OR after `playhtml.init()` — there is no
-ordering rule. Drive writes from `@event` handlers in the template; the view
-re-renders automatically when data changes.
+Put an empty mount point in the HTML, then register an initializer. `register`
+can be called before OR after `playhtml.init()` and before OR after the element
+exists. Use `updateElement` for imperative DOM updates or the experimental
+`view` renderer for lit-html templates.
 
   <div id="myElement" can-play></div>
 
@@ -97,17 +97,21 @@ DATA TYPES (choose the right one):
 
 KEY APIs:
 
-Vanilla HTML (register + view):
+Vanilla HTML (register):
 - playhtml.register(id, init) → handle                         // Bind one element by id
 - playhtml.define(name, init)                                  // Reusable capability for every [name] element
 - init.defaultData = { ... }                                   // Initial state (REQUIRED)
-- init.view = ({ data, setData }) => html`...`                 // Render from state; events via @click (REQUIRED)
+- init.updateElement = ({ element, data }) => { ... }           // Supported imperative renderer
+- init.view = ({ data, setData }) => html`...`                 // Experimental declarative renderer
 - init.onMount = (ctx) => { ...; return cleanup }              // Setup loops/listeners; return a cleanup
 - init.resetShortcut = "shiftKey"                              // Keyboard reset
 - ctx.setData(value | (draft) => { ... })                     // Write shared state
 - ctx.localData / ctx.setLocalData(...)                        // Per-user, un-synced UI state
 - ctx.awareness / ctx.setMyAwareness(...)                      // Presence
 - ctx.requestUpdate()                                          // Repaint clock-driven views (timers)
+
+Use exactly one renderer: `updateElement` or `view`. Do not assign initializer
+fields directly to the DOM element in new code.
 
 React (withSharedState):
 - withSharedState({ defaultData: {...} }, ({ data, setData, ref }) => JSX)

--- a/apps/docs/src/content/docs/integrations/building-with-ai.md
+++ b/apps/docs/src/content/docs/integrations/building-with-ai.md
@@ -51,7 +51,7 @@ playhtml makes HTML elements collaborative and real-time. Here's what you need t
 
 CRITICAL REQUIREMENTS:
 - All elements MUST have a unique `id` attribute
-- Vanilla HTML: register a custom element with `playhtml.register(id, initializer)`
+- Vanilla HTML: register a custom element with `playhtml.register(elementOrId, initializer)`
 - React: Components must be wrapped in <PlayProvider>
 
 SETUP — Vanilla HTML (custom element with register + view):
@@ -98,7 +98,7 @@ DATA TYPES (choose the right one):
 KEY APIs:
 
 Vanilla HTML (register):
-- playhtml.register(id, init) → handle                         // Bind one element by id
+- playhtml.register(elementOrId, init) → handle                // Bind one element by DOM node or id
 - playhtml.define(name, init)                                  // Reusable capability for every [name] element
 - init.defaultData = { ... }                                   // Initial state (REQUIRED)
 - init.updateElement = ({ element, data }) => { ... }           // Supported imperative renderer

--- a/apps/docs/src/content/docs/reference/capabilities.md
+++ b/apps/docs/src/content/docs/reference/capabilities.md
@@ -375,7 +375,7 @@ No reset shortcut.
 Define your own shared data and how the element renders (`updateElement` or experimental `view`). Use it for counters, guestbooks, games, and anything the built-ins do not cover.
 
 **Guide:** [Custom elements](/docs/custom-elements/)  
-**Reference:** [Element API](/docs/reference/element-api/) · [View API](/docs/reference/view-api/)
+**Reference:** [Element API](/docs/reference/element-api/) · [Registration API](/docs/reference/view-api/)
 
 ---
 

--- a/apps/docs/src/content/docs/reference/element-api.md
+++ b/apps/docs/src/content/docs/reference/element-api.md
@@ -1,19 +1,21 @@
 ---
-title: "Element API (can-play)"
-description: "Every property of the ElementInitializer: data defaults, updateElement, view, event handlers, awareness, lifecycle, and callback contexts."
+title: "Element initializer API"
+description: "Configure data defaults, renderers, event handlers, awareness, and lifecycle callbacks."
 sidebar:
   order: 3
 ---
 
-The `ElementInitializer` is the config object for a custom collaborative element. Use the same shape in three places:
+The `ElementInitializer` configures a custom collaborative element. Use the same shape in three supported APIs:
 
-1. **DOM properties** on a `can-play` element, set before `playhtml.init()`
-2. **`playhtml.register(id, init)`** / **`playhtml.define(name, init)`** — see [View API](/docs/reference/view-api/)
-3. **`extraCapabilities`** in `playhtml.init()` — see [init options](/docs/reference/init-options/#extracapabilities)
+1. **`playhtml.register(id, initializer)`** for one element
+2. **`playhtml.define(name, initializer)`** for a reusable capability
+3. **`extraCapabilities`** in `playhtml.init()` for capabilities declared during initialization
 
 The initializer has three state buckets: shared **`data`**, per-user **`localData`**, and ephemeral **`awareness`**.
 
 For usage examples, see [Custom elements](/docs/custom-elements/).
+
+Directly assigning initializer fields to an element remains supported for compatibility, but is deprecated for vanilla code. See [Direct element properties](#direct-element-properties-deprecated).
 
 ## Full shape
 
@@ -60,7 +62,7 @@ Do not call `setData`, `setLocalData`, or `setMyAwareness` during a `view` rende
 
 ### Initializer
 
-Everything you can set on `can-play` (same object for `register`, `define`, and `extraCapabilities`):
+Everything you can put in an initializer for `register`, `define`, or `extraCapabilities`:
 
 ```js
 {
@@ -124,10 +126,14 @@ Everything you can set on `can-play` (same object for `register`, `define`, and 
 **Required.** Starting shared state for new elements. Must be an **object** (or a function that returns one), not a bare primitive like `0` or `""`.
 
 ```js
-el.defaultData = { count: 0 };
+const initializer = {
+  defaultData: { count: 0 },
+};
 
 // Or derive from the element:
-el.defaultData = (element) => ({ color: element.dataset.color ?? "yellow" });
+const derivedInitializer = {
+  defaultData: (element) => ({ color: element.dataset.color ?? "yellow" }),
+};
 ```
 
 ---
@@ -137,7 +143,9 @@ el.defaultData = (element) => ({ color: element.dataset.color ?? "yellow" });
 Per-user, per-tab state that is **not** synced. Use for drag anchors, hover flags, or UI that only the local client needs.
 
 ```js
-el.defaultLocalData = { draft: "" };
+const initializer = {
+  defaultLocalData: { draft: "" },
+};
 ```
 
 ---
@@ -147,7 +155,9 @@ el.defaultLocalData = { draft: "" };
 Your starting awareness value for this element. Awareness is ephemeral — it clears when you disconnect. Other clients read it through the `awareness` array in callbacks.
 
 ```js
-el.myDefaultAwareness = "#2563eb";
+const initializer = {
+  myDefaultAwareness: "#2563eb",
+};
 ```
 
 ---
@@ -159,8 +169,10 @@ Imperative update path. playhtml calls it on mount and whenever shared `data`, `
 Mutually exclusive with `view`. Do not call `setData` inside `updateElement` — that creates a write loop. See [Data essentials](/docs/data/data-essentials/) rule 7.
 
 ```js
-el.updateElement = ({ element, data }) => {
-  element.textContent = String(data.count);
+const initializer = {
+  updateElement: ({ element, data }) => {
+    element.textContent = String(data.count);
+  },
 };
 ```
 
@@ -172,7 +184,7 @@ el.updateElement = ({ element, data }) => {
 
 Mutually exclusive with `updateElement`, `onClick`, `onDrag`, and `onDragStart` — put events in the template (`@click`, etc.).
 
-See [View API](/docs/reference/view-api/) for `register`, `define`, helpers, and handle methods.
+See [Registration API](/docs/reference/view-api/) for `register`, `define`, helpers, and handle methods.
 
 ---
 
@@ -181,8 +193,10 @@ See [View API](/docs/reference/view-api/) for `register`, `define`, helpers, and
 Called when element awareness changes. Same context as `updateElement`, plus `myAwareness` (your own value).
 
 ```js
-el.updateElementAwareness = ({ element, awareness }) => {
-  element.dataset.viewers = String(awareness.length);
+const initializer = {
+  updateElementAwareness: ({ element, awareness }) => {
+    element.dataset.viewers = String(awareness.length);
+  },
 };
 ```
 
@@ -195,8 +209,12 @@ If the element also has a `view`, awareness changes re-render the view automatic
 Fired on click. Ignored when the element uses `view`.
 
 ```js
-el.onClick = (_e, { setData }) => {
-  setData((d) => { d.count += 1; });
+const initializer = {
+  onClick: (_event, { setData }) => {
+    setData((data) => {
+      data.count += 1;
+    });
+  },
 };
 ```
 
@@ -219,31 +237,38 @@ Return a cleanup function when the element is removed.
 **`onMount` vs `playhtml.ready`:** `onMount` fires when this element's handler attaches — that can happen before the room's first sync finishes. `data` may still be `defaultData` until sync lands. Use `onMount` alone for element-scoped setup (listeners, animation loops). Wait on `playhtml.ready` inside `onMount` when you need room-wide state that only exists after sync (presence, `createPageData`, reading final server data):
 
 ```js
-el.onMount = ({ getData, setData }) => {
-  let cancelled = false;
+const initializer = {
+  onMount: ({ getData, setData }) => {
+    let cancelled = false;
 
-  playhtml.ready.then(() => {
-    if (cancelled) return;
-    // Safe to read presence, page data, or fully-hydrated shared state here
-    const presences = playhtml.presence.getPresences();
-    setData((d) => { d.viewerCount = presences.size; });
-  });
+    playhtml.ready.then(() => {
+      if (cancelled) return;
+      const presences = playhtml.presence.getPresences();
+      setData((data) => {
+        data.viewerCount = presences.size;
+      });
+    });
 
-  return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
+  },
 };
 ```
 
 For a clock-driven `view`, `requestAnimationFrame` in `onMount` is enough — you do not need `playhtml.ready`:
 
 ```js
-el.onMount = ({ getData, requestUpdate }) => {
-  let raf;
-  const tick = () => {
-    if (getData().running) requestUpdate();
+const initializer = {
+  onMount: ({ getData, requestUpdate }) => {
+    let raf;
+    const tick = () => {
+      if (getData().running) requestUpdate();
+      raf = requestAnimationFrame(tick);
+    };
     raf = requestAnimationFrame(tick);
-  };
-  raf = requestAnimationFrame(tick);
-  return () => cancelAnimationFrame(raf);
+    return () => cancelAnimationFrame(raf);
+  },
 };
 ```
 
@@ -256,7 +281,9 @@ When set, a click with that modifier held resets the element to `defaultData` fo
 Built-in capabilities use `"shiftKey"`. Custom elements opt in the same way:
 
 ```js
-el.resetShortcut = "shiftKey";
+const initializer = {
+  resetShortcut: "shiftKey",
+};
 ```
 
 ---
@@ -273,30 +300,43 @@ Gate which DOM elements a reusable capability (`define` / `extraCapabilities`) a
 
 ---
 
-## Setting properties on the DOM element
+## Registering an initializer
 
-For `can-play`, set initializer properties on the element before `playhtml.init()`:
+Pass the initializer to `playhtml.register`. The element needs a stable, unique `id`; the `can-play` attribute is optional because `register` supplies the custom capability.
 
 ```html
-<div id="counter" can-play></div>
+<div id="counter"></div>
 
 <script type="module">
   import { playhtml } from "playhtml";
 
-  const el = document.getElementById("counter");
-  el.defaultData = { count: 0 };
-  el.onClick = (_e, { setData }) => setData((d) => { d.count += 1; });
-  el.updateElement = ({ element, data }) => {
-    element.textContent = String(data.count);
-  };
+  playhtml.register("counter", {
+    defaultData: { count: 0 },
+    onClick: (_event, { setData }) => {
+      setData((data) => {
+        data.count += 1;
+      });
+    },
+    updateElement: ({ element, data }) => {
+      element.textContent = String(data.count);
+    },
+  });
 
   playhtml.init();
 </script>
 ```
 
-playhtml reads these keys off the element: `defaultData`, `defaultLocalData`, `myDefaultAwareness`, `updateElement`, `view`, `updateElementAwareness`, `onClick`, `onDrag`, `onDragStart`, `onMount`, `resetShortcut`, `debounceMs`, `isValidElementForTag`.
+`register` can run before or after `playhtml.init()`, and before or after the element exists. It binds when both the registration and element are available.
 
-When an element has both `can-play` and a built-in capability (e.g. `can-move`), built-in tags keep their own initializer; `can-play` properties apply only to the custom slot.
+When the same element also has a built-in capability such as `can-move`, each capability keeps its own data and behavior.
+
+## Direct element properties (deprecated)
+
+Direct assignments such as `element.defaultData = …` and `element.updateElement = …` remain supported so existing sites and React integrations keep working. Do not use them in new vanilla code. Move every initializer field into the object passed to `register`.
+
+The compatibility path reads these keys from the element: `defaultData`, `defaultLocalData`, `myDefaultAwareness`, `updateElement`, `view`, `updateElementAwareness`, `onClick`, `onDrag`, `onDragStart`, `onMount`, `resetShortcut`, `debounceMs`, and `isValidElementForTag`.
+
+If existing code assigns those properties and calls `setupPlayElement(element)`, replace both steps with `register(element.id, initializer)`. `setupPlayElement` remains supported for dynamically added built-in and defined capabilities.
 
 ---
 

--- a/apps/docs/src/content/docs/reference/element-api.md
+++ b/apps/docs/src/content/docs/reference/element-api.md
@@ -7,7 +7,7 @@ sidebar:
 
 The `ElementInitializer` configures a custom collaborative element. Use the same shape in three supported APIs:
 
-1. **`playhtml.register(id, initializer)`** for one element
+1. **`playhtml.register(elementOrId, initializer)`** for one element
 2. **`playhtml.define(name, initializer)`** for a reusable capability
 3. **`extraCapabilities`** in `playhtml.init()` for capabilities declared during initialization
 
@@ -336,7 +336,7 @@ Direct assignments such as `element.defaultData = …` and `element.updateElemen
 
 The compatibility path reads these keys from the element: `defaultData`, `defaultLocalData`, `myDefaultAwareness`, `updateElement`, `view`, `updateElementAwareness`, `onClick`, `onDrag`, `onDragStart`, `onMount`, `resetShortcut`, `debounceMs`, and `isValidElementForTag`.
 
-If existing code assigns those properties and calls `setupPlayElement(element)`, replace both steps with `register(element.id, initializer)`. `setupPlayElement` remains supported for dynamically added built-in and defined capabilities.
+If existing code assigns those properties and calls `setupPlayElement(element)`, replace both steps with `register(element, initializer)`. `setupPlayElement` remains supported for dynamically added built-in and defined capabilities.
 
 ---
 

--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -243,7 +243,7 @@ Directly assigning initializer fields to an element remains supported for compat
 
 **Signature:** `define<T, U, V>(capabilityName: string, init: ElementInitializer<T, U, V>): void`
 
-Registers a reusable capability under an attribute name. Every element carrying `[capabilityName]` binds, including elements added to the DOM later. The runtime equivalent of `init({ extraCapabilities })`.
+Registers a reusable capability under an attribute name. Matching elements already on the page bind immediately, as do matching descendants rendered by a registered view. Call `setupPlayElement(element)` for other elements added after initialization. `define` is the runtime equivalent of `init({ extraCapabilities })`.
 
 ```js
 playhtml.define("can-note", {

--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -22,7 +22,7 @@ playhtml.init();
 |---|---|
 | Lifecycle | `init`, `configure`, `ready`, `isLoading`, `handleNavigation` |
 | Element setup & teardown | `setupPlayElements`, `setupPlayElement`, `setupPlayElementForTag`, `removePlayElement`, `deleteElementData` |
-| Custom elements _(experimental)_ | `register`, `define`, `getHandle` |
+| Custom elements | `register`, `define`, `getHandle` |
 | Events | `dispatchPlayEvent`, `registerPlayEventListener`, `removePlayEventListener` |
 | Page data | `createPageData` |
 | Presence | `presence`, `createPresenceRoom`, `cursorClient` |
@@ -123,11 +123,13 @@ See [Navigation & SPAs](/docs/advanced/navigation/) for a full guide and framewo
 
 **Signature:** `setupPlayElement(element: Element, options?: { ignoreIfAlreadySetup?: boolean }): void`
 
-Registers one element after `init()`. Use for elements added dynamically.
+Registers one element after `init()`. Use for dynamically added built-in or defined capabilities.
 
 Pass `{ ignoreIfAlreadySetup: true }` to skip elements that are already registered.
 
 The element needs a unique `id`.
+
+For a one-off custom element, use [`register(id, initializer)`](#registerelementid-init). It binds the element automatically, so it does not need a separate `setupPlayElement` call.
 
 ```js
 const card = document.createElement("div");
@@ -196,13 +198,9 @@ Throws a console warning if called before `init()` completes sync.
 
 ---
 
-## Custom elements (experimental)
+## Custom elements
 
-:::caution[Experimental]
-`register`, `define`, and `getHandle` are part of the new view API and are **experimental** — signatures may change in a future minor release. The imperative `can-play` path (`updateElement`) is unaffected. Feedback welcome on [#95](https://github.com/spencerc99/playhtml/issues/95).
-:::
-
-These three methods are part of the experimental view API. See [View API](/docs/reference/view-api/).
+Use `register` for one custom element and `define` for a reusable capability. Both accept an `ElementInitializer` with either the supported imperative `updateElement` renderer or the experimental declarative `view` renderer. See [Registration API](/docs/reference/view-api/).
 
 ### `register(elementId, init)`
 
@@ -213,13 +211,18 @@ Binds an initializer to one element by id. Returns a handle for reads and writes
 ```js
 const handle = playhtml.register("my-counter", {
   defaultData: { count: 0 },
-  view: ({ data, setData }) => html`
-    <button @click=${() => setData(d => { d.count++ })}>
-      Clicked ${data.count} times
-    </button>
-  `,
+  onClick: (_event, { setData }) => {
+    setData((data) => {
+      data.count += 1;
+    });
+  },
+  updateElement: ({ element, data }) => {
+    element.textContent = `Clicked ${data.count} times`;
+  },
 });
 ```
+
+Directly assigning initializer fields to an element remains supported for compatibility, but is deprecated for vanilla code.
 
 ---
 

--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -129,7 +129,7 @@ Pass `{ ignoreIfAlreadySetup: true }` to skip elements that are already register
 
 The element needs a unique `id`.
 
-For a one-off custom element, use [`register(id, initializer)`](#registerelementid-init). It binds the element automatically, so it does not need a separate `setupPlayElement` call.
+For a one-off custom element, use [`register(elementOrId, initializer)`](#registerelementorid-init). It binds the element automatically, so it does not need a separate `setupPlayElement` call.
 
 ```js
 const card = document.createElement("div");
@@ -202,14 +202,27 @@ Throws a console warning if called before `init()` completes sync.
 
 Use `register` for one custom element and `define` for a reusable capability. Both accept an `ElementInitializer` with either the supported imperative `updateElement` renderer or the experimental declarative `view` renderer. See [Registration API](/docs/reference/view-api/).
 
-### `register(elementId, init)`
+### `register(elementOrId, init)`
 
-**Signature:** `register<T, U, V>(elementId: string, init: ElementInitializer<T, U, V>): PlayElementHandle<T, U, V>`
+**Signatures:**
 
-Binds an initializer to one element by id. Returns a handle for reads and writes from outside the element's own callbacks. Callable before or after `init()` and before or after the element exists in the DOM.
+```ts
+register<T, U, V>(
+  elementId: string,
+  init: ElementInitializer<T, U, V>,
+): PlayElementHandle<T, U, V>
+
+register<T, U, V>(
+  element: HTMLElement,
+  init: ElementInitializer<T, U, V>,
+): PlayElementHandle<T, U, V>
+```
+
+Binds an initializer to one element. Pass a string id before the element exists, or pass an existing HTML element to bind that node directly. The element form requires a non-empty `id`. Both forms return a handle for reads and writes outside the element's callbacks.
 
 ```js
-const handle = playhtml.register("my-counter", {
+const counter = document.getElementById("my-counter");
+const handle = playhtml.register(counter, {
   defaultData: { count: 0 },
   onClick: (_event, { setData }) => {
     setData((data) => {

--- a/apps/docs/src/content/docs/reference/view-api.md
+++ b/apps/docs/src/content/docs/reference/view-api.md
@@ -15,12 +15,13 @@ The declarative `view` renderer and the lit-html helpers are experimental. `regi
 import { playhtml, html, svg, repeat, classMap, styleMap, nothing } from "playhtml";
 ```
 
-## `playhtml.register(elementId, init)`
+## `playhtml.register(elementOrId, init)`
 
-Binds an initializer to one element by `id` and returns a [handle](#playelementhandle). Call it before or after `playhtml.init()`. If the element does not exist yet, playhtml binds it when it appears.
+Binds an initializer to one element and returns a [handle](#playelementhandle). Pass an element when you already have the DOM node. Pass its `id` when you need to register before the element exists. Both forms work before or after `playhtml.init()`.
 
 ```js
-const handle = playhtml.register("my-counter", {
+const counter = document.getElementById("my-counter");
+const handle = playhtml.register(counter, {
   defaultData: { count: 0 },
   onClick: (_event, { setData }) => {
     setData((data) => {
@@ -33,7 +34,9 @@ const handle = playhtml.register("my-counter", {
 });
 ```
 
-- The element needs a stable, unique `id` (it _is_ the `elementId`). The `can-play` attribute is optional — `register` implies it.
+- The element form requires an HTML element with a stable, non-empty `id`.
+- The id form binds automatically when an element with that id appears.
+- The `can-play` attribute is optional. `register` supplies the custom capability.
 - Re-registering the same id replaces its initializer.
 
 :::note[Direct element properties]

--- a/apps/docs/src/content/docs/reference/view-api.md
+++ b/apps/docs/src/content/docs/reference/view-api.md
@@ -1,14 +1,14 @@
 ---
-title: "View API (vanilla)"
-description: "playhtml.register, playhtml.define, the view function, the element handle, and lit-html helpers."
+title: "Registration API (vanilla)"
+description: "Register one-off elements and reusable capabilities with initializer objects."
 sidebar:
   order: 6
 ---
 
-The vanilla API for building custom collaborative elements. For usage with side-by-side examples, see [Custom elements](/docs/custom-elements/); for the React equivalent, see the [React API](/docs/reference/react-api/).
+Register a custom collaborative element with one initializer object. Use `register` for one element and `define` for a reusable capability.
 
 :::caution[Experimental]
-This API (`register` / `define` / `view`) is new and **experimental** — signatures may change in a future minor release. The imperative `can-play` path (`updateElement`) is unaffected. Feedback welcome on [#95](https://github.com/spencerc99/playhtml/issues/95).
+The declarative `view` renderer and the lit-html helpers are experimental. `register`, `define`, handles, and the imperative `updateElement` renderer are supported APIs.
 :::
 
 ```js
@@ -17,14 +17,28 @@ import { playhtml, html, svg, repeat, classMap, styleMap, nothing } from "playht
 
 ## `playhtml.register(elementId, init)`
 
-Binds an initializer to one element by `id` and returns a [handle](#playelementhandle). Callable before or after `playhtml.init()` and before or after the element exists in the DOM — binding happens once both are present (like `customElements.define`).
+Binds an initializer to one element by `id` and returns a [handle](#playelementhandle). Call it before or after `playhtml.init()`. If the element does not exist yet, playhtml binds it when it appears.
 
 ```js
-const handle = playhtml.register("my-counter", init);
+const handle = playhtml.register("my-counter", {
+  defaultData: { count: 0 },
+  onClick: (_event, { setData }) => {
+    setData((data) => {
+      data.count += 1;
+    });
+  },
+  updateElement: ({ element, data }) => {
+    element.textContent = String(data.count);
+  },
+});
 ```
 
 - The element needs a stable, unique `id` (it _is_ the `elementId`). The `can-play` attribute is optional — `register` implies it.
 - Re-registering the same id replaces its initializer.
+
+:::note[Direct element properties]
+Direct assignments such as `element.defaultData = …` and `element.updateElement = …` remain supported for compatibility. Use `register` for new vanilla code so the initializer stays in one object and dynamic elements bind without a separate `setupPlayElement` call.
+:::
 
 ## `playhtml.define(capabilityName, init)`
 
@@ -46,13 +60,13 @@ const handle = playhtml.getHandle("card-1", "can-move");
 
 ## The `init` object
 
-The full annotated property list is on [Element API](/docs/reference/element-api/#initializer). The `view` argument is **`ctx`** — see [Callback context](/docs/reference/element-api/#callback-context-ctx).
+The full annotated property list is on [Element API](/docs/reference/element-api/#initializer). Both `updateElement` and `view` receive the [callback context](/docs/reference/element-api/#callback-context-ctx).
 
 `defaultData` must be an object (or a function that returns one), not a bare value like `0` or `""`. Use `{ count: 0 }`, not `0`.
 
 A valid initializer provides exactly one update path — `view` **or** `updateElement`.
 
-## The view context
+## The `view` context
 
 `view` receives **`ctx`** ([Callback context](/docs/reference/element-api/#callback-context-ctx)). Drive `ctx.setData` from `@click` handlers, not during render.
 

--- a/apps/docs/src/content/docs/reference/view-api.md
+++ b/apps/docs/src/content/docs/reference/view-api.md
@@ -45,7 +45,7 @@ Direct assignments such as `element.defaultData = …` and `element.updateElemen
 
 ## `playhtml.define(capabilityName, init)`
 
-Registers a reusable capability under an attribute name. Every element carrying `[capabilityName]` binds — including ones added later, or rendered by a [view](#composition). The imperative counterpart of `init({ extraCapabilities })`.
+Registers a reusable capability under an attribute name. Matching elements already on the page bind immediately, as do matching descendants rendered by a [view](#composition). For other elements added after initialization, call `setupPlayElement(element)`. `define` is the imperative counterpart of `init({ extraCapabilities })`.
 
 ```js
 playhtml.define("can-note", init);

--- a/apps/docs/src/scripts/__tests__/enhance-code-blocks.test.ts
+++ b/apps/docs/src/scripts/__tests__/enhance-code-blocks.test.ts
@@ -13,7 +13,7 @@ const handle = {
 vi.mock("playhtml", () => ({
   playhtml: {
     ready: Promise.resolve(),
-    setupPlayElement: vi.fn(),
+    register: vi.fn(() => handle),
     getHandle: vi.fn(() => handle),
     registerPlayEventListener: vi.fn(
       (type: string, event: { onEvent: (payload: unknown) => void }) => {
@@ -50,7 +50,13 @@ describe("docs code-block copy enhancement", () => {
       "docs-code-copy",
       expect.objectContaining({ onEvent: expect.any(Function) }),
     );
-    expect(playhtml.setupPlayElement).toHaveBeenCalledOnce();
+    expect(playhtml.register).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({
+        defaultData: { wear: 0 },
+        updateElement: expect.any(Function),
+      }),
+    );
 
     const button = document.querySelector<HTMLButtonElement>(".ph-copy__btn");
     expect(button).not.toBeNull();

--- a/apps/docs/src/scripts/enhance-code-blocks.ts
+++ b/apps/docs/src/scripts/enhance-code-blocks.ts
@@ -20,11 +20,9 @@
 //   usually what you want: a tally represents "how many people have copied
 //   THIS exact snippet".
 //
-// - Vanilla API path: we set `element.defaultData`, `element.updateElement`,
-//   and the `can-play` attribute on the wrapper, then call
-//   `playhtml.setupPlayElement` once init is done. Clicks go through the
-//   `ElementHandler.setData` on the registered handler so updates fan out
-//   over Yjs like any other shared element.
+// - Vanilla API path: we register each wrapper and its initializer once
+//   playhtml finishes its initial sync. Clicks use `getHandle` so updates fan
+//   out like any other shared element.
 //
 // - Live copy effect: on click we ALSO dispatch a `docs-code-copy` play event
 //   with the copier's cursor color + a seeded burst of particles. Every
@@ -252,7 +250,6 @@ function enhanceBlock(pre: HTMLPreElement): EnhancedBlock | null {
   const wrap = document.createElement("div");
   wrap.className = "ph-copy";
   wrap.id = elementId;
-  wrap.setAttribute("can-play", "");
   wrap.setAttribute("data-wear", "0");
   wrap.setAttribute("data-pulse", "0");
 
@@ -321,35 +318,28 @@ function enhanceBlock(pre: HTMLPreElement): EnhancedBlock | null {
     });
   });
 
-  // Attach the vanilla-API properties playhtml reads off the DOM element
-  // inside `setupPlayElement`. These have to be set BEFORE the setup call.
-  const el = wrap as HTMLElement & {
-    defaultData?: WearData;
-    updateElement?: (data: { data: WearData }) => void;
-  };
-  el.defaultData = { wear: 0 };
-  // Track the previous wear value so we can distinguish "first paint from
-  // server state" (no animation) from "someone just copied" (per-event
-  // bump). Sentinel -1 means we haven't received any data yet.
-  let lastWear = -1;
-  el.updateElement = ({ data }) => {
-    const wear = Number(data?.wear ?? 0);
-    wrap.setAttribute("data-wear", String(wear));
-    if (lastWear < 0) {
-      renderTallyInitial(tally, wear);
-    } else {
-      bumpTally(tally, wear, lastWear);
-    }
-    lastWear = wear;
-  };
-
   return { wrap, tally, btn, pre, elementId };
 }
 
 async function registerWithPlayhtml(block: EnhancedBlock): Promise<void> {
   try {
     await playhtml.ready;
-    playhtml.setupPlayElement(block.wrap, { ignoreIfAlreadySetup: true });
+    // Track the previous wear value so the first paint from shared state does
+    // not animate. Later shared increments animate the new tally marks.
+    let lastWear = -1;
+    playhtml.register<WearData>(block.wrap, {
+      defaultData: { wear: 0 },
+      updateElement: ({ data }) => {
+        const wear = Number(data?.wear ?? 0);
+        block.wrap.setAttribute("data-wear", String(wear));
+        if (lastWear < 0) {
+          renderTallyInitial(block.tally, wear);
+        } else {
+          bumpTally(block.tally, wear, lastWear);
+        }
+        lastWear = wear;
+      },
+    });
   } catch (err) {
     console.warn("[docs] Failed to register code-block wear handler", err);
   }

--- a/claude-plugin/skills/building-playhtml-elements/SKILL.md
+++ b/claude-plugin/skills/building-playhtml-elements/SKILL.md
@@ -29,7 +29,7 @@ These determine which API and data type to use. Getting them wrong means a rewri
 ## Critical Rules
 
 - Every element MUST have a unique `id` attribute — without it, sync silently fails
-- Vanilla HTML: Put custom-element behavior in `playhtml.register(id, initializer)`
+- Vanilla HTML: Put custom-element behavior in `playhtml.register(elementOrId, initializer)`
 - React: Wrap app in `<PlayProvider>`
 
 ## Quick Reference — Vanilla HTML (can-play)
@@ -37,7 +37,8 @@ These determine which API and data type to use. Getting them wrong means a rewri
 ```javascript
 import { playhtml } from "https://unpkg.com/playhtml@latest";
 
-playhtml.register("myElement", {
+const el = document.getElementById("myElement");
+playhtml.register(el, {
   defaultData: { count: 0 },                           // REQUIRED
   updateElement: ({ element, data }) => { ... },        // REQUIRED
   onClick: (e, { data, setData }) => { ... },
@@ -50,8 +51,9 @@ playhtml.register("myElement", {
 playhtml.init();
 ```
 
-`register` works before or after `init()`, and before or after the element exists.
-Use `setupPlayElement(element)` after inserting a dynamic built-in or defined
+Pass an element when you already have the DOM node, or pass its id before it
+exists. `register` works before or after `init()`. Use
+`setupPlayElement(element)` after inserting a dynamic built-in or defined
 capability. Registered custom elements bind automatically.
 
 ## Quick Reference — React (withSharedState)
@@ -169,7 +171,7 @@ See https://playhtml.fun/docs/data/presence/cursors/ for full API.
 
 ## Common Mistakes
 
-1. **Direct element-property setup** (vanilla): Use `playhtml.register(id, initializer)` so setup does not depend on assigning callbacks to a DOM node before initialization.
+1. **Direct element-property setup** (vanilla): Use `playhtml.register(elementOrId, initializer)` so setup does not depend on assigning callbacks to a DOM node before initialization.
 2. **Missing `id`**: No id = no sync. Silent failure.
 3. **Wrong data type**: Awareness for persistent data (disappears on disconnect) or defaultData for ephemeral presence (leaves stale data). Refer to the Data Types table.
 4. **Bad array mutations**: In mutator form, the draft is a Yjs CRDT proxy. Use `push()`/`splice()` only — `shift()`, `pop()`, and `items[i] = x` don't sync correctly.

--- a/claude-plugin/skills/building-playhtml-elements/SKILL.md
+++ b/claude-plugin/skills/building-playhtml-elements/SKILL.md
@@ -29,25 +29,30 @@ These determine which API and data type to use. Getting them wrong means a rewri
 ## Critical Rules
 
 - Every element MUST have a unique `id` attribute — without it, sync silently fails
-- Vanilla HTML: Configure element properties BEFORE `playhtml.init()` (the #1 mistake)
+- Vanilla HTML: Put custom-element behavior in `playhtml.register(id, initializer)`
 - React: Wrap app in `<PlayProvider>`
 
 ## Quick Reference — Vanilla HTML (can-play)
 
 ```javascript
-const el = document.getElementById("myElement");
-el.defaultData = { count: 0 };                           // REQUIRED
-el.updateElement = ({ element, data }) => { ... };        // REQUIRED
-el.onClick = (e, { data, setData }) => { ... };
-el.onDrag = (e, { data, setData, localData, setLocalData }) => { ... };
-el.onDragStart = (e, { setLocalData }) => { ... };
-el.onMount = ({ getData, setData, getElement }) => { ... };
-el.resetShortcut = "shiftKey"; // "shiftKey"|"ctrlKey"|"altKey"|"metaKey"
-
-// THEN import — ordering matters!
 import { playhtml } from "https://unpkg.com/playhtml@latest";
+
+playhtml.register("myElement", {
+  defaultData: { count: 0 },                           // REQUIRED
+  updateElement: ({ element, data }) => { ... },        // REQUIRED
+  onClick: (e, { data, setData }) => { ... },
+  onDrag: (e, { data, setData, localData, setLocalData }) => { ... },
+  onDragStart: (e, { setLocalData }) => { ... },
+  onMount: ({ getData, setData, getElement }) => { ... },
+  resetShortcut: "shiftKey", // "shiftKey"|"ctrlKey"|"altKey"|"metaKey"
+});
+
 playhtml.init();
 ```
+
+`register` works before or after `init()`, and before or after the element exists.
+Use `setupPlayElement(element)` after inserting a dynamic built-in or defined
+capability. Registered custom elements bind automatically.
 
 ## Quick Reference — React (withSharedState)
 
@@ -164,7 +169,7 @@ See https://playhtml.fun/docs/data/presence/cursors/ for full API.
 
 ## Common Mistakes
 
-1. **Config after init** (vanilla): Properties set after `playhtml.init()` are ignored. Configure FIRST.
+1. **Direct element-property setup** (vanilla): Use `playhtml.register(id, initializer)` so setup does not depend on assigning callbacks to a DOM node before initialization.
 2. **Missing `id`**: No id = no sync. Silent failure.
 3. **Wrong data type**: Awareness for persistent data (disappears on disconnect) or defaultData for ephemeral presence (leaves stale data). Refer to the Data Types table.
 4. **Bad array mutations**: In mutator form, the draft is a Yjs CRDT proxy. Use `push()`/`splice()` only — `shift()`, `pop()`, and `items[i] = x` don't sync correctly.

--- a/packages/common/src/canMirror.ts
+++ b/packages/common/src/canMirror.ts
@@ -18,6 +18,12 @@ const LOCAL_LOADING_ATTRIBUTE_VALUES: Record<string, string> = {
   "aria-busy": "true",
   "aria-live": "polite",
 };
+const CAN_MIRROR_OBSERVER_OPTIONS: MutationObserverInit = {
+  childList: true,
+  attributes: true,
+  subtree: false,
+  characterData: true,
+};
 
 enum NodeType {
   Text = "Text",
@@ -53,18 +59,22 @@ export const canMirrorInitializer: ElementInitializer<ElementState> = {
 
     const setDataAny = setData as unknown as (data: any) => void;
 
-    const observer = observeElementChanges(element, (mutations) => {
-      // Filter out mutations for ephemeral awareness-managed attributes
-      const persistentMutations = mutations.filter(
-        (m) =>
-          m.type !== "attributes" ||
-          !EPHEMERAL_ATTRS.includes(m.attributeName || "")
-      );
-      if (persistentMutations.length === 0) return;
-      setDataAny((draft: any) => {
-        applyMutationsInPlace(draft, persistentMutations);
-      });
-    });
+    const observer = observeElementChanges(
+      element,
+      (mutations) => {
+        // Filter out mutations for ephemeral awareness-managed attributes
+        const persistentMutations = mutations.filter(
+          (m) =>
+            m.type !== "attributes" ||
+            !EPHEMERAL_ATTRS.includes(m.attributeName || "")
+        );
+        if (persistentMutations.length === 0) return;
+        setDataAny((draft: any) => {
+          applyMutationsInPlace(draft, persistentMutations);
+        });
+      },
+      CAN_MIRROR_OBSERVER_OPTIONS,
+    );
     // Store the observer on the element so updateElement can
     // disconnect it while applying remote state. MutationObserver
     // callbacks are async, so a boolean flag doesn't work.
@@ -148,12 +158,7 @@ export const canMirrorInitializer: ElementInitializer<ElementState> = {
     }
     updateElementFromState(element, data);
     if (obs) {
-      obs.observe(element, {
-        childList: true,
-        attributes: true,
-        subtree: false,
-        characterData: true,
-      });
+      obs.observe(element, CAN_MIRROR_OBSERVER_OPTIONS);
     }
   },
   updateElementAwareness: ({ element, awareness }) => {
@@ -238,61 +243,13 @@ function areStatesEqual(state1: ElementState, state2: ElementState): boolean {
 
 // --- MutationObserver setup ---
 
-function observeElementChanges(
+export function observeElementChanges(
   element: HTMLElement,
   callback: (mutations: MutationRecord[]) => void,
-  options?: {
-    childList?: boolean;
-    attributes?: boolean;
-    characterData?: boolean;
-    attributeFilter?: string[];
-  }
+  options: MutationObserverInit,
 ): MutationObserver {
-  const defaultOptions = {
-    childList: true,
-    attributes: true,
-    subtree: false,
-    characterData: true,
-  };
-
-  const config = { ...defaultOptions, ...options };
-
-  const mutationCallback = (mutationsList: MutationRecord[]) => {
-    const filteredMutations = mutationsList.filter((mutation) => {
-      if (mutation.target !== element) {
-        return false;
-      }
-
-      if (config.childList && mutation.type === "childList") {
-        return true;
-      }
-
-      if (config.attributes && mutation.type === "attributes") {
-        if (config.attributeFilter) {
-          if (config.attributeFilter.includes(mutation.attributeName || "")) {
-            return true;
-          }
-        } else {
-          return true;
-        }
-      }
-
-      if (config.characterData && mutation.type === "characterData") {
-        return true;
-      }
-
-      if (config.subtree && mutation.type === "childList") {
-        return true;
-      }
-
-      return false;
-    });
-
-    callback(filteredMutations);
-  };
-
-  const observer = new MutationObserver(mutationCallback);
-  observer.observe(element, config);
+  const observer = new MutationObserver(callback);
+  observer.observe(element, options);
   return observer;
 }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Shared types, interfaces, and capability initializers for the playhtml library.
 // ABOUTME: Exports element capabilities, event handler types, and built-in tag definitions.
 import { canMirrorInitializer, type ElementState } from "./canMirror";
-export type { ElementState } from "./canMirror";
+export { observeElementChanges, type ElementState } from "./canMirror";
 
 export type ModifierKey = "ctrlKey" | "altKey" | "shiftKey" | "metaKey";
 export * from "./presence-protocol";

--- a/packages/playhtml/src/__tests__/init-configure.test.ts
+++ b/packages/playhtml/src/__tests__/init-configure.test.ts
@@ -43,6 +43,43 @@ describe("playhtml configure() + init()", () => {
     expect(onError).toHaveBeenCalledOnce();
   });
 
+  it("binds extraCapabilities through the reusable capability path", async () => {
+    const element = document.createElement("div");
+    element.id = "configured-capability";
+    element.setAttribute("can-configured", "");
+    document.body.appendChild(element);
+
+    const updateElement = vi.fn();
+    playhtml.configure({
+      extraCapabilities: {
+        "can-configured": {
+          defaultData: { enabled: true },
+          updateElement,
+        },
+      },
+    });
+    await playhtml.init();
+
+    expect(updateElement).toHaveBeenCalled();
+    expect(
+      playhtml
+        .getHandle("configured-capability", "can-configured")
+        .getData(),
+    ).toEqual({ enabled: true });
+  });
+
+  it("validates extraCapabilities with the same rules as define()", () => {
+    expect(() =>
+      playhtml.configure({
+        extraCapabilities: {
+          "can-invalid-configured": {
+            defaultData: { count: 0 },
+          },
+        },
+      }),
+    ).toThrow(/invalid initializer/);
+  });
+
   it("a repeated empty configure() before init() does not lock config", async () => {
     // configure() with no options is a true no-op: it must not freeze config, so
     // a later real configure() still wins. (configure() is connection-free, so

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -64,7 +64,7 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(playhtml.syncedStore["can-toggle"]["foo"]).toEqual({ on: false });
   });
 
-  it("keeps can-play element props scoped when combined with can-move", async () => {
+  it("keeps direct can-play property configuration compatible with can-move", async () => {
     const el = document.createElement("img");
     el.id = "composed-candle";
     el.setAttribute("can-play", "");

--- a/packages/playhtml/src/__tests__/view-api.test.ts
+++ b/packages/playhtml/src/__tests__/view-api.test.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Covers programmatic element registration, declarative views, and handles.
+// ABOUTME: Verifies lifecycle, validation, composition, and imperative setup behavior.
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { elementHandlers, playhtml, html, svg, repeat } from "../index";
 
@@ -205,6 +207,47 @@ describe("rail 2: lifecycle & guards", () => {
     expect(updateElement.mock.calls.length).toBe(callsAfterMount);
   });
 
+  it("binds imperative registrations without copying initializer fields onto the element", async () => {
+    const el = document.createElement("div");
+    el.id = "direct-imperative";
+    document.body.appendChild(el);
+
+    const updateElement = vi.fn(({ element, data }) => {
+      element.textContent = String(data.count);
+    });
+    playhtml.register("direct-imperative", {
+      defaultData: { count: 3 },
+      updateElement,
+    });
+    await tick();
+
+    expect(updateElement).toHaveBeenCalled();
+    expect(el.textContent).toBe("3");
+    expect(el.hasAttribute("can-play")).toBe(false);
+    expect((el as any).defaultData).toBeUndefined();
+    expect((el as any).updateElement).toBeUndefined();
+  });
+
+  it("uses a registered initializer's element validator without stamping it", async () => {
+    const el = document.createElement("div");
+    el.id = "direct-validator";
+    document.body.appendChild(el);
+
+    const updateElement = vi.fn();
+    const isValidElementForTag = vi.fn(() => false);
+    playhtml.register("direct-validator", {
+      defaultData: { count: 0 },
+      updateElement,
+      isValidElementForTag,
+    });
+    await tick();
+
+    expect(isValidElementForTag).toHaveBeenCalledWith(el);
+    expect(updateElement).not.toHaveBeenCalled();
+    expect(playhtml.getHandle("direct-validator").getData()).toBeUndefined();
+    expect((el as any).isValidElementForTag).toBeUndefined();
+  });
+
   it("does not wire onClick when a view is present (React/props path)", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const el = document.createElement("div");
@@ -350,6 +393,33 @@ describe("rail 2: define + composition", () => {
     expect(
       document.getElementById("chip-1")!.querySelector(".chip")!.textContent,
     ).toBe("chip");
+  });
+
+  it("binds registered view descendants without a can-play attribute", async () => {
+    playhtml.register<{ label: string }>("registered-child", {
+      defaultData: { label: "ready" },
+      updateElement: ({ element, data }) => {
+        element.textContent = data.label;
+      },
+    });
+
+    const root = document.createElement("div");
+    root.id = "registered-child-root";
+    document.body.appendChild(root);
+
+    playhtml.register("registered-child-root", {
+      defaultData: {},
+      view: () => html`<div id="registered-child"></div>`,
+    });
+    await tick();
+    await tick();
+
+    const child = document.getElementById("registered-child")!;
+    expect(child.textContent).toBe("ready");
+    expect(child.hasAttribute("can-play")).toBe(false);
+    expect(playhtml.getHandle("registered-child").getData()).toEqual({
+      label: "ready",
+    });
   });
 
   it("tears down capability children removed from a keyed list (no leak)", async () => {

--- a/packages/playhtml/src/__tests__/view-api.test.ts
+++ b/packages/playhtml/src/__tests__/view-api.test.ts
@@ -162,6 +162,7 @@ describe("rail 2: lifecycle & guards", () => {
     await tick();
     expect(cleanup).not.toHaveBeenCalled();
 
+    el.remove();
     handle.unregister();
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
@@ -226,6 +227,31 @@ describe("rail 2: lifecycle & guards", () => {
     expect(el.hasAttribute("can-play")).toBe(false);
     expect((el as any).defaultData).toBeUndefined();
     expect((el as any).updateElement).toBeUndefined();
+  });
+
+  it("binds an id registration when its element is inserted after init", async () => {
+    const updateElement = vi.fn(({ element, data }) => {
+      element.textContent = String(data.count);
+    });
+    const handle = playhtml.register("deferred-registration", {
+      defaultData: { count: 5 },
+      updateElement,
+    });
+
+    expect(handle.getElement()).toBeNull();
+
+    const el = document.createElement("div");
+    el.id = "deferred-registration";
+    document.body.appendChild(el);
+    await tick();
+    await tick();
+
+    expect(updateElement).toHaveBeenCalled();
+    expect(el.textContent).toBe("5");
+    expect(handle.getElement()).toBe(el);
+    expect(handle.getData()).toEqual({ count: 5 });
+
+    handle.unregister();
   });
 
   it("accepts an element and binds its initializer immediately", async () => {

--- a/packages/playhtml/src/__tests__/view-api.test.ts
+++ b/packages/playhtml/src/__tests__/view-api.test.ts
@@ -228,6 +228,52 @@ describe("rail 2: lifecycle & guards", () => {
     expect((el as any).updateElement).toBeUndefined();
   });
 
+  it("accepts an element and binds its initializer immediately", async () => {
+    const el = document.createElement("div");
+    el.id = "element-registration";
+    document.body.appendChild(el);
+
+    const handle = playhtml.register(el, {
+      defaultData: { count: 4 },
+      updateElement: ({ element, data }) => {
+        element.textContent = String(data.count);
+      },
+    });
+    await tick();
+
+    expect(handle.id).toBe("element-registration");
+    expect(handle.getElement()).toBe(el);
+    expect(handle.getData()).toEqual({ count: 4 });
+    expect(el.textContent).toBe("4");
+    expect((el as any).defaultData).toBeUndefined();
+    expect((el as any).updateElement).toBeUndefined();
+
+    handle.unregister();
+  });
+
+  it("rejects an element registration without an id", () => {
+    const el = document.createElement("div");
+
+    expect(() =>
+      playhtml.register(el, {
+        defaultData: {},
+        updateElement: () => {},
+      }),
+    ).toThrow(/non-empty id/);
+  });
+
+  it("rejects a non-HTML element registration", () => {
+    const el = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    el.id = "svg-registration";
+
+    expect(() =>
+      (playhtml.register as any)(el, {
+        defaultData: {},
+        updateElement: () => {},
+      }),
+    ).toThrow(/requires an HTML element/);
+  });
+
   it("uses a registered initializer's element validator without stamping it", async () => {
     const el = document.createElement("div");
     el.id = "direct-validator";
@@ -335,9 +381,7 @@ describe("rail 2: define + composition", () => {
     el.setAttribute("can-flavor", "");
     document.body.appendChild(el);
 
-    // Bind the define'd capability first. register() below stamps its own
-    // defaultData/view as element props (for can-play), so set up can-flavor
-    // before those props land on the node.
+    // Bind the define'd capability before adding can-play to the same node.
     await playhtml.setupPlayElementForTag(el, "can-flavor");
     await tick();
 

--- a/packages/playhtml/src/elements.ts
+++ b/packages/playhtml/src/elements.ts
@@ -9,6 +9,7 @@ import {
   ElementSetupData,
   ModifierKey,
   ViewTemplate,
+  observeElementChanges,
 } from "@playhtml/common";
 
 // @ts-ignore
@@ -449,13 +450,16 @@ export class ElementHandler<T = any, U = any, V = any> {
     if (!this.onAfterRender || this.descendantObserver) return;
     this.onAfterRender(this.element); // bind children from the first render
     if (typeof MutationObserver !== "undefined") {
-      this.descendantObserver = new MutationObserver(() => {
-        this.onAfterRender?.(this.element);
-      });
-      this.descendantObserver.observe(this.element, {
-        childList: true,
-        subtree: true,
-      });
+      this.descendantObserver = observeElementChanges(
+        this.element,
+        () => {
+          this.onAfterRender?.(this.element);
+        },
+        {
+          childList: true,
+          subtree: true,
+        },
+      );
     }
   }
 

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -16,6 +16,7 @@ import {
   toPublicPlayerIdentity,
   deepReplaceIntoProxy,
   clonePlain,
+  observeElementChanges,
 } from "@playhtml/common";
 import { listSharedElements as devListSharedElements } from "./shared-elements";
 import {
@@ -530,6 +531,47 @@ export interface InitOptions<T = unknown> {
 let capabilitiesToInitializer: Record<TagType | string, ElementInitializer> =
   TagTypeToElement;
 const elementInitializersById = new Map<string, ElementInitializer>();
+let registeredElementObserver: MutationObserver | null = null;
+
+function observeRegisteredElements(): void {
+  if (
+    registeredElementObserver ||
+    elementInitializersById.size === 0 ||
+    typeof MutationObserver === "undefined"
+  ) {
+    return;
+  }
+
+  registeredElementObserver = observeElementChanges(
+    document.documentElement,
+    (mutations) => {
+      for (const mutation of mutations) {
+        for (const addedNode of mutation.addedNodes) {
+          if (!isHTMLElement(addedNode)) continue;
+
+          if (
+            addedNode.id &&
+            elementInitializersById.has(addedNode.id)
+          ) {
+            setupPlayElement(addedNode);
+          }
+
+          addedNode.querySelectorAll<HTMLElement>("[id]").forEach((element) => {
+            if (elementInitializersById.has(element.id)) {
+              setupPlayElement(element);
+            }
+          });
+        }
+      }
+    },
+    { childList: true, subtree: true },
+  );
+}
+
+function disconnectRegisteredElementObserver(): void {
+  registeredElementObserver?.disconnect();
+  registeredElementObserver = null;
+}
 
 function getTagTypes(): (TagType | string)[] {
   return [TagType.CanPlay, ...Object.keys(capabilitiesToInitializer)];
@@ -2119,6 +2161,8 @@ function setupElements(): void {
     return;
   }
 
+  observeRegisteredElements();
+
   for (const tag of getTagTypes()) {
     const tagElements = new Set<HTMLElement>(
       Array.from(document.querySelectorAll(`[${tag}]`)).filter(isHTMLElement),
@@ -2362,6 +2406,7 @@ export async function resetPlayHTML(): Promise<void> {
     pageDataRefCounts.clear();
     pageDataListeners.clear();
     mainProviderSyncWaiters.clear();
+    disconnectRegisteredElementObserver();
 
     teardownElementAwarenessClient();
     teardownPresenceClient();
@@ -3023,9 +3068,13 @@ function createPlayElementHandle(
       handler.requestUpdate();
     },
     unregister: () => {
+      const boundElement = findHandlerForElementId(elementId, tag)?.element;
       elementInitializersById.delete(elementId);
-      const el = document.getElementById(elementId);
-      if (el) removePlayElement(el);
+      if (elementInitializersById.size === 0) {
+        disconnectRegisteredElementObserver();
+      }
+      const element = boundElement ?? document.getElementById(elementId);
+      if (element) removePlayElement(element);
     },
   };
 }
@@ -3070,6 +3119,9 @@ function registerPlayElement<T = any, U = any, V = any>(
 
   validateRegisteredInitializer(elementId, init as ElementInitializer);
   elementInitializersById.set(elementId, init as ElementInitializer);
+  if (hasSynced) {
+    observeRegisteredElements();
+  }
   if (element && isHTMLElement(element)) {
     setupPlayElement(element);
   }
@@ -3092,9 +3144,10 @@ function registerPlayElement<T = any, U = any, V = any>(
 
 /**
  * Registers a reusable capability under an attribute name (e.g. "can-note").
- * Every element carrying that attribute gets the capability — including ones
- * added to the DOM later. The imperative counterpart of
- * `init({ extraCapabilities })`.
+ * Upgrades matching elements already in the DOM. Matching descendants rendered
+ * by a view bind through the view's observer. The imperative counterpart of
+ * `init({ extraCapabilities })`; other elements added later still use
+ * `setupPlayElement`.
  *
  * @param capabilityName - The attribute name elements use to opt in (used in an
  *   attribute selector, e.g. `[can-note]`).

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -529,6 +529,7 @@ export interface InitOptions<T = unknown> {
 
 let capabilitiesToInitializer: Record<TagType | string, ElementInitializer> =
   TagTypeToElement;
+const elementInitializersById = new Map<string, ElementInitializer>();
 
 function getTagTypes(): (TagType | string)[] {
   return [TagType.CanPlay, ...Object.keys(capabilitiesToInitializer)];
@@ -852,6 +853,12 @@ function applyConfig(options: InitOptions): void {
     return;
   }
 
+  if (options.extraCapabilities) {
+    for (const [tag, tagInfo] of Object.entries(options.extraCapabilities)) {
+      validateCapability(tag, tagInfo);
+    }
+  }
+
   // Shallow-copy so a caller that mutates or reuses its options object after
   // declaring config can't silently change the locked config. cursors is
   // copied too since it's the most commonly nested-and-mutated option.
@@ -865,7 +872,7 @@ function applyConfig(options: InitOptions): void {
 
   if (options.extraCapabilities) {
     for (const [tag, tagInfo] of Object.entries(options.extraCapabilities)) {
-      capabilitiesToInitializer[tag] = tagInfo;
+      registerCapability(tag, tagInfo);
     }
   }
   if (options.events) {
@@ -1987,7 +1994,13 @@ function getElementInitializerInfoForElement(
   element: HTMLElement,
 ) {
   if (tag === TagType.CanPlay) {
-    // For can-play, all properties come from the DOM element
+    const registeredInitializer = elementInitializersById.get(element.id);
+    if (registeredInitializer) {
+      return registeredInitializer as Required<ElementInitializer>;
+    }
+
+    // React and the imperative can-play API provide initializer properties on
+    // the DOM element.
     const customProps = getCustomElementProps(element);
     return customProps as Required<ElementInitializer>;
   }
@@ -2105,21 +2118,20 @@ function setupElements(): void {
     return;
   }
 
-  // Stamp any registrations made before init() onto their elements so the
-  // can-play scan below picks them up.
-  for (const [id, init] of pendingRegistrations) {
-    const el = document.getElementById(id);
-    if (el && isHTMLElement(el)) {
-      stampRegistrationOntoElement(el, init);
-    }
-  }
-
   for (const tag of getTagTypes()) {
-    const tagElements: HTMLElement[] = Array.from(
-      document.querySelectorAll(`[${tag}]`),
-    ).filter(isHTMLElement);
+    const tagElements = new Set<HTMLElement>(
+      Array.from(document.querySelectorAll(`[${tag}]`)).filter(isHTMLElement),
+    );
+    if (tag === TagType.CanPlay) {
+      for (const id of elementInitializersById.keys()) {
+        const element = document.getElementById(id);
+        if (element && isHTMLElement(element)) {
+          tagElements.add(element);
+        }
+      }
+    }
 
-    if (!tagElements.length) {
+    if (tagElements.size === 0) {
       continue;
     }
 
@@ -2127,7 +2139,9 @@ function setupElements(): void {
       console.log(`SET UP ${tag}`);
     }
     void Promise.all(
-      tagElements.map((element) => setupPlayElementForTag(element, tag)),
+      Array.from(tagElements).map((element) =>
+        setupPlayElementForTag(element, tag),
+      ),
     );
   }
 
@@ -2492,6 +2506,14 @@ function isElementValidForTag(
   element: HTMLElement,
   tag: TagType | string,
 ): boolean {
+  const registeredValidator =
+    tag === TagType.CanPlay
+      ? elementInitializersById.get(element.id)?.isValidElementForTag
+      : undefined;
+  if (registeredValidator) {
+    return registeredValidator(element);
+  }
+
   const customValidator = shouldReadElementPropsForTag(tag, element)
     ? (element as any).isValidElementForTag
     : undefined;
@@ -2762,12 +2784,6 @@ function setupPlayElement(
     return;
   }
 
-  // If this element was registered via register() before it existed, stamp its
-  // initializer on now so the can-play branch below picks it up.
-  if (element.id && pendingRegistrations.has(element.id)) {
-    stampRegistrationOntoElement(element, pendingRegistrations.get(element.id)!);
-  }
-
   // Check for data-source attribute and handle dynamic discovery
   if (element.hasAttribute("data-source")) {
     handleNewSharedReference(element);
@@ -2779,11 +2795,14 @@ function setupPlayElement(
   }
 
   // Handle loading state for dynamically added elements
-  const hasPlayhtmlAttributes = getTagTypes().some((tag) =>
-    element.hasAttribute(tag),
+  const tags = new Set(
+    getTagTypes().filter((tag) => element.hasAttribute(tag)),
   );
+  if (element.id && elementInitializersById.has(element.id)) {
+    tags.add(TagType.CanPlay);
+  }
 
-  if (hasPlayhtmlAttributes) {
+  if (tags.size > 0) {
     if (hasSynced) {
       // If already synced, element will be ready immediately
       markElementAsReady(element);
@@ -2794,9 +2813,7 @@ function setupPlayElement(
   }
 
   void Promise.all(
-    getTagTypes()
-      .filter((tag) => element.hasAttribute(tag))
-      .map((tag) => setupPlayElementForTag(element, tag)),
+    Array.from(tags).map((tag) => setupPlayElementForTag(element, tag)),
   );
 }
 
@@ -2903,10 +2920,6 @@ export interface PlayElementHandle<T = any, U = any, V = any> {
   unregister(): void;
 }
 
-// elementId -> initializer, pending until both the definition and the DOM
-// element exist (upgrade semantics, like customElements.define).
-const pendingRegistrations = new Map<string, ElementInitializer>();
-
 /**
  * Enforces initializer invariants before register/define stores a capability.
  */
@@ -2944,28 +2957,6 @@ function validateRegisteredInitializer(
       `[playhtml] "${name}" has an invalid initializer: ${issues.join(", ")}.`,
     );
   }
-}
-
-/** Stamps a registration's initializer fields onto its element as props. */
-function stampRegistrationOntoElement(
-  element: HTMLElement,
-  init: ElementInitializer,
-): void {
-  Object.assign(element, init);
-  if (!element.hasAttribute(TagType.CanPlay)) {
-    element.setAttribute(TagType.CanPlay, "");
-  }
-}
-
-/** Applies a pending registration if its element exists and we've synced. */
-function applyPendingRegistration(elementId: string): void {
-  if (!hasSynced) return;
-  const init = pendingRegistrations.get(elementId);
-  if (!init) return;
-  const element = document.getElementById(elementId);
-  if (!element || !isHTMLElement(element)) return;
-  stampRegistrationOntoElement(element, init);
-  void setupPlayElementForTag(element, TagType.CanPlay);
 }
 
 /**
@@ -3032,7 +3023,7 @@ function createPlayElementHandle(
       handler.requestUpdate();
     },
     unregister: () => {
-      pendingRegistrations.delete(elementId);
+      elementInitializersById.delete(elementId);
       const el = document.getElementById(elementId);
       if (el) removePlayElement(el);
     },
@@ -3052,12 +3043,15 @@ function registerPlayElement<T = any, U = any, V = any>(
   init: ElementInitializer<T, U, V>,
 ): PlayElementHandle<T, U, V> {
   validateRegisteredInitializer(elementId, init as ElementInitializer);
-  pendingRegistrations.set(elementId, init as ElementInitializer);
-  applyPendingRegistration(elementId);
+  elementInitializersById.set(elementId, init as ElementInitializer);
+  const element = document.getElementById(elementId);
+  if (element && isHTMLElement(element)) {
+    setupPlayElement(element);
+  }
   if (
     configuredOptions?.developmentMode &&
     hasSynced &&
-    !document.getElementById(elementId)
+    !element
   ) {
     console.warn(
       `[playhtml] register("${elementId}") — no element with that id is in the DOM yet. ` +
@@ -3085,6 +3079,30 @@ function definePlayCapability<T = any, U = any, V = any>(
   capabilityName: string,
   init: ElementInitializer<T, U, V>,
 ): void {
+  registerCapability(capabilityName, init as ElementInitializer);
+}
+
+function registerCapability(
+  capabilityName: string,
+  init: ElementInitializer,
+): void {
+  validateCapability(capabilityName, init);
+  capabilitiesToInitializer[capabilityName] = init;
+  // Upgrade any elements already on the page (no-op before init()).
+  if (hasSynced) {
+    const els = Array.from(
+      document.querySelectorAll(`[${capabilityName}]`),
+    ).filter(isHTMLElement);
+    void Promise.all(
+      els.map((el) => setupPlayElementForTag(el, capabilityName)),
+    );
+  }
+}
+
+function validateCapability(
+  capabilityName: string,
+  init: ElementInitializer,
+): void {
   if (capabilityName === PAGE_TAG) {
     throw new Error(`"${PAGE_TAG}" is a reserved tag name for page-level data`);
   }
@@ -3098,17 +3116,7 @@ function definePlayCapability<T = any, U = any, V = any>(
       `[playhtml] "${capabilityName}" is a built-in capability and cannot be redefined.`,
     );
   }
-  validateRegisteredInitializer(capabilityName, init as ElementInitializer);
-  capabilitiesToInitializer[capabilityName] = init as ElementInitializer;
-  // Upgrade any elements already on the page (no-op before init()).
-  if (hasSynced) {
-    const els = Array.from(
-      document.querySelectorAll(`[${capabilityName}]`),
-    ).filter(isHTMLElement);
-    void Promise.all(
-      els.map((el) => setupPlayElementForTag(el, capabilityName)),
-    );
-  }
+  validateRegisteredInitializer(capabilityName, init);
 }
 
 /**
@@ -3128,18 +3136,21 @@ function definePlayCapability<T = any, U = any, V = any>(
 const viewDescendants = new WeakMap<HTMLElement, Map<string, HTMLElement>>();
 
 function setupViewDescendants(root: HTMLElement): void {
-  // Stamp pending single-element registrations onto matching descendants.
-  for (const [id, init] of pendingRegistrations) {
+  const present = new Map<string, HTMLElement>();
+
+  // Registered elements do not need a can-play attribute, so include matching
+  // descendants by id before scanning capability attributes.
+  for (const id of elementInitializersById.keys()) {
     if (id === root.id) continue;
-    const el = document.getElementById(id);
-    if (el && root.contains(el) && isHTMLElement(el)) {
-      stampRegistrationOntoElement(el, init);
+    const element = document.getElementById(id);
+    if (element && root.contains(element) && isHTMLElement(element)) {
+      present.set(`${TagType.CanPlay}:${id}`, element);
     }
   }
+
   // Capability descendants present in this render, keyed by `tag:id`. The scan
   // is subtree-wide, so each view-root tracks its full descendant set
   // (including nested ones) — teardown below covers every depth.
-  const present = new Map<string, HTMLElement>();
   for (const tag of getTagTypes()) {
     const els = Array.from(root.querySelectorAll(`[${tag}]`)).filter(
       isHTMLElement,
@@ -3156,13 +3167,16 @@ function setupViewDescendants(root: HTMLElement): void {
         continue;
       }
       present.set(`${tag}:${el.id}`, el);
-      const existing = elementHandlers.get(tag)?.get(el.id);
-      if (existing) {
-        if (existing.element === el) continue; // already bound to this node
-      }
-      void setupPlayElementForTag(el, tag);
     }
   }
+
+  for (const [key, element] of present) {
+    const tag = key.slice(0, key.indexOf(":"));
+    const existing = elementHandlers.get(tag)?.get(element.id);
+    if (existing?.element === element) continue;
+    void setupPlayElementForTag(element, tag);
+  }
+
   // Tear down descendants this root bound previously that are gone now.
   const previous = viewDescendants.get(root);
   if (previous) {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1955,7 +1955,8 @@ function getElementInitializerValidationIssues(
   return issues;
 }
 
-// Read custom element properties set by CanPlayElement (React) on the DOM node
+// Read initializer properties from React elements and direct can-play
+// configurations that remain supported for compatibility.
 function getCustomElementProps(element: HTMLElement) {
   const el = element as any;
   const props: Partial<ElementInitializer> = {};
@@ -2280,11 +2281,11 @@ export interface PlayHTMLComponents {
   removePlayElement: typeof removePlayElement;
   deleteElementData: typeof deleteElementData;
   setupPlayElementForTag: typeof setupPlayElementForTag;
-  /** @experimental View API — register a custom element by id. */
+  /** Register a custom element by id. */
   register: typeof registerPlayElement;
-  /** @experimental View API — register a reusable capability by attribute name. */
+  /** Register a reusable capability by attribute name. */
   define: typeof definePlayCapability;
-  /** @experimental View API — get a handle for a bound element. */
+  /** Get a handle for a bound element. */
   getHandle: (elementId: string, tag?: string) => PlayElementHandle;
   syncedStore: ReadOnlyStore<PlayStore["play"]>;
   /** @deprecated Use getHandle(elementId, tag) to access a bound element. */
@@ -2903,7 +2904,6 @@ function removePlayElement(element: Element | null) {
  * bound element. Reads/writes resolve the live handler lazily, so a handle
  * obtained before the element binds still works once it does.
  *
- * @experimental Part of the new view API; subject to change in a future minor.
  */
 export interface PlayElementHandle<T = any, U = any, V = any> {
   id: string;
@@ -3036,7 +3036,6 @@ function createPlayElementHandle(
  * binding happens once both are present. Returns a handle for reads/writes
  * from outside the view (e.g. form submit handlers).
  *
- * @experimental New view API; signature may change in a future minor release.
  */
 function registerPlayElement<T = any, U = any, V = any>(
   elementId: string,
@@ -3073,7 +3072,6 @@ function registerPlayElement<T = any, U = any, V = any>(
  *
  * @param capabilityName - The attribute name elements use to opt in (used in an
  *   attribute selector, e.g. `[can-note]`).
- * @experimental New view API; signature may change in a future minor release.
  */
 function definePlayCapability<T = any, U = any, V = any>(
   capabilityName: string,

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -2281,7 +2281,7 @@ export interface PlayHTMLComponents {
   removePlayElement: typeof removePlayElement;
   deleteElementData: typeof deleteElementData;
   setupPlayElementForTag: typeof setupPlayElementForTag;
-  /** Register a custom element by id. */
+  /** Register a custom element by id or DOM reference. */
   register: typeof registerPlayElement;
   /** Register a reusable capability by attribute name. */
   define: typeof definePlayCapability;
@@ -3031,19 +3031,45 @@ function createPlayElementHandle(
 }
 
 /**
- * Registers a `view`/`updateElement` initializer for a single element by id.
- * Callable before or after `init()` and before or after the element exists;
- * binding happens once both are present. Returns a handle for reads/writes
- * from outside the view (e.g. form submit handlers).
- *
+ * Registers a `view`/`updateElement` initializer for a single element by id or
+ * DOM reference. Callable before or after `init()`. An id registration binds
+ * once the element exists; an element registration binds the provided node.
+ * Returns a handle for reads/writes from outside the view.
  */
 function registerPlayElement<T = any, U = any, V = any>(
   elementId: string,
   init: ElementInitializer<T, U, V>,
+): PlayElementHandle<T, U, V>;
+function registerPlayElement<T = any, U = any, V = any>(
+  element: HTMLElement,
+  init: ElementInitializer<T, U, V>,
+): PlayElementHandle<T, U, V>;
+function registerPlayElement<T = any, U = any, V = any>(
+  elementOrId: string | Element,
+  init: ElementInitializer<T, U, V>,
 ): PlayElementHandle<T, U, V> {
+  let element: HTMLElement | null;
+  let elementId: string;
+  if (typeof elementOrId === "string") {
+    elementId = elementOrId;
+    element = document.getElementById(elementId);
+  } else {
+    if (!isHTMLElement(elementOrId)) {
+      throw new Error(
+        "[playhtml] register(element, initializer) requires an HTML element.",
+      );
+    }
+    if (!elementOrId.id) {
+      throw new Error(
+        "[playhtml] register(element, initializer) requires an element with a non-empty id.",
+      );
+    }
+    element = elementOrId;
+    elementId = element.id;
+  }
+
   validateRegisteredInitializer(elementId, init as ElementInitializer);
   elementInitializersById.set(elementId, init as ElementInitializer);
-  const element = document.getElementById(elementId);
   if (element && isHTMLElement(element)) {
     setupPlayElement(element);
   }
@@ -3106,7 +3132,7 @@ function validateCapability(
   }
   if (capabilityName === TagType.CanPlay) {
     throw new Error(
-      `[playhtml] "${TagType.CanPlay}" is reserved — use register(id, init) for single elements.`,
+      `[playhtml] "${TagType.CanPlay}" is reserved — use register(elementOrId, init) for single elements.`,
     );
   }
   if (Object.prototype.hasOwnProperty.call(TagTypeToElement, capabilityName)) {

--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -232,8 +232,9 @@
       // API: register a render function and playhtml re-renders it whenever the
       // shared `count` changes (locally or from another tab). Writes are driven
       // from the @click handler in the template. `register` works before or
-      // after init(). The view renderer is experimental; registration is a
-      // supported API for both view and imperative updateElement renderers.
+      // after init(), and accepts an element or its id. The view renderer is
+      // experimental; registration is a supported API for both view and
+      // imperative updateElement renderers.
       playhtml.register("reactionBtn", {
         defaultData: { count: 0 },
         view: ({ data, setData }) => {

--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -232,7 +232,8 @@
       // API: register a render function and playhtml re-renders it whenever the
       // shared `count` changes (locally or from another tab). Writes are driven
       // from the @click handler in the template. `register` works before or
-      // after init(). (This is the experimental vanilla view API.)
+      // after init(). The view renderer is experimental; registration is a
+      // supported API for both view and imperative updateElement renderers.
       playhtml.register("reactionBtn", {
         defaultData: { count: 0 },
         view: ({ data, setData }) => {

--- a/templates/react-starter/src/App.tsx
+++ b/templates/react-starter/src/App.tsx
@@ -86,7 +86,7 @@ function PeopleHere() {
 }
 
 // withSharedState is the React API for custom collaborative elements.
-// Vanilla HTML uses playhtml.register(id, initializer) for the same role.
+// Vanilla HTML uses playhtml.register(elementOrId, initializer) for the same role.
 const ReactionButton = withSharedState(
   { defaultData: { count: 0 } },
   ({ data, setData, ref }) => {

--- a/templates/react-starter/src/App.tsx
+++ b/templates/react-starter/src/App.tsx
@@ -85,7 +85,8 @@ function PeopleHere() {
   );
 }
 
-// Reaction button - tracks who has reacted using localStorage
+// withSharedState is the React API for custom collaborative elements.
+// Vanilla HTML uses playhtml.register(id, initializer) for the same role.
 const ReactionButton = withSharedState(
   { defaultData: { count: 0 } },
   ({ data, setData, ref }) => {

--- a/website/candles.html
+++ b/website/candles.html
@@ -40,22 +40,6 @@
           src="/candle-gif.gif"
           class="candle"
         />
-
-        <!-- Set data for custom (can-play) playhtml elements -->
-        <!-- IMPORTANT: this data must be set _before_ importing the playhtml library. -->
-        <script>
-          const candle = document.getElementById("customCandle");
-          candle.defaultData = { on: true };
-          candle.onClick = (_e, { data, setData }) => {
-            const on = typeof data === "object" ? data.on : data;
-            setData(!on);
-          };
-          candle.updateElement = ({ element, data }) => {
-            const on = typeof data === "object" ? data.on : data;
-            element.src = on ? "/candle-gif.gif" : "/candle-off.png";
-          };
-          candle.resetShortcut = "shiftKey";
-        </script>
       </div>
     </div>
     <footer>
@@ -68,6 +52,20 @@
     <script type="module" src="./story.ts"></script>
     <script type="module">
       import { playhtml } from "https://unpkg.com/playhtml@latest";
+
+      playhtml.register("customCandle", {
+        defaultData: { on: true },
+        onClick: (_event, { data, setData }) => {
+          const on = typeof data === "object" ? data.on : data;
+          setData(!on);
+        },
+        updateElement: ({ element, data }) => {
+          const on = typeof data === "object" ? data.on : data;
+          element.src = on ? "/candle-gif.gif" : "/candle-off.png";
+        },
+        resetShortcut: "shiftKey",
+      });
+
       playhtml.init({
         room: window.location.pathname,
         cursors: { enabled: true },

--- a/website/experiments/cinderblock/cinderblock.js
+++ b/website/experiments/cinderblock/cinderblock.js
@@ -510,9 +510,11 @@ const yard = new CinderblockYard({
   status: requireElement("yard-status"),
 });
 
-yardElement.defaultData = createDefaultYard();
-yardElement.updateElement = ({ data }) => yard.applySharedState(data);
-yardElement.onMount = ({ getData, setData }) => yard.mount({ getData, setData });
+playhtml.register("cinderblock-yard", {
+  defaultData: createDefaultYard(),
+  updateElement: ({ data }) => yard.applySharedState(data),
+  onMount: ({ getData, setData }) => yard.mount({ getData, setData }),
+});
 
 playhtml.init({
   room: window.location.pathname,

--- a/website/experiments/cinderblock/index.html
+++ b/website/experiments/cinderblock/index.html
@@ -53,7 +53,7 @@
         class="stage-frame"
         aria-label="Shared cinder-block construction area"
       >
-        <div id="cinderblock-yard" can-play>
+        <div id="cinderblock-yard">
           <div id="block-layer"></div>
           <div class="ground" aria-hidden="true"></div>
         </div>

--- a/website/index.html
+++ b/website/index.html
@@ -192,19 +192,6 @@
           src="/candle-gif.gif"
           class="candle"
         />
-        <!-- Set data for custom (can-play) playhtml elements -->
-        <!-- IMPORTANT: this data must be set _before_ importing the playhtml library. -->
-        <script>
-          const candle = document.getElementById("customCandle");
-          candle.defaultData = { on: true };
-          candle.onClick = (_e, { data, setData }) => {
-            setData({ on: !data.on });
-          };
-          candle.updateElement = ({ element, data }) => {
-            element.src = data.on ? "/candle-gif.gif" : "/candle-off.png";
-          };
-          candle.resetShortcut = "shiftKey";
-        </script>
 
         <p>
           I'd love for you to try this out and make your websites

--- a/website/index.tsx
+++ b/website/index.tsx
@@ -1,12 +1,12 @@
 // ABOUTME: Boots the playhtml homepage and its React-backed shared examples.
 // ABOUTME: Wires homepage-only collaboration state into non-React page chrome.
 
-import { ElementInitializer } from "@playhtml/common";
 import words from "profane-words";
 import "./home.scss";
 // NOTE: this pins it to the working code so we can test library changes through this home page.
 import { createRoot } from "react-dom/client";
 import { PlayProvider } from "@playhtml/react";
+import { playhtml, type ElementInitializer } from "playhtml";
 import FeaturesGrid from "./components/FeaturesGrid";
 import ExperimentsArchive from "./components/ExperimentsArchive";
 import {
@@ -27,10 +27,6 @@ const GuestbookSubmissionLimit = {
 };
 const GuestbookNameStorageKey = "name";
 type HomepageAwareness = { online: true };
-type HomepageAwarenessElement = HTMLElement &
-  Partial<
-    ElementInitializer<Record<string, never>, undefined, HomepageAwareness>
-  >;
 
 function getFormDataId(formData: FormData) {
   return `${formData.name}-${formData.timestamp}`;
@@ -77,24 +73,44 @@ function setupGuestbookNameInput() {
 setupGuestbookNameInput();
 
 function setupHomepageAwarenessStatus() {
-  const statusElement = document.getElementById(
-    "site-console-count",
-  ) as HomepageAwarenessElement | null;
+  const statusElement = document.getElementById("site-console-count");
   const countElement = document.getElementById("site-console-count-number");
   const countLabel = document.querySelector(".site-console__status-label");
   if (!statusElement || !countElement || !countLabel) return;
 
-  statusElement.defaultData = {};
-  statusElement.myDefaultAwareness = { online: true };
-  statusElement.updateElement = () => {};
-  statusElement.updateElementAwareness = ({ awareness }) => {
-    const peopleCount = Math.max(awareness.length, 1);
+  playhtml.register<Record<string, never>, undefined, HomepageAwareness>(
+    "site-console-count",
+    {
+      defaultData: {},
+      myDefaultAwareness: { online: true },
+      updateElement: () => {},
+      updateElementAwareness: ({ awareness }) => {
+        const peopleCount = Math.max(awareness.length, 1);
 
-    if (countElement.textContent === String(peopleCount)) return;
+        if (countElement.textContent === String(peopleCount)) return;
 
-    countElement.textContent = String(peopleCount);
-    countLabel.textContent = ` ${peopleCount === 1 ? "person" : "people"} here`;
-  };
+        countElement.textContent = String(peopleCount);
+        countLabel.textContent = ` ${peopleCount === 1 ? "person" : "people"} here`;
+      },
+    },
+  );
+}
+
+function setupHomepageCandle() {
+  if (!document.getElementById("customCandle")) return;
+
+  playhtml.register("customCandle", {
+    defaultData: { on: true },
+    onClick: (_event, { data, setData }) => {
+      setData({ on: !data.on });
+    },
+    updateElement: ({ element, data }) => {
+      (element as HTMLImageElement).src = data.on
+        ? "/candle-gif.gif"
+        : "/candle-off.png";
+    },
+    resetShortcut: "shiftKey",
+  });
 }
 
 const isCursorRoom = (
@@ -119,6 +135,7 @@ function getLocalPreviewInitOptions() {
 }
 
 setupHomepageAwarenessStatus();
+setupHomepageCandle();
 
 // Render React components
 const reactContentElement = document.getElementById("reactContent");

--- a/website/index.tsx
+++ b/website/index.tsx
@@ -97,9 +97,10 @@ function setupHomepageAwarenessStatus() {
 }
 
 function setupHomepageCandle() {
-  if (!document.getElementById("customCandle")) return;
+  const candle = document.getElementById("customCandle");
+  if (!candle) return;
 
-  playhtml.register("customCandle", {
+  playhtml.register(candle, {
     defaultData: { on: true },
     onClick: (_event, { data, setData }) => {
       setData({ on: !data.on });

--- a/website/story.html
+++ b/website/story.html
@@ -72,7 +72,6 @@
             type="text"
             placeholder="your story word..."
             maxlength="20"
-            can-play
           />
           <button class="wordSubmit">📤</button>
           <br />
@@ -131,104 +130,109 @@
               return word.split(/\s+/).length === 1;
             }
 
-            input.defaultData = [];
-            input.myDefaultAwareness = null;
-            input.onMount = ({ setData, getData, setMyAwareness }) => {
-              const onSubmit = () => {
-                submitBtn.disabled = true;
-                if (!isValidWord(input.value)) {
-                  alert("please enter a single word!");
-                  submitBtn.disabled = false;
-                  return;
-                }
-                if (hasExplicitSlur(input.value)) {
-                  alert("please don't troll and be nice");
-                  submitBtn.disabled = false;
-                  return;
-                }
-                // valid length again
-                if (input.value.length > 20) {
-                  alert("too long!");
-                  submitBtn.disabled = false;
-                  return;
-                }
-                const existingStory = getData();
-                const newEntry = {
-                  word: input.value,
-                  color: getUserColor(),
-                  ts: Date.now(),
-                };
-                setData([...existingStory, newEntry]);
-                input.value = "";
-                setMyAwareness(null);
-                submitBtn.disabled = false;
-              };
+            import("https://unpkg.com/playhtml@latest").then(({ playhtml }) => {
+              playhtml.register("wordInput", {
+                defaultData: [],
+                myDefaultAwareness: null,
+                onMount: ({ setData, getData, setMyAwareness }) => {
+                  const onSubmit = () => {
+                    submitBtn.disabled = true;
+                    if (!isValidWord(input.value)) {
+                      alert("please enter a single word!");
+                      submitBtn.disabled = false;
+                      return;
+                    }
+                    if (hasExplicitSlur(input.value)) {
+                      alert("please don't troll and be nice");
+                      submitBtn.disabled = false;
+                      return;
+                    }
+                    // valid length again
+                    if (input.value.length > 20) {
+                      alert("too long!");
+                      submitBtn.disabled = false;
+                      return;
+                    }
+                    const existingStory = getData();
+                    const newEntry = {
+                      word: input.value,
+                      color: getUserColor(),
+                      ts: Date.now(),
+                    };
+                    setData([...existingStory, newEntry]);
+                    input.value = "";
+                    setMyAwareness(null);
+                    submitBtn.disabled = false;
+                  };
 
-              submitBtn.addEventListener("click", onSubmit);
-              input.addEventListener("keydown", (event) => {
-                if (event.key === "Enter") {
-                  onSubmit();
-                }
-              });
-              input.addEventListener("input", (event) => {
-                if (event.target.value === "") {
-                  setMyAwareness(null);
-                } else {
-                  setMyAwareness(getUserColor());
-                }
-              });
-            };
-            input.updateElementAwareness = ({ awareness, myAwareness }) => {
-              // people active on the site but not typing will be set to null
-              const activeUsers = awareness.filter((c) => Boolean(c));
-              const otherActiveUsers = [...activeUsers];
-              const myIndex = otherActiveUsers.findIndex(
-                (c) => c === myAwareness
-              );
+                  submitBtn.addEventListener("click", onSubmit);
+                  input.addEventListener("keydown", (event) => {
+                    if (event.key === "Enter") {
+                      onSubmit();
+                    }
+                  });
+                  input.addEventListener("input", (event) => {
+                    if (event.target.value === "") {
+                      setMyAwareness(null);
+                    } else {
+                      setMyAwareness(getUserColor());
+                    }
+                  });
+                },
+                updateElementAwareness: ({ awareness, myAwareness }) => {
+                  // people active on the site but not typing will be set to null
+                  const activeUsers = awareness.filter((c) => Boolean(c));
+                  const otherActiveUsers = [...activeUsers];
+                  const myIndex = otherActiveUsers.findIndex(
+                    (c) => c === myAwareness
+                  );
 
-              // remove first instance of myAwareness to get everyone else and handle duplicates
-              if (myIndex !== -1) {
-                otherActiveUsers.splice(myIndex, 1);
-              }
-              const typingUsers = [];
-              for (const color of otherActiveUsers) {
-                typingUsers.push(`<div  class="typingIndicator" style="--word-color:${getColorVar(
-                  color
-                )}">
+                  // remove first instance of myAwareness to get everyone else and handle duplicates
+                  if (myIndex !== -1) {
+                    otherActiveUsers.splice(myIndex, 1);
+                  }
+                  const typingUsers = [];
+                  for (const color of otherActiveUsers) {
+                    typingUsers.push(`<div  class="typingIndicator" style="--word-color:${getColorVar(
+                      color
+                    )}">
                     <span></span>
                     <span></span>
                     <span></span>
                   </div>`);
-              }
-              typingIndicators.innerHTML = typingUsers.join("\n");
+                  }
+                  typingIndicators.innerHTML = typingUsers.join("\n");
 
-              activeUsersCount.innerText = awareness.length;
-            };
-            input.updateElement = ({ data }) => {
-              if (data.length > 0) {
-                const lastDate = new Date(data[data.length - 1].ts);
-                lastUpdatedTime.innerText =
-                  lastDate.toLocaleTimeString() +
-                  " on " +
-                  lastDate.toLocaleDateString();
-              }
+                  activeUsersCount.innerText = awareness.length;
+                },
+                updateElement: ({ data }) => {
+                  if (data.length > 0) {
+                    const lastDate = new Date(data[data.length - 1].ts);
+                    lastUpdatedTime.innerText =
+                      lastDate.toLocaleTimeString() +
+                      " on " +
+                      lastDate.toLocaleDateString();
+                  }
 
-              storyContent.replaceChildren(
-                ...data.flatMap(({ word, color }, index) => {
-                  const wordElement = document.createElement("span");
-                  wordElement.className = "word";
-                  wordElement.style.setProperty(
-                    "--word-color",
-                    getColorVar(color)
+                  storyContent.replaceChildren(
+                    ...data.flatMap(({ word, color }, index) => {
+                      const wordElement = document.createElement("span");
+                      wordElement.className = "word";
+                      wordElement.style.setProperty(
+                        "--word-color",
+                        getColorVar(color)
+                      );
+                      wordElement.textContent = String(word);
+
+                      return index === 0
+                        ? [wordElement]
+                        : [document.createTextNode("\n"), wordElement];
+                    })
                   );
-                  wordElement.textContent = String(word);
-
-                  return index === 0
-                    ? [wordElement]
-                    : [document.createTextNode("\n"), wordElement];
-                })
-              );
-            };
+                },
+              });
+              playhtml.init({ room: window.location.pathname });
+            });
           </script>
         </p>
       </div>
@@ -241,10 +245,6 @@
     </footer>
 
     <script type="module" src="./story.ts"></script>
-    <script type="module">
-      import { playhtml } from "https://unpkg.com/playhtml@latest";
-      playhtml.init({ room: window.location.pathname });
-    </script>
     <!-- import cursor chat -->
     <script src="https://cursor-party.spencerc99.partykit.dev/cursors.js"></script>
   </body>

--- a/website/test/storyRendering.test.ts
+++ b/website/test/storyRendering.test.ts
@@ -10,42 +10,40 @@ const storyHtml = readFileSync(
   "utf8",
 );
 
-const storyScript = storyHtml.match(
-  /<script>\s*(const explicitSlurRegexes[\s\S]*?input\.updateElement = \(\{ data \}\) => \{[\s\S]*?\n\s*\};)\s*<\/script>/,
+const colorHelperSource = storyHtml.match(
+  /(function convertHexToRGB\(hex\) \{[\s\S]*?)(?=\n\s*if \(getUserColor)/,
+)?.[1];
+const updateElementSource = storyHtml.match(
+  /updateElement:\s*(\(\{ data \}\) => \{[\s\S]*?\n\s*\}),\n\s*\}\);/,
 )?.[1];
 
-function runStoryScript() {
-  if (!storyScript) {
-    throw new Error("Could not find the one-word story script");
+function getUpdateElement() {
+  if (!colorHelperSource || !updateElementSource) {
+    throw new Error("Could not find the one-word story renderer");
   }
 
-  new Function(storyScript)();
+  return new Function(
+    "storyContent",
+    "lastUpdatedTime",
+    `${colorHelperSource}
+return ${updateElementSource};`,
+  )(
+    document.getElementById("storyContent"),
+    document.getElementById("lastUpdatedTime"),
+  );
 }
 
 describe("one-word story rendering", () => {
   test("renders hostile persisted words literally", () => {
     document.body.innerHTML = `
-      <input id="colorPicker" type="color" />
-      <input id="wordInput" />
-      <button class="wordSubmit"></button>
       <span id="storyContent"></span>
-      <span id="typingIndicators"></span>
-      <span id="activeUsersCount"></span>
       <span id="lastUpdatedTime"></span>
     `;
-    localStorage.clear();
-    Object.assign(globalThis, {
-      activeUsersCount: document.getElementById("activeUsersCount"),
-      colorPicker: document.getElementById("colorPicker"),
-      lastUpdatedTime: document.getElementById("lastUpdatedTime"),
-    });
-    runStoryScript();
 
     const storyContent = document.getElementById("storyContent");
-    const input = document.getElementById("wordInput");
     const hostileWord = "<svg/onload=alert()>";
 
-    input.updateElement({
+    getUpdateElement()({
       data: [
         { word: "together", color: "#112233", ts: 0 },
         { word: hostileWord, color: "#abcdef", ts: 1 },


### PR DESCRIPTION
## Summary

- make `playhtml.register(elementOrId, initializer)` the recommended vanilla API for one-off custom elements using either `updateElement` or `view`
- accept an existing HTML element to preserve the `setupPlayElement(element)` call shape, or accept an id before the element exists
- route `register()`, `define()`, and configured capabilities through shared validation and setup paths without copying registered initializers onto DOM elements
- migrate public docs, runnable recipes, website examples, both starter templates, and the bundled element-building guide to register-first usage
- reuse the same mutation observer helper for registered view descendants and `can-mirror`

## Soft deprecation

Direct DOM-property setup remains supported for compatibility, with no runtime warning or removal in this PR. New vanilla code should move these fields into the initializer passed to `register`: `defaultData`, `defaultLocalData`, `myDefaultAwareness`, `updateElement`, `view`, `updateElementAwareness`, `onClick`, `onDrag`, `onDragStart`, `onMount`, `resetShortcut`, `debounceMs`, and `isValidElementForTag`.

`register(element, initializer)` requires an HTML element with a stable, non-empty id and binds that node directly. `register(id, initializer)` keeps the existing deferred form and binds when an element with that id appears.

`setupPlayElement()` is not deprecated. It remains the setup path for dynamically inserted built-in or `define()` capabilities. Registered custom elements do not need a separate setup call.

React's `withSharedState` API remains supported, including its internal property-based binding. `register()`, `define()`, handles, and imperative `updateElement` are documented as supported APIs; the declarative `view` renderer and lit-html helpers remain experimental.

## Why

Issue #254 started as duplicated registration and observer plumbing, but the public direction is also important: vanilla custom-element behavior should live in one initializer object rather than being spread across properties assigned to a DOM node. The element overload keeps the familiar element-first setup shape without reviving property assignment. Keeping the property path as a soft compatibility layer lets existing sites and React continue working while docs and examples consistently teach `register()`.

## Validation

- `bun build-packages`
- `bun run --cwd packages/playhtml test` — 507 tests
- `bun run --cwd packages/react test` — 50 unit tests and 1 integration test
- full docs test suite — 41 tests
- `bun build-site`
- `bunx tsc` in `website`
- targeted story renderer test
- `bunx vite build` in both starter templates
- live browser verification: `register(element, initializer)` on the homepage candle, overload docs, HTML and React starter reaction flows, one-word story presence, and cinderblock live sync

Visual evidence: https://github.com/spencerc99/playhtml/pull/334#issuecomment-5097911667

Closes #254