### PR TITLE
extension: canonical dedup collapses near-duplicate scraps

### DIFF
--- a/extension/src/__tests__/background-scrap-dedup.test.ts
+++ b/extension/src/__tests__/background-scrap-dedup.test.ts
@@ -1,0 +1,244 @@
+// ABOUTME: Covers storage-time dedup for internet scraps in the STORE_EVENTS handler.
+// ABOUTME: Verifies canonical-key dedup across batches, lazy init, and concurrency.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CollectionEvent } from "@playhtml/extension-types";
+
+const originalDefineBackground = (globalThis as any).defineBackground;
+
+function makeElementEvent(
+  id: string,
+  data: Record<string, unknown>,
+  url = "https://example.com/",
+): CollectionEvent {
+  return {
+    id,
+    type: "element",
+    ts: 1,
+    data,
+    meta: {
+      pid: "pid",
+      sid: "sid",
+      url,
+      vw: 1024,
+      vh: 768,
+      tz: "America/Los_Angeles",
+    },
+  } as CollectionEvent;
+}
+
+function makeNavigationEvent(id: string): CollectionEvent {
+  return {
+    id,
+    type: "navigation",
+    ts: 1,
+    data: { event: "focus" },
+    meta: {
+      pid: "pid",
+      sid: "sid",
+      url: "https://example.com/",
+      vw: 1024,
+      vh: 768,
+      tz: "America/Los_Angeles",
+    },
+  } as CollectionEvent;
+}
+
+const buttonData = (text: string, backgroundColor = "rgb(1, 2, 3)") => ({
+  kind: "button",
+  text,
+  styles: { backgroundColor },
+  pageTitle: "A page",
+});
+
+interface Setup {
+  store: {
+    addEvents: ReturnType<typeof vi.fn>;
+    queryByType: ReturnType<typeof vi.fn>;
+  };
+  listener: (message: any, sender: any, sendResponse: (r?: any) => void) => boolean;
+}
+
+async function setupBackground(existingElementEvents: CollectionEvent[] = []): Promise<Setup> {
+  vi.resetModules();
+  vi.restoreAllMocks();
+
+  const addEvents = vi.fn().mockResolvedValue(undefined);
+  const queryByType = vi.fn().mockResolvedValue(existingElementEvents);
+  const onMessageAddListener = vi.fn();
+
+  vi.doMock("../storage/LocalEventStore", () => ({
+    LocalEventStore: vi.fn(() => ({ addEvents, queryByType })),
+  }));
+  vi.doMock("../storage/sync", () => ({ uploadEvents: vi.fn() }));
+  vi.doMock("../storage/restore", () => ({ fetchEventsByPid: vi.fn() }));
+  vi.doMock("webextension-polyfill", () => ({
+    default: {
+      storage: {
+        local: {
+          get: vi.fn().mockResolvedValue({}),
+          set: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+      runtime: {
+        onInstalled: { addListener: vi.fn() },
+        onMessage: { addListener: onMessageAddListener },
+        getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      },
+      tabs: {
+        create: vi.fn().mockResolvedValue(undefined),
+        query: vi.fn().mockResolvedValue([]),
+        sendMessage: vi.fn().mockResolvedValue(undefined),
+      },
+      alarms: {
+        create: vi.fn(),
+        onAlarm: { addListener: vi.fn() },
+      },
+    },
+  }));
+
+  (globalThis as any).defineBackground = (setup: () => void) => {
+    setup();
+    return setup;
+  };
+
+  await import("../entrypoints/background");
+  const listener = onMessageAddListener.mock.calls[0][0];
+  return { store: { addEvents, queryByType }, listener };
+}
+
+function storeEvents(
+  listener: Setup["listener"],
+  events: CollectionEvent[],
+): Promise<unknown> {
+  return new Promise((resolve) => {
+    const handled = listener({ type: "STORE_EVENTS", events }, {}, resolve);
+    expect(handled).toBe(true);
+  });
+}
+
+describe("background scrap storage dedup", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalDefineBackground === undefined) {
+      delete (globalThis as any).defineBackground;
+    } else {
+      (globalThis as any).defineBackground = originalDefineBackground;
+    }
+  });
+
+  it("persists only the first of two events sharing a canonical key", async () => {
+    const { store, listener } = await setupBackground();
+
+    const first = makeElementEvent("a", buttonData("Subscribe"));
+    const second = makeElementEvent("b", buttonData("Subscribe"));
+
+    const response = await storeEvents(listener, [first, second]);
+
+    expect(response).toEqual({ success: true });
+    expect(store.addEvents).toHaveBeenCalledTimes(1);
+    const persisted = store.addEvents.mock.calls[0][0] as CollectionEvent[];
+    expect(persisted.map((e) => e.id)).toEqual(["a"]);
+  });
+
+  it("persists both events when canonical keys differ", async () => {
+    const { store, listener } = await setupBackground();
+
+    const first = makeElementEvent("a", buttonData("Subscribe"));
+    const second = makeElementEvent("b", buttonData("Unsubscribe"));
+
+    await storeEvents(listener, [first, second]);
+
+    const persisted = store.addEvents.mock.calls[0][0] as CollectionEvent[];
+    expect(persisted.map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("scans the store once across sequential batches", async () => {
+    const { store, listener } = await setupBackground();
+
+    await storeEvents(listener, [makeElementEvent("a", buttonData("Subscribe"))]);
+    await storeEvents(listener, [makeElementEvent("b", buttonData("Unsubscribe"))]);
+    await storeEvents(listener, [makeElementEvent("c", buttonData("Follow"))]);
+
+    expect(store.queryByType).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a duplicate arriving in a later batch", async () => {
+    const { store, listener } = await setupBackground();
+
+    const first = makeElementEvent("a", buttonData("Subscribe"));
+    await storeEvents(listener, [first]);
+
+    const duplicateLater = makeElementEvent("c", buttonData("Subscribe"));
+    await storeEvents(listener, [duplicateLater]);
+
+    expect(store.addEvents).toHaveBeenCalledTimes(2);
+    const secondBatchPersisted = store.addEvents.mock.calls[1][0] as CollectionEvent[];
+    expect(secondBatchPersisted).toEqual([]);
+  });
+
+  it("picks up canonical keys from events already in the store on lazy init", async () => {
+    const alreadyStored = makeElementEvent("existing", buttonData("Subscribe"));
+    const { store, listener } = await setupBackground([alreadyStored]);
+
+    const duplicate = makeElementEvent("new", buttonData("Subscribe"));
+    await storeEvents(listener, [duplicate]);
+
+    expect(store.queryByType).toHaveBeenCalledWith("element");
+    const persisted = store.addEvents.mock.calls[0][0] as CollectionEvent[];
+    expect(persisted).toEqual([]);
+  });
+
+  it("leaves non-element events unaffected", async () => {
+    const { store, listener } = await setupBackground();
+
+    const nav1 = makeNavigationEvent("nav-1");
+    const nav2 = makeNavigationEvent("nav-2");
+    await storeEvents(listener, [nav1, nav2]);
+
+    const persisted = store.addEvents.mock.calls[0][0] as CollectionEvent[];
+    expect(persisted.map((e) => e.id)).toEqual(["nav-1", "nav-2"]);
+    // No element events in the batch, so the store is never scanned.
+    expect(store.queryByType).not.toHaveBeenCalled();
+  });
+
+  it("collapses duplicates within a single batch", async () => {
+    const { store, listener } = await setupBackground();
+
+    const first = makeElementEvent("a", buttonData("Subscribe"));
+    const second = makeElementEvent("b", buttonData("Subscribe"));
+    const third = makeElementEvent("c", buttonData("Different"));
+
+    await storeEvents(listener, [first, second, third]);
+
+    const persisted = store.addEvents.mock.calls[0][0] as CollectionEvent[];
+    expect(persisted.map((e) => e.id)).toEqual(["a", "c"]);
+  });
+
+  it("does not race two concurrent batches into duplicate scans or duplicate persistence", async () => {
+    const { store, listener } = await setupBackground();
+
+    const first = makeElementEvent("a", buttonData("Subscribe"));
+    const second = makeElementEvent("b", buttonData("Subscribe"));
+
+    // Fire both batches without awaiting the first, so their lazy-init
+    // scans would race if not guarded by a single in-flight promise.
+    const [firstResponse, secondResponse] = await Promise.all([
+      storeEvents(listener, [first]),
+      storeEvents(listener, [second]),
+    ]);
+
+    expect(firstResponse).toEqual({ success: true });
+    expect(secondResponse).toEqual({ success: true });
+    expect(store.queryByType).toHaveBeenCalledTimes(1);
+
+    const allPersistedIds = store.addEvents.mock.calls.flatMap((call) =>
+      (call[0] as CollectionEvent[]).map((e) => e.id),
+    );
+    expect(allPersistedIds).toEqual(["a"]);
+  });
+});

--- a/extension/src/collectors/ScrapCollector.ts
+++ b/extension/src/collectors/ScrapCollector.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Applies per-kind filtering, visibility timing, sanitization, and page-session limits.
 
 import { BaseCollector } from "./BaseCollector";
-import { getScrapKey, serializeSvg } from "./scrapUtils";
+import { getCanonicalScrapKey, serializeSvg } from "./scrapUtils";
 import type {
   ButtonScrapData,
   CursorScrapData,
@@ -10,6 +10,7 @@ import type {
   SvgIconScrapData,
 } from "./types";
 import { getFaviconUrl } from "../utils/pageMetadata";
+import { extractDomain } from "../utils/urlNormalization";
 
 const MIN_IMAGE_DISPLAY_SIZE = 80;
 const MIN_IMAGE_NATURAL_SIZE = 50;
@@ -84,10 +85,10 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
   private observedButtons = new Set<Element>();
   private observedSvgIcons = new Set<SVGSVGElement>();
   private loadHandlers = new Map<HTMLImageElement, () => void>();
-  private seenImageSources = new Set<string>();
-  private seenButtonKeys = new Set<string>();
-  private seenSvgKeys = new Set<string>();
-  private seenCursorUrls = new Set<string>();
+  private seenCanonicalImageKeys = new Set<string>();
+  private seenCanonicalButtonKeys = new Set<string>();
+  private seenCanonicalSvgKeys = new Set<string>();
+  private seenCanonicalCursorKeys = new Set<string>();
   private imageCaptureCount = 0;
   private buttonCaptureCount = 0;
   private svgCaptureCount = 0;
@@ -149,10 +150,10 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     this.observedImages.clear();
     this.observedButtons.clear();
     this.observedSvgIcons.clear();
-    this.seenImageSources.clear();
-    this.seenButtonKeys.clear();
-    this.seenSvgKeys.clear();
-    this.seenCursorUrls.clear();
+    this.seenCanonicalImageKeys.clear();
+    this.seenCanonicalButtonKeys.clear();
+    this.seenCanonicalSvgKeys.clear();
+    this.seenCanonicalCursorKeys.clear();
     this.imageCaptureCount = 0;
     this.buttonCaptureCount = 0;
     this.svgCaptureCount = 0;
@@ -273,12 +274,15 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     }
   }
 
