### PR TITLE
Fix package consumer readiness

### DIFF
--- a/.changeset/honest-package-exports.md
+++ b/.changeset/honest-package-exports.md
@@ -1,0 +1,8 @@
+---
+"@playhtml/common": patch
+"@playhtml/extension-types": patch
+"@playhtml/react": patch
+"playhtml": patch
+---
+
+Mark the packages as ESM-only instead of advertising CommonJS entry points that could not load their exports. The `playhtml/leafEditor` subpath now provides declarations that type-check with NodeNext module resolution.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,8 +22,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
-      "import": "./dist/playhtml-common.es.js",
-      "require": "./dist/playhtml-common.umd.js"
+      "import": "./dist/playhtml-common.es.js"
     }
   },
   "publishConfig": {

--- a/packages/extension-types/package.json
+++ b/packages/extension-types/package.json
@@ -22,8 +22,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/playhtml-extension-types.es.js",
-      "require": "./dist/playhtml-extension-types.umd.js"
+      "import": "./dist/playhtml-extension-types.es.js"
     }
   },
   "publishConfig": {

--- a/packages/playhtml/leafEditor.d.ts
+++ b/packages/playhtml/leafEditor.d.ts
@@ -1,13 +1,30 @@
 // ABOUTME: Declares the inline state editing helpers exported by the playhtml subpath.
-// ABOUTME: Re-exports the generated core package declarations for package consumers.
-export {
-  formatStateLeafValue,
-  isEditableStateLeaf,
-  parseStateLeafValue,
-  replaceStateLeafValue,
-} from "./dist/main";
+// ABOUTME: Defines public signatures without depending on another package entry file.
+export type StatePathSegment = string | number;
+export type EditableStateLeafValue = string | number | boolean | null;
 
-export type {
-  EditableStateLeafValue,
-  StatePathSegment,
-} from "./dist/main";
+type StateLeafParseResult =
+  | { ok: true; value: EditableStateLeafValue }
+  | { ok: false; error: string };
+
+type StateLeafReplaceResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+export declare function isEditableStateLeaf(
+  value: unknown,
+): value is EditableStateLeafValue;
+
+export declare function formatStateLeafValue(
+  value: EditableStateLeafValue,
+): string;
+
+export declare function parseStateLeafValue(
+  input: string,
+): StateLeafParseResult;
+
+export declare function replaceStateLeafValue<T>(
+  data: T,
+  path: StatePathSegment[],
+  value: EditableStateLeafValue,
+): StateLeafReplaceResult<T>;

--- a/packages/playhtml/src/__tests__/package-metadata.test.ts
+++ b/packages/playhtml/src/__tests__/package-metadata.test.ts
@@ -6,6 +6,24 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("playhtml package contract", () => {
+  it("does not advertise unsupported CommonJS entry points", () => {
+    const packagePaths = [
+      "../common/package.json",
+      "../extension-types/package.json",
+      "../react/package.json",
+    ];
+
+    for (const packagePath of packagePaths) {
+      const packageJson = JSON.parse(
+        readFileSync(path.resolve(process.cwd(), packagePath), "utf8"),
+      );
+
+      expect(packageJson.exports["."], packagePath).not.toHaveProperty(
+        "require",
+      );
+    }
+  });
+
   it("keeps @playhtml/common as a package dependency", () => {
     const packageJson = JSON.parse(
       readFileSync(path.resolve(process.cwd(), "package.json"), "utf8"),
@@ -29,5 +47,17 @@ describe("playhtml package contract", () => {
     expect(viteConfigSource).toContain("beforeWriteFile");
     expect(viteConfigSource).toContain('from "@playhtml/common"');
     expect(viteConfigSource).toContain('import("@playhtml/common")');
+  });
+
+  it("publishes self-contained leaf editor declarations", () => {
+    const declarationSource = readFileSync(
+      path.resolve(process.cwd(), "leafEditor.d.ts"),
+      "utf8",
+    );
+
+    expect(declarationSource).not.toContain('from "./dist/main"');
+    expect(declarationSource).toContain(
+      "export declare function parseStateLeafValue",
+    );
   });
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,8 +35,7 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
-      "import": "./dist/react-playhtml.es.js",
-      "require": "./dist/react-playhtml.umd.js"
+      "import": "./dist/react-playhtml.es.js"
     }
   },
   "scripts": {

--- a/templates/html-starter/index.html
+++ b/templates/html-starter/index.html
@@ -81,6 +81,11 @@
             use it to build your own tiny social network. Check out the code and
             hover over the capabilities below to see which of these things are collaborative elements.
           </p>
+          <section>
+            <h2>people here</h2>
+            <p id="peopleHereCount">0 people here</p>
+            <ul id="peopleHere"></ul>
+          </section>
             <script>
           function highlightElements(capability) {
             document.querySelectorAll(`[${capability}]`).forEach((ele) => {
@@ -157,7 +162,7 @@
         </ol>
 
           <p>
-            For all the details about these capabilities and more, see the <a href="https://github.com/spencerc99/playhtml#plug-and-play-capabilities">playhtml docs</a
+            For all the details about these capabilities and more, see the <a href="https://github.com/spencerc99/playhtml#plug-and-play-capabilities">playhtml docs</a>
           </p>
         </div>
       </div>
@@ -204,11 +209,30 @@
         }
       });
 
+      const peopleHere = document.getElementById("peopleHere");
+      const peopleHereCount = document.getElementById("peopleHereCount");
+
+      function renderUsers(users) {
+        peopleHereCount.textContent =
+          users.length === 1 ? "1 person here" : `${users.length} people here`;
+        peopleHere.replaceChildren(
+          ...users.map((user) => {
+            const item = document.createElement("li");
+            item.textContent = user.name ?? "anonymous";
+            item.style.color = user.color;
+            return item;
+          })
+        );
+      }
+
+      playhtml.users.onChange(renderUsers);
+      renderUsers(playhtml.users.getAll());
+
       // Reaction button — a custom collaborative element built with the `view`
       // API: register a render function and playhtml re-renders it whenever the
       // shared `count` changes (locally or from another tab). Writes are driven
       // from the @click handler in the template. `register` works before or
-      // after init(). (This is the new experimental vanilla view API.)
+      // after init(). (This is the experimental vanilla view API.)
       playhtml.register("reactionBtn", {
         defaultData: { count: 0 },
         view: ({ data, setData }) => {

--- a/templates/react-starter/public/illustration.svg
+++ b/templates/react-starter/public/illustration.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <circle cx="100" cy="100" r="80" fill="#ffd166" stroke="#333" stroke-width="4"/>
+  <circle cx="75" cy="85" r="8" fill="#333"/>
+  <circle cx="125" cy="85" r="8" fill="#333"/>
+  <path d="M 65 120 Q 100 145 135 120" stroke="#333" stroke-width="4" fill="none" stroke-linecap="round"/>
+  <path d="M 30 70 L 50 60 M 170 70 L 150 60 M 30 130 L 50 140 M 170 130 L 150 140" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/templates/react-starter/src/App.tsx
+++ b/templates/react-starter/src/App.tsx
@@ -12,6 +12,7 @@ import {
   CanHoverElement,
   CanDuplicateElement,
   withSharedState,
+  useUsers,
 } from "@playhtml/react";
 
 const ShootingStarEventType = "shootingStar";
@@ -66,6 +67,24 @@ function ShootingStar() {
   );
 }
 
+function PeopleHere() {
+  const users = useUsers();
+
+  return (
+    <section style={{ color: "#2800ff" }}>
+      <h2>people here</h2>
+      <p>{users.length === 1 ? "1 person here" : `${users.length} people here`}</p>
+      <ul>
+        {users.map((user) => (
+          <li key={user.pid} style={{ color: user.color }}>
+            {user.name ?? "anonymous"}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
 // Reaction button - tracks who has reacted using localStorage
 const ReactionButton = withSharedState(
   { defaultData: { count: 0 } },
@@ -80,6 +99,7 @@ const ReactionButton = withSharedState(
 
     return (
       <button
+        id="reaction-button"
         onClick={() => {
           if (hasReacted) {
             setData((draft) => {
@@ -139,9 +159,12 @@ function App() {
             Hello World!
           </h1>
 
+          <PeopleHere />
+
           <CanSpinElement>
             <img
-              src="https://cdn.glitch.com/a9975ea6-8949-4bab-addb-8a95021dc2da%2Fillustration.svg?v=1618177344016"
+              id="illustration"
+              src="/illustration.svg"
               alt="Editor illustration"
               style={{ maxWidth: "300px", display: "block", margin: "2rem auto", cursor: "pointer" }}
             />
@@ -150,6 +173,7 @@ function App() {
           <div style={{ marginBottom: "2em" }}>
             <CanMoveElement>
               <img
+                id="open-sign"
                 src="https://media2.giphy.com/media/lL7A3Li0YtFHq/giphy.gif"
                 alt="Open sign"
                 style={{ cursor: "move", display: "block" }}
@@ -158,6 +182,7 @@ function App() {
 
             <CanToggleElement>
               <img
+                id="lamp"
                 src="https://png.pngtree.com/png-vector/20230909/ourmid/pngtree-paper-lamp-paper-png-image_9211580.png"
                 alt="Lamp"
                 style={{ width: "200px", position: "absolute", top: 0, right: "-16px" }}


### PR DESCRIPTION
## Summary

- mark the published package entry points as ESM-only instead of exposing broken CommonJS targets
- make `playhtml/leafEditor` declarations self-contained for NodeNext consumers
- add package metadata regression coverage and a patch changeset
- update both starters with the users roster API and repair the starter issues found during browser verification

## Root cause

The package manifests mapped `require` to UMD `.js` files inside `"type": "module"` packages. CommonJS consumers either received empty exports or failed while loading `@playhtml/react`. The `playhtml/leafEditor` declaration also re-exported through an extensionless `./dist/main` path, which strict NodeNext consumers reject.

## Impact

Documented ESM imports continue to work. Unsupported `require(...)` usage now fails clearly at the package boundary. NodeNext consumers can import `playhtml/leafEditor` without declaration errors. Both starters show the `playhtml.users` / `useUsers()` API.

## Verification

- `bun run build-packages`
- PlayHTML package metadata tests: 4 passed
- React metadata and users-hook tests: 14 passed
- packed tarball install, `npm ls`, and strict NodeNext type-check
- `bunx vite build` in `templates/react-starter`
- live browser verification of both starter templates with clean console output

Visual verification is attached in the PR Evidence comment.