+  private pageDomain(): string {
+    return extractDomain(window.location.href);
+  }
+
   private captureImage(image: HTMLImageElement): void {
     if (!this.enabled || this.imageCaptureCount >= MAX_IMAGES_PER_PAGE) return;
 
     const src = image.currentSrc || image.src;
     if (!src || src.startsWith("data:") || src.startsWith("blob:")) return;
-    if (this.seenImageSources.has(src)) return;
 
     const bounds = image.getBoundingClientRect();
     if (
@@ -294,10 +298,7 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
       return;
     }
 
-    const faviconUrl = getFaviconUrl();
-    this.seenImageSources.add(src);
-    this.imageCaptureCount++;
-    this.emit({
+    const data: ScrapEventData = {
       kind: "image",
       src,
       ...(image.alt ? { alt: image.alt } : {}),
@@ -306,6 +307,15 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
       displayWidth: bounds.width,
       displayHeight: bounds.height,
       pageTitle: document.title,
+    };
+    const canonicalKey = getCanonicalScrapKey(this.pageDomain(), data);
+    if (this.seenCanonicalImageKeys.has(canonicalKey)) return;
+
+    const faviconUrl = getFaviconUrl();
+    this.seenCanonicalImageKeys.add(canonicalKey);
+    this.imageCaptureCount++;
+    this.emit({
+      ...data,
       ...(faviconUrl ? { faviconUrl } : {}),
     });
 
@@ -343,21 +353,23 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
       : undefined;
     if (!text && !innerSvg) return;
 
-    const faviconUrl = getFaviconUrl();
     const data: ButtonScrapData = {
       kind: "button",
       text,
       styles,
       ...(innerSvg ? { innerSvg } : {}),
       pageTitle: document.title,
-      ...(faviconUrl ? { faviconUrl } : {}),
     };
-    const key = getScrapKey(data);
-    if (this.seenButtonKeys.has(key)) return;
+    const canonicalKey = getCanonicalScrapKey(this.pageDomain(), data);
+    if (this.seenCanonicalButtonKeys.has(canonicalKey)) return;
 
-    this.seenButtonKeys.add(key);
+    const faviconUrl = getFaviconUrl();
+    this.seenCanonicalButtonKeys.add(canonicalKey);
     this.buttonCaptureCount++;
-    this.emit(data);
+    this.emit({
+      ...data,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    });
 
     if (this.buttonCaptureCount >= MAX_BUTTONS_PER_PAGE) {
       this.stopObservingButtons();
@@ -434,21 +446,23 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     });
     if (!markup) return;
 
-    const faviconUrl = getFaviconUrl();
     const data: SvgIconScrapData = {
       kind: "svg-icon",
       markup,
       width: bounds.width,
       height: bounds.height,
       pageTitle: document.title,
-      ...(faviconUrl ? { faviconUrl } : {}),
     };
-    const key = getScrapKey(data);
-    if (this.seenSvgKeys.has(key)) return;
+    const canonicalKey = getCanonicalScrapKey(this.pageDomain(), data);
+    if (this.seenCanonicalSvgKeys.has(canonicalKey)) return;
 
-    this.seenSvgKeys.add(key);
+    const faviconUrl = getFaviconUrl();
+    this.seenCanonicalSvgKeys.add(canonicalKey);
     this.svgCaptureCount++;
-    this.emit(data);
+    this.emit({
+      ...data,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    });
 
     if (this.svgCaptureCount >= MAX_SVG_ICONS_PER_PAGE) {
       this.stopObservingSvgIcons();
@@ -462,15 +476,8 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
     this.lastCursorCheckAt = now;
 
     const cursorImage = this.parseCursorImage(getComputedStyle(event.target).cursor);
-    if (
-      !cursorImage ||
-      cursorImage.url.startsWith("blob:") ||
-      this.seenCursorUrls.has(cursorImage.url)
-    ) {
-      return;
-    }
+    if (!cursorImage || cursorImage.url.startsWith("blob:")) return;
 
-    const faviconUrl = getFaviconUrl();
     const data: CursorScrapData = {
       kind: "cursor",
       url: cursorImage.url,
@@ -481,10 +488,16 @@ export class ScrapCollector extends BaseCollector<ScrapEventData> {
         ? { hotspotY: cursorImage.hotspotY }
         : {}),
       pageTitle: document.title,
-      ...(faviconUrl ? { faviconUrl } : {}),
     };
-    this.seenCursorUrls.add(getScrapKey(data));
-    this.emit(data);
+    const canonicalKey = getCanonicalScrapKey(this.pageDomain(), data);
+    if (this.seenCanonicalCursorKeys.has(canonicalKey)) return;
+
+    const faviconUrl = getFaviconUrl();
+    this.seenCanonicalCursorKeys.add(canonicalKey);
+    this.emit({
+      ...data,
+      ...(faviconUrl ? { faviconUrl } : {}),
+    });
   };
 
   private parseCursorImage(cursor: string): CursorImage | undefined {

--- a/extension/src/collectors/__tests__/ScrapCollector.test.ts
+++ b/extension/src/collectors/__tests__/ScrapCollector.test.ts
@@ -553,6 +553,28 @@ describe("ScrapCollector", () => {
     expect(observer().observed.has(uniqueIcons[19])).toBe(false);
   });
 
+  it("captures a same-geometry icon rendered at different sizes once per page", () => {
+    const small = createSvg({ width: 24, height: 24 });
+    small.setAttribute("viewBox", "0 0 24 24");
+    const large = createSvg({ width: 40, height: 40 });
+    large.setAttribute("viewBox", "0 0 24 24");
+    for (const svg of [small, large]) {
+      const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+      path.setAttribute("d", "M2 2h20v20z");
+      svg.appendChild(path);
+    }
+
+    collector.enable();
+    showForCapture([small, large]);
+
+    expect(emitted("svg-icon")).toHaveLength(1);
+    expect(emitted("svg-icon")[0]).toMatchObject({
+      kind: "svg-icon",
+      width: 24,
+      height: 24,
+    });
+  });
+
   it("captures cursor URLs and hotspots while ignoring fallback-only cursors", () => {
     const fallback = document.createElement("div");
     fallback.setAttribute("data-cursor", "pointer");

--- a/extension/src/collectors/scrapUtils.ts
+++ b/extension/src/collectors/scrapUtils.ts
@@ -2,6 +2,12 @@
 // ABOUTME: Sanitizes inline SVG markup before it reaches extension rendering surfaces.
 
 import type { ScrapEventData } from "./types";
+import {
+  canonicalButtonKey,
+  canonicalCursorKey,
+  canonicalImageKey,
+  canonicalSvgIconKey,
+} from "@movement/utils/scrapIdentity";
 
 const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
 const XLINK_NAMESPACE = "http://www.w3.org/1999/xlink";
@@ -82,6 +88,26 @@ export function getScrapKey(data: ScrapEventData): string {
       return hashScrapString(data.markup);
     case "cursor":
       return data.url;
+  }
+}
+
+/**
+ * Canonical identity for near-duplicate detection, matching the collage's
+ * render-time dedup (see ScrapCollage.tsx's canonicalScrapKey). Two scraps
+ * with the same canonical key are treated as the same underlying thing even
+ * if their per-capture `getScrapKey` differs (different computed style
+ * values, different rendered size, different CDN query params).
+ */
+export function getCanonicalScrapKey(domain: string, data: ScrapEventData): string {
+  switch (data.kind) {
+    case "image":
+      return canonicalImageKey(data.src);
+    case "button":
+      return canonicalButtonKey(domain, data.text, data.styles.backgroundColor);
+    case "svg-icon":
+      return canonicalSvgIconKey(domain, data.markup);
+    case "cursor":
+      return canonicalCursorKey(data.url);
   }
 }
 

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -7,7 +7,7 @@ import { uploadEvents } from '../storage/sync'
 import { fetchEventsByPid } from '../storage/restore'
 import type { CollectionEvent } from '@playhtml/extension-types'
 import type { ScrapEventData } from '../collectors/types'
-import { getScrapKey } from '../collectors/scrapUtils'
+import { getCanonicalScrapKey, getScrapKey } from '../collectors/scrapUtils'
 import {
   ensurePlayerIdentity,
   getPlayerProfile,
@@ -134,6 +134,104 @@ function toScrapRecord(event: CollectionEvent): ScrapRecord | undefined {
 }
 
 const store = new LocalEventStore()
+
+/**
+ * Storage-time dedup for scrap ("element") events: drops incoming events
+ * whose canonical identity (see getCanonicalScrapKey) already exists in the
+ * store, so near-duplicates captured across pages/sessions are never
+ * persisted. `knownCanonicalScrapKeys` is lazily populated by scanning
+ * existing stored element events on first use, then kept current as new
+ * events are accepted. This matches the render-time dedup in ScrapCollage's
+ * canonicalScrapKey, but skips persistence entirely instead of collapsing
+ * duplicates at render.
+ *
+ * The set is rebuilt via the same lazy scan on every service-worker restart
+ * (MV3 workers are short-lived) — `knownCanonicalScrapKeysInitPromise` makes
+ * sure two STORE_EVENTS batches arriving before the scan completes don't
+ * both trigger a scan or race past each other.
+ */
+const knownCanonicalScrapKeys = new Set<string>()
+let knownCanonicalScrapKeysInitialized = false
+let knownCanonicalScrapKeysInitPromise: Promise<void> | null = null
+
+function resolveScrapEventDomain(event: CollectionEvent): string {
+  return event.domain || extractDomain(event.meta.url)
+}
+
+async function ensureKnownCanonicalScrapKeys(): Promise<void> {
+  if (knownCanonicalScrapKeysInitialized) return
+  if (knownCanonicalScrapKeysInitPromise) return knownCanonicalScrapKeysInitPromise
+
+  knownCanonicalScrapKeysInitPromise = (async () => {
+    const existing = await store.queryByType('element')
+    for (const event of existing) {
+      const kind = (event.data as { kind?: unknown } | null)?.kind
+      if (
+        kind !== 'image' &&
+        kind !== 'button' &&
+        kind !== 'svg-icon' &&
+        kind !== 'cursor'
+      ) {
+        continue
+      }
+      const domain = resolveScrapEventDomain(event)
+      const canonicalKey = getCanonicalScrapKey(domain, event.data as ScrapEventData)
+      knownCanonicalScrapKeys.add(canonicalKey)
+    }
+  })()
+
+  try {
+    await knownCanonicalScrapKeysInitPromise
+    knownCanonicalScrapKeysInitialized = true
+  } finally {
+    // Cleared so a failed scan retries on the next batch; a successful scan
+    // is latched by knownCanonicalScrapKeysInitialized instead.
+    knownCanonicalScrapKeysInitPromise = null
+  }
+}
+
+/**
+ * Filters incoming events, dropping "element" (scrap) events whose canonical
+ * identity is already known — either already persisted, or a duplicate of
+ * another event earlier in this same batch. Non-element events pass through
+ * unchanged. Accepted scrap events are added to the known-keys set so later
+ * batches (and later events within this batch) see them as duplicates too.
+ */
+async function dedupeScrapEvents(events: CollectionEvent[]): Promise<CollectionEvent[]> {
+  const hasElementEvent = events.some((event) => event.type === 'element')
+  if (!hasElementEvent) return events
+
+  await ensureKnownCanonicalScrapKeys()
+
+  const accepted: CollectionEvent[] = []
+  for (const event of events) {
+    if (event.type !== 'element') {
+      accepted.push(event)
+      continue
+    }
+
+    const kind = (event.data as { kind?: unknown } | null)?.kind
+    if (
+      kind !== 'image' &&
+      kind !== 'button' &&
+      kind !== 'svg-icon' &&
+      kind !== 'cursor'
+    ) {
+      accepted.push(event)
+      continue
+    }
+
+    const domain = resolveScrapEventDomain(event)
+    const canonicalKey = getCanonicalScrapKey(domain, event.data as ScrapEventData)
+    if (knownCanonicalScrapKeys.has(canonicalKey)) continue
+
+    knownCanonicalScrapKeys.add(canonicalKey)
+    accepted.push(event)
+  }
+
+  return accepted
+}
+
 const LOCAL_RAW_EVENT_RETENTION_ENABLED = false
 const LOCAL_RAW_EVENT_RETENTION_DAYS = 30
 const LOCAL_RAW_EVENT_RETENTION_MS = LOCAL_RAW_EVENT_RETENTION_DAYS * 24 * 60 * 60 * 1000
@@ -415,7 +513,8 @@ export default defineBackground(() => {
 
     if (message.type === 'STORE_EVENTS') {
       const events = (message.events || []) as CollectionEvent[]
-      store.addEvents(events)
+      dedupeScrapEvents(events)
+        .then((dedupedEvents) => store.addEvents(dedupedEvents))
         .then(() => {
           // A navigation focus is the canonical "user is now looking at this
           // domain" signal — the moment a domain-visit milestone could fire

--- a/extension/website/scraps-preview/demoScraps.ts
+++ b/extension/website/scraps-preview/demoScraps.ts
@@ -420,5 +420,104 @@ export function buildItems(): ScrapItem[] {
     });
   });
 
+  // Planted near-duplicates: exercise canonicalScrapKey dedup in curateScraps.
+  // (a) Same Subscribe button text+color on videotube.example, only boxShadow
+  // differs -- canonical key ignores it, so this collapses into the original.
+  const subscribeButton = BUTTONS[0];
+  items.push({
+    id: "btn-subscribe-dup",
+    key: `btn-${subscribeButton.domain}-${subscribeButton.text}-dup`,
+    kind: "button",
+    text: subscribeButton.text,
+    styles: {
+      ...subscribeButton.styles,
+      boxShadow: "rgba(204, 0, 0, 0.35) 0px 4px 10px 0px",
+    },
+    pageTitle: "moss time-lapse, part two",
+    domain: subscribeButton.domain,
+    pageUrl: `https://${subscribeButton.domain}/part-two`,
+    ts: NOW - 90 * 60 * 1000,
+  });
+
+  // (b) Same heart icon markup on birdsite.example rendered at 32px instead
+  // of 24px -- canonical key hashes only path/viewBox geometry, so this
+  // collapses into the original.
+  const heartIcon = SVG_ICONS.find((icon) => icon.name === "heart");
+  if (!heartIcon) throw new Error("expected heart icon in SVG_ICONS");
+  items.push({
+    id: "svg-heart-dup",
+    key: "svg-heart-dup",
+    kind: "svg-icon",
+    markup: heartIcon.markup.replace(/width="24"/, 'width="32"').replace(/height="24"/, 'height="32"'),
+    width: 32,
+    height: 32,
+    pageTitle: heartIcon.pageTitle,
+    domain: heartIcon.domain,
+    pageUrl: `https://${heartIcon.domain}/`,
+    ts: NOW - 100 * 60 * 1000,
+  });
+
+  // (c) Pear image src with a fake CDN query string appended -- canonical
+  // key strips query/hash, so this collapses into the original.
+  const pearImage = FAKE_IMAGES.find((image) => image.name === "pear");
+  if (!pearImage) throw new Error("expected pear image in FAKE_IMAGES");
+  items.push({
+    id: "img-pear-dup",
+    key: `${svgDataUri(pearImage.markup)}?w=480&fit=crop`,
+    kind: "image",
+    src: `${svgDataUri(pearImage.markup)}?w=480&fit=crop`,
+    alt: pearImage.name,
+    naturalWidth: pearImage.naturalWidth,
+    naturalHeight: pearImage.naturalHeight,
+    pageTitle: "Heirloom pears, ranked (mirror)",
+    domain: pearImage.domain,
+    pageUrl: `https://${pearImage.domain}/mirror`,
+    ts: NOW - 110 * 60 * 1000,
+  });
+
+  // (d) Two "Preview" buttons on the SAME domain (codeforge.example) with
+  // identical text but different backgroundColor -- canonical key includes
+  // backgroundColor, so these must NOT collapse into each other.
+  items.push({
+    id: "btn-preview-teal",
+    key: "btn-codeforge.example-Preview-teal",
+    kind: "button",
+    text: "Preview",
+    styles: {
+      backgroundColor: "rgb(74, 154, 138)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none",
+      borderRadius: "6px",
+      padding: "8px 16px",
+      fontFamily: "monospace",
+      fontSize: "13px",
+      fontWeight: "500",
+    },
+    pageTitle: "tiny-collage-engine",
+    domain: "codeforge.example",
+    pageUrl: "https://codeforge.example/",
+    ts: NOW - 120 * 60 * 1000,
+  });
+  items.push({
+    id: "btn-preview-gray",
+    key: "btn-codeforge.example-Preview-gray",
+    kind: "button",
+    text: "Preview",
+    styles: {
+      backgroundColor: "rgb(110, 110, 110)",
+      color: "rgb(255, 255, 255)",
+      border: "0px none",
+      borderRadius: "6px",
+      padding: "8px 16px",
+      fontFamily: "monospace",
+      fontSize: "13px",
+      fontWeight: "500",
+    },
+    pageTitle: "tiny-collage-engine, archived fork",
+    domain: "codeforge.example",
+    pageUrl: "https://codeforge.example/archived-fork",
+    ts: NOW - 130 * 60 * 1000,
+  });
+
   return items;
 }

--- a/extension/website/shared/components/ScrapCollage.tsx
+++ b/extension/website/shared/components/ScrapCollage.tsx
@@ -3,6 +3,12 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { hashString, seededRandom } from "../utils/styleUtils";
+import {
+  canonicalButtonKey,
+  canonicalCursorKey,
+  canonicalImageKey,
+  canonicalSvgIconKey,
+} from "../utils/scrapIdentity";
 
 interface ScrapItemBase {
   id: string;
@@ -100,32 +106,6 @@ function itemOrder(item: ScrapItem, seed: number): number {
   return seededRandom(seed + hashString(item.key));
 }
 
-const PATH_DATA_PATTERN = /\bd="([^"]*)"/g;
-const VIEW_BOX_PATTERN = /\bviewBox="([^"]*)"/;
-const SIZE_AND_PAINT_ATTRIBUTE_PATTERN =
-  /\b(?:width|height|fill|stroke|style)="[^"]*"/g;
-
-function normalizeWhitespace(value: string): string {
-  return value.trim().replace(/\s+/g, " ");
-}
-
-function svgGeometryHash(markup: string): string {
-  const pathData: string[] = [];
-  for (const match of markup.matchAll(PATH_DATA_PATTERN)) {
-    pathData.push(match[1]);
-  }
-  const viewBox = markup.match(VIEW_BOX_PATTERN)?.[1] ?? "";
-
-  if (pathData.length > 0) {
-    return String(
-      hashString(normalizeWhitespace(pathData.join("|") + "|" + viewBox)),
-    );
-  }
-
-  const shapeMarkup = markup.replace(SIZE_AND_PAINT_ATTRIBUTE_PATTERN, "");
-  return String(hashString(normalizeWhitespace(shapeMarkup)));
-}
-
 /**
  * Canonical identity for near-duplicate detection: two scraps with the same
  * canonical key are treated as the same underlying thing even if their raw
@@ -136,25 +116,14 @@ function svgGeometryHash(markup: string): string {
  */
 export function canonicalScrapKey(item: ScrapItem): string {
   switch (item.kind) {
-    case "image": {
-      try {
-        const url = new URL(item.src);
-        url.search = "";
-        url.hash = "";
-        return url.toString();
-      } catch {
-        return item.src;
-      }
-    }
-    case "button": {
-      const normalizedText = normalizeWhitespace(item.text.toLowerCase());
-      const backgroundColor = item.styles.backgroundColor ?? "";
-      return `${item.domain}|button|${normalizedText}|${backgroundColor}`;
-    }
+    case "image":
+      return canonicalImageKey(item.src);
+    case "button":
+      return canonicalButtonKey(item.domain, item.text, item.styles.backgroundColor);
     case "svg-icon":
-      return `${item.domain}|svg|${svgGeometryHash(item.markup)}`;
+      return canonicalSvgIconKey(item.domain, item.markup);
     case "cursor":
-      return item.url;
+      return canonicalCursorKey(item.url);
   }
 }
 

--- a/extension/website/shared/components/ScrapCollage.tsx
+++ b/extension/website/shared/components/ScrapCollage.tsx
@@ -100,6 +100,64 @@ function itemOrder(item: ScrapItem, seed: number): number {
   return seededRandom(seed + hashString(item.key));
 }
 
+const PATH_DATA_PATTERN = /\bd="([^"]*)"/g;
+const VIEW_BOX_PATTERN = /\bviewBox="([^"]*)"/;
+const SIZE_AND_PAINT_ATTRIBUTE_PATTERN =
+  /\b(?:width|height|fill|stroke|style)="[^"]*"/g;
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function svgGeometryHash(markup: string): string {
+  const pathData: string[] = [];
+  for (const match of markup.matchAll(PATH_DATA_PATTERN)) {
+    pathData.push(match[1]);
+  }
+  const viewBox = markup.match(VIEW_BOX_PATTERN)?.[1] ?? "";
+
+  if (pathData.length > 0) {
+    return String(
+      hashString(normalizeWhitespace(pathData.join("|") + "|" + viewBox)),
+    );
+  }
+
+  const shapeMarkup = markup.replace(SIZE_AND_PAINT_ATTRIBUTE_PATTERN, "");
+  return String(hashString(normalizeWhitespace(shapeMarkup)));
+}
+
+/**
+ * Canonical identity for near-duplicate detection: two scraps with the same
+ * canonical key are treated as the same underlying thing even if their raw
+ * `key` differs (different computed style values, different rendered size,
+ * different CDN query params). Used only for the dedup/count steps in
+ * curateScraps -- `item.key` remains the identity used for layout seeding,
+ * React keys, and per-item jitter so surviving tiles keep stable placement.
+ */
+export function canonicalScrapKey(item: ScrapItem): string {
+  switch (item.kind) {
+    case "image": {
+      try {
+        const url = new URL(item.src);
+        url.search = "";
+        url.hash = "";
+        return url.toString();
+      } catch {
+        return item.src;
+      }
+    }
+    case "button": {
+      const normalizedText = normalizeWhitespace(item.text.toLowerCase());
+      const backgroundColor = item.styles.backgroundColor ?? "";
+      return `${item.domain}|button|${normalizedText}|${backgroundColor}`;
+    }
+    case "svg-icon":
+      return `${item.domain}|svg|${svgGeometryHash(item.markup)}`;
+    case "cursor":
+      return item.url;
+  }
+}
+
 function compareDomainScraps(a: ScrapItem, b: ScrapItem, seed: number): number {
   const areaDifference = naturalArea(b) - naturalArea(a);
   if (areaDifference !== 0) return areaDifference;
@@ -127,16 +185,17 @@ export function curateScraps(
   );
   if (perDomainCap === 0 || targetCount === 0) return [];
 
-  const newestByKey = new Map<string, ScrapItem>();
+  const newestByCanonicalKey = new Map<string, ScrapItem>();
   for (const item of items) {
-    const current = newestByKey.get(item.key);
+    const canonicalKey = canonicalScrapKey(item);
+    const current = newestByCanonicalKey.get(canonicalKey);
     if (!current || item.ts > current.ts) {
-      newestByKey.set(item.key, item);
+      newestByCanonicalKey.set(canonicalKey, item);
     }
   }
 
   const scrapsByDomain = new Map<string, ScrapItem[]>();
-  for (const item of newestByKey.values()) {
+  for (const item of newestByCanonicalKey.values()) {
     const domainScraps = scrapsByDomain.get(item.domain);
     if (domainScraps) {
       domainScraps.push(item);
@@ -716,7 +775,11 @@ export function ScrapCollage({
       "svg-icon": 0,
       cursor: 0,
     };
+    const seenCanonicalKeys = new Set<string>();
     for (const item of items) {
+      const canonicalKey = canonicalScrapKey(item);
+      if (seenCanonicalKeys.has(canonicalKey)) continue;
+      seenCanonicalKeys.add(canonicalKey);
       counts[item.kind] += 1;
     }
     return counts;

--- a/extension/website/shared/utils/scrapIdentity.ts
+++ b/extension/website/shared/utils/scrapIdentity.ts
@@ -1,0 +1,73 @@
+// ABOUTME: Canonical identity for internet scraps, shared between render-time collage
+// ABOUTME: dedup and extension storage-time dedup so near-duplicates never persist.
+
+/**
+ * Canonical identity for near-duplicate detection: two scraps with the same
+ * canonical key are treated as the same underlying thing even though their
+ * raw capture differs (different computed style values, different rendered
+ * size, different CDN query params).
+ */
+
+function hashString(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    const char = value.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash);
+}
+
+const PATH_DATA_PATTERN = /\bd="([^"]*)"/g;
+const VIEW_BOX_PATTERN = /\bviewBox="([^"]*)"/;
+const SIZE_AND_PAINT_ATTRIBUTE_PATTERN =
+  /\b(?:width|height|fill|stroke|style)="[^"]*"/g;
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function svgGeometryHash(markup: string): string {
+  const pathData: string[] = [];
+  for (const match of markup.matchAll(PATH_DATA_PATTERN)) {
+    pathData.push(match[1]);
+  }
+  const viewBox = markup.match(VIEW_BOX_PATTERN)?.[1] ?? "";
+
+  if (pathData.length > 0) {
+    return String(
+      hashString(normalizeWhitespace(pathData.join("|") + "|" + viewBox)),
+    );
+  }
+
+  const shapeMarkup = markup.replace(SIZE_AND_PAINT_ATTRIBUTE_PATTERN, "");
+  return String(hashString(normalizeWhitespace(shapeMarkup)));
+}
+
+export function canonicalImageKey(src: string): string {
+  try {
+    const url = new URL(src);
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return src;
+  }
+}
+
+export function canonicalButtonKey(
+  domain: string,
+  text: string,
+  backgroundColor: string | undefined,
+): string {
+  const normalizedText = normalizeWhitespace(text.toLowerCase());
+  return `${domain}|button|${normalizedText}|${backgroundColor ?? ""}`;
+}
+
+export function canonicalSvgIconKey(domain: string, markup: string): string {
+  return `${domain}|svg|${svgGeometryHash(markup)}`;
+}
+
+export function canonicalCursorKey(url: string): string {
+  return url;
+}


### PR DESCRIPTION
## Summary

Follow-up to #325, prompted by real-collection testing: the same button captured on different pages (trivially different computed styles), the same icon at different rendered sizes, and the same image under different CDN query params all survived dedup, cluttering the collage with near-duplicates.

Adds `canonicalScrapKey` — a looser, per-kind identity used for the dedup-newest-wins step, chip counts, and the "everything" count in `curateScraps`:

- **image**: src minus query string and hash fragment
- **button**: domain + normalized text + backgroundColor (so a genuinely differently-designed same-text button on the same domain still survives)
- **svg-icon**: domain + geometry hash (path data + viewBox via regex, size/color-baked attributes ignored; shape-only icons fall back to attribute-stripped markup hash)
- **cursor**: unchanged (url)

`item.key` still drives layout seeding and React keys, so surviving tiles keep stable placement. Dedup is render-time only — raw collected events keep everything, so rules can be loosened later without data loss.

## Verification

- Planted near-duplicate fixtures in the preview demo data: duplicate Subscribe (differs only by boxShadow), heart icon at 32px vs 24px, pear image with `?w=480&fit=crop`, plus a same-domain same-text different-color "Preview" pair that must NOT collapse.
- Browser-verified on /scraps-preview/: chips read `all 34 / buttons 10 / everything 31` (3 planted dupes collapsed), exactly one Subscribe/heart/pear rendered, both Previews survive. Verified independently twice (agent + reviewer).
- Extension typecheck at the 40-error pre-existing baseline (none in changed files); website tsconfig clean.

No PENDING.md bullet (feature still dark behind the dev toggle).