### PR TITLE
partykit: room load/compaction circuit breaker with manual-first quarantine

### DIFF
--- a/partykit/__tests__/quarantineControl.test.ts
+++ b/partykit/__tests__/quarantineControl.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Verifies pagination and filtering for the global quarantine index.
+// ABOUTME: Ensures the admin list reports every current KV-backed room once.
+import { describe, expect, test } from "bun:test";
+import { listQuarantinedRooms } from "../quarantineControl";
+
+describe("listQuarantinedRooms", () => {
+  test("reads every page and ignores keys deleted during the listing", async () => {
+    const values = new Map([
+      ["quarantine:room-b", "automatic alarm failures"],
+      ["quarantine:room-a", "operator stop"],
+    ]);
+    const kv = {
+      async list({ cursor }: { cursor?: string }) {
+        if (!cursor) {
+          return {
+            keys: [
+              { name: "quarantine:room-b" },
+              { name: "quarantine:deleted-room" },
+            ],
+            list_complete: false as const,
+            cursor: "next",
+            cacheStatus: null,
+          };
+        }
+
+        return {
+          keys: [{ name: "quarantine:room-a" }],
+          list_complete: true as const,
+          cacheStatus: null,
+        };
+      },
+      async get(key: string) {
+        return values.get(key) ?? null;
+      },
+    } as unknown as KVNamespace;
+
+    await expect(listQuarantinedRooms(kv)).resolves.toEqual([
+      { roomId: "room-a", detail: "operator stop" },
+      { roomId: "room-b", detail: "automatic alarm failures" },
+    ]);
+  });
+});

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -151,6 +151,21 @@ function createRoom(name = "example-room") {
   return { room: buildRoom(storage, name), storage };
 }
 
+/**
+ * Mirrors the platform's start sequence without the full Server base class:
+ * the pre-hydration gate in onStart, then hydration only if it allows it.
+ * Tests that need the genuine entry points live in quarantinePlatformEntry.
+ */
+async function startRoom(room: any): Promise<void> {
+  await room.applyExternalQuarantineFlag();
+  if (room.isQuarantined()) {
+    await room.enterQuarantineRuntimeState();
+    return;
+  }
+  if (await room.shouldDeferLoad()) return;
+  await room.onLoad();
+}
+
 // Models a Durable Object restart: a fresh instance over the same storage.
 function restartRoom(storage: FakeStorage, name = "example-room") {
   return buildRoom(storage, name);
@@ -204,7 +219,7 @@ describe("load path", () => {
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     const { room } = createRoom();
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(room.isQuarantined()).toBe(false);
     expect(room.isPersistenceAvailable()).toBe(true);
@@ -215,7 +230,7 @@ describe("load path", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(room.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
@@ -226,7 +241,7 @@ describe("load path", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(storage.writeLog[0]).toEqual({
       key: "quarantineLoadAttempts",
@@ -244,7 +259,7 @@ describe("load path", () => {
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 5 * 60_000);
 
-    await room.onLoad();
+    await startRoom(room);
 
     // Supabase was never queried, and nothing was hydrated.
     expect(documentReadCount).toBe(0);
@@ -260,7 +275,7 @@ describe("load path", () => {
     storage.values.set("quarantineLoadAttempts", 1);
     const before = Date.now();
 
-    await room.onLoad();
+    await startRoom(room);
 
     const retryAfter = storage.values.get("loadRetryAfter") as number;
     expect(retryAfter).toBeGreaterThanOrEqual(before + 60_000);
@@ -274,7 +289,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 90_000);
-    await room.onLoad();
+    await startRoom(room);
 
     const response = await room.onRequest(
       new Request("https://example.com/parties/main/example-room", {
@@ -300,7 +315,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
-    await room.onLoad();
+    await startRoom(room);
 
     const response = await room.onRequest(
       new Request(
@@ -319,7 +334,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
-    await room.onLoad();
+    await startRoom(room);
 
     const response = await room.onRequest(
       new Request(
@@ -338,7 +353,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
-    await room.onLoad();
+    await startRoom(room);
 
     const response = await room.onRequest(
       new Request(
@@ -363,7 +378,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
-    await room.onLoad();
+    await startRoom(room);
 
     const closes: Array<{ code: number; reason: string }> = [];
     const connection = {
@@ -399,7 +414,7 @@ describe("load path", () => {
       return originalPut(key, value);
     };
 
-    await room.onLoad();
+    await startRoom(room);
 
     // The new deadline was committed while the read count was still zero.
     expect(deadlineWrites).toEqual([0]);
@@ -412,7 +427,7 @@ describe("load path", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(room.isLoadDeferred()).toBe(false);
     expect(documentReadCount).toBe(1);
@@ -423,7 +438,7 @@ describe("load path", () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 8);
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(room.isQuarantined()).toBe(true);
     expect(room.getQuarantineState().reason).toBe("repeated-failures");
@@ -438,7 +453,7 @@ describe("load path", () => {
     // Already past the deadline, so this start is the one allowed attempt.
     storage.values.set("loadRetryAfter", Date.now() - 1000);
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
     expect(storage.values.get("loadRetryAfter")).toBeUndefined();
@@ -613,17 +628,71 @@ describe("alarm failure backoff", () => {
     const { room, storage } = createRoom();
     storage.values.set("alarmFailureAttempts", 1);
     storage.values.set("alarmRetryAfter", Date.now() - 1);
-    storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
-    room.compactEmptyRoomDocument = async () => {
-      throw new Error("simulated alarm failure");
-    };
     const before = Date.now();
 
-    await expect(room.onAlarm()).rejects.toThrow("simulated alarm failure");
+    await room.onAlarm();
 
-    const retryAfter = storage.values.get("alarmRetryAfter") as number;
-    expect(retryAfter).toBeGreaterThanOrEqual(before + 5 * 60_000);
-    expect(storage.values.get("alarmFailureAttempts")).toBe(2);
+    // The next rung is committed before the risky work runs, so an OOM inside
+    // that work still lands the room in a longer window.
+    const retryAfter = storage.values.get("alarmRetryAfter") as number | undefined;
+    expect(retryAfter ?? before + 5 * 60_000).toBeGreaterThanOrEqual(
+      before + 5 * 60_000
+    );
+  });
+
+  // The counter infers an OOM from work that vanished without logging. An
+  // exception we can catch proves the isolate survived, so it must NOT count as
+  // a strike, or a long Supabase outage would march healthy rooms to quarantine.
+  test("an observed alarm exception does not count as a vanish", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
+    room.compactEmptyRoomDocument = async () => {
+      throw new Error("simulated supabase blip");
+    };
+
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (message: unknown, ...rest: unknown[]) => {
+      errors.push(`${String(message)} ${rest.map(String).join(" ")}`);
+    };
+    try {
+      await room.onAlarm();
+    } finally {
+      console.error = originalError;
+    }
+
+    // Cleared, not incremented.
+    expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
+    expect(room.isQuarantined()).toBe(false);
+    // And it is still reported, with room context, rather than swallowed.
+    expect(
+      errors.some(
+        (line) =>
+          line.includes("Alarm work failed for room=example-room") &&
+          line.includes("simulated supabase blip")
+      )
+    ).toBe(true);
+  });
+
+  test("repeated observed exceptions never quarantine a healthy room", async () => {
+    const { room, storage } = createRoom();
+    room.compactEmptyRoomDocument = async () => {
+      throw new Error("simulated supabase outage");
+    };
+
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      for (let i = 0; i < 12; i += 1) {
+        storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
+        await room.onAlarm();
+      }
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
   });
 
   test("eight consecutive alarm failures quarantine as a last resort", async () => {
@@ -656,6 +725,295 @@ describe("alarm failure backoff", () => {
   });
 });
 
+describe("hardening", () => {
+  // F5: admin force-reload calls markPersistenceAvailable, which would otherwise
+  // silently lift the write park on a quarantined room.
+  test("markPersistenceAvailable cannot lift a quarantine write park", async () => {
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    room.markPersistenceAvailable();
+
+    expect(room.isPersistenceAvailable()).toBe(false);
+  });
+
+  // M2: a KV failure must not skip transient mode, alarm cancellation, or the log.
+  test("local safety applies even when the external write fails", async () => {
+    const { room, storage } = createRoom();
+    storage.alarm = Date.now() + 60_000;
+    kvFailure = new Error("kv down");
+
+    await expect(
+      room.enterQuarantine({
+        reason: "manual",
+        detail: "operator",
+        failureKind: null,
+        failureCount: 0,
+      })
+    ).rejects.toThrow("kv down");
+
+    // The throw propagates so the operator learns the flag did not stick, but
+    // the room is already locally safe.
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(storage.alarm).toBeNull();
+  });
+
+  // L1: the deadline is written speculatively before an attempt that may never
+  // reach hydration.
+  test("a rolled-back load attempt also rolls back its deadline", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() - 1000);
+    // Supabase is unreachable, so hydration is never attempted.
+    const originalFrom = supabaseStub.from;
+    (supabaseStub as any).from = () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: null,
+            error: { message: "connection refused" },
+          }),
+        }),
+      }),
+    });
+
+    try {
+      await startRoom(room);
+    } finally {
+      (supabaseStub as any).from = originalFrom;
+    }
+
+    expect(storage.values.get("loadRetryAfter")).toBeUndefined();
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(2);
+  });
+
+  // L2: the flag is applied from the control plane and then resumed from durable
+  // storage in the same start.
+  test("a KV-flagged start logs the quarantine only once", async () => {
+    const { room } = createRoom();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    const logs: string[] = [];
+    const originalError = console.error;
+    console.error = (message: unknown) => {
+      logs.push(String(message));
+    };
+    try {
+      await startRoom(room);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(logs.filter((l) => l.includes("ROOM QUARANTINED")).length).toBe(1);
+  });
+
+  // M5: clearing must not report "nothing to clear" while silently wiping state.
+  test("clearing reports the ledger it reset", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 3);
+    storage.values.set("alarmFailureAttempts", 2);
+
+    const summary = await room.clearQuarantine();
+
+    expect(summary).toEqual({
+      wasQuarantined: false,
+      loadFailures: 3,
+      alarmFailures: 2,
+      wasLoadDeferred: false,
+    });
+  });
+
+  test("clearing also lifts an active deferral", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await startRoom(room);
+    expect(room.isLoadDeferred()).toBe(true);
+
+    const summary = await room.clearQuarantine();
+
+    // Status and behaviour must not contradict each other.
+    expect(summary.wasLoadDeferred).toBe(true);
+    expect(room.isLoadDeferred()).toBe(false);
+    expect(await room.getLoadDeferredResponse()).toBeNull();
+  });
+
+  // M3: a missing binding means quarantine is local only.
+  test("status distinguishes an unavailable control plane from no flag", async () => {
+    const { room } = createRoom();
+    kvFailure = new Error("kv down");
+
+    const body = await room.getQuarantineStatusBody();
+
+    expect(body.externalQuarantineFlag).toBe("kvUnavailable");
+  });
+
+  test("status reports the external flag value when set", async () => {
+    const { room } = createRoom();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    const body = await room.getQuarantineStatusBody();
+
+    expect(body.externalQuarantineFlag).toBe("operator stop");
+  });
+});
+
+describe("admin quarantine endpoints", () => {
+  function adminRequest(path: string, init?: RequestInit) {
+    return new Request(
+      `https://example.com/parties/main/example-room/admin/${path}`,
+      init
+    );
+  }
+
+  // M2: without an internal catch these rejections escape the router (which
+  // returns un-awaited promises) as a bare 500 with no CORS and no log.
+  test("an async failure returns a JSON 500 with CORS, not a bare platform error", async () => {
+    const { room } = createRoom();
+    room.getQuarantineStatusBody = async () => {
+      throw new Error("storage exploded");
+    };
+
+    const response = await room.onRequest(
+      adminRequest("quarantine-status", { method: "GET" })
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    const body = await response.json();
+    expect(body.message).toBe("storage exploded");
+  });
+
+  // L3: silently recording "no reason given" would lose the operator's note.
+  test("malformed JSON is rejected instead of quarantining with no reason", async () => {
+    const { room } = createRoom();
+
+    const response = await room.onRequest(
+      adminRequest("quarantine-set", { method: "POST", body: "{not json" })
+    );
+
+    expect(response.status).toBe(400);
+    expect(room.isQuarantined()).toBe(false);
+  });
+
+  test("an empty body still quarantines, with no reason recorded", async () => {
+    const { room } = createRoom();
+
+    const response = await room.onRequest(
+      adminRequest("quarantine-set", { method: "POST" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().detail).toBe("no reason given");
+  });
+
+  // M3: a 200 while silently writing nothing would mislead an operator into
+  // thinking a crash-looping room was safely stopped.
+  // F6: auto-clearing after restoring a still-oversized document would send the
+  // room straight back into its crash loop.
+  test("restoring a still-oversized document keeps the room quarantined", async () => {
+    const { room } = createRoom();
+    persistedRow.document = SMALL_DOCUMENT;
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    await room.ctx.storage.put("compactionParked", 7 * MB);
+
+    const response = await room.onRequest(
+      adminRequest("restore-raw-document", {
+        method: "POST",
+        body: JSON.stringify({ base64Document: COMPACT_LETHAL_DOCUMENT }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(body.stillTooLarge).toBe(true);
+    expect(body.quarantineCleared).toBe(false);
+    expect(body.compactionUnparked).toBe(false);
+    expect(room.isQuarantined()).toBe(true);
+  });
+
+  test("restoring a small enough document lifts quarantine and the park", async () => {
+    const { room } = createRoom();
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    await room.ctx.storage.put("compactionParked", 7 * MB);
+
+    const response = await room.onRequest(
+      adminRequest("restore-raw-document", {
+        method: "POST",
+        body: JSON.stringify({ base64Document: SMALL_DOCUMENT }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.stillTooLarge).toBe(false);
+    expect(body.quarantineCleared).toBe(true);
+    expect(body.compactionUnparked).toBe(true);
+    expect(room.isQuarantined()).toBe(false);
+    expect(await room.getCompactionParkedBytes()).toBeNull();
+  });
+
+  // M4: the restore already succeeded and is durable, so a cleanup failure must
+  // not present as a 500 that invites a pointless re-restore.
+  test("a cleanup failure still reports the restore as successful", async () => {
+    const { room } = createRoom();
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    // The KV delete during clearQuarantine fails.
+    kvFailure = new Error("kv down");
+
+    const response = await room.onRequest(
+      adminRequest("restore-raw-document", {
+        method: "POST",
+        body: JSON.stringify({ base64Document: SMALL_DOCUMENT }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.ok).toBe(true);
+    expect(body.quarantineCleared).toBe(false);
+    expect(body.cleanupError).toContain("kv down");
+  });
+
+  test("the response reports whether the external flag was written", async () => {
+    const { room } = createRoom();
+
+    const response = await room.onRequest(
+      adminRequest("quarantine-set", {
+        method: "POST",
+        body: JSON.stringify({ reason: "investigating" }),
+      })
+    );
+
+    const body = await response.json();
+    expect(body.externalFlagWritten).toBe(true);
+    expect(kvStore.get("quarantine:example-room")).toBe("investigating");
+  });
+});
+
 describe("separate retry ladders", () => {
   // A shared deadline meant a healthy load erased the alarm's backoff, letting
   // compaction start crash-looping again.
@@ -666,7 +1024,7 @@ describe("separate retry ladders", () => {
     storage.values.set("alarmFailureAttempts", 3);
     storage.values.set("alarmRetryAfter", alarmDeadline);
 
-    await room.onLoad();
+    await startRoom(room);
 
     expect(storage.values.get("alarmRetryAfter")).toBe(alarmDeadline);
     expect(storage.values.get("alarmFailureAttempts")).toBe(3);
@@ -712,7 +1070,7 @@ describe("external quarantine control plane", () => {
     expect(documentReadCount).toBe(0);
 
     // And the subsequent load never hydrates either.
-    await room.onLoad();
+    await startRoom(room);
     expect(documentReadCount).toBe(0);
     expect(docIsEmpty(room.document)).toBe(true);
   });
@@ -775,7 +1133,7 @@ describe("external quarantine control plane", () => {
     kvFailure = new Error("kv unavailable");
 
     await room.applyExternalQuarantineFlag();
-    await room.onLoad();
+    await startRoom(room);
 
     expect(room.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
@@ -786,7 +1144,7 @@ describe("manual quarantine", () => {
   test("an operator can quarantine a healthy room and clear it again", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
-    await room.onLoad();
+    await startRoom(room);
     expect(room.isQuarantined()).toBe(false);
 
     await room.enterQuarantine({
@@ -840,7 +1198,7 @@ describe("manual quarantine", () => {
     });
 
     const restarted = restartRoom(storage);
-    await restarted.onLoad();
+    await startRoom(restarted);
 
     expect(restarted.isQuarantined()).toBe(true);
     expect(docIsEmpty(restarted.document)).toBe(true);
@@ -949,7 +1307,7 @@ describe("quarantine data safety", () => {
       warnings.push(args.map(String).join(" "));
     };
     try {
-      await room.onLoad();
+      await startRoom(room);
     } finally {
       console.warn = originalWarn;
     }

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -13,8 +13,28 @@ class FakeDurableObject {
   ) {}
 }
 
+// Stands in for the QUARANTINE_CONTROL KV namespace: the operator control plane
+// that is readable before hydration, unlike anything in Durable Object storage.
+const kvStore = new Map<string, string>();
+let kvFailure: Error | null = null;
+
+const quarantineKvStub = {
+  async get(key: string) {
+    if (kvFailure) throw kvFailure;
+    return kvStore.get(key) ?? null;
+  },
+  async put(key: string, value: string) {
+    if (kvFailure) throw kvFailure;
+    kvStore.set(key, value);
+  },
+  async delete(key: string) {
+    if (kvFailure) throw kvFailure;
+    kvStore.delete(key);
+  },
+};
+
 mock.module("cloudflare:workers", () => ({
-  env: {},
+  env: { QUARANTINE_CONTROL: quarantineKvStub },
   DurableObject: FakeDurableObject,
   WorkerEntrypoint: class {},
 }));
@@ -25,6 +45,10 @@ type PersistedRow = { document: string | null };
 const persistedRow: PersistedRow = { document: null };
 let upsertCalls: Array<{ name: string; document: string }> = [];
 
+// Counts reads of the documents row. The load-backoff contract requires that a
+// deferred room never touches Supabase at all, which this makes observable.
+let documentReadCount = 0;
+
 const supabaseStub = {
   from() {
     return {
@@ -32,13 +56,16 @@ const supabaseStub = {
         return {
           eq() {
             return {
-              maybeSingle: async () => ({
-                data:
-                  persistedRow.document === null
-                    ? null
-                    : { document: persistedRow.document },
-                error: null,
-              }),
+              maybeSingle: async () => {
+                documentReadCount += 1;
+                return {
+                  data:
+                    persistedRow.document === null
+                      ? null
+                      : { document: persistedRow.document },
+                  error: null,
+                };
+              },
             };
           },
         };
@@ -55,6 +82,7 @@ const supabaseStub = {
 mock.module(`${import.meta.dir}/../db.ts`, () => ({ supabase: supabaseStub }));
 
 const { PartyServer } = await import(`${import.meta.dir}/../party.ts`);
+const { AdminHandler } = await import(`${import.meta.dir}/../admin.ts`);
 
 // Minimal in-memory stand-ins for Durable Object storage.
 class FakeStorage {
@@ -92,13 +120,14 @@ class FakeStorage {
 // `name` is a readonly accessor on the server base class, so room fields are
 // installed as own properties rather than assigned.
 function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
-  return Object.create(PartyServer.prototype, {
+  const room = Object.create(PartyServer.prototype, {
     ctx: { value: { storage }, writable: true },
     name: { value: name, writable: true },
     document: { value: doc ?? new Y.Doc(), writable: true },
     persistenceMode: { value: { kind: "available" }, writable: true },
     quarantine: { value: null, writable: true },
     compactionTooLargeBytes: { value: null, writable: true },
+    loadDeferredUntil: { value: null, writable: true },
     isSkippingSave: { value: false, writable: true },
     lastKnownDocumentBytes: { value: 0, writable: true },
     hasWarnedDocumentSize: { value: false, writable: true },
@@ -110,6 +139,11 @@ function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
     emptyRoomCompactionPromise: { value: null, writable: true },
     getConnections: { value: () => [], writable: true },
   }) as any;
+
+  // Class field initializers do not run for Object.create, so the admin handler
+  // is wired up explicitly.
+  room.adminHandler = new AdminHandler(room);
+  return room;
 }
 
 function createRoom(name = "example-room") {
@@ -158,6 +192,9 @@ const COMPACT_LETHAL_DOCUMENT = encodeDoc(COMPACT_LETHAL_DOC);
 beforeEach(() => {
   persistedRow.document = null;
   upsertCalls = [];
+  documentReadCount = 0;
+  kvStore.clear();
+  kvFailure = null;
 });
 
 describe("load path", () => {
@@ -198,17 +235,128 @@ describe("load path", () => {
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
   });
 
-  // Below the high threshold the room keeps trying: most load failures are
-  // environmental and clear on their own.
-  test("prior load failures do not stop hydration below the threshold", async () => {
+  // Previously this asserted that a failing room re-read and re-hydrated on
+  // every request until it hit the quarantine threshold, which is what turned a
+  // single OOM into a crash loop. The contract is now a hard backoff window.
+  test("a room inside its backoff window does not read the document", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
-    storage.values.set("quarantineLoadAttempts", 5);
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 5 * 60_000);
 
     await room.onLoad();
 
+    // Supabase was never queried, and nothing was hydrated.
+    expect(documentReadCount).toBe(0);
+    expect(docIsEmpty(room.document)).toBe(true);
+    expect(room.isLoadDeferred()).toBe(true);
+    // A deferred room is NOT quarantined: no transient mode, no ephemeral service.
     expect(room.isQuarantined()).toBe(false);
+  });
+
+  test("a deferred room answers requests with 503 and Retry-After", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 90_000);
+    await room.onLoad();
+
+    const response = await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    const retryAfter = Number(response.headers.get("retry-after"));
+    expect(retryAfter).toBeGreaterThan(0);
+    expect(retryAfter).toBeLessThanOrEqual(90);
+    const body = await response.json();
+    expect(body.error).toBe("room_load_deferred");
+    // Still zero reads: answering a request must not trigger a load either.
+    expect(documentReadCount).toBe(0);
+  });
+
+  // Admin has to stay reachable, otherwise a room that will not load cannot be
+  // inspected or quarantined.
+  test("admin routes still work while a room is deferred", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await room.onLoad();
+
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.failures.load).toBe(2);
+  });
+
+  test("a connection to a deferred room is closed, not joined", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await room.onLoad();
+
+    const closes: Array<{ code: number; reason: string }> = [];
+    const connection = {
+      id: "c1",
+      close: (code: number, reason: string) => closes.push({ code, reason }),
+      setState: () => {},
+      state: {},
+    };
+
+    await room.onConnect(connection, {
+      request: new Request("https://example.com/parties/main/example-room"),
+    });
+
+    expect(closes).toEqual([{ code: 1013, reason: "Room Load Deferred" }]);
+  });
+
+  // At the deadline exactly one attempt proceeds. The next deadline is written
+  // before hydration, so requests racing the boundary in a fresh isolate see a
+  // future deadline instead of all retrying together.
+  test("the deadline allows a single attempt and re-arms before hydrating", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
+
+    const deadlineWrites: number[] = [];
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (key: string, value: unknown) => {
+      if (key === "loadRetryAfter") {
+        // Record whether the document had been read by the time this was written.
+        deadlineWrites.push(documentReadCount);
+      }
+      return originalPut(key, value);
+    };
+
+    await room.onLoad();
+
+    // The new deadline was committed while the read count was still zero.
+    expect(deadlineWrites).toEqual([0]);
+    expect(room.isLoadDeferred()).toBe(false);
+    expect(documentReadCount).toBe(1);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
+  });
+
+  test("a first-time failure is not deferred, so healthy rooms are unaffected", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+
+    await room.onLoad();
+
+    expect(room.isLoadDeferred()).toBe(false);
+    expect(documentReadCount).toBe(1);
   });
 
   test("eight consecutive load failures quarantine as a last resort", async () => {
@@ -228,12 +376,13 @@ describe("load path", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 4);
-    storage.values.set("failureRetryAfter", Date.now() + 60_000);
+    // Already past the deadline, so this start is the one allowed attempt.
+    storage.values.set("loadRetryAfter", Date.now() - 1000);
 
     await room.onLoad();
 
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
-    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+    expect(storage.values.get("loadRetryAfter")).toBeUndefined();
   });
 });
 
@@ -295,6 +444,31 @@ describe("in-DO compaction size gate", () => {
     expect(await room.getCompactionParkedBytes()).toBeNull();
   });
 
+  // A later disconnect would otherwise re-schedule the compaction that was just
+  // parked, putting the room straight back into the crash loop.
+  test("a parked room does not reschedule compaction on disconnect", async () => {
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    await room.compactEmptyRoomDocument();
+    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    storage.setAlarmCalls = [];
+
+    // The last visitor leaves again.
+    await room.scheduleEmptyRoomCompaction();
+
+    expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
+    expect(storage.setAlarmCalls).toEqual([]);
+  });
+
+  test("an unparked room still schedules compaction on disconnect", async () => {
+    const { room, storage } = createRoom();
+
+    await room.scheduleEmptyRoomCompaction();
+
+    expect(storage.values.get("emptyRoomCompactAfter")).toBeGreaterThan(0);
+  });
+
   test("parking is reported once, not on every attempt", async () => {
     const storage = new FakeStorage();
     const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
@@ -341,7 +515,7 @@ describe("alarm failure backoff", () => {
 
     await room.onAlarm();
 
-    const retryAfter = storage.values.get("failureRetryAfter") as number;
+    const retryAfter = storage.values.get("alarmRetryAfter") as number;
     // First failure backs off by one minute, absorbing the platform's rapid retry.
     expect(retryAfter).toBeGreaterThanOrEqual(before + 60_000);
     // The alarm is re-armed at the backoff time, and no work ran.
@@ -356,7 +530,7 @@ describe("alarm failure backoff", () => {
       storage.values.set("alarmFailureAttempts", failures);
       const before = Date.now();
       await room.onAlarm();
-      delays.push((storage.values.get("failureRetryAfter") as number) - before);
+      delays.push((storage.values.get("alarmRetryAfter") as number) - before);
     }
 
     expect(delays[0]).toBeLessThan(delays[1]);
@@ -367,13 +541,13 @@ describe("alarm failure backoff", () => {
     const { room, storage } = createRoom();
     storage.values.set("alarmFailureAttempts", 1);
     // The backoff window has already passed.
-    storage.values.set("failureRetryAfter", Date.now() - 1000);
+    storage.values.set("alarmRetryAfter", Date.now() - 1000);
 
     await room.onAlarm();
 
     // The alarm ran its work and cleared the failure history.
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
-    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+    expect(storage.values.get("alarmRetryAfter")).toBeUndefined();
   });
 
   test("eight consecutive alarm failures quarantine as a last resort", async () => {
@@ -403,6 +577,132 @@ describe("alarm failure backoff", () => {
 
     expect(storage.setAlarmCalls).toEqual([]);
     expect(storage.alarm).toBeNull();
+  });
+});
+
+describe("separate retry ladders", () => {
+  // A shared deadline meant a healthy load erased the alarm's backoff, letting
+  // compaction start crash-looping again.
+  test("a successful load leaves the alarm backoff intact", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    const alarmDeadline = Date.now() + 30 * 60_000;
+    storage.values.set("alarmFailureAttempts", 3);
+    storage.values.set("alarmRetryAfter", alarmDeadline);
+
+    await room.onLoad();
+
+    expect(storage.values.get("alarmRetryAfter")).toBe(alarmDeadline);
+    expect(storage.values.get("alarmFailureAttempts")).toBe(3);
+  });
+
+  test("a successful alarm leaves the load backoff intact", async () => {
+    const { room, storage } = createRoom();
+    const loadDeadline = Date.now() + 30 * 60_000;
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", loadDeadline);
+
+    await room.onAlarm();
+
+    expect(storage.values.get("loadRetryAfter")).toBe(loadDeadline);
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(2);
+  });
+
+  test("status reports each deadline separately", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("loadRetryAfter", 1779829545000);
+    storage.values.set("alarmRetryAfter", 1779829999000);
+
+    const body = await room.getQuarantineStatusBody();
+
+    expect(body.failures.loadRetryAfter).toBe("2026-05-26T21:05:45.000Z");
+    expect(body.failures.alarmRetryAfter).toBe("2026-05-26T21:13:19.000Z");
+  });
+});
+
+describe("external quarantine control plane", () => {
+  // Every admin route runs after hydration, so a room that OOMs on start can
+  // only be stopped by a flag consulted before hydration happens.
+  test("a KV-flagged room quarantines without reading the document", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    kvStore.set("quarantine:example-room", "microcosmos incident");
+
+    await room.applyExternalQuarantineFlag();
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().reason).toBe("manual");
+    expect(room.getQuarantineState().detail).toBe("microcosmos incident");
+    expect(documentReadCount).toBe(0);
+
+    // And the subsequent load never hydrates either.
+    await room.onLoad();
+    expect(documentReadCount).toBe(0);
+    expect(docIsEmpty(room.document)).toBe(true);
+  });
+
+  test("setting quarantine writes the flag that survives a crashing room", async () => {
+    const { room } = createRoom();
+
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator note",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    expect(kvStore.get("quarantine:example-room")).toBe("operator note");
+  });
+
+  test("clearing quarantine removes the external flag", async () => {
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator note",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    await room.clearQuarantine();
+
+    expect(kvStore.has("quarantine:example-room")).toBe(false);
+  });
+
+  test("set and clear round-trip through KV across restarts", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator note",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    // A brand new isolate with EMPTY durable storage still sees the flag.
+    const freshStorage = new FakeStorage();
+    const restarted = buildRoom(freshStorage, "example-room");
+    await restarted.applyExternalQuarantineFlag();
+    expect(restarted.isQuarantined()).toBe(true);
+
+    await restarted.clearQuarantine();
+
+    const afterClear = buildRoom(new FakeStorage(), "example-room");
+    await afterClear.applyExternalQuarantineFlag();
+    expect(afterClear.isQuarantined()).toBe(false);
+  });
+
+  // Manual quarantine is an operator tool, not a correctness gate: a KV outage
+  // must never take rooms offline.
+  test("a KV read failure fails open", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    kvFailure = new Error("kv unavailable");
+
+    await room.applyExternalQuarantineFlag();
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
   });
 });
 
@@ -436,7 +736,8 @@ describe("manual quarantine", () => {
     const { room, storage } = createRoom();
     storage.values.set("alarmFailureAttempts", 8);
     storage.values.set("quarantineLoadAttempts", 3);
-    storage.values.set("failureRetryAfter", Date.now() + 1000);
+    storage.values.set("loadRetryAfter", Date.now() + 1000);
+    storage.values.set("alarmRetryAfter", Date.now() + 1000);
     await room.enterQuarantine({
       reason: "repeated-failures",
       detail: "alarm work failed 8 times in a row",
@@ -448,7 +749,8 @@ describe("manual quarantine", () => {
 
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
-    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+    expect(storage.values.get("loadRetryAfter")).toBeUndefined();
+    expect(storage.values.get("alarmRetryAfter")).toBeUndefined();
   });
 
   test("a quarantined room resumes quarantine on restart without hydrating", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1,0 +1,501 @@
+// ABOUTME: Drives the real PartyServer load path to verify quarantine behavior end to end.
+// ABOUTME: Asserts hydration is skipped, persisted rows survive, and alarms stop being scheduled.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as Y from "yjs";
+import { Buffer } from "node:buffer";
+
+// PartyServer imports Cloudflare-only modules and constructs a Supabase client at
+// module scope. Stub both so the real class can be exercised under bun test.
+class FakeDurableObject {
+  constructor(
+    public ctx: unknown,
+    public env: unknown,
+  ) {}
+}
+
+mock.module("cloudflare:workers", () => ({
+  env: {},
+  DurableObject: FakeDurableObject,
+  WorkerEntrypoint: class {},
+}));
+
+// A single mutable row stands in for the room's `documents` record. Tests assert
+// against `persistedRow.document` to prove quarantine never overwrites real data.
+type PersistedRow = { document: string | null };
+const persistedRow: PersistedRow = { document: null };
+let upsertCalls: Array<{ name: string; document: string }> = [];
+
+const supabaseStub = {
+  from() {
+    return {
+      select() {
+        return {
+          eq() {
+            return {
+              maybeSingle: async () => ({
+                data:
+                  persistedRow.document === null
+                    ? null
+                    : { document: persistedRow.document },
+                error: null,
+              }),
+            };
+          },
+        };
+      },
+      async upsert(row: { name: string; document: string }) {
+        upsertCalls.push(row);
+        persistedRow.document = row.document;
+        return { error: null };
+      },
+    };
+  },
+};
+
+mock.module(`${import.meta.dir}/../db.ts`, () => ({ supabase: supabaseStub }));
+
+const { PartyServer } = await import(`${import.meta.dir}/../party.ts`);
+
+// Minimal in-memory stand-ins for Durable Object storage and the YServer base.
+class FakeStorage {
+  values = new Map<string, unknown>();
+  alarm: number | null = null;
+  deleteAlarmCalls = 0;
+  setAlarmCalls: number[] = [];
+  // Ordered log of awaited writes, used to prove the load-attempt counter is
+  // committed before the risky hydration work runs.
+  writeLog: Array<{ key: string; value: unknown }> = [];
+
+  async get(key: string) {
+    return this.values.get(key);
+  }
+  async put(key: string, value: unknown) {
+    this.writeLog.push({ key, value });
+    this.values.set(key, value);
+  }
+  async delete(key: string) {
+    this.values.delete(key);
+  }
+  async getAlarm() {
+    return this.alarm;
+  }
+  async setAlarm(time: number) {
+    this.alarm = time;
+    this.setAlarmCalls.push(time);
+  }
+  async deleteAlarm() {
+    this.alarm = null;
+    this.deleteAlarmCalls += 1;
+  }
+}
+
+// `name` is a readonly accessor on the server base class, so the room fields are
+// installed as own properties rather than assigned.
+function buildRoom(storage: FakeStorage, name: string) {
+  return Object.create(PartyServer.prototype, {
+    ctx: { value: { storage }, writable: true },
+    name: { value: name, writable: true },
+    document: { value: new Y.Doc(), writable: true },
+    persistenceMode: { value: { kind: "available" }, writable: true },
+    quarantine: { value: null, writable: true },
+    isSkippingSave: { value: false, writable: true },
+    lastKnownDocumentBytes: { value: 0, writable: true },
+    hasWarnedDocumentSize: { value: false, writable: true },
+    cachedSubscribers: { value: null, writable: true },
+    cachedSharedRefs: { value: null, writable: true },
+    cachedSharedPerms: { value: null, writable: true },
+    cachedResetEpoch: { value: undefined, writable: true },
+    compactionAutosaveSnapshot: { value: null, writable: true },
+    getConnections: { value: () => [], writable: true },
+  }) as any;
+}
+
+function createRoom(name = "example-room") {
+  const storage = new FakeStorage();
+  return { room: buildRoom(storage, name), storage };
+}
+
+// Models a Durable Object restart: a fresh instance over the same storage.
+function restartRoom(storage: FakeStorage, name = "example-room") {
+  return buildRoom(storage, name);
+}
+
+// Builds a base64 Y.Doc payload of at least `targetBytes`, so the size gate sees a
+// document that is both realistic and genuinely oversized.
+function buildDocumentBase64(targetBytes: number): string {
+  const doc = new Y.Doc();
+  const map = doc.getMap("play");
+  let index = 0;
+  let encoded = Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+  while (encoded.length < targetBytes) {
+    map.set(`key-${index}`, "x".repeat(4096));
+    index += 1;
+    encoded = Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+  }
+  return encoded;
+}
+
+function docIsEmpty(doc: Y.Doc): boolean {
+  return Object.keys(doc.getMap("play").toJSON()).length === 0;
+}
+
+const SMALL_DOCUMENT = (() => {
+  const doc = new Y.Doc();
+  doc.getMap("play").set("greeting", "hello");
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+})();
+
+const OVERSIZED_DOCUMENT = buildDocumentBase64(1024 * 1024 * 7);
+
+beforeEach(() => {
+  persistedRow.document = null;
+  upsertCalls = [];
+});
+
+describe("size gate", () => {
+  test("an oversized document is never hydrated and the room is quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().reason).toBe("document-size");
+    expect(room.getQuarantineState().documentBytes).toBe(
+      OVERSIZED_DOCUMENT.length,
+    );
+    // The live doc was never populated: hydration did not run.
+    expect(docIsEmpty(room.document)).toBe(true);
+    // Quarantine is durable so the next start short-circuits before hydrating.
+    expect(storage.values.get("quarantine")).toBeDefined();
+  });
+
+  test("a below-threshold room loads normally and is left alone", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+    expect(room.isPersistenceAvailable()).toBe(true);
+    // The load-attempt counter is cleared after a healthy hydration.
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+  });
+
+  test("an empty room stays healthy", async () => {
+    const { room } = createRoom();
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(true);
+  });
+});
+
+describe("crash-loop breaker", () => {
+  test("the load-attempt counter is durable before hydration begins", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+
+    await room.onLoad();
+
+    // The counter is the FIRST awaited storage write of the load. An isolate that
+    // OOMs later in the load therefore leaves the increment committed, which is
+    // what lets the third start trip the breaker.
+    expect(storage.writeLog[0]).toEqual({
+      key: "quarantineLoadAttempts",
+      value: 1,
+    });
+    // A completed load clears the counter again.
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+  });
+
+  test("three failed starts quarantine the room without touching the document", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    // Three prior attempts started and none reported completion.
+    storage.values.set("quarantineLoadAttempts", 3);
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().reason).toBe("crash-loop");
+    expect(docIsEmpty(room.document)).toBe(true);
+    // The document is untouched in the database.
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  // A Supabase outage must not rewind evidence of real hydration crashes,
+  // otherwise a sub-threshold lethal document can crash-loop forever without the
+  // counter ever reaching the limit.
+  test("a Supabase outage rolls back only its own attempt", async () => {
+    const { room, storage } = createRoom();
+    // Two earlier starts reached hydration and died there.
+    storage.values.set("quarantineLoadAttempts", 2);
+    // This start cannot even read the document.
+    persistedRow.document = null;
+    const originalFrom = supabaseStub.from;
+    (supabaseStub as any).from = () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: null,
+            error: { message: "connection timeout" },
+          }),
+        }),
+      }),
+    });
+
+    try {
+      await room.onLoad();
+    } finally {
+      (supabaseStub as any).from = originalFrom;
+    }
+
+    expect(room.isQuarantined()).toBe(false);
+    // Back to the two genuine hydration failures, not reset to zero.
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(2);
+    expect(room.isPersistenceAvailable()).toBe(false);
+  });
+
+  test("two failed starts still allow a hydration attempt", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+  });
+});
+
+describe("quarantine semantics", () => {
+  test("a quarantined room runs in the existing transient mode", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+
+    await room.onLoad();
+
+    // Transient mode is what lets visitors connect and sync live while nothing
+    // persists, and it is what admin write endpoints already refuse against.
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(room.getPersistenceUnavailableResponse()?.status).toBe(503);
+  });
+
+  test("autosave cannot overwrite the persisted document while quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+
+    await room.onLoad();
+    expect(docIsEmpty(room.document)).toBe(true);
+
+    // onSave is the autosave entry point. Running it against the empty live doc
+    // is exactly the scenario that would destroy the persisted data.
+    await room.onSave();
+
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  test("the document write helper refuses to run while quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+
+    await room.onLoad();
+
+    // Direct call bypassing the autosave guards: the chokepoint itself must throw
+    // rather than silently persisting an unhydrated document.
+    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
+      /Refusing to persist document for quarantined room/,
+    );
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  // Compaction is the other route to saveDocumentBase64. Its entry points all
+  // gate on persistence availability, which quarantine turns off, so the room
+  // never rebuilds and rewrites a document it never loaded.
+  test("empty-room compaction does not run while quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+    await room.onLoad();
+
+    await room.compactEmptyRoomDocument();
+
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  // A hard reset derives the new document from the empty live doc, or falls back
+  // to re-reading the persisted one. Both destroy or re-crash a quarantined room.
+  test("a hard reset refuses to run while quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+    await room.onLoad();
+
+    await expect(room.performHardReset()).rejects.toThrow(
+      /Refusing to hard reset for quarantined room/
+    );
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  // force-reload-live reaches restoreFromSnapshot without going through
+  // saveDocumentBase64, so the guard has to live on the restore itself.
+  test("restoring a snapshot refuses by default while quarantined", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+    await room.onLoad();
+
+    await expect(
+      room.restoreFromSnapshot(OVERSIZED_DOCUMENT, { bumpEpoch: true })
+    ).rejects.toThrow(/Refusing to restore a snapshot for quarantined room/);
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  // Replacing the document with a repaired one is the sanctioned recovery path,
+  // so it opts in explicitly rather than being blocked with everything else.
+  test("an explicit repair restore is allowed and replaces the document", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room } = createRoom();
+    await room.onLoad();
+
+    await room.restoreFromSnapshot(SMALL_DOCUMENT, {
+      bumpEpoch: true,
+      allowQuarantined: true,
+    });
+
+    expect(upsertCalls.length).toBe(1);
+    expect(persistedRow.document).not.toBe(OVERSIZED_DOCUMENT);
+  });
+
+  test("a restart re-enters quarantine without reading the document", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+
+    // Second start, same storage: reuse the persisted quarantine record.
+    const restarted = restartRoom(storage);
+
+    await restarted.onLoad();
+
+    expect(restarted.isQuarantined()).toBe(true);
+    expect(docIsEmpty(restarted.document)).toBe(true);
+    expect(restarted.isPersistenceAvailable()).toBe(false);
+  });
+});
+
+describe("alarms", () => {
+  test("entering quarantine cancels any pending alarm", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.alarm = Date.now() + 60_000;
+
+    await room.onLoad();
+
+    expect(storage.alarm).toBeNull();
+    expect(storage.deleteAlarmCalls).toBeGreaterThan(0);
+  });
+
+  test("a quarantined room never schedules another alarm", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+    storage.setAlarmCalls = [];
+
+    // Bridge leases would normally force a prune alarm to be scheduled.
+    await room.setSubscribers([
+      { consumerRoomId: "other-room", elementIds: ["a"] },
+    ]);
+    await room.scheduleNextAlarm();
+
+    expect(storage.setAlarmCalls).toEqual([]);
+    expect(storage.alarm).toBeNull();
+  });
+
+  test("a firing alarm on a quarantined room does no work and reschedules nothing", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+    storage.setAlarmCalls = [];
+
+    await room.onAlarm();
+
+    expect(storage.setAlarmCalls).toEqual([]);
+    expect(storage.alarm).toBeNull();
+    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+  });
+
+  // onStart runs after onLoad and calls ensureAlarmScheduled. This is the exact
+  // path the crash loop travels, so a quarantined room must come out of it with
+  // no alarm pending.
+  test("the post-load startup path does not re-arm the alarm", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+
+    await room.setSubscribers([
+      { consumerRoomId: "other-room", elementIds: ["a"] },
+    ]);
+    storage.setAlarmCalls = [];
+    storage.alarm = Date.now() + 60_000;
+
+    await room.ensureAlarmScheduled();
+
+    expect(storage.setAlarmCalls).toEqual([]);
+    expect(storage.alarm).toBeNull();
+  });
+
+  test("a healthy room still schedules alarms for bridge leases", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+
+    await room.setSubscribers([
+      { consumerRoomId: "other-room", elementIds: ["a"] },
+    ]);
+    await room.scheduleNextAlarm();
+
+    expect(storage.setAlarmCalls.length).toBe(1);
+  });
+});
+
+describe("quarantine-clear", () => {
+  test("clearing quarantine lets the next load hydrate again", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+    expect(room.isQuarantined()).toBe(true);
+
+    await room.clearQuarantine();
+
+    expect(room.isQuarantined()).toBe(false);
+    expect(storage.values.get("quarantine")).toBeUndefined();
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+
+    // Operator shrank the document, then restarted the room.
+    persistedRow.document = SMALL_DOCUMENT;
+    const restarted = restartRoom(storage);
+
+    await restarted.onLoad();
+
+    expect(restarted.isQuarantined()).toBe(false);
+    expect(restarted.document.getMap("play").get("greeting")).toBe("hello");
+  });
+
+  test("clearing quarantine on a still-oversized room re-quarantines it", async () => {
+    persistedRow.document = OVERSIZED_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.onLoad();
+    await room.clearQuarantine();
+
+    const restarted = restartRoom(storage);
+
+    await restarted.onLoad();
+
+    expect(restarted.isQuarantined()).toBe(true);
+    expect(restarted.getQuarantineState().reason).toBe("document-size");
+  });
+});

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Drives the real PartyServer load path to verify quarantine behavior end to end.
-// ABOUTME: Asserts hydration is skipped, persisted rows survive, and alarms stop being scheduled.
+// ABOUTME: Drives the real PartyServer load and alarm paths to verify breaker behavior.
+// ABOUTME: Asserts oversized rooms still load, compaction is skipped, and backoff self-heals.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import * as Y from "yjs";
 import { Buffer } from "node:buffer";
@@ -9,7 +9,7 @@ import { Buffer } from "node:buffer";
 class FakeDurableObject {
   constructor(
     public ctx: unknown,
-    public env: unknown,
+    public env: unknown
   ) {}
 }
 
@@ -20,7 +20,7 @@ mock.module("cloudflare:workers", () => ({
 }));
 
 // A single mutable row stands in for the room's `documents` record. Tests assert
-// against `persistedRow.document` to prove quarantine never overwrites real data.
+// against `persistedRow.document` to prove risky paths never overwrite real data.
 type PersistedRow = { document: string | null };
 const persistedRow: PersistedRow = { document: null };
 let upsertCalls: Array<{ name: string; document: string }> = [];
@@ -56,14 +56,14 @@ mock.module(`${import.meta.dir}/../db.ts`, () => ({ supabase: supabaseStub }));
 
 const { PartyServer } = await import(`${import.meta.dir}/../party.ts`);
 
-// Minimal in-memory stand-ins for Durable Object storage and the YServer base.
+// Minimal in-memory stand-ins for Durable Object storage.
 class FakeStorage {
   values = new Map<string, unknown>();
   alarm: number | null = null;
   deleteAlarmCalls = 0;
   setAlarmCalls: number[] = [];
-  // Ordered log of awaited writes, used to prove the load-attempt counter is
-  // committed before the risky hydration work runs.
+  // Ordered log of awaited writes, used to prove failure counters are committed
+  // before the risky work they protect.
   writeLog: Array<{ key: string; value: unknown }> = [];
 
   async get(key: string) {
@@ -89,15 +89,16 @@ class FakeStorage {
   }
 }
 
-// `name` is a readonly accessor on the server base class, so the room fields are
+// `name` is a readonly accessor on the server base class, so room fields are
 // installed as own properties rather than assigned.
-function buildRoom(storage: FakeStorage, name: string) {
+function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
   return Object.create(PartyServer.prototype, {
     ctx: { value: { storage }, writable: true },
     name: { value: name, writable: true },
-    document: { value: new Y.Doc(), writable: true },
+    document: { value: doc ?? new Y.Doc(), writable: true },
     persistenceMode: { value: { kind: "available" }, writable: true },
     quarantine: { value: null, writable: true },
+    compactionTooLargeBytes: { value: null, writable: true },
     isSkippingSave: { value: false, writable: true },
     lastKnownDocumentBytes: { value: 0, writable: true },
     hasWarnedDocumentSize: { value: false, writable: true },
@@ -106,6 +107,7 @@ function buildRoom(storage: FakeStorage, name: string) {
     cachedSharedPerms: { value: null, writable: true },
     cachedResetEpoch: { value: undefined, writable: true },
     compactionAutosaveSnapshot: { value: null, writable: true },
+    emptyRoomCompactionPromise: { value: null, writable: true },
     getConnections: { value: () => [], writable: true },
   }) as any;
 }
@@ -120,57 +122,59 @@ function restartRoom(storage: FakeStorage, name = "example-room") {
   return buildRoom(storage, name);
 }
 
-// Builds a base64 Y.Doc payload of at least `targetBytes`, so the size gate sees a
-// document that is both realistic and genuinely oversized.
-function buildDocumentBase64(targetBytes: number): string {
+// Builds a Y.Doc whose encoded form is at least `targetBytes`, so size checks see
+// a realistic document rather than a synthetic string.
+function buildLargeDoc(targetBytes: number): Y.Doc {
   const doc = new Y.Doc();
   const map = doc.getMap("play");
   let index = 0;
-  let encoded = Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
-  while (encoded.length < targetBytes) {
-    map.set(`key-${index}`, "x".repeat(4096));
+  while (Y.encodeStateAsUpdate(doc).length * 1.34 < targetBytes) {
+    map.set(`key-${index}`, "x".repeat(8192));
     index += 1;
-    encoded = Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
   }
-  return encoded;
+  return doc;
+}
+
+function encodeDoc(doc: Y.Doc): string {
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
 }
 
 function docIsEmpty(doc: Y.Doc): boolean {
   return Object.keys(doc.getMap("play").toJSON()).length === 0;
 }
 
+const MB = 1024 * 1024;
+
 const SMALL_DOCUMENT = (() => {
   const doc = new Y.Doc();
   doc.getMap("play").set("greeting", "hello");
-  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+  return encodeDoc(doc);
 })();
 
-const OVERSIZED_DOCUMENT = buildDocumentBase64(1024 * 1024 * 7);
+// Sits in the band that loads fine but OOMs when compacted in place.
+const COMPACT_LETHAL_DOC = buildLargeDoc(6 * MB);
+const COMPACT_LETHAL_DOCUMENT = encodeDoc(COMPACT_LETHAL_DOC);
 
 beforeEach(() => {
   persistedRow.document = null;
   upsertCalls = [];
 });
 
-describe("size gate", () => {
-  test("an oversized document is never hydrated and the room is quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
+describe("load path", () => {
+  // The central correction: rooms in the 6-8MB band load successfully in
+  // production, so size must never block hydration.
+  test("a large document still loads and the room stays normal", async () => {
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    const { room } = createRoom();
 
     await room.onLoad();
 
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().reason).toBe("document-size");
-    expect(room.getQuarantineState().documentBytes).toBe(
-      OVERSIZED_DOCUMENT.length,
-    );
-    // The live doc was never populated: hydration did not run.
-    expect(docIsEmpty(room.document)).toBe(true);
-    // Quarantine is durable so the next start short-circuits before hydrating.
-    expect(storage.values.get("quarantine")).toBeDefined();
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(docIsEmpty(room.document)).toBe(false);
   });
 
-  test("a below-threshold room loads normally and is left alone", async () => {
+  test("a small document loads normally", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
 
@@ -178,207 +182,286 @@ describe("size gate", () => {
 
     expect(room.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
-    expect(room.isPersistenceAvailable()).toBe(true);
-    // The load-attempt counter is cleared after a healthy hydration.
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
   });
 
-  test("an empty room stays healthy", async () => {
-    const { room } = createRoom();
-
-    await room.onLoad();
-
-    expect(room.isQuarantined()).toBe(false);
-    expect(room.isPersistenceAvailable()).toBe(true);
-  });
-});
-
-describe("crash-loop breaker", () => {
-  test("the load-attempt counter is durable before hydration begins", async () => {
+  test("the load counter is committed before hydration and cleared after", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
 
     await room.onLoad();
 
-    // The counter is the FIRST awaited storage write of the load. An isolate that
-    // OOMs later in the load therefore leaves the increment committed, which is
-    // what lets the third start trip the breaker.
     expect(storage.writeLog[0]).toEqual({
       key: "quarantineLoadAttempts",
       value: 1,
     });
-    // A completed load clears the counter again.
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
   });
 
-  test("three failed starts quarantine the room without touching the document", async () => {
+  // Below the high threshold the room keeps trying: most load failures are
+  // environmental and clear on their own.
+  test("prior load failures do not stop hydration below the threshold", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
-    // Three prior attempts started and none reported completion.
-    storage.values.set("quarantineLoadAttempts", 3);
-
-    await room.onLoad();
-
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().reason).toBe("crash-loop");
-    expect(docIsEmpty(room.document)).toBe(true);
-    // The document is untouched in the database.
-    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
-  });
-
-  // A Supabase outage must not rewind evidence of real hydration crashes,
-  // otherwise a sub-threshold lethal document can crash-loop forever without the
-  // counter ever reaching the limit.
-  test("a Supabase outage rolls back only its own attempt", async () => {
-    const { room, storage } = createRoom();
-    // Two earlier starts reached hydration and died there.
-    storage.values.set("quarantineLoadAttempts", 2);
-    // This start cannot even read the document.
-    persistedRow.document = null;
-    const originalFrom = supabaseStub.from;
-    (supabaseStub as any).from = () => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: async () => ({
-            data: null,
-            error: { message: "connection timeout" },
-          }),
-        }),
-      }),
-    });
-
-    try {
-      await room.onLoad();
-    } finally {
-      (supabaseStub as any).from = originalFrom;
-    }
-
-    expect(room.isQuarantined()).toBe(false);
-    // Back to the two genuine hydration failures, not reset to zero.
-    expect(storage.values.get("quarantineLoadAttempts")).toBe(2);
-    expect(room.isPersistenceAvailable()).toBe(false);
-  });
-
-  test("two failed starts still allow a hydration attempt", async () => {
-    persistedRow.document = SMALL_DOCUMENT;
-    const { room, storage } = createRoom();
-    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("quarantineLoadAttempts", 5);
 
     await room.onLoad();
 
     expect(room.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
   });
+
+  test("eight consecutive load failures quarantine as a last resort", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 8);
+
+    await room.onLoad();
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().reason).toBe("repeated-failures");
+    expect(docIsEmpty(room.document)).toBe(true);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("a successful load clears failure history and pending backoff", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 4);
+    storage.values.set("failureRetryAfter", Date.now() + 60_000);
+
+    await room.onLoad();
+
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+  });
 });
 
-describe("quarantine semantics", () => {
-  test("a quarantined room runs in the existing transient mode", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-
-    await room.onLoad();
-
-    // Transient mode is what lets visitors connect and sync live while nothing
-    // persists, and it is what admin write endpoints already refuse against.
-    expect(room.isPersistenceAvailable()).toBe(false);
-    expect(room.getPersistenceUnavailableResponse()?.status).toBe(503);
-  });
-
-  test("autosave cannot overwrite the persisted document while quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-
-    await room.onLoad();
-    expect(docIsEmpty(room.document)).toBe(true);
-
-    // onSave is the autosave entry point. Running it against the empty live doc
-    // is exactly the scenario that would destroy the persisted data.
-    await room.onSave();
-
-    expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
-  });
-
-  test("the document write helper refuses to run while quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-
-    await room.onLoad();
-
-    // Direct call bypassing the autosave guards: the chokepoint itself must throw
-    // rather than silently persisting an unhydrated document.
-    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
-      /Refusing to persist document for quarantined room/,
-    );
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
-  });
-
-  // Compaction is the other route to saveDocumentBase64. Its entry points all
-  // gate on persistence availability, which quarantine turns off, so the room
-  // never rebuilds and rewrites a document it never loaded.
-  test("empty-room compaction does not run while quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-    await room.onLoad();
+describe("in-DO compaction size gate", () => {
+  test("an oversized document is not compacted and the room stays normal", async () => {
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+    await room.setEmptyRoomCompactAfter(Date.now() - 1000);
 
     await room.compactEmptyRoomDocument();
 
+    // Persisted data untouched, and compaction is parked so the alarm stops
+    // retrying doomed work.
     expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
+    expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
+    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
+    // Critically, this is NOT a quarantine.
+    expect(room.isQuarantined()).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(true);
   });
 
-  // A hard reset derives the new document from the empty live doc, or falls back
-  // to re-reading the persisted one. Both destroy or re-crash a quarantined room.
-  test("a hard reset refuses to run while quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-    await room.onLoad();
+  test("a healthy small room still compacts normally", async () => {
+    // Deleted entries leave tombstones behind, which is the history compaction
+    // actually removes. A doc without history compacts larger and is correctly
+    // skipped, so the churn here has to be real.
+    const doc = new Y.Doc();
+    const map = doc.getMap("play");
+    for (let i = 0; i < 400; i += 1) {
+      map.set(`key-${i}`, "value-".repeat(40) + i);
+    }
+    for (let i = 0; i < 399; i += 1) {
+      map.delete(`key-${i}`);
+    }
+    persistedRow.document = encodeDoc(doc);
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", doc);
 
-    await expect(room.performHardReset()).rejects.toThrow(
-      /Refusing to hard reset for quarantined room/
-    );
-    expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
-  });
+    await room.compactEmptyRoomDocument();
 
-  // force-reload-live reaches restoreFromSnapshot without going through
-  // saveDocumentBase64, so the guard has to live on the restore itself.
-  test("restoring a snapshot refuses by default while quarantined", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-    await room.onLoad();
-
-    await expect(
-      room.restoreFromSnapshot(OVERSIZED_DOCUMENT, { bumpEpoch: true })
-    ).rejects.toThrow(/Refusing to restore a snapshot for quarantined room/);
-    expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
-  });
-
-  // Replacing the document with a repaired one is the sanctioned recovery path,
-  // so it opts in explicitly rather than being blocked with everything else.
-  test("an explicit repair restore is allowed and replaces the document", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room } = createRoom();
-    await room.onLoad();
-
-    await room.restoreFromSnapshot(SMALL_DOCUMENT, {
-      bumpEpoch: true,
-      allowQuarantined: true,
-    });
-
+    // Not parked, and the compacted document was persisted.
+    expect(await room.getCompactionParkedBytes()).toBeNull();
     expect(upsertCalls.length).toBe(1);
-    expect(persistedRow.document).not.toBe(OVERSIZED_DOCUMENT);
+    expect(persistedRow.document).not.toBe("");
   });
 
-  test("a restart re-enters quarantine without reading the document", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
+  // After an external compaction the room should resume compacting on its own,
+  // without an operator having to unpark it by hand.
+  test("parking clears so a repaired room compacts again", async () => {
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    await room.compactEmptyRoomDocument();
+    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+
+    await room.clearCompactionPark();
+
+    expect(await room.getCompactionParkedBytes()).toBeNull();
+  });
+
+  test("parking is reported once, not on every attempt", async () => {
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (message: unknown) => {
+      errors.push(String(message));
+    };
+    try {
+      await room.compactEmptyRoomDocument();
+      await room.compactEmptyRoomDocument();
+      await room.compactEmptyRoomDocument();
+    } finally {
+      console.error = originalError;
+    }
+
+    const parkLogs = errors.filter((line) =>
+      line.includes("REQUIRES EXTERNAL COMPACTION")
+    );
+    expect(parkLogs.length).toBe(1);
+  });
+});
+
+describe("alarm failure backoff", () => {
+  test("the alarm counter is committed before the risky work", async () => {
+    const { room, storage } = createRoom();
+
+    await room.onAlarm();
+
+    expect(
+      storage.writeLog.some((entry) => entry.key === "alarmFailureAttempts")
+    ).toBe(true);
+    // Completing the alarm clears it again.
+    expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
+  });
+
+  test("a failed alarm backs off instead of retrying immediately", async () => {
+    const { room, storage } = createRoom();
+    // A previous alarm started and never completed.
+    storage.values.set("alarmFailureAttempts", 1);
+    const before = Date.now();
+
+    await room.onAlarm();
+
+    const retryAfter = storage.values.get("failureRetryAfter") as number;
+    // First failure backs off by one minute, absorbing the platform's rapid retry.
+    expect(retryAfter).toBeGreaterThanOrEqual(before + 60_000);
+    // The alarm is re-armed at the backoff time, and no work ran.
+    expect(storage.alarm).toBe(retryAfter);
+  });
+
+  test("backoff escalates with consecutive failures", async () => {
+    const delays: number[] = [];
+
+    for (const failures of [1, 2, 3]) {
+      const { room, storage } = createRoom();
+      storage.values.set("alarmFailureAttempts", failures);
+      const before = Date.now();
+      await room.onAlarm();
+      delays.push((storage.values.get("failureRetryAfter") as number) - before);
+    }
+
+    expect(delays[0]).toBeLessThan(delays[1]);
+    expect(delays[1]).toBeLessThan(delays[2]);
+  });
+
+  test("work resumes once the backoff has elapsed", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("alarmFailureAttempts", 1);
+    // The backoff window has already passed.
+    storage.values.set("failureRetryAfter", Date.now() - 1000);
+
+    await room.onAlarm();
+
+    // The alarm ran its work and cleared the failure history.
+    expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
+    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+  });
+
+  test("eight consecutive alarm failures quarantine as a last resort", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("alarmFailureAttempts", 8);
+
+    await room.onAlarm();
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().reason).toBe("repeated-failures");
+    expect(room.getQuarantineState().failureKind).toBe("alarm");
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("a quarantined room does no alarm work and parks the alarm", async () => {
+    const { room, storage } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    storage.setAlarmCalls = [];
+
+    await room.onAlarm();
+
+    expect(storage.setAlarmCalls).toEqual([]);
+    expect(storage.alarm).toBeNull();
+  });
+});
+
+describe("manual quarantine", () => {
+  test("an operator can quarantine a healthy room and clear it again", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
     await room.onLoad();
+    expect(room.isQuarantined()).toBe(false);
 
-    // Second start, same storage: reuse the persisted quarantine record.
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "investigating runaway growth",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    expect(room.isQuarantined()).toBe(true);
+    expect(room.getQuarantineState().detail).toBe(
+      "investigating runaway growth"
+    );
+    // Manual quarantine still suppresses persistence.
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(storage.alarm).toBeNull();
+
+    await room.clearQuarantine();
+    expect(room.isQuarantined()).toBe(false);
+  });
+
+  test("clearing quarantine also clears the failure history behind it", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("alarmFailureAttempts", 8);
+    storage.values.set("quarantineLoadAttempts", 3);
+    storage.values.set("failureRetryAfter", Date.now() + 1000);
+    await room.enterQuarantine({
+      reason: "repeated-failures",
+      detail: "alarm work failed 8 times in a row",
+      failureKind: "alarm",
+      failureCount: 8,
+    });
+
+    await room.clearQuarantine();
+
+    expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+    expect(storage.values.get("failureRetryAfter")).toBeUndefined();
+  });
+
+  test("a quarantined room resumes quarantine on restart without hydrating", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+
     const restarted = restartRoom(storage);
-
     await restarted.onLoad();
 
     expect(restarted.isQuarantined()).toBe(true);
@@ -387,115 +470,88 @@ describe("quarantine semantics", () => {
   });
 });
 
-describe("alarms", () => {
-  test("entering quarantine cancels any pending alarm", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    storage.alarm = Date.now() + 60_000;
-
-    await room.onLoad();
-
-    expect(storage.alarm).toBeNull();
-    expect(storage.deleteAlarmCalls).toBeGreaterThan(0);
-  });
-
-  test("a quarantined room never schedules another alarm", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
-    storage.setAlarmCalls = [];
-
-    // Bridge leases would normally force a prune alarm to be scheduled.
-    await room.setSubscribers([
-      { consumerRoomId: "other-room", elementIds: ["a"] },
-    ]);
-    await room.scheduleNextAlarm();
-
-    expect(storage.setAlarmCalls).toEqual([]);
-    expect(storage.alarm).toBeNull();
-  });
-
-  test("a firing alarm on a quarantined room does no work and reschedules nothing", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
-    storage.setAlarmCalls = [];
-
-    await room.onAlarm();
-
-    expect(storage.setAlarmCalls).toEqual([]);
-    expect(storage.alarm).toBeNull();
-    expect(persistedRow.document).toBe(OVERSIZED_DOCUMENT);
-  });
-
-  // onStart runs after onLoad and calls ensureAlarmScheduled. This is the exact
-  // path the crash loop travels, so a quarantined room must come out of it with
-  // no alarm pending.
-  test("the post-load startup path does not re-arm the alarm", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
-
-    await room.setSubscribers([
-      { consumerRoomId: "other-room", elementIds: ["a"] },
-    ]);
-    storage.setAlarmCalls = [];
-    storage.alarm = Date.now() + 60_000;
-
-    await room.ensureAlarmScheduled();
-
-    expect(storage.setAlarmCalls).toEqual([]);
-    expect(storage.alarm).toBeNull();
-  });
-
-  test("a healthy room still schedules alarms for bridge leases", async () => {
+describe("quarantine data safety", () => {
+  test("autosave cannot overwrite the persisted document while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
 
-    await room.setSubscribers([
-      { consumerRoomId: "other-room", elementIds: ["a"] },
-    ]);
-    await room.scheduleNextAlarm();
+    await room.onSave();
 
-    expect(storage.setAlarmCalls.length).toBe(1);
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
-});
 
-describe("quarantine-clear", () => {
-  test("clearing quarantine lets the next load hydrate again", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
-    expect(room.isQuarantined()).toBe(true);
-
-    await room.clearQuarantine();
-
-    expect(room.isQuarantined()).toBe(false);
-    expect(storage.values.get("quarantine")).toBeUndefined();
-    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
-
-    // Operator shrank the document, then restarted the room.
+  test("the document write helper refuses to run while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
-    const restarted = restartRoom(storage);
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
 
-    await restarted.onLoad();
-
-    expect(restarted.isQuarantined()).toBe(false);
-    expect(restarted.document.getMap("play").get("greeting")).toBe("hello");
+    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
+      /Refusing to persist document for quarantined room/
+    );
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
 
-  test("clearing quarantine on a still-oversized room re-quarantines it", async () => {
-    persistedRow.document = OVERSIZED_DOCUMENT;
-    const { room, storage } = createRoom();
-    await room.onLoad();
-    await room.clearQuarantine();
+  test("a hard reset refuses to run while quarantined", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
 
-    const restarted = restartRoom(storage);
+    await expect(room.performHardReset()).rejects.toThrow(
+      /Refusing to hard reset for quarantined room/
+    );
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
 
-    await restarted.onLoad();
+  test("restoring a snapshot refuses by default while quarantined", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
 
-    expect(restarted.isQuarantined()).toBe(true);
-    expect(restarted.getQuarantineState().reason).toBe("document-size");
+    await expect(
+      room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+    ).rejects.toThrow(/Refusing to restore a snapshot for quarantined room/);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  // Replacing the document with a repaired one is the sanctioned recovery path.
+  test("an explicit repair restore is allowed and replaces the document", async () => {
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    const { room } = createRoom();
+    await room.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    await room.restoreFromSnapshot(SMALL_DOCUMENT, {
+      bumpEpoch: true,
+      allowQuarantined: true,
+    });
+
+    expect(upsertCalls.length).toBe(1);
+    expect(persistedRow.document).not.toBe(COMPACT_LETHAL_DOCUMENT);
   });
 });

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -254,6 +254,21 @@ describe("load path", () => {
     expect(room.isQuarantined()).toBe(false);
   });
 
+  test("the first inferred load failure waits on the one-minute rung", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 1);
+    const before = Date.now();
+
+    await room.onLoad();
+
+    const retryAfter = storage.values.get("loadRetryAfter") as number;
+    expect(retryAfter).toBeGreaterThanOrEqual(before + 60_000);
+    expect(retryAfter).toBeLessThanOrEqual(before + 61_000);
+    expect(documentReadCount).toBe(0);
+    expect(room.isLoadDeferred()).toBe(true);
+  });
+
   test("a deferred room answers requests with 503 and Retry-After", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
@@ -297,6 +312,50 @@ describe("load path", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.failures.load).toBe(2);
+  });
+
+  test("admin write routes cannot persist an un-hydrated deferred document", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await room.onLoad();
+
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/force-save-live",
+        { method: "POST" }
+      )
+    );
+
+    expect(response.status).toBe(503);
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("manual quarantine remains reachable while a room is deferred", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await room.onLoad();
+
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        {
+          method: "POST",
+          body: JSON.stringify({ reason: "operator intervention" }),
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(room.isQuarantined()).toBe(true);
+    expect(kvStore.get("quarantine:example-room")).toBe(
+      "operator intervention"
+    );
+    expect(documentReadCount).toBe(0);
   });
 
   test("a connection to a deferred room is closed, not joined", async () => {
@@ -548,6 +607,23 @@ describe("alarm failure backoff", () => {
     // The alarm ran its work and cleared the failure history.
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
     expect(storage.values.get("alarmRetryAfter")).toBeUndefined();
+  });
+
+  test("a due alarm reserves the next backoff rung before risky work", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("alarmFailureAttempts", 1);
+    storage.values.set("alarmRetryAfter", Date.now() - 1);
+    storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
+    room.compactEmptyRoomDocument = async () => {
+      throw new Error("simulated alarm failure");
+    };
+    const before = Date.now();
+
+    await expect(room.onAlarm()).rejects.toThrow("simulated alarm failure");
+
+    const retryAfter = storage.values.get("alarmRetryAfter") as number;
+    expect(retryAfter).toBeGreaterThanOrEqual(before + 5 * 60_000);
+    expect(storage.values.get("alarmFailureAttempts")).toBe(2);
   });
 
   test("eight consecutive alarm failures quarantine as a last resort", async () => {
@@ -819,6 +895,72 @@ describe("quarantine data safety", () => {
       /Refusing to hard reset for quarantined room/
     );
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("a hard reset parks an oversized room before rebuilding or writing", async () => {
+    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
+    const storage = new FakeStorage();
+    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    let response: Response;
+    try {
+      response = await room.onRequest(
+        new Request(
+          "https://example.com/parties/main/example-room/admin/hard-reset",
+          { method: "POST" }
+        )
+      );
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: "External compaction required",
+      roomId: "example-room",
+    });
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
+    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(
+      errors.some((line) => line.includes("ExternalCompactionRequiredError"))
+    ).toBe(true);
+  });
+
+  test("loading a committed reset repairs a stale server epoch", async () => {
+    const resetEpoch = 1_785_299_170_000;
+    const resetDocument = new Y.Doc();
+    resetDocument.getMap("play").set("greeting", "hello");
+    resetDocument.getMap("__playhtml_meta").set("resetEpoch", resetEpoch);
+    persistedRow.document = encodeDoc(resetDocument);
+
+    const { room, storage } = createRoom();
+    storage.values.set("resetEpoch", resetEpoch - 10_000);
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      await room.onLoad();
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(await room.getResetEpoch()).toBe(resetEpoch);
+    expect(storage.values.get("resetEpoch")).toBe(resetEpoch);
+    expect(
+      warnings.some((line) =>
+        line.includes("Loaded document advanced the server reset epoch")
+      )
+    ).toBe(true);
   });
 
   test("restoring a snapshot refuses by default while quarantined", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Drives the real PartyServer load and alarm paths to verify breaker behavior.
-// ABOUTME: Asserts oversized rooms still load, compaction is skipped, and backoff self-heals.
+// ABOUTME: Asserts rooms stay available while failed work backs off or is disabled.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import * as Y from "yjs";
 import { Buffer } from "node:buffer";
@@ -170,8 +170,8 @@ function restartRoom(storage: FakeStorage, name = "example-room") {
   return buildRoom(storage, name);
 }
 
-// Builds a Y.Doc whose encoded form is at least `targetBytes`, so size checks see
-// a realistic document rather than a synthetic string.
+// Builds a Y.Doc whose encoded form is at least `targetBytes`, so large-document
+// tests exercise a realistic Yjs document rather than a synthetic string.
 function buildLargeDoc(targetBytes: number): Y.Doc {
   const doc = new Y.Doc();
   const map = doc.getMap("play");
@@ -461,26 +461,22 @@ describe("load path", () => {
   });
 });
 
-describe("in-DO compaction size gate", () => {
-  test("an oversized document is not compacted and the room stays normal", async () => {
-    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    const storage = new FakeStorage();
-    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
-    await room.setEmptyRoomCompactAfter(Date.now() - 1000);
+describe("automatic compaction breaker", () => {
+  test("document size does not block creation of a compaction candidate", () => {
+    const room = buildRoom(
+      new FakeStorage(),
+      "example-room",
+      COMPACT_LETHAL_DOC
+    );
 
-    await room.compactEmptyRoomDocument();
+    const compacted = room.buildCompactedDocument(
+      COMPACT_LETHAL_DOC,
+      COMPACT_LETHAL_DOCUMENT
+    );
 
-    // Persisted data untouched, and compaction is parked so the alarm stops
-    // retrying doomed work.
-    expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
-    expect(
-      await room.circuitBreaker.getCompactionParkedBytes()
-    ).toBeGreaterThan(0);
-    expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
-    // Critically, this is NOT a quarantine.
-    expect(room.circuitBreaker.isQuarantined()).toBe(false);
-    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(compacted).not.toBeNull();
+    expect(compacted.beforeSize).toBeGreaterThan(4 * MB);
+    expect(compacted.afterSize).toBeGreaterThan(0);
   });
 
   test("a healthy small room still compacts normally", async () => {
@@ -501,77 +497,86 @@ describe("in-DO compaction size gate", () => {
 
     await room.compactEmptyRoomDocument();
 
-    // Not parked, and the compacted document was persisted.
-    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
     expect(upsertCalls.length).toBe(1);
     expect(persistedRow.document).not.toBe("");
+    expect(storage.values.get("compactionAttempts")).toBeUndefined();
+    expect(storage.values.get("compactionRetryAfter")).toBeUndefined();
   });
 
-  // After an external compaction the room should resume compacting on its own,
-  // without an operator having to unpark it by hand.
-  test("parking clears so a repaired room compacts again", async () => {
-    const storage = new FakeStorage();
-    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
-    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    await room.compactEmptyRoomDocument();
-    expect(
-      await room.circuitBreaker.getCompactionParkedBytes()
-    ).toBeGreaterThan(0);
+  test("three vanished attempts retry after 15s and 30s, then disable", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
+    storage.values.set("compactionAttempts", 1);
 
-    await room.circuitBreaker.clearCompactionPark();
+    const firstRetryStart = Date.now();
+    expect(await room.circuitBreaker.getCompactionAdmission()).toEqual({
+      kind: "defer",
+      retryAt: expect.any(Number),
+    });
+    const firstRetryAt = storage.values.get("compactionRetryAfter") as number;
+    expect(firstRetryAt).toBeGreaterThanOrEqual(firstRetryStart + 15_000);
+    expect(firstRetryAt).toBeLessThanOrEqual(firstRetryStart + 16_000);
 
-    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
+    storage.values.set("compactionRetryAfter", Date.now() - 1);
+    expect(await room.circuitBreaker.getCompactionAdmission()).toEqual({
+      kind: "run",
+    });
+    const secondRetryAt = storage.values.get("compactionRetryAfter") as number;
+    expect(secondRetryAt).toBeGreaterThanOrEqual(Date.now() + 29_000);
+    expect(await room.circuitBreaker.beginCompactionAttempt()).toBe(2);
+
+    storage.values.set("compactionRetryAfter", Date.now() - 1);
+    expect(await room.circuitBreaker.getCompactionAdmission()).toEqual({
+      kind: "run",
+    });
+    expect(storage.values.get("compactionRetryAfter")).toBeUndefined();
+    expect(await room.circuitBreaker.beginCompactionAttempt()).toBe(3);
+
+    const disabled = await room.circuitBreaker.getCompactionAdmission();
+    expect(disabled).toEqual({
+      kind: "disabled",
+      disabledAt: expect.any(Number),
+    });
+    expect(storage.values.get("compactionDisabledAt")).toBe(
+      disabled.disabledAt
+    );
+    expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(true);
   });
 
-  // A later disconnect would otherwise re-schedule the compaction that was just
-  // parked, putting the room straight back into the crash loop.
-  test("a parked room does not reschedule compaction on disconnect", async () => {
-    const storage = new FakeStorage();
-    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
-    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    await room.compactEmptyRoomDocument();
-    expect(
-      await room.circuitBreaker.getCompactionParkedBytes()
-    ).toBeGreaterThan(0);
+  test("an observed exception clears the compaction attempt marker", async () => {
+    const { room, storage } = createRoom();
+    room.buildCompactedDocument = () => {
+      throw new Error("observed compaction failure");
+    };
+
+    await expect(room.compactEmptyRoomDocument()).rejects.toThrow(
+      "observed compaction failure"
+    );
+
+    expect(storage.values.get("compactionAttempts")).toBeUndefined();
+    expect(storage.values.get("compactionRetryAfter")).toBeUndefined();
+    expect(storage.values.get("compactionDisabledAt")).toBeUndefined();
+  });
+
+  test("a disabled room still loads and persists without rescheduling compaction", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("compactionAttempts", 3);
+    await room.circuitBreaker.getCompactionAdmission();
     storage.setAlarmCalls = [];
 
-    // The last visitor leaves again.
-    await room.scheduleEmptyRoomCompaction();
+    await startRoom(room);
+    room.document.getMap("play").set("greeting", "updated");
+    await room.onSave();
 
+    expect(room.document.getMap("play").get("greeting")).toBe("updated");
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).not.toBe(SMALL_DOCUMENT);
     expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
     expect(storage.setAlarmCalls).toEqual([]);
-  });
-
-  test("an unparked room still schedules compaction on disconnect", async () => {
-    const { room, storage } = createRoom();
-
-    await room.scheduleEmptyRoomCompaction();
-
-    expect(storage.values.get("emptyRoomCompactAfter")).toBeGreaterThan(0);
-  });
-
-  test("parking is reported once, not on every attempt", async () => {
-    const storage = new FakeStorage();
-    const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
-    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-
-    const errors: string[] = [];
-    const originalError = console.error;
-    console.error = (message: unknown) => {
-      errors.push(String(message));
-    };
-    try {
-      await room.compactEmptyRoomDocument();
-      await room.compactEmptyRoomDocument();
-      await room.compactEmptyRoomDocument();
-    } finally {
-      console.error = originalError;
-    }
-
-    const parkLogs = errors.filter((line) =>
-      line.includes("REQUIRES EXTERNAL COMPACTION")
-    );
-    expect(parkLogs.length).toBe(1);
+    expect(await room.circuitBreaker.getCompactionDisabledAt()).not.toBeNull();
   });
 });
 
@@ -649,10 +654,9 @@ describe("alarm failure backoff", () => {
     );
   });
 
-  // The counter infers an OOM from work that vanished without logging. An
-  // exception we can catch proves the isolate survived, so it must NOT count as
-  // a strike, or a long Supabase outage would march healthy rooms to quarantine.
-  test("an observed alarm exception does not count as a vanish", async () => {
+  // A caught compaction exception proves the isolate survived, so it must not
+  // count as either a compaction vanish or a generic alarm failure.
+  test("an observed compaction exception does not count as a vanish", async () => {
     const { room, storage } = createRoom();
     storage.values.set("emptyRoomCompactAfter", Date.now() - 1);
     room.compactEmptyRoomDocument = async () => {
@@ -670,14 +674,15 @@ describe("alarm failure backoff", () => {
       console.error = originalError;
     }
 
-    // Cleared, not incremented.
+    // Neither independent ledger is incremented.
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
+    expect(storage.values.get("compactionAttempts")).toBeUndefined();
     expect(room.circuitBreaker.isQuarantined()).toBe(false);
     // And it is still reported, with room context, rather than swallowed.
     expect(
       errors.some(
         (line) =>
-          line.includes("Alarm work failed for room=example-room") &&
+          line.includes("Automatic compaction failed for room=example-room") &&
           line.includes("simulated supabase blip")
       )
     ).toBe(true);
@@ -928,11 +933,7 @@ describe("admin quarantine endpoints", () => {
     );
   });
 
-  // M3: a 200 while silently writing nothing would mislead an operator into
-  // thinking a crash-looping room was safely stopped.
-  // F6: auto-clearing after restoring a still-oversized document would send the
-  // room straight back into its crash loop.
-  test("restoring a still-oversized document keeps the room quarantined", async () => {
+  test("restoring a document clears quarantine and compaction failure state", async () => {
     const { room } = createRoom();
     persistedRow.document = SMALL_DOCUMENT;
     await room.circuitBreaker.enterQuarantine({
@@ -941,7 +942,9 @@ describe("admin quarantine endpoints", () => {
       failureKind: null,
       failureCount: 0,
     });
-    await room.ctx.storage.put("compactionParked", 7 * MB);
+    await room.ctx.storage.put("compactionAttempts", 3);
+    await room.ctx.storage.put("compactionRetryAfter", Date.now() + 30_000);
+    await room.ctx.storage.put("compactionDisabledAt", Date.now());
 
     const response = await room.onRequest(
       adminRequest("restore-raw-document", {
@@ -952,36 +955,32 @@ describe("admin quarantine endpoints", () => {
 
     const body = await response.json();
     expect(body.ok).toBe(true);
-    expect(body.stillTooLarge).toBe(true);
-    expect(body.quarantineCleared).toBe(false);
-    expect(body.compactionUnparked).toBe(false);
-    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(body.quarantineCleared).toBe(true);
+    expect(body.compactionFailureCleared).toBe(true);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
+    expect(await room.circuitBreaker.getCompactionFailureCount()).toBe(0);
+    expect(await room.circuitBreaker.getCompactionRetryAfter()).toBeNull();
+    expect(await room.circuitBreaker.getCompactionDisabledAt()).toBeNull();
   });
 
-  test("restoring a small enough document lifts quarantine and the park", async () => {
+  test("the compaction retry endpoint clears the breaker and runs compaction", async () => {
     const { room } = createRoom();
-    persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    await room.circuitBreaker.enterQuarantine({
-      reason: "manual",
-      detail: "operator",
-      failureKind: null,
-      failureCount: 0,
-    });
-    await room.ctx.storage.put("compactionParked", 7 * MB);
+    persistedRow.document = SMALL_DOCUMENT;
+    room.document.getMap("play").set("greeting", "hello");
+    await room.ctx.storage.put("compactionAttempts", 3);
+    await room.ctx.storage.put("compactionDisabledAt", Date.now());
 
     const response = await room.onRequest(
-      adminRequest("restore-raw-document", {
-        method: "POST",
-        body: JSON.stringify({ base64Document: SMALL_DOCUMENT }),
-      })
+      adminRequest("compaction-retry", { method: "POST" })
     );
 
     const body = await response.json();
-    expect(body.stillTooLarge).toBe(false);
-    expect(body.quarantineCleared).toBe(true);
-    expect(body.compactionUnparked).toBe(true);
-    expect(room.circuitBreaker.isQuarantined()).toBe(false);
-    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
+    expect(response.status).toBe(200);
+    expect(body.reset.failures).toBe(3);
+    expect(body.reset.disabledAt).toEqual(expect.any(Number));
+    expect(body.compaction.disabled).toBe(false);
+    expect(body.compaction.failures).toBe(0);
+    expect(await room.circuitBreaker.getCompactionDisabledAt()).toBeNull();
   });
 
   // M4: the restore already succeeded and is durable, so a cleanup failure must
@@ -1271,42 +1270,25 @@ describe("quarantine data safety", () => {
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
 
-  test("a hard reset parks an oversized room before rebuilding or writing", async () => {
+  test("a hard reset is not rejected by a document-size threshold", async () => {
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     const storage = new FakeStorage();
     const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
 
-    const errors: string[] = [];
-    const originalError = console.error;
-    console.error = (...args: unknown[]) => {
-      errors.push(args.map(String).join(" "));
-    };
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/hard-reset",
+        { method: "POST" }
+      )
+    );
 
-    let response: Response;
-    try {
-      response = await room.onRequest(
-        new Request(
-          "https://example.com/parties/main/example-room/admin/hard-reset",
-          { method: "POST" }
-        )
-      );
-    } finally {
-      console.error = originalError;
-    }
-
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      error: "External compaction required",
-      roomId: "example-room",
+      ok: true,
+      message: "Hard reset completed successfully",
     });
-    expect(upsertCalls).toEqual([]);
-    expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
-    expect(
-      await room.circuitBreaker.getCompactionParkedBytes()
-    ).toBeGreaterThan(0);
-    expect(
-      errors.some((line) => line.includes("ExternalCompactionRequiredError"))
-    ).toBe(true);
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).not.toBe(COMPACT_LETHAL_DOCUMENT);
   });
 
   test("loading a committed reset repairs a stale server epoch", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -128,6 +128,8 @@ function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
     quarantine: { value: null, writable: true },
     compactionTooLargeBytes: { value: null, writable: true },
     loadDeferredUntil: { value: null, writable: true },
+    realtimeSyncStarted: { value: true, writable: true },
+    documentLoadCompleted: { value: false, writable: true },
     isSkippingSave: { value: false, writable: true },
     lastKnownDocumentBytes: { value: 0, writable: true },
     hasWarnedDocumentSize: { value: false, writable: true },
@@ -829,7 +831,7 @@ describe("hardening", () => {
     });
   });
 
-  test("clearing also lifts an active deferral", async () => {
+  test("clearing replaces an active deferral with an immediate guarded reload", async () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
@@ -838,10 +840,11 @@ describe("hardening", () => {
 
     const summary = await room.clearQuarantine();
 
-    // Status and behaviour must not contradict each other.
+    // The original backoff is gone, but the empty document stays gated until a
+    // normal request or connection completes a guarded hydration.
     expect(summary.wasLoadDeferred).toBe(true);
-    expect(room.isLoadDeferred()).toBe(false);
-    expect(await room.getLoadDeferredResponse()).toBeNull();
+    expect(room.isLoadDeferred()).toBe(true);
+    expect(docIsEmpty(room.document)).toBe(true);
   });
 
   // M3: a missing binding means quarantine is local only.

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -125,9 +125,6 @@ function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
     name: { value: name, writable: true },
     document: { value: doc ?? new Y.Doc(), writable: true },
     persistenceMode: { value: { kind: "available" }, writable: true },
-    quarantine: { value: null, writable: true },
-    compactionTooLargeBytes: { value: null, writable: true },
-    loadDeferredUntil: { value: null, writable: true },
     realtimeSyncStarted: { value: true, writable: true },
     documentLoadCompleted: { value: false, writable: true },
     isSkippingSave: { value: false, writable: true },
@@ -159,12 +156,12 @@ function createRoom(name = "example-room") {
  * Tests that need the genuine entry points live in quarantinePlatformEntry.
  */
 async function startRoom(room: any): Promise<void> {
-  await room.applyExternalQuarantineFlag();
-  if (room.isQuarantined()) {
-    await room.enterQuarantineRuntimeState();
+  await room.circuitBreaker.applyExternalQuarantineFlag();
+  if (room.circuitBreaker.isQuarantined()) {
+    await room.circuitBreaker.enterQuarantineRuntimeState();
     return;
   }
-  if (await room.shouldDeferLoad()) return;
+  if (await room.circuitBreaker.shouldDeferLoad()) return;
   await room.onLoad();
 }
 
@@ -223,7 +220,7 @@ describe("load path", () => {
 
     await startRoom(room);
 
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     expect(room.isPersistenceAvailable()).toBe(true);
     expect(docIsEmpty(room.document)).toBe(false);
   });
@@ -234,7 +231,7 @@ describe("load path", () => {
 
     await startRoom(room);
 
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
   });
@@ -266,9 +263,9 @@ describe("load path", () => {
     // Supabase was never queried, and nothing was hydrated.
     expect(documentReadCount).toBe(0);
     expect(docIsEmpty(room.document)).toBe(true);
-    expect(room.isLoadDeferred()).toBe(true);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(true);
     // A deferred room is NOT quarantined: no transient mode, no ephemeral service.
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
   test("the first inferred load failure waits on the one-minute rung", async () => {
@@ -283,7 +280,7 @@ describe("load path", () => {
     expect(retryAfter).toBeGreaterThanOrEqual(before + 60_000);
     expect(retryAfter).toBeLessThanOrEqual(before + 61_000);
     expect(documentReadCount).toBe(0);
-    expect(room.isLoadDeferred()).toBe(true);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(true);
   });
 
   test("a deferred room answers requests with 503 and Retry-After", async () => {
@@ -368,7 +365,7 @@ describe("load path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(room.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
     expect(kvStore.get("quarantine:example-room")).toBe(
       "operator intervention"
     );
@@ -420,7 +417,7 @@ describe("load path", () => {
 
     // The new deadline was committed while the read count was still zero.
     expect(deadlineWrites).toEqual([0]);
-    expect(room.isLoadDeferred()).toBe(false);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(false);
     expect(documentReadCount).toBe(1);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
   });
@@ -431,7 +428,7 @@ describe("load path", () => {
 
     await startRoom(room);
 
-    expect(room.isLoadDeferred()).toBe(false);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(false);
     expect(documentReadCount).toBe(1);
   });
 
@@ -442,8 +439,10 @@ describe("load path", () => {
 
     await startRoom(room);
 
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().reason).toBe("repeated-failures");
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.getQuarantineState().reason).toBe(
+      "repeated-failures"
+    );
     expect(docIsEmpty(room.document)).toBe(true);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
@@ -475,10 +474,12 @@ describe("in-DO compaction size gate", () => {
     // retrying doomed work.
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
-    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(
+      await room.circuitBreaker.getCompactionParkedBytes()
+    ).toBeGreaterThan(0);
     expect(storage.values.get("emptyRoomCompactAfter")).toBeUndefined();
     // Critically, this is NOT a quarantine.
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     expect(room.isPersistenceAvailable()).toBe(true);
   });
 
@@ -501,7 +502,7 @@ describe("in-DO compaction size gate", () => {
     await room.compactEmptyRoomDocument();
 
     // Not parked, and the compacted document was persisted.
-    expect(await room.getCompactionParkedBytes()).toBeNull();
+    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
     expect(upsertCalls.length).toBe(1);
     expect(persistedRow.document).not.toBe("");
   });
@@ -513,11 +514,13 @@ describe("in-DO compaction size gate", () => {
     const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     await room.compactEmptyRoomDocument();
-    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(
+      await room.circuitBreaker.getCompactionParkedBytes()
+    ).toBeGreaterThan(0);
 
-    await room.clearCompactionPark();
+    await room.circuitBreaker.clearCompactionPark();
 
-    expect(await room.getCompactionParkedBytes()).toBeNull();
+    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
   });
 
   // A later disconnect would otherwise re-schedule the compaction that was just
@@ -527,7 +530,9 @@ describe("in-DO compaction size gate", () => {
     const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     await room.compactEmptyRoomDocument();
-    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(
+      await room.circuitBreaker.getCompactionParkedBytes()
+    ).toBeGreaterThan(0);
     storage.setAlarmCalls = [];
 
     // The last visitor leaves again.
@@ -636,7 +641,9 @@ describe("alarm failure backoff", () => {
 
     // The next rung is committed before the risky work runs, so an OOM inside
     // that work still lands the room in a longer window.
-    const retryAfter = storage.values.get("alarmRetryAfter") as number | undefined;
+    const retryAfter = storage.values.get("alarmRetryAfter") as
+      | number
+      | undefined;
     expect(retryAfter ?? before + 5 * 60_000).toBeGreaterThanOrEqual(
       before + 5 * 60_000
     );
@@ -665,7 +672,7 @@ describe("alarm failure backoff", () => {
 
     // Cleared, not incremented.
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     // And it is still reported, with room context, rather than swallowed.
     expect(
       errors.some(
@@ -693,7 +700,7 @@ describe("alarm failure backoff", () => {
       console.error = originalError;
     }
 
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
   });
 
@@ -704,15 +711,17 @@ describe("alarm failure backoff", () => {
 
     await room.onAlarm();
 
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().reason).toBe("repeated-failures");
-    expect(room.getQuarantineState().failureKind).toBe("alarm");
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.getQuarantineState().reason).toBe(
+      "repeated-failures"
+    );
+    expect(room.circuitBreaker.getQuarantineState().failureKind).toBe("alarm");
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
 
   test("a quarantined room does no alarm work and parks the alarm", async () => {
     const { room, storage } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -732,7 +741,7 @@ describe("hardening", () => {
   // silently lift the write park on a quarantined room.
   test("markPersistenceAvailable cannot lift a quarantine write park", async () => {
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -751,7 +760,7 @@ describe("hardening", () => {
     kvFailure = new Error("kv down");
 
     await expect(
-      room.enterQuarantine({
+      room.circuitBreaker.enterQuarantine({
         reason: "manual",
         detail: "operator",
         failureKind: null,
@@ -761,7 +770,7 @@ describe("hardening", () => {
 
     // The throw propagates so the operator learns the flag did not stick, but
     // the room is already locally safe.
-    expect(room.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
     expect(room.isPersistenceAvailable()).toBe(false);
     expect(storage.alarm).toBeNull();
   });
@@ -821,7 +830,7 @@ describe("hardening", () => {
     storage.values.set("quarantineLoadAttempts", 3);
     storage.values.set("alarmFailureAttempts", 2);
 
-    const summary = await room.clearQuarantine();
+    const summary = await room.circuitBreaker.clearQuarantine();
 
     expect(summary).toEqual({
       wasQuarantined: false,
@@ -836,14 +845,14 @@ describe("hardening", () => {
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() + 60_000);
     await startRoom(room);
-    expect(room.isLoadDeferred()).toBe(true);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(true);
 
-    const summary = await room.clearQuarantine();
+    const summary = await room.circuitBreaker.clearQuarantine();
 
     // The original backoff is gone, but the empty document stays gated until a
     // normal request or connection completes a guarded hydration.
     expect(summary.wasLoadDeferred).toBe(true);
-    expect(room.isLoadDeferred()).toBe(true);
+    expect(room.circuitBreaker.isLoadDeferred()).toBe(true);
     expect(docIsEmpty(room.document)).toBe(true);
   });
 
@@ -852,7 +861,7 @@ describe("hardening", () => {
     const { room } = createRoom();
     kvFailure = new Error("kv down");
 
-    const body = await room.getQuarantineStatusBody();
+    const body = await room.circuitBreaker.getQuarantineStatusBody();
 
     expect(body.externalQuarantineFlag).toBe("kvUnavailable");
   });
@@ -861,7 +870,7 @@ describe("hardening", () => {
     const { room } = createRoom();
     kvStore.set("quarantine:example-room", "operator stop");
 
-    const body = await room.getQuarantineStatusBody();
+    const body = await room.circuitBreaker.getQuarantineStatusBody();
 
     expect(body.externalQuarantineFlag).toBe("operator stop");
   });
@@ -879,7 +888,7 @@ describe("admin quarantine endpoints", () => {
   // returns un-awaited promises) as a bare 500 with no CORS and no log.
   test("an async failure returns a JSON 500 with CORS, not a bare platform error", async () => {
     const { room } = createRoom();
-    room.getQuarantineStatusBody = async () => {
+    room.circuitBreaker.getQuarantineStatusBody = async () => {
       throw new Error("storage exploded");
     };
 
@@ -902,7 +911,7 @@ describe("admin quarantine endpoints", () => {
     );
 
     expect(response.status).toBe(400);
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
   test("an empty body still quarantines, with no reason recorded", async () => {
@@ -913,8 +922,10 @@ describe("admin quarantine endpoints", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().detail).toBe("no reason given");
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.getQuarantineState().detail).toBe(
+      "no reason given"
+    );
   });
 
   // M3: a 200 while silently writing nothing would mislead an operator into
@@ -924,7 +935,7 @@ describe("admin quarantine endpoints", () => {
   test("restoring a still-oversized document keeps the room quarantined", async () => {
     const { room } = createRoom();
     persistedRow.document = SMALL_DOCUMENT;
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -944,13 +955,13 @@ describe("admin quarantine endpoints", () => {
     expect(body.stillTooLarge).toBe(true);
     expect(body.quarantineCleared).toBe(false);
     expect(body.compactionUnparked).toBe(false);
-    expect(room.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
   });
 
   test("restoring a small enough document lifts quarantine and the park", async () => {
     const { room } = createRoom();
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -969,8 +980,8 @@ describe("admin quarantine endpoints", () => {
     expect(body.stillTooLarge).toBe(false);
     expect(body.quarantineCleared).toBe(true);
     expect(body.compactionUnparked).toBe(true);
-    expect(room.isQuarantined()).toBe(false);
-    expect(await room.getCompactionParkedBytes()).toBeNull();
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
+    expect(await room.circuitBreaker.getCompactionParkedBytes()).toBeNull();
   });
 
   // M4: the restore already succeeded and is durable, so a cleanup failure must
@@ -978,7 +989,7 @@ describe("admin quarantine endpoints", () => {
   test("a cleanup failure still reports the restore as successful", async () => {
     const { room } = createRoom();
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1050,7 +1061,7 @@ describe("separate retry ladders", () => {
     storage.values.set("loadRetryAfter", 1779829545000);
     storage.values.set("alarmRetryAfter", 1779829999000);
 
-    const body = await room.getQuarantineStatusBody();
+    const body = await room.circuitBreaker.getQuarantineStatusBody();
 
     expect(body.failures.loadRetryAfter).toBe("2026-05-26T21:05:45.000Z");
     expect(body.failures.alarmRetryAfter).toBe("2026-05-26T21:13:19.000Z");
@@ -1065,11 +1076,13 @@ describe("external quarantine control plane", () => {
     const { room } = createRoom();
     kvStore.set("quarantine:example-room", "microcosmos incident");
 
-    await room.applyExternalQuarantineFlag();
+    await room.circuitBreaker.applyExternalQuarantineFlag();
 
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().reason).toBe("manual");
-    expect(room.getQuarantineState().detail).toBe("microcosmos incident");
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.getQuarantineState().reason).toBe("manual");
+    expect(room.circuitBreaker.getQuarantineState().detail).toBe(
+      "microcosmos incident"
+    );
     expect(documentReadCount).toBe(0);
 
     // And the subsequent load never hydrates either.
@@ -1081,7 +1094,7 @@ describe("external quarantine control plane", () => {
   test("setting quarantine writes the flag that survives a crashing room", async () => {
     const { room } = createRoom();
 
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator note",
       failureKind: null,
@@ -1093,14 +1106,14 @@ describe("external quarantine control plane", () => {
 
   test("clearing quarantine removes the external flag", async () => {
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator note",
       failureKind: null,
       failureCount: 0,
     });
 
-    await room.clearQuarantine();
+    await room.circuitBreaker.clearQuarantine();
 
     expect(kvStore.has("quarantine:example-room")).toBe(false);
   });
@@ -1108,7 +1121,7 @@ describe("external quarantine control plane", () => {
   test("set and clear round-trip through KV across restarts", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator note",
       failureKind: null,
@@ -1118,14 +1131,14 @@ describe("external quarantine control plane", () => {
     // A brand new isolate with EMPTY durable storage still sees the flag.
     const freshStorage = new FakeStorage();
     const restarted = buildRoom(freshStorage, "example-room");
-    await restarted.applyExternalQuarantineFlag();
-    expect(restarted.isQuarantined()).toBe(true);
+    await restarted.circuitBreaker.applyExternalQuarantineFlag();
+    expect(restarted.circuitBreaker.isQuarantined()).toBe(true);
 
-    await restarted.clearQuarantine();
+    await restarted.circuitBreaker.clearQuarantine();
 
     const afterClear = buildRoom(new FakeStorage(), "example-room");
-    await afterClear.applyExternalQuarantineFlag();
-    expect(afterClear.isQuarantined()).toBe(false);
+    await afterClear.circuitBreaker.applyExternalQuarantineFlag();
+    expect(afterClear.circuitBreaker.isQuarantined()).toBe(false);
   });
 
   // Manual quarantine is an operator tool, not a correctness gate: a KV outage
@@ -1135,10 +1148,10 @@ describe("external quarantine control plane", () => {
     const { room } = createRoom();
     kvFailure = new Error("kv unavailable");
 
-    await room.applyExternalQuarantineFlag();
+    await room.circuitBreaker.applyExternalQuarantineFlag();
     await startRoom(room);
 
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
   });
 });
@@ -1148,25 +1161,25 @@ describe("manual quarantine", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
     await startRoom(room);
-    expect(room.isQuarantined()).toBe(false);
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
 
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "investigating runaway growth",
       failureKind: null,
       failureCount: 0,
     });
 
-    expect(room.isQuarantined()).toBe(true);
-    expect(room.getQuarantineState().detail).toBe(
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.circuitBreaker.getQuarantineState().detail).toBe(
       "investigating runaway growth"
     );
     // Manual quarantine still suppresses persistence.
     expect(room.isPersistenceAvailable()).toBe(false);
     expect(storage.alarm).toBeNull();
 
-    await room.clearQuarantine();
-    expect(room.isQuarantined()).toBe(false);
+    await room.circuitBreaker.clearQuarantine();
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
   test("clearing quarantine also clears the failure history behind it", async () => {
@@ -1175,14 +1188,14 @@ describe("manual quarantine", () => {
     storage.values.set("quarantineLoadAttempts", 3);
     storage.values.set("loadRetryAfter", Date.now() + 1000);
     storage.values.set("alarmRetryAfter", Date.now() + 1000);
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "repeated-failures",
       detail: "alarm work failed 8 times in a row",
       failureKind: "alarm",
       failureCount: 8,
     });
 
-    await room.clearQuarantine();
+    await room.circuitBreaker.clearQuarantine();
 
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
     expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
@@ -1193,7 +1206,7 @@ describe("manual quarantine", () => {
   test("a quarantined room resumes quarantine on restart without hydrating", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1203,7 +1216,7 @@ describe("manual quarantine", () => {
     const restarted = restartRoom(storage);
     await startRoom(restarted);
 
-    expect(restarted.isQuarantined()).toBe(true);
+    expect(restarted.circuitBreaker.isQuarantined()).toBe(true);
     expect(docIsEmpty(restarted.document)).toBe(true);
     expect(restarted.isPersistenceAvailable()).toBe(false);
   });
@@ -1213,7 +1226,7 @@ describe("quarantine data safety", () => {
   test("autosave cannot overwrite the persisted document while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1229,7 +1242,7 @@ describe("quarantine data safety", () => {
   test("the document write helper refuses to run while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1245,7 +1258,7 @@ describe("quarantine data safety", () => {
   test("a hard reset refuses to run while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1288,7 +1301,9 @@ describe("quarantine data safety", () => {
     });
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(COMPACT_LETHAL_DOCUMENT);
-    expect(await room.getCompactionParkedBytes()).toBeGreaterThan(0);
+    expect(
+      await room.circuitBreaker.getCompactionParkedBytes()
+    ).toBeGreaterThan(0);
     expect(
       errors.some((line) => line.includes("ExternalCompactionRequiredError"))
     ).toBe(true);
@@ -1327,7 +1342,7 @@ describe("quarantine data safety", () => {
   test("restoring a snapshot refuses by default while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,
@@ -1344,7 +1359,7 @@ describe("quarantine data safety", () => {
   test("an explicit repair restore is allowed and replaces the document", async () => {
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     const { room } = createRoom();
-    await room.enterQuarantine({
+    await room.circuitBreaker.enterQuarantine({
       reason: "manual",
       detail: "operator",
       failureKind: null,

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -168,7 +168,7 @@ describe("alarm entry point", () => {
     await server.alarm();
 
     expect(documentReadCount).toBe(0);
-    expect(server.isLoadDeferred()).toBe(true);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(true);
   });
 
   test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
@@ -178,7 +178,7 @@ describe("alarm entry point", () => {
     await server.alarm();
 
     expect(documentReadCount).toBe(0);
-    expect(server.isQuarantined()).toBe(true);
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
     // Nothing may be written back over the untouched document.
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
@@ -190,8 +190,8 @@ describe("alarm entry point", () => {
     await server.alarm();
 
     expect(documentReadCount).toBe(1);
-    expect(server.isQuarantined()).toBe(false);
-    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.circuitBreaker.isQuarantined()).toBe(false);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
   });
 
   test("an alarm on a room past its deferral deadline retries exactly once", async () => {
@@ -202,7 +202,7 @@ describe("alarm entry point", () => {
     await server.alarm();
 
     expect(documentReadCount).toBe(1);
-    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
   });
 });
 
@@ -219,7 +219,7 @@ describe("fetch entry point", () => {
     await server.__unsafe_ensureInitialized?.();
 
     expect(documentReadCount).toBe(0);
-    expect(server.isQuarantined()).toBe(true);
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
     expect(sentMessages.length).toBeGreaterThan(0);
 
     sentMessages.length = 0;
@@ -239,7 +239,7 @@ describe("fetch entry point", () => {
     await server.__unsafe_ensureInitialized?.();
 
     expect(documentReadCount).toBe(0);
-    expect(server.isQuarantined()).toBe(true);
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
     expect(sentMessages.length).toBeGreaterThan(0);
   });
 
@@ -272,7 +272,7 @@ describe("fetch entry point", () => {
     );
 
     expect(documentReadCount).toBe(0);
-    expect(server.isQuarantined()).toBe(true);
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
   });
 
   // Without in-place recovery a live isolate would 503 forever, since onStart
@@ -304,7 +304,7 @@ describe("fetch entry point", () => {
     // Exactly one hydration attempt, and the room is serving again.
     expect(documentReadCount).toBe(1);
     expect(recovered.status).not.toBe(503);
-    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
   });
 
   test("a recovered room completes Yjs and bridge startup", async () => {
@@ -326,7 +326,7 @@ describe("fetch entry point", () => {
     expect(deferred.status).toBe(503);
     expect(sentMessages).toEqual([]);
 
-    (server as any).loadDeferredUntil = Date.now() - 1;
+    (server as any).circuitBreaker.setLoadDeferredUntil(Date.now() - 1);
     const recovered = await server.fetch(
       new Request("https://example.com/parties/main/example-room", {
         method: "POST",
@@ -394,7 +394,7 @@ describe("fetch entry point", () => {
         { method: "GET" }
       )
     );
-    (server as any).loadDeferredUntil = Date.now() - 1;
+    (server as any).circuitBreaker.setLoadDeferredUntil(Date.now() - 1);
 
     const response = await server.fetch(
       new Request(
@@ -405,7 +405,7 @@ describe("fetch entry point", () => {
 
     expect(response.status).toBe(200);
     expect(documentReadCount).toBe(0);
-    expect(server.isLoadDeferred()).toBe(true);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(true);
   });
 
   test("manual quarantine turns a deferred room into transient realtime service", async () => {
@@ -424,7 +424,7 @@ describe("fetch entry point", () => {
         { method: "GET" }
       )
     );
-    expect(server.isLoadDeferred()).toBe(true);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(true);
 
     const response = await server.fetch(
       new Request(
@@ -438,8 +438,8 @@ describe("fetch entry point", () => {
 
     expect(response.status).toBe(200);
     expect(documentReadCount).toBe(0);
-    expect(server.isQuarantined()).toBe(true);
-    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
     expect(sentMessages.length).toBeGreaterThan(0);
   });
 
@@ -464,8 +464,8 @@ describe("fetch entry point", () => {
     );
 
     expect(cleared.status).toBe(200);
-    expect(server.isQuarantined()).toBe(false);
-    expect(server.isLoadDeferred()).toBe(true);
+    expect(server.circuitBreaker.isQuarantined()).toBe(false);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(true);
     expect(documentReadCount).toBe(0);
 
     const status = await server.fetch(
@@ -486,7 +486,7 @@ describe("fetch entry point", () => {
 
     expect(recovered.status).not.toBe(503);
     expect(documentReadCount).toBe(1);
-    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
     expect(server.document.getMap("play").get("greeting")).toBe("hello");
   });
 });
@@ -503,9 +503,7 @@ describe("global quarantine admin endpoint", () => {
     kvStore.set("quarantine:a-room", "operator stop");
 
     const response = await worker.fetch(
-      new Request(
-        "https://api.playhtml.fun/admin/quarantines?token=secret"
-      ),
+      new Request("https://api.playhtml.fun/admin/quarantines?token=secret"),
       workerEnv
     );
 

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -22,6 +22,15 @@ const quarantineKvStub = {
   async delete(key: string) {
     kvStore.delete(key);
   },
+  async list({ prefix }: { prefix?: string }) {
+    return {
+      keys: Array.from(kvStore.keys())
+        .filter((key) => !prefix || key.startsWith(prefix))
+        .map((name) => ({ name })),
+      list_complete: true as const,
+      cacheStatus: null,
+    };
+  },
 };
 
 mock.module("cloudflare:workers", () => ({
@@ -71,7 +80,9 @@ const supabaseStub = {
 
 mock.module(`${import.meta.dir}/../db.ts`, () => ({ supabase: supabaseStub }));
 
-const { PartyServer } = await import(`${import.meta.dir}/../party.ts`);
+const partyModule = await import(`${import.meta.dir}/../party.ts`);
+const { PartyServer } = partyModule;
+const worker = partyModule.default;
 
 // Mirrors the Durable Object storage surface the server actually uses.
 class FakeStorage {
@@ -291,5 +302,47 @@ describe("fetch entry point", () => {
     const body = await response.json();
     expect(body.loadDeferred.active).toBe(true);
     expect(documentReadCount).toBe(0);
+  });
+});
+
+describe("global quarantine admin endpoint", () => {
+  const workerEnv = {
+    ADMIN_TOKEN: "secret",
+    QUARANTINE_CONTROL: quarantineKvStub,
+  } as never;
+
+  test("lists every current quarantine without initializing a room", async () => {
+    kvStore.set("quarantine:z-room", "automatic load failures");
+    kvStore.set("unrelated:key", "ignore me");
+    kvStore.set("quarantine:a-room", "operator stop");
+
+    const response = await worker.fetch(
+      new Request(
+        "https://api.playhtml.fun/admin/quarantines?token=secret"
+      ),
+      workerEnv
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      available: true,
+      count: 2,
+      rooms: [
+        { roomId: "a-room", detail: "operator stop" },
+        { roomId: "z-room", detail: "automatic load failures" },
+      ],
+    });
+    expect(documentReadCount).toBe(0);
+  });
+
+  test("requires the admin token", async () => {
+    kvStore.set("quarantine:private-room", "operator stop");
+
+    const response = await worker.fetch(
+      new Request("https://api.playhtml.fun/admin/quarantines"),
+      workerEnv
+    );
+
+    expect(response.status).toBe(401);
   });
 });

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -117,7 +117,10 @@ class FakeStorage {
  * entry points the runtime calls. `blockConcurrencyWhile` and `id.name` are the
  * only pieces of DurableObjectState the initialization path touches.
  */
-function createServer(name = "example-room") {
+function createServer(
+  name = "example-room",
+  connections: Array<{ readyState: number; send(message: unknown): void }> = []
+) {
   const storage = new FakeStorage();
   const ctx = {
     storage,
@@ -131,6 +134,9 @@ function createServer(name = "example-room") {
   };
 
   const server = new PartyServer(ctx as never, {} as never);
+  Object.defineProperty(server, "getConnections", {
+    value: () => connections,
+  });
   return { server, storage };
 }
 
@@ -201,6 +207,42 @@ describe("alarm entry point", () => {
 });
 
 describe("fetch entry point", () => {
+  test("a cold quarantined room completes Yjs startup without hydrating", async () => {
+    const sentMessages: unknown[] = [];
+    const connection = {
+      readyState: 1,
+      send: (message: unknown) => sentMessages.push(message),
+    };
+    const { server } = createServer("example-room", [connection]);
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    await server.__unsafe_ensureInitialized?.();
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isQuarantined()).toBe(true);
+    expect(sentMessages.length).toBeGreaterThan(0);
+
+    sentMessages.length = 0;
+    server.document.getMap("play").set("transient", "shared");
+    expect(sentMessages.length).toBeGreaterThan(0);
+  });
+
+  test("automatic quarantine completes Yjs startup without hydrating", async () => {
+    const sentMessages: unknown[] = [];
+    const connection = {
+      readyState: 1,
+      send: (message: unknown) => sentMessages.push(message),
+    };
+    const { server, storage } = createServer("example-room", [connection]);
+    storage.values.set("quarantineLoadAttempts", 8);
+
+    await server.__unsafe_ensureInitialized?.();
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isQuarantined()).toBe(true);
+    expect(sentMessages.length).toBeGreaterThan(0);
+  });
+
   test("a deferred room answers 503 without reading the document", async () => {
     const { server, storage } = createServer();
     storage.values.set("quarantineLoadAttempts", 2);
@@ -265,6 +307,43 @@ describe("fetch entry point", () => {
     expect(server.isLoadDeferred()).toBe(false);
   });
 
+  test("a recovered room completes Yjs and bridge startup", async () => {
+    const sentMessages: unknown[] = [];
+    const connection = {
+      readyState: 1,
+      send: (message: unknown) => sentMessages.push(message),
+    };
+    const { server, storage } = createServer("example-room", [connection]);
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    const deferred = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+    expect(deferred.status).toBe(503);
+    expect(sentMessages).toEqual([]);
+
+    (server as any).loadDeferredUntil = Date.now() - 1;
+    const recovered = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    expect(recovered.status).not.toBe(503);
+    expect(documentReadCount).toBe(1);
+    expect(sentMessages.length).toBeGreaterThan(0);
+    expect((server as any).observersAttached).toBe(true);
+
+    sentMessages.length = 0;
+    server.document.getMap("play").set("afterRecovery", "shared");
+    expect(sentMessages.length).toBeGreaterThan(0);
+  });
+
   test("concurrent requests at the deadline share a single hydration", async () => {
     const { server, storage } = createServer();
     storage.values.set("quarantineLoadAttempts", 2);
@@ -302,6 +381,113 @@ describe("fetch entry point", () => {
     const body = await response.json();
     expect(body.loadDeferred.active).toBe(true);
     expect(documentReadCount).toBe(0);
+  });
+
+  test("admin control routes do not retry hydration after the deadline", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+    (server as any).loadDeferredUntil = Date.now() - 1;
+
+    const response = await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(documentReadCount).toBe(0);
+    expect(server.isLoadDeferred()).toBe(true);
+  });
+
+  test("manual quarantine turns a deferred room into transient realtime service", async () => {
+    const sentMessages: unknown[] = [];
+    const connection = {
+      readyState: 1,
+      send: (message: unknown) => sentMessages.push(message),
+    };
+    const { server, storage } = createServer("example-room", [connection]);
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+    expect(server.isLoadDeferred()).toBe(true);
+
+    const response = await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        {
+          method: "POST",
+          body: JSON.stringify({ reason: "operator stop" }),
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(documentReadCount).toBe(0);
+    expect(server.isQuarantined()).toBe(true);
+    expect(server.isLoadDeferred()).toBe(false);
+    expect(sentMessages.length).toBeGreaterThan(0);
+  });
+
+  test("clearing a cold quarantine keeps traffic gated until hydration succeeds", async () => {
+    const { server } = createServer();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+    expect(documentReadCount).toBe(0);
+    expect(server.document.getMap("play").get("greeting")).toBeUndefined();
+
+    const cleared = await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-clear",
+        { method: "POST" }
+      )
+    );
+
+    expect(cleared.status).toBe(200);
+    expect(server.isQuarantined()).toBe(false);
+    expect(server.isLoadDeferred()).toBe(true);
+    expect(documentReadCount).toBe(0);
+
+    const status = await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+    expect(status.status).toBe(200);
+    expect(documentReadCount).toBe(0);
+
+    const recovered = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    expect(recovered.status).not.toBe(503);
+    expect(documentReadCount).toBe(1);
+    expect(server.isLoadDeferred()).toBe(false);
+    expect(server.document.getMap("play").get("greeting")).toBe("hello");
   });
 });
 

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -1,0 +1,295 @@
+// ABOUTME: Drives PartyServer through the real platform entry points (alarm, fetch).
+// ABOUTME: Catches guards that sit downstream of the hydration they are meant to prevent.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as Y from "yjs";
+import { Buffer } from "node:buffer";
+
+// The platform initializes a room before invoking any handler: alarm() and
+// fetch() both call ensureInitialized() -> onStart() -> onLoad(), which
+// hydrates. Tests that call onLoad()/onAlarm() directly therefore cannot see
+// guards that are placed downstream of hydration. These tests go through the
+// same entry points the runtime uses.
+
+const kvStore = new Map<string, string>();
+
+const quarantineKvStub = {
+  async get(key: string) {
+    return kvStore.get(key) ?? null;
+  },
+  async put(key: string, value: string) {
+    kvStore.set(key, value);
+  },
+  async delete(key: string) {
+    kvStore.delete(key);
+  },
+};
+
+mock.module("cloudflare:workers", () => ({
+  env: { QUARANTINE_CONTROL: quarantineKvStub },
+  DurableObject: class {
+    constructor(
+      public ctx: unknown,
+      public env: unknown
+    ) {}
+  },
+  WorkerEntrypoint: class {},
+}));
+
+const persistedRow: { document: string | null } = { document: null };
+let documentReadCount = 0;
+let upsertCalls: Array<{ name: string; document: string }> = [];
+
+const supabaseStub = {
+  from() {
+    return {
+      select() {
+        return {
+          eq() {
+            return {
+              maybeSingle: async () => {
+                documentReadCount += 1;
+                return {
+                  data:
+                    persistedRow.document === null
+                      ? null
+                      : { document: persistedRow.document },
+                  error: null,
+                };
+              },
+            };
+          },
+        };
+      },
+      async upsert(row: { name: string; document: string }) {
+        upsertCalls.push(row);
+        persistedRow.document = row.document;
+        return { error: null };
+      },
+    };
+  },
+};
+
+mock.module(`${import.meta.dir}/../db.ts`, () => ({ supabase: supabaseStub }));
+
+const { PartyServer } = await import(`${import.meta.dir}/../party.ts`);
+
+// Mirrors the Durable Object storage surface the server actually uses.
+class FakeStorage {
+  values = new Map<string, unknown>();
+  alarm: number | null = null;
+
+  async get(key: string) {
+    return this.values.get(key);
+  }
+  async put(key: string, value: unknown) {
+    this.values.set(key, value);
+  }
+  async delete(key: string) {
+    this.values.delete(key);
+  }
+  async list() {
+    return new Map();
+  }
+  async getAlarm() {
+    return this.alarm;
+  }
+  async setAlarm(time: number) {
+    this.alarm = time;
+  }
+  async deleteAlarm() {
+    this.alarm = null;
+  }
+}
+
+/**
+ * Builds a server instance the way the platform does, then exposes the same
+ * entry points the runtime calls. `blockConcurrencyWhile` and `id.name` are the
+ * only pieces of DurableObjectState the initialization path touches.
+ */
+function createServer(name = "example-room") {
+  const storage = new FakeStorage();
+  const ctx = {
+    storage,
+    id: { name },
+    blockConcurrencyWhile: async (fn: () => Promise<void>) => fn(),
+    waitUntil: () => {},
+    // The hibernating connection manager enumerates live sockets on start.
+    getWebSockets: () => [],
+    acceptWebSocket: () => {},
+    getTags: () => [],
+  };
+
+  const server = new PartyServer(ctx as never, {} as never);
+  return { server, storage };
+}
+
+function encodeDoc(doc: Y.Doc): string {
+  return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
+}
+
+const SMALL_DOCUMENT = (() => {
+  const doc = new Y.Doc();
+  doc.getMap("play").set("greeting", "hello");
+  return encodeDoc(doc);
+})();
+
+beforeEach(() => {
+  persistedRow.document = SMALL_DOCUMENT;
+  documentReadCount = 0;
+  upsertCalls = [];
+  kvStore.clear();
+});
+
+describe("alarm entry point", () => {
+  // The platform initializes (and hydrates) before onAlarm runs, so a guard that
+  // lives only in onAlarm never executes for a room that dies during hydration.
+  test("a deferred room does not read the document when its alarm fires", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isLoadDeferred()).toBe(true);
+  });
+
+  test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
+    const { server } = createServer();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isQuarantined()).toBe(true);
+    // Nothing may be written back over the untouched document.
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("a healthy room still hydrates and runs its alarm work", async () => {
+    const { server } = createServer();
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(1);
+    expect(server.isQuarantined()).toBe(false);
+    expect(server.isLoadDeferred()).toBe(false);
+  });
+
+  test("an alarm on a room past its deferral deadline retries exactly once", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() - 1000);
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(1);
+    expect(server.isLoadDeferred()).toBe(false);
+  });
+});
+
+describe("fetch entry point", () => {
+  test("a deferred room answers 503 without reading the document", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    const response = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(503);
+    expect(Number(response.headers.get("retry-after"))).toBeGreaterThan(0);
+    expect(documentReadCount).toBe(0);
+  });
+
+  test("a KV-quarantined room never hydrates through fetch", async () => {
+    const { server } = createServer();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isQuarantined()).toBe(true);
+  });
+
+  // Without in-place recovery a live isolate would 503 forever, since onStart
+  // runs once and client retries keep the isolate alive.
+  test("a request past the deadline recovers the room in place", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 200);
+
+    const deferred = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: "{}",
+      })
+    );
+    expect(deferred.status).toBe(503);
+    expect(documentReadCount).toBe(0);
+
+    // The deadline passes while this isolate stays alive.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const recovered = await server.fetch(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    // Exactly one hydration attempt, and the room is serving again.
+    expect(documentReadCount).toBe(1);
+    expect(recovered.status).not.toBe(503);
+    expect(server.isLoadDeferred()).toBe(false);
+  });
+
+  test("concurrent requests at the deadline share a single hydration", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() - 1000);
+
+    // Force the deferral without hydrating, as a fresh isolate would see it.
+    await server.__unsafe_ensureInitialized?.();
+
+    const requests = Array.from({ length: 5 }, () =>
+      server.fetch(
+        new Request("https://example.com/parties/main/example-room", {
+          method: "POST",
+          body: "{}",
+        })
+      )
+    );
+    await Promise.all(requests);
+
+    expect(documentReadCount).toBe(1);
+  });
+
+  test("admin status stays reachable on a deferred room", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    const response = await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.loadDeferred.active).toBe(true);
+    expect(documentReadCount).toBe(0);
+  });
+});

--- a/partykit/__tests__/quarantinePolicy.test.ts
+++ b/partykit/__tests__/quarantinePolicy.test.ts
@@ -239,7 +239,8 @@ describe("createQuarantineStatusBody", () => {
       failureThreshold: 8,
       loadFailures: 0,
       alarmFailures: 0,
-      retryAfter: null,
+      loadRetryAfter: null,
+      alarmRetryAfter: null,
       compactionParkedBytes: null,
     });
 
@@ -248,7 +249,8 @@ describe("createQuarantineStatusBody", () => {
       load: 0,
       alarm: 0,
       quarantineAfter: 8,
-      retryAfter: null,
+      loadRetryAfter: null,
+      alarmRetryAfter: null,
     });
     expect(body.compaction.parked).toBe(false);
   });
@@ -268,7 +270,8 @@ describe("createQuarantineStatusBody", () => {
       failureThreshold: 8,
       loadFailures: 0,
       alarmFailures: 8,
-      retryAfter: 1779829545000,
+      loadRetryAfter: null,
+      alarmRetryAfter: 1779829545000,
       compactionParkedBytes: 7 * MB,
     });
 
@@ -276,7 +279,9 @@ describe("createQuarantineStatusBody", () => {
     expect(body.reason).toBe("repeated-failures");
     expect(body.quarantinedAt).toBe("2026-05-26T21:05:45.000Z");
     expect(body.failures.alarm).toBe(8);
-    expect(body.failures.retryAfter).toBe("2026-05-26T21:05:45.000Z");
+    expect(body.failures.alarmRetryAfter).toBe("2026-05-26T21:05:45.000Z");
+    // A load that never failed keeps a null deadline of its own.
+    expect(body.failures.loadRetryAfter).toBeNull();
     expect(body.compaction).toEqual({
       parked: true,
       documentBytes: 7 * MB,

--- a/partykit/__tests__/quarantinePolicy.test.ts
+++ b/partykit/__tests__/quarantinePolicy.test.ts
@@ -1,0 +1,159 @@
+// ABOUTME: Verifies the load-time quarantine decisions that stop OOM crash loops.
+// ABOUTME: Covers the size gate, the crash-loop counter, operator logs, and status payloads.
+import { describe, expect, test } from "bun:test";
+import {
+  createQuarantineStatusBody,
+  formatQuarantineLog,
+  shouldQuarantineForDocumentSize,
+  shouldQuarantineForLoadAttempts,
+  DEFAULT_QUARANTINE_LOAD_ATTEMPTS,
+} from "../quarantinePolicy";
+import { DEFAULT_QUARANTINE_DOCUMENT_BYTES } from "../const";
+
+const SIX_MB = 1024 * 1024 * 6;
+
+describe("shouldQuarantineForDocumentSize", () => {
+  test("quarantines documents above the threshold", () => {
+    expect(
+      shouldQuarantineForDocumentSize({
+        documentBytes: SIX_MB + 1,
+        thresholdBytes: SIX_MB,
+      }),
+    ).toBe(true);
+  });
+
+  test("leaves documents at or below the threshold alone", () => {
+    expect(
+      shouldQuarantineForDocumentSize({
+        documentBytes: SIX_MB,
+        thresholdBytes: SIX_MB,
+      }),
+    ).toBe(false);
+    expect(
+      shouldQuarantineForDocumentSize({
+        documentBytes: 1024,
+        thresholdBytes: SIX_MB,
+      }),
+    ).toBe(false);
+  });
+
+  // The two live rooms that crash-loop sit at 7-8MB, and one observed document
+  // reached 13MB. The default threshold must catch all of them.
+  test("the default threshold catches the observed lethal document sizes", () => {
+    for (const megabytes of [7, 8, 13]) {
+      expect(
+        shouldQuarantineForDocumentSize({
+          documentBytes: 1024 * 1024 * megabytes,
+          thresholdBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  test("the default threshold leaves ordinary rooms untouched", () => {
+    for (const kilobytes of [1, 64, 512, 4096]) {
+      expect(
+        shouldQuarantineForDocumentSize({
+          documentBytes: 1024 * kilobytes,
+          thresholdBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+        }),
+      ).toBe(false);
+    }
+  });
+});
+
+describe("shouldQuarantineForLoadAttempts", () => {
+  test("allows the first attempts and trips at the configured maximum", () => {
+    const maxLoadAttempts = DEFAULT_QUARANTINE_LOAD_ATTEMPTS;
+    expect(
+      shouldQuarantineForLoadAttempts({ loadAttempts: 0, maxLoadAttempts }),
+    ).toBe(false);
+    expect(
+      shouldQuarantineForLoadAttempts({ loadAttempts: 2, maxLoadAttempts }),
+    ).toBe(false);
+    expect(
+      shouldQuarantineForLoadAttempts({ loadAttempts: 3, maxLoadAttempts }),
+    ).toBe(true);
+    expect(
+      shouldQuarantineForLoadAttempts({ loadAttempts: 9, maxLoadAttempts }),
+    ).toBe(true);
+  });
+});
+
+describe("formatQuarantineLog", () => {
+  test("names the room, the size reason, and the recovery procedure", () => {
+    const message = formatQuarantineLog({
+      roomName: "aliaelkattan.com-music-room",
+      reason: "document-size",
+      documentBytes: 8_000_000,
+      thresholdBytes: SIX_MB,
+      loadAttempts: 1,
+    });
+
+    expect(message).toContain("ROOM QUARANTINED");
+    expect(message).toContain("room=aliaelkattan.com-music-room");
+    expect(message).toContain("reason=document-size");
+    expect(message).toContain("documentBytes=8000000");
+    expect(message).toContain("too large to hydrate");
+    expect(message).toContain("will NOT be overwritten");
+    expect(message).toContain("admin/quarantine-clear");
+  });
+
+  test("explains the crash-loop reason when the size gate did not fire", () => {
+    const message = formatQuarantineLog({
+      roomName: "kwolanne.github.io-offerings",
+      reason: "crash-loop",
+      documentBytes: null,
+      thresholdBytes: SIX_MB,
+      loadAttempts: 3,
+    });
+
+    expect(message).toContain("reason=crash-loop");
+    expect(message).toContain("documentBytes=unknown");
+    expect(message).toContain("hydration failed 3 times");
+    expect(message).toContain("TRANSIENT MODE");
+  });
+});
+
+describe("createQuarantineStatusBody", () => {
+  test("reports a healthy room as not quarantined", () => {
+    const body = createQuarantineStatusBody({
+      roomName: "healthy-room",
+      quarantine: null,
+      thresholdBytes: SIX_MB,
+      maxLoadAttempts: 3,
+      loadAttempts: 0,
+    });
+
+    expect(body).toEqual({
+      roomId: "healthy-room",
+      quarantined: false,
+      reason: null,
+      documentBytes: null,
+      quarantinedAt: null,
+      loadAttempts: 0,
+      thresholdBytes: SIX_MB,
+      maxLoadAttempts: 3,
+    });
+  });
+
+  test("reports the reason and size for a quarantined room", () => {
+    const body = createQuarantineStatusBody({
+      roomName: "sick-room",
+      quarantine: {
+        reason: "document-size",
+        documentBytes: 8_000_000,
+        loadAttempts: 1,
+        quarantinedAt: 1779829545000,
+      },
+      thresholdBytes: SIX_MB,
+      maxLoadAttempts: 3,
+      loadAttempts: 1,
+    });
+
+    expect(body.quarantined).toBe(true);
+    expect(body.reason).toBe("document-size");
+    expect(body.documentBytes).toBe(8_000_000);
+    expect(body.quarantinedAt).toBe("2026-05-26T21:05:45.000Z");
+  });
+});

--- a/partykit/__tests__/quarantinePolicy.test.ts
+++ b/partykit/__tests__/quarantinePolicy.test.ts
@@ -1,159 +1,286 @@
-// ABOUTME: Verifies the load-time quarantine decisions that stop OOM crash loops.
-// ABOUTME: Covers the size gate, the crash-loop counter, operator logs, and status payloads.
+// ABOUTME: Verifies the policy decisions behind compaction skips, backoff, and quarantine.
+// ABOUTME: Covers the size-warning boundary, the backoff ladder, and operator-facing logs.
 import { describe, expect, test } from "bun:test";
 import {
   createQuarantineStatusBody,
+  formatCompactionSkipLog,
+  formatFailureBackoffLog,
   formatQuarantineLog,
-  shouldQuarantineForDocumentSize,
-  shouldQuarantineForLoadAttempts,
-  DEFAULT_QUARANTINE_LOAD_ATTEMPTS,
+  getFailureBackoffMs,
+  getFailureRetryAt,
+  isDocumentOversized,
+  isRetryDue,
+  isTooLargeToCompactInDurableObject,
+  shouldQuarantineForFailures,
 } from "../quarantinePolicy";
-import { DEFAULT_QUARANTINE_DOCUMENT_BYTES } from "../const";
+import {
+  DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+  DEFAULT_FAILURE_BACKOFF_MAX_MS,
+  DEFAULT_FAILURE_BACKOFF_MS,
+  DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+  DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
+} from "../const";
 
-const SIX_MB = 1024 * 1024 * 6;
+const MB = 1024 * 1024;
+const MINUTE = 60 * 1000;
 
-describe("shouldQuarantineForDocumentSize", () => {
-  test("quarantines documents above the threshold", () => {
+describe("isDocumentOversized", () => {
+  test("reports documents above the warning threshold", () => {
     expect(
-      shouldQuarantineForDocumentSize({
-        documentBytes: SIX_MB + 1,
-        thresholdBytes: SIX_MB,
-      }),
+      isDocumentOversized({
+        documentBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES + 1,
+        thresholdBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+      })
     ).toBe(true);
   });
 
-  test("leaves documents at or below the threshold alone", () => {
-    expect(
-      shouldQuarantineForDocumentSize({
-        documentBytes: SIX_MB,
-        thresholdBytes: SIX_MB,
-      }),
-    ).toBe(false);
-    expect(
-      shouldQuarantineForDocumentSize({
-        documentBytes: 1024,
-        thresholdBytes: SIX_MB,
-      }),
-    ).toBe(false);
-  });
-
-  // The two live rooms that crash-loop sit at 7-8MB, and one observed document
-  // reached 13MB. The default threshold must catch all of them.
-  test("the default threshold catches the observed lethal document sizes", () => {
-    for (const megabytes of [7, 8, 13]) {
+  // Rooms that crash-loop on compaction sit in the 6-8MB band, and so do healthy
+  // production rooms. Loading is not what kills them, so this must not fire.
+  test("leaves the 6-8MB band alone", () => {
+    for (const megabytes of [6, 7, 8]) {
       expect(
-        shouldQuarantineForDocumentSize({
-          documentBytes: 1024 * 1024 * megabytes,
+        isDocumentOversized({
+          documentBytes: MB * megabytes,
           thresholdBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-        }),
-      ).toBe(true);
-    }
-  });
-
-  test("the default threshold leaves ordinary rooms untouched", () => {
-    for (const kilobytes of [1, 64, 512, 4096]) {
-      expect(
-        shouldQuarantineForDocumentSize({
-          documentBytes: 1024 * kilobytes,
-          thresholdBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-        }),
+        })
       ).toBe(false);
     }
   });
 });
 
-describe("shouldQuarantineForLoadAttempts", () => {
-  test("allows the first attempts and trips at the configured maximum", () => {
-    const maxLoadAttempts = DEFAULT_QUARANTINE_LOAD_ATTEMPTS;
+describe("isTooLargeToCompactInDurableObject", () => {
+  // Compaction holds the live doc, its JSON projection, and the rebuild at once,
+  // so rooms that survive loading still cannot be compacted in place.
+  test("catches the 6-8MB band that OOMs during compaction", () => {
+    for (const megabytes of [6, 7, 8, 13]) {
+      expect(
+        isTooLargeToCompactInDurableObject({
+          documentBytes: MB * megabytes,
+          maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+        })
+      ).toBe(true);
+    }
+  });
+
+  test("leaves ordinary rooms compactable", () => {
+    for (const kilobytes of [1, 64, 512, 2048]) {
+      expect(
+        isTooLargeToCompactInDurableObject({
+          documentBytes: 1024 * kilobytes,
+          maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+        })
+      ).toBe(false);
+    }
+  });
+
+  test("the compaction ceiling sits well below the load warning", () => {
+    expect(DEFAULT_COMPACTION_MAX_IN_DO_BYTES).toBeLessThan(
+      DEFAULT_QUARANTINE_DOCUMENT_BYTES
+    );
+  });
+});
+
+describe("getFailureBackoffMs", () => {
+  test("escalates 1min, 5min, 20min, 1h, 6h on the default base", () => {
+    const baseMs = DEFAULT_FAILURE_BACKOFF_MS;
+    const maxMs = DEFAULT_FAILURE_BACKOFF_MAX_MS;
+    const ladder = [1, 2, 3, 4, 5].map((failureCount) =>
+      getFailureBackoffMs({ failureCount, baseMs, maxMs })
+    );
+
+    expect(ladder).toEqual([
+      1 * MINUTE,
+      5 * MINUTE,
+      20 * MINUTE,
+      60 * MINUTE,
+      360 * MINUTE,
+    ]);
+  });
+
+  test("keeps growing past the ladder but never exceeds the cap", () => {
+    const baseMs = DEFAULT_FAILURE_BACKOFF_MS;
+    const maxMs = DEFAULT_FAILURE_BACKOFF_MAX_MS;
+
+    for (let failureCount = 6; failureCount <= 20; failureCount += 1) {
+      const delay = getFailureBackoffMs({ failureCount, baseMs, maxMs });
+      expect(delay).toBeLessThanOrEqual(maxMs);
+      expect(delay).toBeGreaterThan(0);
+    }
+    expect(getFailureBackoffMs({ failureCount: 20, baseMs, maxMs })).toBe(maxMs);
+  });
+
+  test("is monotonic, so retries never get more aggressive", () => {
+    const baseMs = DEFAULT_FAILURE_BACKOFF_MS;
+    const maxMs = DEFAULT_FAILURE_BACKOFF_MAX_MS;
+    let previous = 0;
+    for (let failureCount = 1; failureCount <= 12; failureCount += 1) {
+      const delay = getFailureBackoffMs({ failureCount, baseMs, maxMs });
+      expect(delay).toBeGreaterThanOrEqual(previous);
+      previous = delay;
+    }
+  });
+
+  test("a cleared counter means no delay", () => {
     expect(
-      shouldQuarantineForLoadAttempts({ loadAttempts: 0, maxLoadAttempts }),
-    ).toBe(false);
+      getFailureBackoffMs({ failureCount: 0, baseMs: MINUTE, maxMs: MINUTE })
+    ).toBe(0);
+  });
+});
+
+describe("getFailureRetryAt and isRetryDue", () => {
+  test("a retry is not due before its backoff elapses", () => {
+    const now = 1_000_000;
+    const retryAfter = getFailureRetryAt({
+      failureCount: 2,
+      baseMs: DEFAULT_FAILURE_BACKOFF_MS,
+      maxMs: DEFAULT_FAILURE_BACKOFF_MAX_MS,
+      now,
+    });
+
+    expect(retryAfter).toBe(now + 5 * MINUTE);
+    expect(isRetryDue({ retryAfter, now })).toBe(false);
+    expect(isRetryDue({ retryAfter, now: retryAfter })).toBe(true);
+  });
+
+  test("no recorded backoff means work may proceed", () => {
+    expect(isRetryDue({ retryAfter: null, now: 1 })).toBe(true);
+  });
+});
+
+describe("shouldQuarantineForFailures", () => {
+  test("holds off until the high threshold is reached", () => {
+    const failureThreshold = DEFAULT_QUARANTINE_FAILURE_THRESHOLD;
+    for (const failureCount of [1, 3, 5, 7]) {
+      expect(
+        shouldQuarantineForFailures({ failureCount, failureThreshold })
+      ).toBe(false);
+    }
     expect(
-      shouldQuarantineForLoadAttempts({ loadAttempts: 2, maxLoadAttempts }),
-    ).toBe(false);
-    expect(
-      shouldQuarantineForLoadAttempts({ loadAttempts: 3, maxLoadAttempts }),
-    ).toBe(true);
-    expect(
-      shouldQuarantineForLoadAttempts({ loadAttempts: 9, maxLoadAttempts }),
+      shouldQuarantineForFailures({ failureCount: 8, failureThreshold })
     ).toBe(true);
   });
 });
 
+describe("formatCompactionSkipLog", () => {
+  test("names the room and points at the external compaction runbook", () => {
+    const message = formatCompactionSkipLog({
+      roomName: "kwolanne.github.io-offerings",
+      documentBytes: 7 * MB,
+      maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+    });
+
+    expect(message).toContain("REQUIRES EXTERNAL COMPACTION");
+    expect(message).toContain("room=kwolanne.github.io-offerings");
+    expect(message).toContain("admin/raw-data");
+    expect(message).toContain("admin/restore-raw-document");
+    // The room is explicitly NOT broken, which matters for triage.
+    expect(message).toContain("loads and runs normally");
+  });
+});
+
+describe("formatFailureBackoffLog", () => {
+  test("reports the failing operation, the retry time, and self-healing", () => {
+    const message = formatFailureBackoffLog({
+      roomName: "example-room",
+      failureKind: "alarm",
+      failureCount: 2,
+      retryAt: 1779829545000,
+      failureThreshold: 8,
+    });
+
+    expect(message).toContain("ROOM WORK FAILING");
+    expect(message).toContain("operation=alarm");
+    expect(message).toContain("consecutiveFailures=2");
+    expect(message).toContain("2026-05-26T21:05:45.000Z");
+    expect(message).toContain("quarantineAfter=8");
+    expect(message).toContain("clears itself");
+  });
+});
+
 describe("formatQuarantineLog", () => {
-  test("names the room, the size reason, and the recovery procedure", () => {
+  test("explains an operator-initiated quarantine", () => {
     const message = formatQuarantineLog({
-      roomName: "aliaelkattan.com-music-room",
-      reason: "document-size",
-      documentBytes: 8_000_000,
-      thresholdBytes: SIX_MB,
-      loadAttempts: 1,
+      roomName: "example-room",
+      reason: "manual",
+      detail: "investigating runaway growth",
+      failureKind: null,
+      failureCount: 0,
     });
 
     expect(message).toContain("ROOM QUARANTINED");
-    expect(message).toContain("room=aliaelkattan.com-music-room");
-    expect(message).toContain("reason=document-size");
-    expect(message).toContain("documentBytes=8000000");
-    expect(message).toContain("too large to hydrate");
-    expect(message).toContain("will NOT be overwritten");
+    expect(message).toContain("reason=manual");
+    expect(message).toContain("investigating runaway growth");
     expect(message).toContain("admin/quarantine-clear");
   });
 
-  test("explains the crash-loop reason when the size gate did not fire", () => {
+  test("explains a last-resort automatic quarantine", () => {
     const message = formatQuarantineLog({
-      roomName: "kwolanne.github.io-offerings",
-      reason: "crash-loop",
-      documentBytes: null,
-      thresholdBytes: SIX_MB,
-      loadAttempts: 3,
+      roomName: "example-room",
+      reason: "repeated-failures",
+      detail: "alarm work failed 8 times in a row",
+      failureKind: "alarm",
+      failureCount: 8,
     });
 
-    expect(message).toContain("reason=crash-loop");
-    expect(message).toContain("documentBytes=unknown");
-    expect(message).toContain("hydration failed 3 times");
+    expect(message).toContain("reason=repeated-failures");
+    expect(message).toContain("exhausted the retry backoff");
+    expect(message).toContain("will NOT be overwritten");
     expect(message).toContain("TRANSIENT MODE");
   });
 });
 
 describe("createQuarantineStatusBody", () => {
-  test("reports a healthy room as not quarantined", () => {
+  test("reports a healthy room with no failures and no parking", () => {
     const body = createQuarantineStatusBody({
       roomName: "healthy-room",
       quarantine: null,
-      thresholdBytes: SIX_MB,
-      maxLoadAttempts: 3,
-      loadAttempts: 0,
+      documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+      failureThreshold: 8,
+      loadFailures: 0,
+      alarmFailures: 0,
+      retryAfter: null,
+      compactionParkedBytes: null,
     });
 
-    expect(body).toEqual({
-      roomId: "healthy-room",
-      quarantined: false,
-      reason: null,
-      documentBytes: null,
-      quarantinedAt: null,
-      loadAttempts: 0,
-      thresholdBytes: SIX_MB,
-      maxLoadAttempts: 3,
+    expect(body.quarantined).toBe(false);
+    expect(body.failures).toEqual({
+      load: 0,
+      alarm: 0,
+      quarantineAfter: 8,
+      retryAfter: null,
     });
+    expect(body.compaction.parked).toBe(false);
   });
 
-  test("reports the reason and size for a quarantined room", () => {
+  test("surfaces backoff state and compaction parking for triage", () => {
     const body = createQuarantineStatusBody({
       roomName: "sick-room",
       quarantine: {
-        reason: "document-size",
-        documentBytes: 8_000_000,
-        loadAttempts: 1,
+        reason: "repeated-failures",
+        detail: "alarm work failed 8 times in a row",
+        failureKind: "alarm",
+        failureCount: 8,
         quarantinedAt: 1779829545000,
       },
-      thresholdBytes: SIX_MB,
-      maxLoadAttempts: 3,
-      loadAttempts: 1,
+      documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+      failureThreshold: 8,
+      loadFailures: 0,
+      alarmFailures: 8,
+      retryAfter: 1779829545000,
+      compactionParkedBytes: 7 * MB,
     });
 
     expect(body.quarantined).toBe(true);
-    expect(body.reason).toBe("document-size");
-    expect(body.documentBytes).toBe(8_000_000);
+    expect(body.reason).toBe("repeated-failures");
     expect(body.quarantinedAt).toBe("2026-05-26T21:05:45.000Z");
+    expect(body.failures.alarm).toBe(8);
+    expect(body.failures.retryAfter).toBe("2026-05-26T21:05:45.000Z");
+    expect(body.compaction).toEqual({
+      parked: true,
+      documentBytes: 7 * MB,
+      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+    });
   });
 });

--- a/partykit/__tests__/quarantinePolicy.test.ts
+++ b/partykit/__tests__/quarantinePolicy.test.ts
@@ -1,20 +1,23 @@
-// ABOUTME: Verifies the policy decisions behind compaction skips, backoff, and quarantine.
-// ABOUTME: Covers the size-warning boundary, the backoff ladder, and operator-facing logs.
+// ABOUTME: Verifies the policy decisions behind compaction retries, backoff, and quarantine.
+// ABOUTME: Covers failure boundaries, retry ladders, and operator-facing logs.
 import { describe, expect, test } from "bun:test";
 import {
   createQuarantineStatusBody,
-  formatCompactionSkipLog,
+  formatCompactionBackoffLog,
+  formatCompactionDisabledLog,
   formatFailureBackoffLog,
   formatQuarantineLog,
+  getCompactionRetryDelayMs,
   getFailureBackoffMs,
   getFailureRetryAt,
   isDocumentOversized,
   isRetryDue,
-  isTooLargeToCompactInDurableObject,
+  shouldDisableCompaction,
   shouldQuarantineForFailures,
 } from "../quarantinePolicy";
 import {
-  DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+  DEFAULT_COMPACTION_DISABLE_AFTER,
+  DEFAULT_COMPACTION_RETRY_DELAYS_MS,
   DEFAULT_FAILURE_BACKOFF_MAX_MS,
   DEFAULT_FAILURE_BACKOFF_MS,
   DEFAULT_QUARANTINE_DOCUMENT_BYTES,
@@ -48,35 +51,31 @@ describe("isDocumentOversized", () => {
   });
 });
 
-describe("isTooLargeToCompactInDurableObject", () => {
-  // Compaction holds the live doc, its JSON projection, and the rebuild at once,
-  // so rooms that survive loading still cannot be compacted in place.
-  test("catches the 6-8MB band that OOMs during compaction", () => {
-    for (const megabytes of [6, 7, 8, 13]) {
-      expect(
-        isTooLargeToCompactInDurableObject({
-          documentBytes: MB * megabytes,
-          maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+describe("automatic compaction failure policy", () => {
+  test("retries after 15 seconds and then 30 seconds", () => {
+    expect(
+      [1, 2, 3].map((failureCount) =>
+        getCompactionRetryDelayMs({
+          failureCount,
+          retryDelaysMs: DEFAULT_COMPACTION_RETRY_DELAYS_MS,
         })
-      ).toBe(true);
-    }
+      )
+    ).toEqual([15_000, 30_000, null]);
   });
 
-  test("leaves ordinary rooms compactable", () => {
-    for (const kilobytes of [1, 64, 512, 2048]) {
-      expect(
-        isTooLargeToCompactInDurableObject({
-          documentBytes: 1024 * kilobytes,
-          maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
-        })
-      ).toBe(false);
-    }
-  });
-
-  test("the compaction ceiling sits well below the load warning", () => {
-    expect(DEFAULT_COMPACTION_MAX_IN_DO_BYTES).toBeLessThan(
-      DEFAULT_QUARANTINE_DOCUMENT_BYTES
-    );
+  test("disables only after the third vanished attempt", () => {
+    expect(
+      shouldDisableCompaction({
+        failureCount: DEFAULT_COMPACTION_DISABLE_AFTER - 1,
+        disableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
+      })
+    ).toBe(false);
+    expect(
+      shouldDisableCompaction({
+        failureCount: DEFAULT_COMPACTION_DISABLE_AFTER,
+        disableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
+      })
+    ).toBe(true);
   });
 });
 
@@ -161,20 +160,31 @@ describe("shouldQuarantineForFailures", () => {
   });
 });
 
-describe("formatCompactionSkipLog", () => {
-  test("names the room and points at the external compaction runbook", () => {
-    const message = formatCompactionSkipLog({
+describe("compaction failure logs", () => {
+  test("reports a delayed retry without claiming the room is unavailable", () => {
+    const message = formatCompactionBackoffLog({
       roomName: "kwolanne.github.io-offerings",
-      documentBytes: 7 * MB,
-      maxBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+      failureCount: 1,
+      retryAt: 1779829545000,
     });
 
-    expect(message).toContain("REQUIRES EXTERNAL COMPACTION");
+    expect(message).toContain("AUTOMATIC COMPACTION BACKOFF");
     expect(message).toContain("room=kwolanne.github.io-offerings");
-    expect(message).toContain("admin/raw-data");
-    expect(message).toContain("admin/restore-raw-document");
-    // The room is explicitly NOT broken, which matters for triage.
-    expect(message).toContain("loads and runs normally");
+    expect(message).toContain("vanishedAttempts=1");
+    expect(message).toContain("2026-05-26T21:05:45.000Z");
+    expect(message).toContain("continues loading, syncing, and persisting");
+  });
+
+  test("reports failure-based disablement and the operator retry path", () => {
+    const message = formatCompactionDisabledLog({
+      roomName: "kwolanne.github.io-offerings",
+      failureCount: 3,
+    });
+
+    expect(message).toContain("AUTOMATIC COMPACTION DISABLED");
+    expect(message).toContain("vanishedAttempts=3");
+    expect(message).toContain("without affecting room service or persistence");
+    expect(message).toContain("admin/compaction-retry");
   });
 });
 
@@ -230,18 +240,20 @@ describe("formatQuarantineLog", () => {
 });
 
 describe("createQuarantineStatusBody", () => {
-  test("reports a healthy room with no failures and no parking", () => {
+  test("reports a healthy room with no failures or compaction delay", () => {
     const body = createQuarantineStatusBody({
       roomName: "healthy-room",
       quarantine: null,
       documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
       failureThreshold: 8,
       loadFailures: 0,
       alarmFailures: 0,
       loadRetryAfter: null,
       alarmRetryAfter: null,
-      compactionParkedBytes: null,
+      compactionFailures: 0,
+      compactionRetryAfter: null,
+      compactionDisabledAt: null,
+      compactionDisableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
     });
 
     expect(body.quarantined).toBe(false);
@@ -252,10 +264,16 @@ describe("createQuarantineStatusBody", () => {
       loadRetryAfter: null,
       alarmRetryAfter: null,
     });
-    expect(body.compaction.parked).toBe(false);
+    expect(body.compaction).toEqual({
+      disabled: false,
+      disabledAt: null,
+      failures: 0,
+      disableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
+      retryAfter: null,
+    });
   });
 
-  test("surfaces backoff state and compaction parking for triage", () => {
+  test("surfaces independent quarantine and compaction failure state", () => {
     const body = createQuarantineStatusBody({
       roomName: "sick-room",
       quarantine: {
@@ -266,13 +284,15 @@ describe("createQuarantineStatusBody", () => {
         quarantinedAt: 1779829545000,
       },
       documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
       failureThreshold: 8,
       loadFailures: 0,
       alarmFailures: 8,
       loadRetryAfter: null,
       alarmRetryAfter: 1779829545000,
-      compactionParkedBytes: 7 * MB,
+      compactionFailures: 3,
+      compactionRetryAfter: null,
+      compactionDisabledAt: 1779829999000,
+      compactionDisableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
     });
 
     expect(body.quarantined).toBe(true);
@@ -283,9 +303,11 @@ describe("createQuarantineStatusBody", () => {
     // A load that never failed keeps a null deadline of its own.
     expect(body.failures.loadRetryAfter).toBeNull();
     expect(body.compaction).toEqual({
-      parked: true,
-      documentBytes: 7 * MB,
-      maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+      disabled: true,
+      disabledAt: "2026-05-26T21:13:19.000Z",
+      failures: 3,
+      disableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
+      retryAfter: null,
     });
   });
 });

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -9,6 +9,30 @@ import { docToJson, encodeDocToBase64 } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
 import { ExternalCompactionRequiredError } from "./quarantinePolicy";
 
+export function getAdminAuthError(
+  request: Request,
+  adminToken: string | undefined
+): Response | null {
+  if (!adminToken) return null;
+
+  const url = new URL(request.url);
+  const token =
+    url.searchParams.get("token") ||
+    request.headers.get("Authorization")?.replace("Bearer ", "");
+
+  if (!token || token !== adminToken) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
+  return null;
+}
+
 function compareKeys(
   obj1: any,
   obj2: any
@@ -125,21 +149,7 @@ export class AdminHandler {
   }
 
   private checkAdminAuth(request: Request): Response | null {
-    const adminToken = env.ADMIN_TOKEN;
-    if (adminToken) {
-      const url = new URL(request.url);
-      const token =
-        url.searchParams.get("token") ||
-        request.headers.get("Authorization")?.replace("Bearer ", "");
-
-      if (!token || token !== adminToken) {
-        return new Response(JSON.stringify({ error: "Unauthorized" }), {
-          status: 401,
-          headers: { "content-type": "application/json" },
-        });
-      }
-    }
-    return null;
+    return getAdminAuthError(request, env.ADMIN_TOKEN);
   }
 
   private checkPersistenceWriteAvailable(): Response | null {

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -57,64 +57,64 @@ export class AdminHandler {
 
       // Route admin endpoints
       if (path.includes("admin/inspect") && request.method === "GET") {
-        return this.handleAdminInspect(request);
+        return await this.handleAdminInspect(request);
       }
       if (path.includes("admin/raw-data") && request.method === "GET") {
-        return this.handleAdminRawData(request);
+        return await this.handleAdminRawData(request);
       }
       if (
         path.includes("admin/remove-subscriber") &&
         request.method === "POST"
       ) {
-        return this.handleAdminRemoveSubscriber(request);
+        return await this.handleAdminRemoveSubscriber(request);
       }
       if (path.includes("admin/live-compare") && request.method === "GET") {
-        return this.handleAdminLiveCompare(request);
+        return await this.handleAdminLiveCompare(request);
       }
       if (path.includes("admin/force-save-live") && request.method === "POST") {
-        return this.handleAdminForceSaveLive(request);
+        return await this.handleAdminForceSaveLive(request);
       }
       if (
         path.includes("admin/force-reload-live") &&
         request.method === "POST"
       ) {
-        return this.handleAdminForceReloadLive(request);
+        return await this.handleAdminForceReloadLive(request);
       }
       if (
         path.includes("admin/save-edited-data") &&
         request.method === "POST"
       ) {
-        return this.handleAdminSaveEditedData(request);
+        return await this.handleAdminSaveEditedData(request);
       }
       if (
         path.includes("admin/moderation-remove") &&
         request.method === "POST"
       ) {
-        return this.handleModerationRemove(request);
+        return await this.handleModerationRemove(request);
       }
       if (path.includes("admin/cleanup-orphans") && request.method === "POST") {
-        return this.handleAdminCleanupOrphans(request);
+        return await this.handleAdminCleanupOrphans(request);
       }
       if (path.includes("admin/hard-reset") && request.method === "POST") {
-        return this.handleAdminHardReset(request);
+        return await this.handleAdminHardReset(request);
       }
       if (
         path.includes("admin/restore-raw-document") &&
         request.method === "POST"
       ) {
-        return this.handleAdminRestoreRawDocument(request);
+        return await this.handleAdminRestoreRawDocument(request);
       }
       if (path.includes("admin/quarantine-status") && request.method === "GET") {
-        return this.handleAdminQuarantineStatus(request);
+        return await this.handleAdminQuarantineStatus(request);
       }
       if (path.includes("admin/quarantine-set") && request.method === "POST") {
-        return this.handleAdminQuarantineSet(request);
+        return await this.handleAdminQuarantineSet(request);
       }
       if (
         path.includes("admin/quarantine-clear") &&
         request.method === "POST"
       ) {
-        return this.handleAdminQuarantineClear(request);
+        return await this.handleAdminQuarantineClear(request);
       }
 
       return new Response("Admin endpoint not found", { status: 404 });
@@ -1043,21 +1043,52 @@ export class AdminHandler {
         { bumpEpoch: true, allowQuarantined: true }
       );
 
-      // The persisted document has been replaced, so the conditions that parked
-      // compaction or quarantined the room are gone. Lift both here rather than
-      // making the operator run follow-up calls.
-      await this.context.clearCompactionPark();
-      if (this.context.isQuarantined()) {
-        await this.context.clearQuarantine();
+      // Only lift the parks if the replacement document is actually small
+      // enough to work with. Auto-clearing after restoring a still-oversized
+      // document would send the room straight back into its crash loop.
+      const maxInDurableObjectBytes =
+        this.context.getCompactionMaxInDurableObjectBytes();
+      const stillTooLarge = result.documentSize > maxInDurableObjectBytes;
+
+      let quarantineCleared = false;
+      let compactionUnparked = false;
+      let cleanupError: string | null = null;
+
+      if (!stillTooLarge) {
+        // The restore itself already succeeded and is durable. A failure in this
+        // cleanup must not turn into a 500, or an operator would re-run a
+        // restore that actually worked.
+        try {
+          await this.context.clearCompactionPark();
+          compactionUnparked = true;
+          if (this.context.isQuarantined()) {
+            await this.context.clearQuarantine();
+            quarantineCleared = true;
+          }
+        } catch (error) {
+          cleanupError =
+            error instanceof Error ? error.message : String(error);
+          console.error(
+            `[Restore Raw] Post-restore cleanup failed for room ${roomId}:`,
+            error
+          );
+        }
       }
 
       return new Response(
         JSON.stringify({
           ok: true,
-          message: "Raw document restored successfully",
+          message: stillTooLarge
+            ? "Raw document restored, but it is still too large to compact in the room, so the room stays quarantined and compaction stays parked. Compact it further and restore again."
+            : "Raw document restored successfully",
           documentSize: result.documentSize,
           resetEpoch: result.resetEpoch,
           closedConnections: result.closedConnections,
+          stillTooLarge,
+          maxInDurableObjectBytes,
+          quarantineCleared,
+          compactionUnparked,
+          cleanupError,
         }),
         {
           headers: {
@@ -1090,22 +1121,51 @@ export class AdminHandler {
     }
   }
 
+  // The three quarantine handlers carry their own try/catch. Without it a
+  // rejection escapes the router's catch (which returns un-awaited promises) and
+  // surfaces as a bare platform 500 with no CORS headers and no log.
+  private quarantineErrorResponse(operation: string, error: unknown): Response {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      `[Admin] ${operation} failed for room ${this.context.name}:`,
+      error
+    );
+    return new Response(
+      JSON.stringify({
+        error: `Failed to ${operation}`,
+        message,
+        roomId: this.context.name,
+      }),
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
+
   private async handleAdminQuarantineStatus(
     request: Request
   ): Promise<Response> {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
 
-    const body = await this.context.getQuarantineStatusBody();
+    try {
+      const body = await this.context.getQuarantineStatusBody();
 
-    return new Response(JSON.stringify(body, null, 2), {
-      headers: {
-        "content-type": "application/json",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET",
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
-      },
-    });
+      return new Response(JSON.stringify(body, null, 2), {
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        },
+      });
+    } catch (error) {
+      return this.quarantineErrorResponse("read quarantine status", error);
+    }
   }
 
   // Quarantine is primarily an operator decision: it takes a room out of
@@ -1115,28 +1175,70 @@ export class AdminHandler {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
 
-    const body = (await request.json().catch(() => null)) as {
-      reason?: string;
-    } | null;
-
-    await this.context.enterQuarantine({
-      reason: "manual",
-      detail: body?.reason?.trim() || "no reason given",
-      failureKind: null,
-      failureCount: 0,
-    });
-
-    return new Response(
-      JSON.stringify(await this.context.getQuarantineStatusBody(), null, 2),
-      {
-        headers: {
-          "content-type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        },
+    let body: { reason?: string } | null = null;
+    const rawBody = await request.text();
+    if (rawBody.trim()) {
+      try {
+        body = JSON.parse(rawBody) as { reason?: string };
+      } catch {
+        // Silently recording "no reason given" would lose the operator's note.
+        return new Response(
+          JSON.stringify({
+            error: "Invalid JSON body",
+            message:
+              "Send {\"reason\": \"...\"} or an empty body to quarantine without a note.",
+          }),
+          {
+            status: 400,
+            headers: {
+              "content-type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            },
+          }
+        );
       }
-    );
+    }
+
+    try {
+      const hasControlPlane = this.context.hasQuarantineControlPlane();
+      await this.context.enterQuarantine({
+        reason: "manual",
+        detail: body?.reason?.trim() || "no reason given",
+        failureKind: null,
+        failureCount: 0,
+      });
+
+      const externalFlag = await this.context.readExternalQuarantineFlag();
+      const status = await this.context.getQuarantineStatusBody();
+
+      return new Response(
+        JSON.stringify(
+          {
+            ...status,
+            // Without the binding the room is quarantined locally only, which
+            // will NOT survive a restart of a room that crashes on start.
+            externalFlagWritten: externalFlag.available
+              ? externalFlag.value !== null
+              : false,
+            warning: hasControlPlane
+              ? undefined
+              : "No quarantine control plane is configured, so this quarantine is local only and will not survive a restart.",
+          },
+          null,
+          2
+        ),
+        {
+          headers: {
+            "content-type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+          },
+        }
+      );
+    } catch (error) {
+      return this.quarantineErrorResponse("set quarantine", error);
+    }
   }
 
   // Clearing quarantine removes the flag and the failure history. The room stays
@@ -1148,33 +1250,51 @@ export class AdminHandler {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
 
-    const previous = this.context.getQuarantineState();
-    await this.context.clearQuarantine();
+    try {
+      const previous = this.context.getQuarantineState();
+      const reset = await this.context.clearQuarantine();
 
-    return new Response(
-      JSON.stringify(
+      // Even when nothing was quarantined this may have reset a failure ledger,
+      // so the response reports what actually changed.
+      const resetSomething =
+        reset.wasQuarantined ||
+        reset.loadFailures > 0 ||
+        reset.alarmFailures > 0 ||
+        reset.wasLoadDeferred;
+
+      return new Response(
+        JSON.stringify(
+          {
+            roomId: this.context.name,
+            cleared: reset.wasQuarantined,
+            previousReason: previous?.reason ?? null,
+            previousDetail: previous?.detail ?? null,
+            reset: {
+              loadFailures: reset.loadFailures,
+              alarmFailures: reset.alarmFailures,
+              loadDeferral: reset.wasLoadDeferred,
+            },
+            stillTransient: !this.context.isPersistenceAvailable(),
+            message: reset.wasQuarantined
+              ? "Quarantine cleared, along with the failure history that caused it. This room stays transient (nothing persists) until it restarts; the next load retries hydration."
+              : resetSomething
+                ? "Room was not quarantined, but its failure history was reset."
+                : "Room was not quarantined and had no failure history; nothing changed.",
+          },
+          null,
+          2
+        ),
         {
-          roomId: this.context.name,
-          cleared: previous !== null,
-          previousReason: previous?.reason ?? null,
-          previousDetail: previous?.detail ?? null,
-          stillTransient: !this.context.isPersistenceAvailable(),
-          message:
-            previous === null
-              ? "Room was not quarantined; nothing to clear."
-              : "Quarantine cleared, along with the failure history that caused it. This room stays transient (nothing persists) until it restarts; the next load retries hydration.",
-        },
-        null,
-        2
-      ),
-      {
-        headers: {
-          "content-type": "application/json",
-          "Access-Control-Allow-Origin": "*",
-          "Access-Control-Allow-Methods": "POST, OPTIONS",
-          "Access-Control-Allow-Headers": "Content-Type, Authorization",
-        },
-      }
-    );
+          headers: {
+            "content-type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+          },
+        }
+      );
+    } catch (error) {
+      return this.quarantineErrorResponse("clear quarantine", error);
+    }
   }
 }

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -7,7 +7,6 @@ import { supabase } from "./db";
 import { PartyServer } from "./party";
 import { docToJson, encodeDocToBase64 } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
-import { ExternalCompactionRequiredError } from "./quarantinePolicy";
 import { getAdminAuthError } from "./adminAuth";
 
 export { getAdminAuthError } from "./adminAuth";
@@ -119,6 +118,12 @@ export class AdminHandler {
       ) {
         return await this.handleAdminQuarantineClear(request);
       }
+      if (
+        path.includes("admin/compaction-retry") &&
+        request.method === "POST"
+      ) {
+        return await this.handleAdminCompactionRetry(request);
+      }
 
       return new Response("Admin endpoint not found", { status: 404 });
     } catch (err) {
@@ -191,7 +196,6 @@ export class AdminHandler {
               },
               connections: Array.from(this.context.getConnections()).length,
               timestamp: new Date().toISOString(),
-              documentSize: quarantine.compaction.documentBytes ?? 0,
               resetEpoch: await this.context.getResetEpoch(),
             },
             null,
@@ -924,22 +928,6 @@ export class AdminHandler {
         }
       );
     } catch (error: unknown) {
-      if (error instanceof ExternalCompactionRequiredError) {
-        return new Response(
-          JSON.stringify({
-            error: "External compaction required",
-            message: error.message,
-            roomId,
-            documentBytes: error.documentBytes,
-            maxInDurableObjectBytes: error.maxBytes,
-          }),
-          {
-            status: 409,
-            headers: { "content-type": "application/json" },
-          }
-        );
-      }
-
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       const errorStack = error instanceof Error ? error.stack : undefined;
@@ -1008,7 +996,11 @@ export class AdminHandler {
         );
         // Try to decode a Y.Doc to validate it's a valid YJS document
         const testDoc = new Y.Doc();
-        Y.applyUpdate(testDoc, buffer);
+        try {
+          Y.applyUpdate(testDoc, buffer);
+        } finally {
+          testDoc.destroy();
+        }
       } catch (validationError) {
         return new Response(
           JSON.stringify({
@@ -1033,51 +1025,37 @@ export class AdminHandler {
         { bumpEpoch: true, allowQuarantined: true }
       );
 
-      // Only lift the parks if the replacement document is actually small
-      // enough to work with. Auto-clearing after restoring a still-oversized
-      // document would send the room straight back into its crash loop.
-      const maxInDurableObjectBytes =
-        this.context.circuitBreaker.getCompactionMaxInDurableObjectBytes();
-      const stillTooLarge = result.documentSize > maxInDurableObjectBytes;
-
       let quarantineCleared = false;
-      let compactionUnparked = false;
+      let compactionFailureCleared = false;
       let cleanupError: string | null = null;
 
-      if (!stillTooLarge) {
-        // The restore itself already succeeded and is durable. A failure in this
-        // cleanup must not turn into a 500, or an operator would re-run a
-        // restore that actually worked.
-        try {
-          await this.context.circuitBreaker.clearCompactionPark();
-          compactionUnparked = true;
-          if (this.context.circuitBreaker.isQuarantined()) {
-            await this.context.circuitBreaker.clearQuarantine();
-            quarantineCleared = true;
-          }
-        } catch (error) {
-          cleanupError =
-            error instanceof Error ? error.message : String(error);
-          console.error(
-            `[Restore Raw] Post-restore cleanup failed for room ${roomId}:`,
-            error
-          );
+      // The restore itself already succeeded and is durable. A failure in this
+      // cleanup must not turn into a 500, or an operator would re-run a restore
+      // that actually worked.
+      try {
+        await this.context.circuitBreaker.clearCompactionFailure();
+        compactionFailureCleared = true;
+        if (this.context.circuitBreaker.isQuarantined()) {
+          await this.context.circuitBreaker.clearQuarantine();
+          quarantineCleared = true;
         }
+      } catch (error) {
+        cleanupError = error instanceof Error ? error.message : String(error);
+        console.error(
+          `[Restore Raw] Post-restore cleanup failed for room ${roomId}:`,
+          error
+        );
       }
 
       return new Response(
         JSON.stringify({
           ok: true,
-          message: stillTooLarge
-            ? "Raw document restored, but it is still too large to compact in the room, so the room stays quarantined and compaction stays parked. Compact it further and restore again."
-            : "Raw document restored successfully",
+          message: "Raw document restored successfully",
           documentSize: result.documentSize,
           resetEpoch: result.resetEpoch,
           closedConnections: result.closedConnections,
-          stillTooLarge,
-          maxInDurableObjectBytes,
           quarantineCleared,
-          compactionUnparked,
+          compactionFailureCleared,
           cleanupError,
         }),
         {
@@ -1111,10 +1089,9 @@ export class AdminHandler {
     }
   }
 
-  // The three quarantine handlers carry their own try/catch. Without it a
-  // rejection escapes the router's catch (which returns un-awaited promises) and
-  // surfaces as a bare platform 500 with no CORS headers and no log.
-  private quarantineErrorResponse(operation: string, error: unknown): Response {
+  // The room safety handlers carry their own try/catch so failures include
+  // structured details and CORS headers instead of a bare platform 500.
+  private controlErrorResponse(operation: string, error: unknown): Response {
     const message = error instanceof Error ? error.message : String(error);
     console.error(
       `[Admin] ${operation} failed for room ${this.context.name}:`,
@@ -1154,7 +1131,7 @@ export class AdminHandler {
         },
       });
     } catch (error) {
-      return this.quarantineErrorResponse("read quarantine status", error);
+      return this.controlErrorResponse("read quarantine status", error);
     }
   }
 
@@ -1230,7 +1207,7 @@ export class AdminHandler {
         }
       );
     } catch (error) {
-      return this.quarantineErrorResponse("set quarantine", error);
+      return this.controlErrorResponse("set quarantine", error);
     }
   }
 
@@ -1286,7 +1263,47 @@ export class AdminHandler {
         }
       );
     } catch (error) {
-      return this.quarantineErrorResponse("clear quarantine", error);
+      return this.controlErrorResponse("clear quarantine", error);
+    }
+  }
+
+  private async handleAdminCompactionRetry(
+    request: Request
+  ): Promise<Response> {
+    const authError = this.checkAdminAuth(request);
+    if (authError) return authError;
+
+    try {
+      const reset = await this.context.retryAutomaticCompaction();
+      const status =
+        await this.context.circuitBreaker.getQuarantineStatusBody();
+
+      return new Response(
+        JSON.stringify(
+          {
+            ...status,
+            reset: {
+              failures: reset.failures,
+              retryAfter: reset.retryAfter,
+              disabledAt: reset.disabledAt,
+            },
+            message:
+              "Automatic compaction failure state cleared and compaction retried.",
+          },
+          null,
+          2
+        ),
+        {
+          headers: {
+            "content-type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
+          },
+        }
+      );
+    } catch (error) {
+      return this.controlErrorResponse("retry automatic compaction", error);
     }
   }
 }

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -103,6 +103,15 @@ export class AdminHandler {
       ) {
         return this.handleAdminRestoreRawDocument(request);
       }
+      if (path.includes("admin/quarantine-status") && request.method === "GET") {
+        return this.handleAdminQuarantineStatus(request);
+      }
+      if (
+        path.includes("admin/quarantine-clear") &&
+        request.method === "POST"
+      ) {
+        return this.handleAdminQuarantineClear(request);
+      }
 
       return new Response("Admin endpoint not found", { status: 404 });
     } catch (err) {
@@ -169,6 +178,44 @@ export class AdminHandler {
       const subscribers = await this.context.getSubscribers();
       const sharedReferences = await this.context.getSharedReferences();
       const sharedPermissions = await this.context.getSharedPermissions();
+      const quarantineLoadAttempts =
+        await this.context.getQuarantineLoadAttempts();
+      const quarantine =
+        this.context.getQuarantineStatusBody(quarantineLoadAttempts);
+
+      // Never rebuild the Y.Doc of a quarantined room: applying that update is
+      // exactly what OOMs the isolate.
+      if (this.context.isQuarantined()) {
+        return new Response(
+          JSON.stringify(
+            {
+              roomId: this.context.name,
+              subscribers,
+              sharedReferences,
+              sharedPermissions,
+              quarantine,
+              ydoc: {
+                error:
+                  "Room is quarantined; the persisted document was not loaded because hydrating it crashes the room.",
+              },
+              connections: Array.from(this.context.getConnections()).length,
+              timestamp: new Date().toISOString(),
+              documentSize: quarantine.documentBytes ?? 0,
+              resetEpoch: await this.context.getResetEpoch(),
+            },
+            null,
+            2
+          ),
+          {
+            headers: {
+              "content-type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+              "Access-Control-Allow-Methods": "GET",
+              "Access-Control-Allow-Headers": "Content-Type",
+            },
+          }
+        );
+      }
 
       // Get Y.Doc data if available - use direct approach for consistency
       let ydocData = null;
@@ -235,6 +282,7 @@ export class AdminHandler {
         subscribers,
         sharedReferences,
         sharedPermissions,
+        quarantine,
         ydoc: ydocData,
         connections: Array.from(this.context.getConnections()).length,
         timestamp: new Date().toISOString(),
@@ -467,6 +515,11 @@ export class AdminHandler {
   ): Promise<Response> {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
+    // Reloading the persisted document into the live doc is the exact operation
+    // that OOMs a quarantined room, and it is a tempting thing to reach for
+    // while a room looks broken.
+    const persistenceError = this.checkPersistenceWriteAvailable();
+    if (persistenceError) return persistenceError;
 
     try {
       // Load snapshot from DB
@@ -915,8 +968,13 @@ export class AdminHandler {
   ): Promise<Response> {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
-    const persistenceError = this.checkPersistenceWriteAvailable();
-    if (persistenceError) return persistenceError;
+    // Quarantine also runs the room in transient mode, but this endpoint is how
+    // an oversized document gets replaced with a repaired one, so it stays open
+    // for a quarantined room. A genuine Supabase outage still blocks it.
+    if (!this.context.isQuarantined()) {
+      const persistenceError = this.checkPersistenceWriteAvailable();
+      if (persistenceError) return persistenceError;
+    }
 
     const roomId = this.context.name;
     console.log(`[Restore Raw] Starting for room: ${roomId}`);
@@ -960,11 +1018,20 @@ export class AdminHandler {
         );
       }
 
-      // Use the centralized restoreFromSnapshot method (bump epoch)
+      // Use the centralized restoreFromSnapshot method (bump epoch).
+      // The document here is operator-supplied and already validated above, so
+      // this is the sanctioned way to replace a quarantined room's document.
       const result = await this.context.restoreFromSnapshot(
         body.base64Document,
-        { bumpEpoch: true }
+        { bumpEpoch: true, allowQuarantined: true }
       );
+
+      // The persisted document has been replaced, so the condition that caused
+      // quarantine is gone. Lift it here rather than making the operator run a
+      // second call.
+      if (this.context.isQuarantined()) {
+        await this.context.clearQuarantine();
+      }
 
       return new Response(
         JSON.stringify({
@@ -1003,5 +1070,64 @@ export class AdminHandler {
         { status: 500, headers: { "content-type": "application/json" } }
       );
     }
+  }
+
+  private async handleAdminQuarantineStatus(
+    request: Request
+  ): Promise<Response> {
+    const authError = this.checkAdminAuth(request);
+    if (authError) return authError;
+
+    const loadAttempts = await this.context.getQuarantineLoadAttempts();
+    const body = this.context.getQuarantineStatusBody(loadAttempts);
+
+    return new Response(JSON.stringify(body, null, 2), {
+      headers: {
+        "content-type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      },
+    });
+  }
+
+  // Clearing quarantine only removes the flag and the counter. The room stays in
+  // transient mode until it restarts, so the next load is the one that retries
+  // hydration. Clear this only after the persisted document has been shrunk or
+  // repaired, otherwise the room will simply re-quarantine.
+  private async handleAdminQuarantineClear(
+    request: Request
+  ): Promise<Response> {
+    const authError = this.checkAdminAuth(request);
+    if (authError) return authError;
+
+    const previous = this.context.getQuarantineState();
+    await this.context.clearQuarantine();
+
+    return new Response(
+      JSON.stringify(
+        {
+          roomId: this.context.name,
+          cleared: previous !== null,
+          previousReason: previous?.reason ?? null,
+          previousDocumentBytes: previous?.documentBytes ?? null,
+          stillTransient: !this.context.isPersistenceAvailable(),
+          message:
+            previous === null
+              ? "Room was not quarantined; nothing to clear."
+              : "Quarantine cleared. This room stays transient (nothing persists) until it restarts; the next load retries hydration and will re-quarantine if the document is still oversized.",
+        },
+        null,
+        2
+      ),
+      {
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        },
+      }
+    );
   }
 }

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -106,6 +106,9 @@ export class AdminHandler {
       if (path.includes("admin/quarantine-status") && request.method === "GET") {
         return this.handleAdminQuarantineStatus(request);
       }
+      if (path.includes("admin/quarantine-set") && request.method === "POST") {
+        return this.handleAdminQuarantineSet(request);
+      }
       if (
         path.includes("admin/quarantine-clear") &&
         request.method === "POST"
@@ -178,10 +181,7 @@ export class AdminHandler {
       const subscribers = await this.context.getSubscribers();
       const sharedReferences = await this.context.getSharedReferences();
       const sharedPermissions = await this.context.getSharedPermissions();
-      const quarantineLoadAttempts =
-        await this.context.getQuarantineLoadAttempts();
-      const quarantine =
-        this.context.getQuarantineStatusBody(quarantineLoadAttempts);
+      const quarantine = await this.context.getQuarantineStatusBody();
 
       // Never rebuild the Y.Doc of a quarantined room: applying that update is
       // exactly what OOMs the isolate.
@@ -200,7 +200,7 @@ export class AdminHandler {
               },
               connections: Array.from(this.context.getConnections()).length,
               timestamp: new Date().toISOString(),
-              documentSize: quarantine.documentBytes ?? 0,
+              documentSize: quarantine.compaction.documentBytes ?? 0,
               resetEpoch: await this.context.getResetEpoch(),
             },
             null,
@@ -1026,9 +1026,10 @@ export class AdminHandler {
         { bumpEpoch: true, allowQuarantined: true }
       );
 
-      // The persisted document has been replaced, so the condition that caused
-      // quarantine is gone. Lift it here rather than making the operator run a
-      // second call.
+      // The persisted document has been replaced, so the conditions that parked
+      // compaction or quarantined the room are gone. Lift both here rather than
+      // making the operator run follow-up calls.
+      await this.context.clearCompactionPark();
       if (this.context.isQuarantined()) {
         await this.context.clearQuarantine();
       }
@@ -1078,8 +1079,7 @@ export class AdminHandler {
     const authError = this.checkAdminAuth(request);
     if (authError) return authError;
 
-    const loadAttempts = await this.context.getQuarantineLoadAttempts();
-    const body = this.context.getQuarantineStatusBody(loadAttempts);
+    const body = await this.context.getQuarantineStatusBody();
 
     return new Response(JSON.stringify(body, null, 2), {
       headers: {
@@ -1091,10 +1091,40 @@ export class AdminHandler {
     });
   }
 
-  // Clearing quarantine only removes the flag and the counter. The room stays in
-  // transient mode until it restarts, so the next load is the one that retries
-  // hydration. Clear this only after the persisted document has been shrunk or
-  // repaired, otherwise the room will simply re-quarantine.
+  // Quarantine is primarily an operator decision: it takes a room out of
+  // persistence entirely, so nothing automatic reaches for it except as a last
+  // resort after the retry backoff is exhausted.
+  private async handleAdminQuarantineSet(request: Request): Promise<Response> {
+    const authError = this.checkAdminAuth(request);
+    if (authError) return authError;
+
+    const body = (await request.json().catch(() => null)) as {
+      reason?: string;
+    } | null;
+
+    await this.context.enterQuarantine({
+      reason: "manual",
+      detail: body?.reason?.trim() || "no reason given",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    return new Response(
+      JSON.stringify(await this.context.getQuarantineStatusBody(), null, 2),
+      {
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        },
+      }
+    );
+  }
+
+  // Clearing quarantine removes the flag and the failure history. The room stays
+  // in transient mode until it restarts, so the next load is the one that
+  // retries hydration.
   private async handleAdminQuarantineClear(
     request: Request
   ): Promise<Response> {
@@ -1110,12 +1140,12 @@ export class AdminHandler {
           roomId: this.context.name,
           cleared: previous !== null,
           previousReason: previous?.reason ?? null,
-          previousDocumentBytes: previous?.documentBytes ?? null,
+          previousDetail: previous?.detail ?? null,
           stillTransient: !this.context.isPersistenceAvailable(),
           message:
             previous === null
               ? "Room was not quarantined; nothing to clear."
-              : "Quarantine cleared. This room stays transient (nothing persists) until it restarts; the next load retries hydration and will re-quarantine if the document is still oversized.",
+              : "Quarantine cleared, along with the failure history that caused it. This room stays transient (nothing persists) until it restarts; the next load retries hydration.",
         },
         null,
         2

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -1251,9 +1251,8 @@ export class AdminHandler {
     }
   }
 
-  // Clearing quarantine removes the flag and the failure history. The room stays
-  // in transient mode until it restarts, so the next load is the one that
-  // retries hydration.
+  // Clearing quarantine removes the flag and failure history, then leaves normal
+  // traffic gated until a guarded load restores the persisted document.
   private async handleAdminQuarantineClear(
     request: Request
   ): Promise<Response> {
@@ -1286,9 +1285,9 @@ export class AdminHandler {
             },
             stillTransient: !this.context.isPersistenceAvailable(),
             message: reset.wasQuarantined
-              ? "Quarantine cleared, along with the failure history that caused it. This room stays transient (nothing persists) until it restarts; the next load retries hydration."
+              ? "Quarantine cleared, along with the failure history that caused it. Normal traffic stays gated until a guarded load restores the persisted document."
               : resetSomething
-                ? "Room was not quarantined, but its failure history was reset."
+                ? "Room was not quarantined, but its failure history was reset. Normal traffic stays gated until a guarded load restores the persisted document."
                 : "Room was not quarantined and had no failure history; nothing changed.",
           },
           null,

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -8,30 +8,9 @@ import { PartyServer } from "./party";
 import { docToJson, encodeDocToBase64 } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
 import { ExternalCompactionRequiredError } from "./quarantinePolicy";
+import { getAdminAuthError } from "./adminAuth";
 
-export function getAdminAuthError(
-  request: Request,
-  adminToken: string | undefined
-): Response | null {
-  if (!adminToken) return null;
-
-  const url = new URL(request.url);
-  const token =
-    url.searchParams.get("token") ||
-    request.headers.get("Authorization")?.replace("Bearer ", "");
-
-  if (!token || token !== adminToken) {
-    return new Response(JSON.stringify({ error: "Unauthorized" }), {
-      status: 401,
-      headers: {
-        "content-type": "application/json",
-        "Access-Control-Allow-Origin": "*",
-      },
-    });
-  }
-
-  return null;
-}
+export { getAdminAuthError } from "./adminAuth";
 
 function compareKeys(
   obj1: any,
@@ -192,11 +171,12 @@ export class AdminHandler {
       const subscribers = await this.context.getSubscribers();
       const sharedReferences = await this.context.getSharedReferences();
       const sharedPermissions = await this.context.getSharedPermissions();
-      const quarantine = await this.context.getQuarantineStatusBody();
+      const quarantine =
+        await this.context.circuitBreaker.getQuarantineStatusBody();
 
       // Never rebuild the Y.Doc of a quarantined room: applying that update is
       // exactly what OOMs the isolate.
-      if (this.context.isQuarantined()) {
+      if (this.context.circuitBreaker.isQuarantined()) {
         return new Response(
           JSON.stringify(
             {
@@ -998,7 +978,7 @@ export class AdminHandler {
     // Quarantine also runs the room in transient mode, but this endpoint is how
     // an oversized document gets replaced with a repaired one, so it stays open
     // for a quarantined room. A genuine Supabase outage still blocks it.
-    if (!this.context.isQuarantined()) {
+    if (!this.context.circuitBreaker.isQuarantined()) {
       const persistenceError = this.checkPersistenceWriteAvailable();
       if (persistenceError) return persistenceError;
     }
@@ -1057,7 +1037,7 @@ export class AdminHandler {
       // enough to work with. Auto-clearing after restoring a still-oversized
       // document would send the room straight back into its crash loop.
       const maxInDurableObjectBytes =
-        this.context.getCompactionMaxInDurableObjectBytes();
+        this.context.circuitBreaker.getCompactionMaxInDurableObjectBytes();
       const stillTooLarge = result.documentSize > maxInDurableObjectBytes;
 
       let quarantineCleared = false;
@@ -1069,10 +1049,10 @@ export class AdminHandler {
         // cleanup must not turn into a 500, or an operator would re-run a
         // restore that actually worked.
         try {
-          await this.context.clearCompactionPark();
+          await this.context.circuitBreaker.clearCompactionPark();
           compactionUnparked = true;
-          if (this.context.isQuarantined()) {
-            await this.context.clearQuarantine();
+          if (this.context.circuitBreaker.isQuarantined()) {
+            await this.context.circuitBreaker.clearQuarantine();
             quarantineCleared = true;
           }
         } catch (error) {
@@ -1163,7 +1143,7 @@ export class AdminHandler {
     if (authError) return authError;
 
     try {
-      const body = await this.context.getQuarantineStatusBody();
+      const body = await this.context.circuitBreaker.getQuarantineStatusBody();
 
       return new Response(JSON.stringify(body, null, 2), {
         headers: {
@@ -1210,16 +1190,19 @@ export class AdminHandler {
     }
 
     try {
-      const hasControlPlane = this.context.hasQuarantineControlPlane();
-      await this.context.enterQuarantine({
+      const hasControlPlane =
+        this.context.circuitBreaker.hasQuarantineControlPlane();
+      await this.context.circuitBreaker.enterQuarantine({
         reason: "manual",
         detail: body?.reason?.trim() || "no reason given",
         failureKind: null,
         failureCount: 0,
       });
 
-      const externalFlag = await this.context.readExternalQuarantineFlag();
-      const status = await this.context.getQuarantineStatusBody();
+      const externalFlag =
+        await this.context.circuitBreaker.readExternalQuarantineFlag();
+      const status =
+        await this.context.circuitBreaker.getQuarantineStatusBody();
 
       return new Response(
         JSON.stringify(
@@ -1260,8 +1243,8 @@ export class AdminHandler {
     if (authError) return authError;
 
     try {
-      const previous = this.context.getQuarantineState();
-      const reset = await this.context.clearQuarantine();
+      const previous = this.context.circuitBreaker.getQuarantineState();
+      const reset = await this.context.circuitBreaker.clearQuarantine();
 
       // Even when nothing was quarantined this may have reset a failure ledger,
       // so the response reports what actually changed.

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -7,6 +7,7 @@ import { supabase } from "./db";
 import { PartyServer } from "./party";
 import { docToJson, encodeDocToBase64 } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
+import { ExternalCompactionRequiredError } from "./quarantinePolicy";
 
 function compareKeys(
   obj1: any,
@@ -933,6 +934,22 @@ export class AdminHandler {
         }
       );
     } catch (error: unknown) {
+      if (error instanceof ExternalCompactionRequiredError) {
+        return new Response(
+          JSON.stringify({
+            error: "External compaction required",
+            message: error.message,
+            roomId,
+            documentBytes: error.documentBytes,
+            maxInDurableObjectBytes: error.maxBytes,
+          }),
+          {
+            status: 409,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       const errorStack = error instanceof Error ? error.stack : undefined;

--- a/partykit/adminAuth.ts
+++ b/partykit/adminAuth.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Authenticates administrative PartyServer and Worker requests.
+// ABOUTME: Keeps shared token handling independent from room and control handlers.
+export function getAdminAuthError(
+  request: Request,
+  adminToken: string | undefined
+): Response | null {
+  if (!adminToken) return null;
+
+  const url = new URL(request.url);
+  const token =
+    url.searchParams.get("token") ||
+    request.headers.get("Authorization")?.replace("Bearer ", "");
+
+  if (!token || token !== adminToken) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: {
+        "content-type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
+  return null;
+}

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -21,6 +21,14 @@ export const STORAGE_KEYS = {
   quarantine: "quarantine",
   // Counts hydration attempts that started but never reported completion
   quarantineLoadAttempts: "quarantineLoadAttempts",
+  // Counts alarm runs that started but never reported completion, which is how
+  // an OOM inside compaction is detected
+  alarmFailureAttempts: "alarmFailureAttempts",
+  // Earliest time the alarm should retry risky work after repeated failures
+  failureRetryAfter: "failureRetryAfter",
+  // Set when a document is too large to compact inside the Durable Object and
+  // must be compacted externally
+  compactionParked: "compactionParked",
 };
 // Subscriber lease configuration (default 12 hours)
 export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
@@ -61,13 +69,37 @@ export const DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES = (() => {
 export const DEFAULT_DOCUMENT_WARNING_BYTES = (() => {
   return 1024 * 1024 * 40;
 })();
-// Persisted documents above this size are never hydrated. Lethality varies with
-// isolate co-tenancy: 7-8MB rooms have OOMed on load, but four healthy production
-// rooms also sit in the 6-8MB band, so the size gate only catches the absurd
-// (10MB+); empirically-lethal smaller documents are caught by the crash-loop
-// counter instead (3 failed loads -> quarantine).
+// Documents above this size are reported as a load risk. Lethality varies with
+// isolate co-tenancy: 7-8MB rooms have OOMed, but healthy production rooms also
+// sit in the 6-8MB band, so size alone never blocks a load or quarantines a
+// room. It is a warning; repeated real failures are what drive backoff.
 export const DEFAULT_QUARANTINE_DOCUMENT_BYTES = (() => {
   return 1024 * 1024 * 10;
+})();
+// In-DO compaction rebuilds the document and holds the live Y.Doc, its JSON
+// projection, and the rebuilt copy at once, so it costs several times the
+// document size in peak memory. The ceiling therefore sits far below the load
+// ceiling: above this, compaction is skipped and the document must be compacted
+// externally. Skipping is not a quarantine -- the room loads and runs normally.
+export const DEFAULT_COMPACTION_MAX_IN_DO_BYTES = (() => {
+  return 1024 * 1024 * 4;
+})();
+// Consecutive failures of the same risky operation before the room is
+// quarantined as a last resort. The backoff ladder below is expected to absorb
+// transient failures long before this is reached.
+export const DEFAULT_QUARANTINE_FAILURE_THRESHOLD = (() => {
+  return 8;
+})();
+// Retry backoff for risky work that keeps failing. Cloudflare retries a failed
+// alarm within seconds, which is what turns one OOM into a crash loop, so the
+// alarm is rescheduled onto this ladder instead: 1min, 5min, 20min, 1h, 6h,
+// then capped. Failures self-heal -- a success clears the counter and restores
+// the normal cadence.
+export const DEFAULT_FAILURE_BACKOFF_MS = (() => {
+  return 60 * 1000;
+})();
+export const DEFAULT_FAILURE_BACKOFF_MAX_MS = (() => {
+  return 60 * 60 * 1000 * 24;
 })();
 export const DEFAULT_SUPABASE_LOAD_TIMEOUT_MS = (() => {
   return 5000;

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -21,17 +21,19 @@ export const STORAGE_KEYS = {
   quarantine: "quarantine",
   // Counts hydration attempts that started but never reported completion
   quarantineLoadAttempts: "quarantineLoadAttempts",
-  // Counts alarm runs that started but never reported completion, which is how
-  // an OOM inside compaction is detected
+  // Counts generic alarm runs that started but never reported completion.
   alarmFailureAttempts: "alarmFailureAttempts",
   // Earliest time each risky operation may be retried after repeated failures.
   // Load and alarm keep separate deadlines so a success on one never erases the
   // other's backoff.
   loadRetryAfter: "loadRetryAfter",
   alarmRetryAfter: "alarmRetryAfter",
-  // Set when a document is too large to compact inside the Durable Object and
-  // must be compacted externally
-  compactionParked: "compactionParked",
+  // Tracks automatic compaction attempts that started but never completed.
+  compactionAttempts: "compactionAttempts",
+  // Earliest time a failed automatic compaction may be retried.
+  compactionRetryAfter: "compactionRetryAfter",
+  // Timestamp set after automatic compaction vanishes three times in a row.
+  compactionDisabledAt: "compactionDisabledAt",
 };
 // Subscriber lease configuration (default 12 hours)
 export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
@@ -79,14 +81,10 @@ export const DEFAULT_DOCUMENT_WARNING_BYTES = (() => {
 export const DEFAULT_QUARANTINE_DOCUMENT_BYTES = (() => {
   return 1024 * 1024 * 10;
 })();
-// In-DO compaction rebuilds the document and holds the live Y.Doc, its JSON
-// projection, and the rebuilt copy at once, so it costs several times the
-// document size in peak memory. The ceiling therefore sits far below the load
-// ceiling: above this, compaction is skipped and the document must be compacted
-// externally. Skipping is not a quarantine -- the room loads and runs normally.
-export const DEFAULT_COMPACTION_MAX_IN_DO_BYTES = (() => {
-  return 1024 * 1024 * 4;
-})();
+// Automatic compaction gets two delayed retries after the initial attempt.
+// A third vanished attempt disables automatic compaction for that room.
+export const DEFAULT_COMPACTION_RETRY_DELAYS_MS = [15_000, 30_000] as const;
+export const DEFAULT_COMPACTION_DISABLE_AFTER = 3;
 // Consecutive failures of the same risky operation before the room is
 // quarantined as a last resort. The backoff ladder below is expected to absorb
 // transient failures long before this is reached.

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -24,8 +24,11 @@ export const STORAGE_KEYS = {
   // Counts alarm runs that started but never reported completion, which is how
   // an OOM inside compaction is detected
   alarmFailureAttempts: "alarmFailureAttempts",
-  // Earliest time the alarm should retry risky work after repeated failures
-  failureRetryAfter: "failureRetryAfter",
+  // Earliest time each risky operation may be retried after repeated failures.
+  // Load and alarm keep separate deadlines so a success on one never erases the
+  // other's backoff.
+  loadRetryAfter: "loadRetryAfter",
+  alarmRetryAfter: "alarmRetryAfter",
   // Set when a document is too large to compact inside the Durable Object and
   // must be compacted externally
   compactionParked: "compactionParked",

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -16,6 +16,11 @@ export const STORAGE_KEYS = {
   emergencyCompactCheckAfter: "emergencyCompactCheckAfter",
   // Stores the next time autosave should try compacting before persistence
   persistedDocumentCompactCheckAfter: "persistedDocumentCompactCheckAfter",
+  // Stores the quarantine record for a room whose persisted document cannot be
+  // hydrated without crashing the Durable Object
+  quarantine: "quarantine",
+  // Counts hydration attempts that started but never reported completion
+  quarantineLoadAttempts: "quarantineLoadAttempts",
 };
 // Subscriber lease configuration (default 12 hours)
 export const DEFAULT_SUBSCRIBER_LEASE_MS = (() => {
@@ -55,6 +60,12 @@ export const DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES = (() => {
 })();
 export const DEFAULT_DOCUMENT_WARNING_BYTES = (() => {
   return 1024 * 1024 * 40;
+})();
+// Persisted documents above this size are never hydrated. Rooms observed at
+// 7-8MB base64 OOM the Durable Object during load, which resets the isolate and
+// kills every co-located room, so the gate sits below that range.
+export const DEFAULT_QUARANTINE_DOCUMENT_BYTES = (() => {
+  return 1024 * 1024 * 6;
 })();
 export const DEFAULT_SUPABASE_LOAD_TIMEOUT_MS = (() => {
   return 5000;

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -61,11 +61,13 @@ export const DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES = (() => {
 export const DEFAULT_DOCUMENT_WARNING_BYTES = (() => {
   return 1024 * 1024 * 40;
 })();
-// Persisted documents above this size are never hydrated. Rooms observed at
-// 7-8MB base64 OOM the Durable Object during load, which resets the isolate and
-// kills every co-located room, so the gate sits below that range.
+// Persisted documents above this size are never hydrated. Lethality varies with
+// isolate co-tenancy: 7-8MB rooms have OOMed on load, but four healthy production
+// rooms also sit in the 6-8MB band, so the size gate only catches the absurd
+// (10MB+); empirically-lethal smaller documents are caught by the crash-loop
+// counter instead (3 failed loads -> quarantine).
 export const DEFAULT_QUARANTINE_DOCUMENT_BYTES = (() => {
-  return 1024 * 1024 * 6;
+  return 1024 * 1024 * 10;
 })();
 export const DEFAULT_SUPABASE_LOAD_TIMEOUT_MS = (() => {
   return 5000;

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -217,6 +217,10 @@ export class PartyServer extends YServer {
   private hasLoggedQuarantine = false;
   // Single-flight guard for an in-place re-load attempt at the deadline.
   private inFlightReload: Promise<boolean> | null = null;
+  // Tracks the two startup phases separately because a deferred room hydrates
+  // after the platform's one-time onStart hook has already returned.
+  private realtimeSyncStarted = false;
+  private documentLoadCompleted = false;
 
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -251,6 +255,7 @@ export class PartyServer extends YServer {
 
     if (this.isQuarantined()) {
       await this.enterQuarantineRuntimeState();
+      await this.startRealtimeSync();
       return;
     }
 
@@ -259,7 +264,17 @@ export class PartyServer extends YServer {
       return;
     }
 
+    await this.startRealtimeSync();
+    await this.completeRoomStartup();
+  }
+
+  private async startRealtimeSync(): Promise<void> {
+    if (this.realtimeSyncStarted) return;
     await super.onStart();
+    this.realtimeSyncStarted = true;
+  }
+
+  private async completeRoomStartup(): Promise<void> {
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
     await this.ensureAlarmScheduled();
@@ -756,6 +771,8 @@ export class PartyServer extends YServer {
     if (!skipExternalWrite) {
       await this.writeExternalQuarantineFlag(detail);
     }
+
+    await this.startRealtimeSync();
   }
 
   /**
@@ -773,6 +790,9 @@ export class PartyServer extends YServer {
       reason: `room quarantined (${quarantine.reason})`,
       failedAt: quarantine.quarantinedAt,
     };
+    // Quarantine intentionally serves an ephemeral collaborative room instead
+    // of refusing traffic behind the load-backoff gate.
+    this.loadDeferredUntil = null;
 
     await this.cancelAlarmForQuarantine();
 
@@ -952,23 +972,35 @@ export class PartyServer extends YServer {
         });
         await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
 
-        console.error(
-          formatFailureBackoffLog({
-            roomName: this.name,
-            failureKind: "load",
-            failureCount: previousFailures,
-            retryAt: nextRetryAt,
-            failureThreshold,
-          }) + " Retrying hydration in place now."
-        );
+        if (previousFailures === 0) {
+          console.log(
+            `[PartyServer] Starting guarded hydration after quarantine clear: room=${this.name}`
+          );
+        } else {
+          console.error(
+            formatFailureBackoffLog({
+              roomName: this.name,
+              failureKind: "load",
+              failureCount: previousFailures,
+              retryAt: nextRetryAt,
+              failureThreshold,
+            }) + " Retrying hydration in place now."
+          );
+        }
 
-        // Clear the flag so onLoad does not short-circuit on it.
+        // Clear the flag so the guarded load does not short-circuit on it.
         this.loadDeferredUntil = null;
-        await this.onLoad();
+        this.documentLoadCompleted = false;
+        if (this.realtimeSyncStarted) {
+          await this.onLoad();
+        } else {
+          await this.startRealtimeSync();
+        }
 
         // onLoad clears the counter on success.
         const remainingFailures = await this.getFailureCount("load");
-        if (remainingFailures === 0) {
+        if (remainingFailures === 0 && this.documentLoadCompleted) {
+          await this.completeRoomStartup();
           console.log(
             `[PartyServer] Room recovered after deferral: room=${this.name}`
           );
@@ -1077,6 +1109,8 @@ export class PartyServer extends YServer {
       alarmFailures: await this.getFailureCount("alarm"),
       wasLoadDeferred: this.loadDeferredUntil !== null,
     };
+    const needsGuardedReload =
+      summary.wasQuarantined || summary.wasLoadDeferred;
 
     // Clear the external flag first: if it survived while local state did not,
     // the room would silently re-quarantine on its next start.
@@ -1084,8 +1118,10 @@ export class PartyServer extends YServer {
 
     this.quarantine = null;
     this.hasLoggedQuarantine = false;
-    // Otherwise status would report a healthy room while requests still 503.
-    this.loadDeferredUntil = null;
+    this.documentLoadCompleted = false;
+    // The persisted document was not necessarily loaded in this isolate. Keep
+    // normal traffic gated until the next guarded load proves it is safe.
+    this.loadDeferredUntil = needsGuardedReload ? Date.now() : null;
     await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
     await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
     await this.ctx.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
@@ -1096,7 +1132,8 @@ export class PartyServer extends YServer {
         `wasQuarantined=${summary.wasQuarantined}, ` +
         `loadFailuresReset=${summary.loadFailures}, ` +
         `alarmFailuresReset=${summary.alarmFailures}, ` +
-        `wasLoadDeferred=${summary.wasLoadDeferred}. The next load will attempt hydration again.`
+        `wasLoadDeferred=${summary.wasLoadDeferred}, ` +
+        `recoveryPending=${needsGuardedReload}.`
     );
     return summary;
   }
@@ -2238,6 +2275,7 @@ export class PartyServer extends YServer {
    * the quarantine check is repeated here as a cheap safety net.
    */
   override async onLoad(): Promise<void> {
+    this.documentLoadCompleted = false;
     this.quarantine = await this.readStoredQuarantine();
     if (this.quarantine !== null) {
       await this.enterQuarantineRuntimeState();
@@ -2318,6 +2356,7 @@ export class PartyServer extends YServer {
     // Hydration completed without killing the isolate, so the failure history
     // and any pending backoff are cleared.
     await this.completeRiskyOperation("load");
+    this.documentLoadCompleted = true;
   }
 
   // Undoes this start's increment when the load ended before hydration could be
@@ -2687,8 +2726,10 @@ export class PartyServer extends YServer {
           "/admin/quarantine-set",
           "/admin/quarantine-clear",
         ].some((path) => url.pathname.includes(path));
-        const loadDeferred = await this.getLoadDeferredResponse();
-        if (loadDeferred && !isLoadControlRoute) return loadDeferred;
+        if (!isLoadControlRoute) {
+          const loadDeferred = await this.getLoadDeferredResponse();
+          if (loadDeferred) return loadDeferred;
+        }
         // Awaited so a rejection lands in this method's catch rather than
         // escaping as a bare platform 500 with no CORS headers and no log.
         return await this.adminHandler.handleRequest(request);

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -207,6 +207,9 @@ export class PartyServer extends YServer {
   // Set by buildCompactedDocument when the document is too large to rebuild in
   // memory. Callers turn this into a parked compaction schedule and one loud log.
   private compactionTooLargeBytes: number | null = null;
+  // Deadline of an active load-backoff window. While set, this isolate never
+  // hydrated, so every request is refused rather than served an empty document.
+  private loadDeferredUntil: number | null = null;
 
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -227,6 +230,12 @@ export class PartyServer extends YServer {
   private adminHandler = new AdminHandler(this);
 
   override async onStart(): Promise<void> {
+    // Read the operator control plane BEFORE super.onStart(), which hydrates.
+    // A room that crashes during hydration can never be reached by an admin
+    // route, so the only way to take it out of service is an external flag
+    // consulted before the crash happens.
+    await this.applyExternalQuarantineFlag();
+
     await super.onStart();
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
@@ -498,8 +507,14 @@ export class PartyServer extends YServer {
     return typeof value === "number" ? value : 0;
   }
 
-  async getFailureRetryAfter(): Promise<number | null> {
-    const value = await this.ctx.storage.get(STORAGE_KEYS.failureRetryAfter);
+  private retryKeyFor(kind: FailureKind): string {
+    return kind === "load"
+      ? STORAGE_KEYS.loadRetryAfter
+      : STORAGE_KEYS.alarmRetryAfter;
+  }
+
+  async getFailureRetryAfter(kind: FailureKind): Promise<number | null> {
+    const value = await this.ctx.storage.get(this.retryKeyFor(kind));
     return typeof value === "number" ? value : null;
   }
 
@@ -526,7 +541,9 @@ export class PartyServer extends YServer {
    */
   private async completeRiskyOperation(kind: FailureKind): Promise<void> {
     await this.ctx.storage.delete(this.failureKeyFor(kind));
-    await this.ctx.storage.delete(STORAGE_KEYS.failureRetryAfter);
+    // Only this operation's deadline is cleared: a healthy load must not erase
+    // the alarm's backoff, or compaction would start crash-looping again.
+    await this.ctx.storage.delete(this.retryKeyFor(kind));
   }
 
   /**
@@ -559,7 +576,7 @@ export class PartyServer extends YServer {
       maxMs: this.getFailureBackoffMaxMs(),
       now: Date.now(),
     });
-    await this.ctx.storage.put(STORAGE_KEYS.failureRetryAfter, retryAt);
+    await this.ctx.storage.put(this.retryKeyFor(kind), retryAt);
 
     console.error(
       formatFailureBackoffLog({
@@ -591,11 +608,13 @@ export class PartyServer extends YServer {
     detail,
     failureKind,
     failureCount,
+    skipExternalWrite = false,
   }: {
     reason: QuarantineReason;
     detail: string;
     failureKind: FailureKind | null;
     failureCount: number;
+    skipExternalWrite?: boolean;
   }): Promise<void> {
     const quarantine: QuarantineState = {
       reason,
@@ -606,6 +625,12 @@ export class PartyServer extends YServer {
     };
     this.quarantine = quarantine;
     await this.ctx.storage.put(STORAGE_KEYS.quarantine, quarantine);
+
+    // KV is the pre-hydration authority; DO storage is the local record. Both
+    // are written so a quarantine survives a room that cannot start.
+    if (!skipExternalWrite) {
+      await this.writeExternalQuarantineFlag(detail);
+    }
 
     // Transient mode is the existing ephemeral-only path: realtime sync keeps
     // working, autosave and persistence writes are refused.
@@ -630,6 +655,113 @@ export class PartyServer extends YServer {
 
   private async cancelAlarmForQuarantine(): Promise<void> {
     await this.ctx.storage.deleteAlarm?.();
+  }
+
+  isLoadDeferred(): boolean {
+    return this.loadDeferredUntil !== null;
+  }
+
+  private getQuarantineControlKv(): KVNamespace | null {
+    // Absent in tests and in any deployment where the binding is not configured.
+    return env.QUARANTINE_CONTROL ?? null;
+  }
+
+  private getQuarantineControlKey(): string {
+    return `quarantine:${this.name}`;
+  }
+
+  /**
+   * Reads the external quarantine flag before hydration. This is the only
+   * quarantine path that works for a room which crashes on start, because every
+   * admin route runs after hydration has already happened.
+   *
+   * Fails OPEN: a KV outage must not take rooms offline. Manual quarantine is an
+   * operator tool, not a correctness gate.
+   */
+  private async applyExternalQuarantineFlag(): Promise<void> {
+    const kv = this.getQuarantineControlKv();
+    if (kv === null) return;
+
+    let flag: string | null;
+    try {
+      flag = await kv.get(this.getQuarantineControlKey());
+    } catch (error) {
+      console.warn(
+        `[PartyServer] Quarantine control lookup failed for room=${this.name}; proceeding normally. ` +
+          `reason=${getErrorMessage(error)}`
+      );
+      return;
+    }
+
+    if (flag === null) return;
+
+    await this.enterQuarantine({
+      reason: "manual",
+      detail: flag || "no reason given",
+      failureKind: null,
+      failureCount: 0,
+      // KV is already the source of truth here; writing back would be a no-op.
+      skipExternalWrite: true,
+    });
+  }
+
+  private async writeExternalQuarantineFlag(
+    detail: string | null
+  ): Promise<void> {
+    const kv = this.getQuarantineControlKv();
+    if (kv === null) return;
+
+    const key = this.getQuarantineControlKey();
+    try {
+      if (detail === null) {
+        await kv.delete(key);
+      } else {
+        await kv.put(key, detail);
+      }
+    } catch (error) {
+      // Surfaced loudly: the operator needs to know the pre-hydration flag did
+      // not stick, because that is the copy that survives a crashing room.
+      console.error(
+        `[PartyServer] Quarantine control write FAILED for room=${this.name}; ` +
+          `the pre-hydration flag is NOT set and will not survive a restart. ` +
+          `reason=${getErrorMessage(error)}`
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Response for a room inside its load-backoff window. This is deliberately a
+   * hard failure rather than transient mode: the document was never read, so
+   * serving the empty live doc would look like data loss to a visitor. Quarantine
+   * is the opposite trade-off, where an operator has accepted ephemeral service.
+   */
+  getLoadDeferredResponse(): Response | null {
+    if (this.loadDeferredUntil === null) return null;
+
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((this.loadDeferredUntil - Date.now()) / 1000)
+    );
+
+    return new Response(
+      JSON.stringify({
+        error: "room_load_deferred",
+        message:
+          "This room failed to load and is waiting before trying again. Its data is intact and was not read or modified.",
+        roomId: this.name,
+        retryAfterSeconds,
+        retryAt: new Date(this.loadDeferredUntil).toISOString(),
+      }),
+      {
+        status: 503,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": String(retryAfterSeconds),
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
   }
 
   /**
@@ -681,11 +813,16 @@ export class PartyServer extends YServer {
   // Clears quarantine along with the failure history that caused it, so the room
   // starts from a clean slate rather than re-quarantining on the next failure.
   async clearQuarantine(): Promise<void> {
+    // Clear the external flag first: if it survived while local state did not,
+    // the room would silently re-quarantine on its next start.
+    await this.writeExternalQuarantineFlag(null);
+
     this.quarantine = null;
     await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
     await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
     await this.ctx.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
-    await this.ctx.storage.delete(STORAGE_KEYS.failureRetryAfter);
+    await this.ctx.storage.delete(STORAGE_KEYS.loadRetryAfter);
+    await this.ctx.storage.delete(STORAGE_KEYS.alarmRetryAfter);
     console.log(
       `[PartyServer] Quarantine cleared for room=${this.name}; the next load will attempt hydration again.`
     );
@@ -706,7 +843,8 @@ export class PartyServer extends YServer {
       failureThreshold: this.getQuarantineFailureThreshold(),
       loadFailures: await this.getFailureCount("load"),
       alarmFailures: await this.getFailureCount("alarm"),
-      retryAfter: await this.getFailureRetryAfter(),
+      loadRetryAfter: await this.getFailureRetryAfter("load"),
+      alarmRetryAfter: await this.getFailureRetryAfter("alarm"),
       compactionParkedBytes: await this.getCompactionParkedBytes(),
     });
   }
@@ -1258,6 +1396,9 @@ export class PartyServer extends YServer {
     if (this.isSkippingSave) return;
     if (!this.isPersistenceAvailable()) return;
     if (this.getOpenConnectionCount() !== 0) return;
+    // Parked rooms must never be re-scheduled by a later disconnect, or the
+    // alarm would keep waking the room to retry work that cannot succeed.
+    if ((await this.getCompactionParkedBytes()) !== null) return;
 
     const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
     await this.setEmptyRoomCompactAfter(compactAfter);
@@ -1591,6 +1732,23 @@ export class PartyServer extends YServer {
     ctx: Party.ConnectionContext
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
+
+    // Inside a load-backoff window the live document is empty because it was
+    // never read. Joining a visitor to it would look like their data vanished,
+    // so the socket is closed instead.
+    if (this.loadDeferredUntil !== null) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((this.loadDeferredUntil - Date.now()) / 1000)
+      );
+      console.warn(
+        `[PartyServer] Refusing connection to deferred room=${this.name}: ` +
+          `connectionId=${connection.id}, retryAfterSeconds=${retryAfterSeconds}`
+      );
+      connection.close(1013, "Room Load Deferred");
+      return;
+    }
+
     await this.waitForEmptyRoomCompaction();
 
     const url = new URL(ctx.request.url);
@@ -1780,9 +1938,7 @@ export class PartyServer extends YServer {
       return;
     }
 
-    // Evidence of previous loads that started and never finished. Hydration is
-    // still attempted: loads succeed for documents in the size band that has
-    // OOMed, so refusing to load would break healthy rooms.
+    // Evidence of previous loads that started and never finished.
     const previousFailures = await this.getFailureCount("load");
     if (previousFailures > 0) {
       const failureThreshold = this.getQuarantineFailureThreshold();
@@ -1800,6 +1956,33 @@ export class PartyServer extends YServer {
         });
         return;
       }
+
+      // Inside the backoff window the room serves nothing at all: hydration is
+      // what crashes it, and an un-hydrated room would otherwise hand visitors
+      // an empty document as if it were their data. Requests get a 503 with
+      // Retry-After instead, and Supabase is never queried.
+      const retryAfter = await this.getFailureRetryAfter("load");
+      if (!isRetryDue({ retryAfter, now: Date.now() })) {
+        this.loadDeferredUntil = ensureExists(retryAfter);
+        console.warn(
+          `[PartyServer] Load deferred for room=${this.name}: ` +
+            `consecutiveFailures=${previousFailures}, ` +
+            `retryAt=${new Date(this.loadDeferredUntil).toISOString()}. ` +
+            "Serving 503 until the retry deadline; the document was not read."
+        );
+        return;
+      }
+
+      // The deadline has arrived. Exactly one attempt is allowed through: record
+      // the next backoff BEFORE hydrating, so requests racing the deadline in a
+      // fresh isolate see a future deadline rather than all retrying at once.
+      const nextRetryAt = getFailureRetryAt({
+        failureCount: previousFailures + 1,
+        baseMs: this.getFailureBackoffBaseMs(),
+        maxMs: this.getFailureBackoffMaxMs(),
+        now: Date.now(),
+      });
+      await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
     }
 
     // Durable BEFORE the risky work: if hydration kills the isolate, this
@@ -2237,9 +2420,15 @@ export class PartyServer extends YServer {
 
       // Route admin requests to admin handler
       // PartyKit paths are like /parties/main/room-id/admin/inspect
+      // Admin stays reachable during a load-backoff window: diagnosing and
+      // quarantining a room that will not load is the whole point.
       if (url.pathname.includes("/admin")) {
         return this.adminHandler.handleRequest(request);
       }
+
+      // The document was never read, so there is nothing to serve.
+      const loadDeferred = this.getLoadDeferredResponse();
+      if (loadDeferred) return loadDeferred;
 
       if (request.method !== "POST") {
         return new Response("Method Not Allowed", { status: 405 });
@@ -2799,7 +2988,7 @@ export class PartyServer extends YServer {
     if (previousFailures > 0) {
       // Check the existing window BEFORE recording a new one, otherwise a retry
       // that has come due would be pushed out again and never run.
-      const retryAfter = await this.getFailureRetryAfter();
+      const retryAfter = await this.getFailureRetryAfter("alarm");
       if (!isRetryDue({ retryAfter, now: Date.now() })) {
         // Not yet time to retry: re-arm at the backoff time and do no work.
         await this.ctx.storage.setAlarm?.(ensureExists(retryAfter));

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -34,7 +34,6 @@ import {
   DEFAULT_MESSAGE_RATE_WINDOW_MS,
   DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES,
   DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-  DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
   DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
   DEFAULT_FAILURE_BACKOFF_MS,
   DEFAULT_FAILURE_BACKOFF_MAX_MS,
@@ -97,10 +96,7 @@ import {
   type PersistenceMode,
 } from "./persistenceMode";
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
-import {
-  isDocumentOversized,
-  isTooLargeToCompactInDurableObject,
-} from "./quarantinePolicy";
+import { isDocumentOversized } from "./quarantinePolicy";
 import { RoomCircuitBreaker } from "./roomCircuitBreaker";
 import { handleQuarantineControlRequest } from "./quarantineControl";
 export { PresenceServer } from "./presenceServer";
@@ -142,6 +138,12 @@ type UsefulCompactedDocumentOptions = {
   setRecheckAfter: (timestamp: number) => Promise<void>;
   onMissingPlayData?: () => void;
   onNotUseful: (compactedDocument: CompactedDocument) => void;
+};
+
+type AutomaticCompactionOptions<T> = {
+  run: () => Promise<T>;
+  onDeferred: (retryAt: number) => Promise<void>;
+  onDisabled: () => Promise<void>;
 };
 
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
@@ -226,7 +228,6 @@ export class PartyServer extends YServer {
         readPositiveNumber: readPositiveNumberEnv,
         defaults: {
           documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
-          maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
           failureThreshold: DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
           failureBackoffMs: DEFAULT_FAILURE_BACKOFF_MS,
           failureBackoffMaxMs: DEFAULT_FAILURE_BACKOFF_MAX_MS,
@@ -247,8 +248,9 @@ export class PartyServer extends YServer {
             await this.startRealtimeSync();
           }
 
-          const remainingFailures =
-            await this.circuitBreaker.getFailureCount("load");
+          const remainingFailures = await this.circuitBreaker.getFailureCount(
+            "load"
+          );
           if (remainingFailures !== 0 || !this.documentLoadCompleted) {
             return false;
           }
@@ -599,23 +601,8 @@ export class PartyServer extends YServer {
     doc: Y.Doc,
     sourceDocumentBase64?: string
   ): CompactedDocument | null {
-    // Measure BEFORE docToJson: the projection is itself a full copy of the
-    // document, so an oversized room would already be over budget by the time a
-    // later check ran. Encoding the source is one copy and is the cheapest
-    // faithful measure available here.
     const sourceBase64 = sourceDocumentBase64 ?? encodeDocToBase64(doc);
     const beforeSize = sourceBase64.length;
-    const maxInDurableObjectBytes =
-      this.circuitBreaker.getCompactionMaxInDurableObjectBytes();
-    if (
-      isTooLargeToCompactInDurableObject({
-        documentBytes: beforeSize,
-        maxBytes: maxInDurableObjectBytes,
-      })
-    ) {
-      this.circuitBreaker.markCompactionTooLarge(beforeSize);
-      return null;
-    }
 
     const currentPlayData = docToJson(doc);
     if (!currentPlayData) {
@@ -624,16 +611,49 @@ export class PartyServer extends YServer {
 
     const resetEpoch = Date.now();
     const compactDoc = jsonToDoc(currentPlayData);
-    setDocResetEpoch(compactDoc, resetEpoch);
-    const base64 = encodeDocToBase64(compactDoc);
+    try {
+      setDocResetEpoch(compactDoc, resetEpoch);
+      const base64 = encodeDocToBase64(compactDoc);
 
-    return {
-      base64,
-      sourceBase64,
-      beforeSize,
-      afterSize: base64.length,
-      resetEpoch,
-    };
+      return {
+        base64,
+        sourceBase64,
+        beforeSize,
+        afterSize: base64.length,
+        resetEpoch,
+      };
+    } finally {
+      compactDoc.destroy();
+    }
+  }
+
+  private async runAutomaticCompaction<T>({
+    run,
+    onDeferred,
+    onDisabled,
+  }: AutomaticCompactionOptions<T>): Promise<T | null> {
+    const admission = await this.circuitBreaker.getCompactionAdmission();
+    if (admission.kind === "defer") {
+      await onDeferred(admission.retryAt);
+      return null;
+    }
+    if (admission.kind === "disabled") {
+      await onDisabled();
+      return null;
+    }
+
+    await this.circuitBreaker.beginCompactionAttempt();
+    try {
+      const result = await run();
+      await this.circuitBreaker.completeCompactionAttempt();
+      return result;
+    } catch (error) {
+      // A caught exception proves the isolate survived. Only work that vanishes
+      // mid-flight is evidence of an OOM, so observed failures do not advance
+      // the compaction failure counter.
+      await this.circuitBreaker.completeCompactionAttempt();
+      throw error;
+    }
   }
 
   private async restoreResetEpoch(resetEpoch: number | null): Promise<void> {
@@ -1068,9 +1088,7 @@ export class PartyServer extends YServer {
     if (this.isSkippingSave) return;
     if (!this.isPersistenceAvailable()) return;
     if (this.getOpenConnectionCount() !== 0) return;
-    // Parked rooms must never be re-scheduled by a later disconnect, or the
-    // alarm would keep waking the room to retry work that cannot succeed.
-    if ((await this.circuitBreaker.getCompactionParkedBytes()) !== null) return;
+    if ((await this.circuitBreaker.getCompactionDisabledAt()) !== null) return;
 
     const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
     await this.setEmptyRoomCompactAfter(compactAfter);
@@ -1079,6 +1097,24 @@ export class PartyServer extends YServer {
     console.log(
       `[PartyServer] Empty-room compaction scheduled: room=${this.name}, compactAfter=${compactAfter}`
     );
+  }
+
+  async retryAutomaticCompaction() {
+    if (!this.isPersistenceAvailable()) {
+      throw new Error(
+        "Cannot retry automatic compaction while persistence is unavailable"
+      );
+    }
+    if (this.getOpenConnectionCount() !== 0) {
+      throw new Error(
+        "Cannot retry automatic compaction while the room has active connections"
+      );
+    }
+
+    const reset = await this.circuitBreaker.clearCompactionFailure();
+    await this.clearEmptyRoomCompactAfter();
+    await this.compactEmptyRoomDocument();
+    return reset;
   }
 
   // --- Helper: group SharedReferences into storage entries
@@ -1713,12 +1749,6 @@ export class PartyServer extends YServer {
       sourceBase64
     );
     if (compactedDocument === null) {
-      // Too large to rebuild in memory: park the schedule and report the
-      // external-compaction runbook rather than retrying on every autosave.
-      if (await this.circuitBreaker.parkCompactionIfTooLarge()) {
-        await setRecheckAfter(recheckAfter);
-        return null;
-      }
       await setRecheckAfter(recheckAfter);
       onMissingPlayData?.();
       return null;
@@ -1752,6 +1782,36 @@ export class PartyServer extends YServer {
     recheckAfter: number;
     thresholdBytes: number;
   }): Promise<boolean> {
+    const result = await this.runAutomaticCompaction({
+      onDeferred: (retryAt) =>
+        this.setPersistedDocumentCompactCheckAfter(retryAt),
+      onDisabled: () =>
+        this.setPersistedDocumentCompactCheckAfter(recheckAfter),
+      run: () =>
+        this.compactAutosaveCandidate({
+          activeConnectionCount,
+          documentBase64,
+          documentSize,
+          recheckAfter,
+          thresholdBytes,
+        }),
+    });
+    return result ?? false;
+  }
+
+  private async compactAutosaveCandidate({
+    activeConnectionCount,
+    documentBase64,
+    documentSize,
+    recheckAfter,
+    thresholdBytes,
+  }: {
+    activeConnectionCount: number;
+    documentBase64: string;
+    documentSize: number;
+    recheckAfter: number;
+    thresholdBytes: number;
+  }): Promise<boolean> {
     const compactedDocument = await this.getUsefulCompactedDocument({
       sourceBase64: documentBase64,
       documentSize,
@@ -1773,9 +1833,7 @@ export class PartyServer extends YServer {
         );
       },
     });
-    if (compactedDocument === null) {
-      return false;
-    }
+    if (compactedDocument === null) return false;
 
     await this.commitCompactedDocument({
       compactedDocument,
@@ -1981,6 +2039,28 @@ export class PartyServer extends YServer {
     // while clients are connected can merge stale client history back into the
     // room. If compaction is not useful, the cooldown prevents every later
     // autosave of a naturally large document from rebuilding the whole Y.Doc.
+    const result = await this.runAutomaticCompaction({
+      onDeferred: (retryAt) => this.setEmergencyCompactCheckAfter(retryAt),
+      onDisabled: () => this.setEmergencyCompactCheckAfter(recheckAfter),
+      run: () =>
+        this.compactLargeConnectedRoom({
+          documentSize,
+          thresholdBytes,
+          recheckAfter,
+        }),
+    });
+    return result ?? false;
+  }
+
+  private async compactLargeConnectedRoom({
+    documentSize,
+    thresholdBytes,
+    recheckAfter,
+  }: {
+    documentSize: number;
+    thresholdBytes: number;
+    recheckAfter: number;
+  }): Promise<boolean> {
     const compactedDocument = await this.getUsefulCompactedDocument({
       documentSize,
       thresholdBytes,
@@ -1993,9 +2073,7 @@ export class PartyServer extends YServer {
         );
       },
     });
-    if (compactedDocument === null) {
-      return false;
-    }
+    if (compactedDocument === null) return false;
 
     const committed = await this.commitCompactedDocument({
       compactedDocument,
@@ -2347,7 +2425,6 @@ export class PartyServer extends YServer {
       console.log(`[Hard Reset] Successfully retrieved live Y.Doc`);
 
       let beforeSize = encodeDocToBase64(liveYDoc).length;
-      await this.circuitBreaker.assertCanCompactDocument(beforeSize);
 
       // Extract current state as JSON
       let currentPlayData = docToJson(liveYDoc);
@@ -2377,7 +2454,6 @@ export class PartyServer extends YServer {
 
         if (dbRow?.document) {
           beforeSize = dbRow.document.length;
-          await this.circuitBreaker.assertCanCompactDocument(beforeSize);
           const fallbackDoc = new Y.Doc();
           try {
             Y.applyUpdate(
@@ -2529,6 +2605,49 @@ export class PartyServer extends YServer {
     }
   }
 
+  private async compactEmptyRoomDocumentOnce(): Promise<void> {
+    const compactedDocument = this.buildCompactedDocument(this.document);
+    if (compactedDocument === null) {
+      await this.clearEmptyRoomCompactAfter();
+      return;
+    }
+
+    if (
+      !shouldStoreCompactedDocument(
+        compactedDocument.beforeSize,
+        compactedDocument.afterSize
+      )
+    ) {
+      await this.clearEmptyRoomCompactAfter();
+      console.log(
+        `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes`
+      );
+      return;
+    }
+
+    const committed = await this.commitCompactedDocument({
+      compactedDocument,
+      beforeCommit: async () => {
+        if (this.getOpenConnectionCount() === 0) {
+          return true;
+        }
+        await this.clearEmptyRoomCompactAfter();
+        return false;
+      },
+      afterReplace: async () => {
+        await this.clearEmptyRoomCompactAfter();
+      },
+    });
+    if (!committed) {
+      await this.clearEmptyRoomCompactAfter();
+    }
+    if (committed) {
+      console.log(
+        `[PartyServer] Empty-room compacted: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes (${((1 - compactedDocument.afterSize / compactedDocument.beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${compactedDocument.resetEpoch}`
+      );
+    }
+  }
+
   private async compactEmptyRoomDocument(): Promise<void> {
     if (this.emptyRoomCompactionPromise) {
       await this.emptyRoomCompactionPromise;
@@ -2540,50 +2659,11 @@ export class PartyServer extends YServer {
     if (this.getOpenConnectionCount() !== 0) return;
 
     const run = async () => {
-      const compactedDocument = this.buildCompactedDocument(this.document);
-      if (compactedDocument === null) {
-        // Distinguishes "nothing to compact" from "too large to compact here":
-        // the latter parks the schedule and reports the external-compaction
-        // runbook.
-        if (await this.circuitBreaker.parkCompactionIfTooLarge()) return;
-        await this.clearEmptyRoomCompactAfter();
-        return;
-      }
-
-      if (
-        !shouldStoreCompactedDocument(
-          compactedDocument.beforeSize,
-          compactedDocument.afterSize
-        )
-      ) {
-        await this.clearEmptyRoomCompactAfter();
-        console.log(
-          `[PartyServer] Empty-room compaction skipped: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes`
-        );
-        return;
-      }
-
-      const committed = await this.commitCompactedDocument({
-        compactedDocument,
-        beforeCommit: async () => {
-          if (this.getOpenConnectionCount() === 0) {
-            return true;
-          }
-          await this.clearEmptyRoomCompactAfter();
-          return false;
-        },
-        afterReplace: async () => {
-          await this.clearEmptyRoomCompactAfter();
-        },
+      await this.runAutomaticCompaction({
+        onDeferred: (retryAt) => this.setEmptyRoomCompactAfter(retryAt),
+        onDisabled: () => this.clearEmptyRoomCompactAfter(),
+        run: () => this.compactEmptyRoomDocumentOnce(),
       });
-      if (!committed) {
-        await this.clearEmptyRoomCompactAfter();
-      }
-      if (committed) {
-        console.log(
-          `[PartyServer] Empty-room compacted: room=${this.name}, ${compactedDocument.beforeSize} -> ${compactedDocument.afterSize} bytes (${((1 - compactedDocument.afterSize / compactedDocument.beforeSize) * 100).toFixed(1)}% reduction), resetEpoch=${compactedDocument.resetEpoch}`
-        );
-      }
     };
 
     this.emptyRoomCompactionPromise = run();
@@ -2624,33 +2704,36 @@ export class PartyServer extends YServer {
   override async onAlarm(): Promise<void> {
     if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
-    // Durable BEFORE the risky work, mirroring the load path.
-    await this.circuitBreaker.beginRiskyOperation("alarm");
-
     try {
       const compactAfter = await this.getEmptyRoomCompactAfter();
       if (compactAfter !== null && compactAfter <= Date.now()) {
         if (this.getOpenConnectionCount() === 0) {
-          await this.compactEmptyRoomDocument();
+          try {
+            await this.compactEmptyRoomDocument();
+          } catch (error) {
+            console.error(
+              `[PartyServer] Automatic compaction failed for room=${this.name} (observed exception, not a vanish):`,
+              error
+            );
+          }
         } else {
           await this.clearEmptyRoomCompactAfter();
         }
       }
 
-      await this.pruneBridgeLeases();
-      // Reached only if the risky work above did not kill the isolate.
-      await this.circuitBreaker.completeRiskyOperation("alarm");
-    } catch (error) {
-      // An exception we can observe is NOT the failure mode this counter infers.
-      // The counter exists to detect work that vanished mid-flight (an OOM kills
-      // the isolate, so nothing gets to log). A caught throw means the isolate
-      // survived, so it is cleared: otherwise a long Supabase outage would march
-      // healthy rooms all the way to quarantine and mislabel them as OOM.
-      await this.circuitBreaker.completeRiskyOperation("alarm");
-      console.error(
-        `[PartyServer] Alarm work failed for room=${this.name} (observed exception, not a vanish):`,
-        error
-      );
+      // Generic alarm work keeps its own longer backoff. Starting this marker
+      // after compaction prevents a compaction OOM from advancing both ledgers.
+      await this.circuitBreaker.beginRiskyOperation("alarm");
+      try {
+        await this.pruneBridgeLeases();
+        await this.circuitBreaker.completeRiskyOperation("alarm");
+      } catch (error) {
+        await this.circuitBreaker.completeRiskyOperation("alarm");
+        console.error(
+          `[PartyServer] Alarm work failed for room=${this.name} (observed exception, not a vanish):`,
+          error
+        );
+      }
     } finally {
       // scheduleNextAlarm's quarantine guard is what stops a room quarantined
       // moments ago inside this try block from having its alarm re-armed here.

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -34,6 +34,10 @@ import {
   DEFAULT_MESSAGE_RATE_WINDOW_MS,
   DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES,
   DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+  DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+  DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
+  DEFAULT_FAILURE_BACKOFF_MS,
+  DEFAULT_FAILURE_BACKOFF_MAX_MS,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
@@ -95,10 +99,15 @@ import {
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
 import {
   createQuarantineStatusBody,
+  formatCompactionSkipLog,
+  formatFailureBackoffLog,
   formatQuarantineLog,
-  shouldQuarantineForDocumentSize,
-  shouldQuarantineForLoadAttempts,
-  DEFAULT_QUARANTINE_LOAD_ATTEMPTS,
+  getFailureRetryAt,
+  isDocumentOversized,
+  isRetryDue,
+  isTooLargeToCompactInDurableObject,
+  shouldQuarantineForFailures,
+  type FailureKind,
   type QuarantineReason,
   type QuarantineState,
 } from "./quarantinePolicy";
@@ -195,6 +204,9 @@ export class PartyServer extends YServer {
   // Set when this room must never hydrate or persist its document. Loaded from
   // storage at the top of onLoad, before any hydration work happens.
   private quarantine: QuarantineState | null = null;
+  // Set by buildCompactedDocument when the document is too large to rebuild in
+  // memory. Callers turn this into a parked compaction schedule and one loud log.
+  private compactionTooLargeBytes: number | null = null;
 
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -439,10 +451,31 @@ export class PartyServer extends YServer {
     );
   }
 
-  private getQuarantineMaxLoadAttempts(): number {
+  private getCompactionMaxInDurableObjectBytes(): number {
     return readPositiveNumberEnv(
-      "QUARANTINE_LOAD_ATTEMPTS",
-      DEFAULT_QUARANTINE_LOAD_ATTEMPTS
+      "COMPACTION_MAX_IN_DO_BYTES",
+      DEFAULT_COMPACTION_MAX_IN_DO_BYTES
+    );
+  }
+
+  private getQuarantineFailureThreshold(): number {
+    return readPositiveNumberEnv(
+      "QUARANTINE_FAILURE_THRESHOLD",
+      DEFAULT_QUARANTINE_FAILURE_THRESHOLD
+    );
+  }
+
+  private getFailureBackoffBaseMs(): number {
+    return readPositiveNumberEnv(
+      "FAILURE_BACKOFF_MS",
+      DEFAULT_FAILURE_BACKOFF_MS
+    );
+  }
+
+  private getFailureBackoffMaxMs(): number {
+    return readPositiveNumberEnv(
+      "FAILURE_BACKOFF_MAX_MS",
+      DEFAULT_FAILURE_BACKOFF_MAX_MS
     );
   }
 
@@ -454,11 +487,91 @@ export class PartyServer extends YServer {
     return this.quarantine;
   }
 
-  async getQuarantineLoadAttempts(): Promise<number> {
-    const value = await this.ctx.storage.get(
-      STORAGE_KEYS.quarantineLoadAttempts
-    );
+  private failureKeyFor(kind: FailureKind): string {
+    return kind === "load"
+      ? STORAGE_KEYS.quarantineLoadAttempts
+      : STORAGE_KEYS.alarmFailureAttempts;
+  }
+
+  async getFailureCount(kind: FailureKind): Promise<number> {
+    const value = await this.ctx.storage.get(this.failureKeyFor(kind));
     return typeof value === "number" ? value : 0;
+  }
+
+  async getFailureRetryAfter(): Promise<number | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.failureRetryAfter);
+    return typeof value === "number" ? value : null;
+  }
+
+  async getCompactionParkedBytes(): Promise<number | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.compactionParked);
+    return typeof value === "number" ? value : null;
+  }
+
+  /**
+   * Records that a risky operation is starting. The write is awaited so that an
+   * isolate killed mid-operation leaves the increment behind: that is the only
+   * evidence an out-of-memory crash ever produces.
+   */
+  private async beginRiskyOperation(kind: FailureKind): Promise<number> {
+    const attempt = (await this.getFailureCount(kind)) + 1;
+    await this.ctx.storage.put(this.failureKeyFor(kind), attempt);
+    return attempt;
+  }
+
+  /**
+   * Marks a risky operation as completed. Clearing the counter is what makes
+   * failures self-healing: once the underlying cause clears, the room returns to
+   * its normal cadence without any operator action.
+   */
+  private async completeRiskyOperation(kind: FailureKind): Promise<void> {
+    await this.ctx.storage.delete(this.failureKeyFor(kind));
+    await this.ctx.storage.delete(STORAGE_KEYS.failureRetryAfter);
+  }
+
+  /**
+   * Reacts to a previous attempt that started and never finished. Backoff comes
+   * first so the platform's rapid alarm retry cannot spin; quarantine is the
+   * last resort once the whole ladder has been exhausted.
+   */
+  private async handleRepeatedFailures({
+    kind,
+    failureCount,
+  }: {
+    kind: FailureKind;
+    failureCount: number;
+  }): Promise<{ quarantined: boolean; retryAt: number }> {
+    const failureThreshold = this.getQuarantineFailureThreshold();
+
+    if (shouldQuarantineForFailures({ failureCount, failureThreshold })) {
+      await this.enterQuarantine({
+        reason: "repeated-failures",
+        detail: `${kind} work failed ${failureCount} times in a row`,
+        failureKind: kind,
+        failureCount,
+      });
+      return { quarantined: true, retryAt: 0 };
+    }
+
+    const retryAt = getFailureRetryAt({
+      failureCount,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.ctx.storage.put(STORAGE_KEYS.failureRetryAfter, retryAt);
+
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.name,
+        failureKind: kind,
+        failureCount,
+        retryAt,
+        failureThreshold,
+      })
+    );
+
+    return { quarantined: false, retryAt };
   }
 
   private async readStoredQuarantine(): Promise<QuarantineState | null> {
@@ -470,22 +583,25 @@ export class PartyServer extends YServer {
    * Enters quarantine: the persisted document is never hydrated and never
    * overwritten. The room keeps serving visitors through the existing transient
    * mode, which already suppresses autosave, admin writes, and bridge flushes.
-   * Pending alarms are canceled so Cloudflare stops retrying the load that
+   * Pending alarms are canceled so the platform stops retrying the work that
    * killed the isolate.
    */
-  private async enterQuarantine({
+  async enterQuarantine({
     reason,
-    documentBytes,
-    loadAttempts,
+    detail,
+    failureKind,
+    failureCount,
   }: {
     reason: QuarantineReason;
-    documentBytes: number | null;
-    loadAttempts: number;
+    detail: string;
+    failureKind: FailureKind | null;
+    failureCount: number;
   }): Promise<void> {
     const quarantine: QuarantineState = {
       reason,
-      documentBytes,
-      loadAttempts,
+      detail,
+      failureKind,
+      failureCount,
       quarantinedAt: Date.now(),
     };
     this.quarantine = quarantine;
@@ -505,15 +621,47 @@ export class PartyServer extends YServer {
       formatQuarantineLog({
         roomName: this.name,
         reason,
-        documentBytes,
-        thresholdBytes: this.getQuarantineDocumentBytes(),
-        loadAttempts,
+        detail,
+        failureKind,
+        failureCount,
       })
     );
   }
 
   private async cancelAlarmForQuarantine(): Promise<void> {
     await this.ctx.storage.deleteAlarm?.();
+  }
+
+  /**
+   * Handles a compaction attempt that was refused because the document is too
+   * large to rebuild in memory. The compaction schedule is parked so the alarm
+   * stops retrying doomed work, and the room is otherwise untouched: it loads,
+   * serves visitors, and persists normally. This is not a quarantine.
+   *
+   * Returns true when a skip was recorded, so callers can stop.
+   */
+  private async parkCompactionIfTooLarge(): Promise<boolean> {
+    const documentBytes = this.compactionTooLargeBytes;
+    this.compactionTooLargeBytes = null;
+    if (documentBytes === null) return false;
+
+    const alreadyParked = await this.getCompactionParkedBytes();
+    await this.ctx.storage.put(STORAGE_KEYS.compactionParked, documentBytes);
+    // Parking clears the pending compaction request so the alarm does not keep
+    // waking the room to retry work that cannot succeed.
+    await this.clearEmptyRoomCompactAfter();
+
+    // One loud log per room, not one per alarm.
+    if (alreadyParked === null) {
+      console.error(
+        formatCompactionSkipLog({
+          roomName: this.name,
+          documentBytes,
+          maxBytes: this.getCompactionMaxInDurableObjectBytes(),
+        })
+      );
+    }
+    return true;
   }
 
   /**
@@ -530,22 +678,36 @@ export class PartyServer extends YServer {
     );
   }
 
+  // Clears quarantine along with the failure history that caused it, so the room
+  // starts from a clean slate rather than re-quarantining on the next failure.
   async clearQuarantine(): Promise<void> {
     this.quarantine = null;
     await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
     await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+    await this.ctx.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
+    await this.ctx.storage.delete(STORAGE_KEYS.failureRetryAfter);
     console.log(
       `[PartyServer] Quarantine cleared for room=${this.name}; the next load will attempt hydration again.`
     );
   }
 
-  getQuarantineStatusBody(loadAttempts: number) {
+  // Lets an operator re-enable in-DO compaction after shrinking a document
+  // externally.
+  async clearCompactionPark(): Promise<void> {
+    await this.ctx.storage.delete(STORAGE_KEYS.compactionParked);
+  }
+
+  async getQuarantineStatusBody() {
     return createQuarantineStatusBody({
       roomName: this.name,
       quarantine: this.quarantine,
-      thresholdBytes: this.getQuarantineDocumentBytes(),
-      maxLoadAttempts: this.getQuarantineMaxLoadAttempts(),
-      loadAttempts,
+      documentWarningBytes: this.getQuarantineDocumentBytes(),
+      maxInDurableObjectBytes: this.getCompactionMaxInDurableObjectBytes(),
+      failureThreshold: this.getQuarantineFailureThreshold(),
+      loadFailures: await this.getFailureCount("load"),
+      alarmFailures: await this.getFailureCount("alarm"),
+      retryAfter: await this.getFailureRetryAfter(),
+      compactionParkedBytes: await this.getCompactionParkedBytes(),
     });
   }
 
@@ -628,13 +790,28 @@ export class PartyServer extends YServer {
     doc: Y.Doc,
     sourceDocumentBase64?: string
   ): CompactedDocument | null {
+    // Measure BEFORE docToJson: the projection is itself a full copy of the
+    // document, so an oversized room would already be over budget by the time a
+    // later check ran. Encoding the source is one copy and is the cheapest
+    // faithful measure available here.
+    const sourceBase64 = sourceDocumentBase64 ?? encodeDocToBase64(doc);
+    const beforeSize = sourceBase64.length;
+    const maxInDurableObjectBytes = this.getCompactionMaxInDurableObjectBytes();
+    if (
+      isTooLargeToCompactInDurableObject({
+        documentBytes: beforeSize,
+        maxBytes: maxInDurableObjectBytes,
+      })
+    ) {
+      this.compactionTooLargeBytes = beforeSize;
+      return null;
+    }
+
     const currentPlayData = docToJson(doc);
     if (!currentPlayData) {
       return null;
     }
 
-    const sourceBase64 = sourceDocumentBase64 ?? encodeDocToBase64(doc);
-    const beforeSize = sourceBase64.length;
     const resetEpoch = Date.now();
     const compactDoc = jsonToDoc(currentPlayData);
     setDocResetEpoch(compactDoc, resetEpoch);
@@ -1594,38 +1771,40 @@ export class PartyServer extends YServer {
   }
 
   override async onLoad(): Promise<void> {
-    // The crash-loop breaker and size gate both run before any hydration work.
-    // A room whose document OOMs the isolate never reaches the end of this
-    // method, so anything protective has to be durable before that point.
+    // A quarantined room never hydrates. Quarantine is an operator decision or a
+    // last resort after the retry backoff has been exhausted; it is never
+    // entered just because a document is large.
     this.quarantine = await this.readStoredQuarantine();
     if (this.quarantine !== null) {
       await this.resumeQuarantine();
       return;
     }
 
-    const maxLoadAttempts = this.getQuarantineMaxLoadAttempts();
-    const previousAttempts = await this.getQuarantineLoadAttempts();
-    if (
-      shouldQuarantineForLoadAttempts({
-        loadAttempts: previousAttempts,
-        maxLoadAttempts,
-      })
-    ) {
-      await this.enterQuarantine({
-        reason: "crash-loop",
-        documentBytes: null,
-        loadAttempts: previousAttempts,
-      });
-      return;
+    // Evidence of previous loads that started and never finished. Hydration is
+    // still attempted: loads succeed for documents in the size band that has
+    // OOMed, so refusing to load would break healthy rooms.
+    const previousFailures = await this.getFailureCount("load");
+    if (previousFailures > 0) {
+      const failureThreshold = this.getQuarantineFailureThreshold();
+      if (
+        shouldQuarantineForFailures({
+          failureCount: previousFailures,
+          failureThreshold,
+        })
+      ) {
+        await this.enterQuarantine({
+          reason: "repeated-failures",
+          detail: `load work failed ${previousFailures} times in a row`,
+          failureKind: "load",
+          failureCount: previousFailures,
+        });
+        return;
+      }
     }
 
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
-    const loadAttempts = previousAttempts + 1;
-    await this.ctx.storage.put(
-      STORAGE_KEYS.quarantineLoadAttempts,
-      loadAttempts
-    );
+    const loadAttempts = await this.beginRiskyOperation("load");
 
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
@@ -1659,21 +1838,17 @@ export class PartyServer extends YServer {
     this.markPersistenceAvailable();
 
     if (result.data) {
-      // Size gate. The download itself is safe; Y.applyUpdate is what OOMs the
-      // Durable Object, so the check sits between the two.
+      // Size is reported, never enforced. Hydration is one copy of the document
+      // and succeeds well past this threshold; it is compaction that multiplies
+      // memory, so that is where the hard ceiling lives.
       const documentBytes = result.data.document.length;
-      if (
-        shouldQuarantineForDocumentSize({
-          documentBytes,
-          thresholdBytes: this.getQuarantineDocumentBytes(),
-        })
-      ) {
-        await this.enterQuarantine({
-          reason: "document-size",
-          documentBytes,
-          loadAttempts,
-        });
-        return;
+      const thresholdBytes = this.getQuarantineDocumentBytes();
+      if (isDocumentOversized({ documentBytes, thresholdBytes })) {
+        console.warn(
+          `[PartyServer] Large document load for room=${this.name}: ` +
+            `documentBytes=${documentBytes}, warningThresholdBytes=${thresholdBytes}. ` +
+            "Loading anyway. Consider compacting this document externally."
+        );
       }
 
       this.markDocumentPersisted(result.data.document);
@@ -1683,21 +1858,18 @@ export class PartyServer extends YServer {
       );
     }
 
-    // Hydration completed without killing the isolate.
-    await this.clearLoadAttempts();
-  }
-
-  private async clearLoadAttempts(): Promise<void> {
-    await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+    // Hydration completed without killing the isolate, so the failure history
+    // and any pending backoff are cleared.
+    await this.completeRiskyOperation("load");
   }
 
   // Undoes this start's increment when the load ended before hydration could be
-  // attempted. Attempts that DID reach hydration stay counted, so the crash-loop
-  // breaker keeps its evidence even if Supabase is flaky in between.
+  // attempted. Attempts that DID reach hydration stay counted, so the failure
+  // history keeps its evidence even if Supabase is flaky in between.
   private async releaseLoadAttempt(loadAttempts: number): Promise<void> {
     const remaining = loadAttempts - 1;
     if (remaining <= 0) {
-      await this.clearLoadAttempts();
+      await this.completeRiskyOperation("load");
       return;
     }
     await this.ctx.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
@@ -1717,9 +1889,9 @@ export class PartyServer extends YServer {
       formatQuarantineLog({
         roomName: this.name,
         reason: quarantine.reason,
-        documentBytes: quarantine.documentBytes,
-        thresholdBytes: this.getQuarantineDocumentBytes(),
-        loadAttempts: quarantine.loadAttempts,
+        detail: quarantine.detail,
+        failureKind: quarantine.failureKind,
+        failureCount: quarantine.failureCount,
       })
     );
   }
@@ -1742,6 +1914,12 @@ export class PartyServer extends YServer {
       sourceBase64
     );
     if (compactedDocument === null) {
+      // Too large to rebuild in memory: park the schedule and report the
+      // external-compaction runbook rather than retrying on every autosave.
+      if (await this.parkCompactionIfTooLarge()) {
+        await setRecheckAfter(recheckAfter);
+        return null;
+      }
       await setRecheckAfter(recheckAfter);
       onMissingPlayData?.();
       return null;
@@ -2526,6 +2704,10 @@ export class PartyServer extends YServer {
     const run = async () => {
       const compactedDocument = this.buildCompactedDocument(this.document);
       if (compactedDocument === null) {
+        // Distinguishes "nothing to compact" from "too large to compact here":
+        // the latter parks the schedule and reports the external-compaction
+        // runbook.
+        if (await this.parkCompactionIfTooLarge()) return;
         await this.clearEmptyRoomCompactAfter();
         return;
       }
@@ -2610,6 +2792,37 @@ export class PartyServer extends YServer {
       return;
     }
 
+    // A previous alarm started risky work and never finished it, which is what
+    // an out-of-memory crash looks like from here. Back off instead of letting
+    // the platform's rapid retry turn one crash into a permanent loop.
+    const previousFailures = await this.getFailureCount("alarm");
+    if (previousFailures > 0) {
+      // Check the existing window BEFORE recording a new one, otherwise a retry
+      // that has come due would be pushed out again and never run.
+      const retryAfter = await this.getFailureRetryAfter();
+      if (!isRetryDue({ retryAfter, now: Date.now() })) {
+        // Not yet time to retry: re-arm at the backoff time and do no work.
+        await this.ctx.storage.setAlarm?.(ensureExists(retryAfter));
+        return;
+      }
+
+      const outcome = await this.handleRepeatedFailures({
+        kind: "alarm",
+        failureCount: previousFailures,
+      });
+      if (outcome.quarantined) return;
+
+      // A fresh backoff was just recorded for this failure count. Honour it
+      // unless this attempt is the one allowed to proceed.
+      if (retryAfter === null) {
+        await this.ctx.storage.setAlarm?.(outcome.retryAt);
+        return;
+      }
+    }
+
+    // Durable BEFORE the risky work, mirroring the load path.
+    await this.beginRiskyOperation("alarm");
+
     try {
       const compactAfter = await this.getEmptyRoomCompactAfter();
       if (compactAfter !== null && compactAfter <= Date.now()) {
@@ -2621,6 +2834,8 @@ export class PartyServer extends YServer {
       }
 
       await this.pruneBridgeLeases();
+      // Reached only if the risky work above did not kill the isolate.
+      await this.completeRiskyOperation("alarm");
     } finally {
       await this.scheduleNextAlarm();
     }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -9,7 +9,7 @@ import { env } from "cloudflare:workers";
 import { Buffer } from "node:buffer";
 import * as Y from "yjs";
 import { supabase } from "./db";
-import { AdminHandler } from "./admin";
+import { AdminHandler, getAdminAuthError } from "./admin";
 import {
   docToJson,
   jsonToDoc,
@@ -112,6 +112,7 @@ import {
   type QuarantineReason,
   type QuarantineState,
 } from "./quarantinePolicy";
+import { listQuarantinedRooms } from "./quarantineControl";
 export { PresenceServer } from "./presenceServer";
 
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
@@ -3479,10 +3480,75 @@ export class PartyServer extends YServer {
 
 export default {
   // Set up your fetch handler to use configured Servers
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, workerEnv: Env): Promise<Response> {
     try {
+      const url = new URL(request.url);
+      if (url.pathname === "/admin/quarantines") {
+        if (request.method === "OPTIONS") {
+          return new Response(null, {
+            status: 200,
+            headers: {
+              "Access-Control-Allow-Origin": "*",
+              "Access-Control-Allow-Methods": "GET, OPTIONS",
+              "Access-Control-Allow-Headers":
+                "Content-Type, Authorization",
+            },
+          });
+        }
+
+        if (request.method !== "GET") {
+          return new Response("Method Not Allowed", {
+            status: 405,
+            headers: { Allow: "GET, OPTIONS" },
+          });
+        }
+
+        const authError = getAdminAuthError(
+          request,
+          workerEnv.ADMIN_TOKEN
+        );
+        if (authError) return authError;
+
+        try {
+          const rooms = await listQuarantinedRooms(
+            workerEnv.QUARANTINE_CONTROL
+          );
+          return new Response(
+            JSON.stringify({
+              available: true,
+              count: rooms.length,
+              rooms,
+            }),
+            {
+              headers: {
+                "content-type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            }
+          );
+        } catch (error) {
+          console.error(
+            "[PartyServer] Failed to list quarantined rooms:",
+            error
+          );
+          return new Response(
+            JSON.stringify({
+              available: false,
+              error: "Failed to read the quarantine control plane",
+            }),
+            {
+              status: 503,
+              headers: {
+                "content-type": "application/json",
+                "Access-Control-Allow-Origin": "*",
+              },
+            }
+          );
+        }
+      }
+
       return (
-        (await routePartykitRequest(request, env)) ||
+        (await routePartykitRequest(request, workerEnv)) ||
         new Response("Not Found", { status: 404 })
       );
     } catch (error) {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -99,6 +99,7 @@ import {
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
 import {
   createQuarantineStatusBody,
+  ExternalCompactionRequiredError,
   formatCompactionSkipLog,
   formatFailureBackoffLog,
   formatQuarantineLog,
@@ -554,9 +555,11 @@ export class PartyServer extends YServer {
   private async handleRepeatedFailures({
     kind,
     failureCount,
+    retryFailureCount = failureCount,
   }: {
     kind: FailureKind;
     failureCount: number;
+    retryFailureCount?: number;
   }): Promise<{ quarantined: boolean; retryAt: number }> {
     const failureThreshold = this.getQuarantineFailureThreshold();
 
@@ -571,7 +574,7 @@ export class PartyServer extends YServer {
     }
 
     const retryAt = getFailureRetryAt({
-      failureCount,
+      failureCount: retryFailureCount,
       baseMs: this.getFailureBackoffBaseMs(),
       maxMs: this.getFailureBackoffMaxMs(),
       now: Date.now(),
@@ -794,6 +797,22 @@ export class PartyServer extends YServer {
       );
     }
     return true;
+  }
+
+  private async assertCanCompactDocument(documentBytes: number): Promise<void> {
+    const maxBytes = this.getCompactionMaxInDurableObjectBytes();
+    if (
+      !isTooLargeToCompactInDurableObject({
+        documentBytes,
+        maxBytes,
+      })
+    ) {
+      return;
+    }
+
+    this.compactionTooLargeBytes = documentBytes;
+    await this.parkCompactionIfTooLarge();
+    throw new ExternalCompactionRequiredError(documentBytes, maxBytes);
   }
 
   /**
@@ -1973,6 +1992,24 @@ export class PartyServer extends YServer {
         return;
       }
 
+      if (retryAfter === null) {
+        const firstRetryAt = getFailureRetryAt({
+          failureCount: previousFailures,
+          baseMs: this.getFailureBackoffBaseMs(),
+          maxMs: this.getFailureBackoffMaxMs(),
+          now: Date.now(),
+        });
+        await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
+        this.loadDeferredUntil = firstRetryAt;
+        console.warn(
+          `[PartyServer] Load deferred for room=${this.name}: ` +
+            `consecutiveFailures=${previousFailures}, ` +
+            `retryAt=${new Date(firstRetryAt).toISOString()}. ` +
+            "Serving 503 until the retry deadline; the document was not read."
+        );
+        return;
+      }
+
       // The deadline has arrived. Exactly one attempt is allowed through: record
       // the next backoff BEFORE hydrating, so requests racing the deadline in a
       // fresh isolate see a future deadline rather than all retrying at once.
@@ -2039,6 +2076,19 @@ export class PartyServer extends YServer {
         this.document,
         new Uint8Array(Buffer.from(result.data.document, "base64"))
       );
+
+      const documentResetEpoch = getDocResetEpoch(this.document);
+      const storedResetEpoch = await this.getResetEpoch();
+      if (
+        documentResetEpoch !== null &&
+        (storedResetEpoch === null || documentResetEpoch > storedResetEpoch)
+      ) {
+        await this.setResetEpoch(documentResetEpoch);
+        console.warn(
+          `[PartyServer] Loaded document advanced the server reset epoch for room=${this.name}: ` +
+            `documentResetEpoch=${documentResetEpoch}, storedResetEpoch=${storedResetEpoch ?? "none"}`
+        );
+      }
     }
 
     // Hydration completed without killing the isolate, so the failure history
@@ -2420,9 +2470,18 @@ export class PartyServer extends YServer {
 
       // Route admin requests to admin handler
       // PartyKit paths are like /parties/main/room-id/admin/inspect
-      // Admin stays reachable during a load-backoff window: diagnosing and
-      // quarantining a room that will not load is the whole point.
       if (url.pathname.includes("/admin")) {
+        // The control-plane routes stay reachable during load backoff so an
+        // operator can inspect or quarantine the room. Every other admin route
+        // is blocked: the live document was never hydrated, so a write derived
+        // from it could overwrite the real snapshot with an empty document.
+        const isLoadControlRoute = [
+          "/admin/quarantine-status",
+          "/admin/quarantine-set",
+          "/admin/quarantine-clear",
+        ].some((path) => url.pathname.includes(path));
+        const loadDeferred = this.getLoadDeferredResponse();
+        if (loadDeferred && !isLoadControlRoute) return loadDeferred;
         return this.adminHandler.handleRequest(request);
       }
 
@@ -2716,6 +2775,9 @@ export class PartyServer extends YServer {
       const liveYDoc = this.document;
       console.log(`[Hard Reset] Successfully retrieved live Y.Doc`);
 
+      let beforeSize = encodeDocToBase64(liveYDoc).length;
+      await this.assertCanCompactDocument(beforeSize);
+
       // Extract current state as JSON
       let currentPlayData = docToJson(liveYDoc);
       console.log(
@@ -2743,12 +2805,18 @@ export class PartyServer extends YServer {
         }
 
         if (dbRow?.document) {
+          beforeSize = dbRow.document.length;
+          await this.assertCanCompactDocument(beforeSize);
           const fallbackDoc = new Y.Doc();
-          Y.applyUpdate(
-            fallbackDoc,
-            new Uint8Array(Buffer.from(dbRow.document, "base64"))
-          );
-          currentPlayData = docToJson(fallbackDoc);
+          try {
+            Y.applyUpdate(
+              fallbackDoc,
+              new Uint8Array(Buffer.from(dbRow.document, "base64"))
+            );
+            currentPlayData = docToJson(fallbackDoc);
+          } finally {
+            fallbackDoc.destroy();
+          }
           console.log(
             `[Hard Reset] Loaded from database: ${
               currentPlayData ? "has data" : "still empty"
@@ -2757,8 +2825,6 @@ export class PartyServer extends YServer {
         }
       }
 
-      // Calculate before size
-      const beforeSize = encodeDocToBase64(liveYDoc).length;
       console.log(
         `[Hard Reset] Before size: ${beforeSize} bytes (${(
           beforeSize /
@@ -2777,19 +2843,27 @@ export class PartyServer extends YServer {
           `[Hard Reset] Room is empty in both live doc and database, creating empty fresh doc...`
         );
         const emptyDoc = new Y.Doc();
-        setDocResetEpoch(emptyDoc, resetEpoch);
-        freshBase64 = encodeDocToBase64(emptyDoc);
+        try {
+          setDocResetEpoch(emptyDoc, resetEpoch);
+          freshBase64 = encodeDocToBase64(emptyDoc);
+        } finally {
+          emptyDoc.destroy();
+        }
         afterSize = freshBase64.length;
         console.log(`[Hard Reset] Empty doc size: ${afterSize} bytes`);
       } else {
         // Create a fresh Y.Doc with the current state (no history/tombstones)
         console.log(`[Hard Reset] Creating fresh Y.Doc from play data...`);
         const freshDoc = jsonToDoc(currentPlayData);
-        setDocResetEpoch(freshDoc, resetEpoch);
-        console.log(`[Hard Reset] Successfully created fresh Y.Doc`);
+        try {
+          setDocResetEpoch(freshDoc, resetEpoch);
+          console.log(`[Hard Reset] Successfully created fresh Y.Doc`);
 
-        // Encode the fresh doc
-        freshBase64 = encodeDocToBase64(freshDoc);
+          // Encode the fresh doc
+          freshBase64 = encodeDocToBase64(freshDoc);
+        } finally {
+          freshDoc.destroy();
+        }
         afterSize = freshBase64.length;
         console.log(
           `[Hard Reset] After size: ${afterSize} bytes (${(
@@ -2799,6 +2873,10 @@ export class PartyServer extends YServer {
           ).toFixed(2)} MB)`
         );
       }
+
+      // The plain projection can be substantially larger than the encoded Y.Doc.
+      // Release it before the database write and live-document replacement.
+      currentPlayData = null;
 
       // Save to database
       console.log(`[Hard Reset] Saving fresh doc to database...`);
@@ -2998,6 +3076,10 @@ export class PartyServer extends YServer {
       const outcome = await this.handleRepeatedFailures({
         kind: "alarm",
         failureCount: previousFailures,
+        // The current deadline has elapsed, so this is the retry attempt. Store
+        // the following rung before risky work in case this attempt also OOMs.
+        retryFailureCount:
+          retryAfter === null ? previousFailures : previousFailures + 1,
       });
       if (outcome.quarantined) return;
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -9,7 +9,7 @@ import { env } from "cloudflare:workers";
 import { Buffer } from "node:buffer";
 import * as Y from "yjs";
 import { supabase } from "./db";
-import { AdminHandler, getAdminAuthError } from "./admin";
+import { AdminHandler } from "./admin";
 import {
   docToJson,
   jsonToDoc,
@@ -98,21 +98,11 @@ import {
 } from "./persistenceMode";
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
 import {
-  createQuarantineStatusBody,
-  ExternalCompactionRequiredError,
-  formatCompactionSkipLog,
-  formatFailureBackoffLog,
-  formatQuarantineLog,
-  getFailureRetryAt,
   isDocumentOversized,
-  isRetryDue,
   isTooLargeToCompactInDurableObject,
-  shouldQuarantineForFailures,
-  type FailureKind,
-  type QuarantineReason,
-  type QuarantineState,
 } from "./quarantinePolicy";
-import { listQuarantinedRooms } from "./quarantineControl";
+import { RoomCircuitBreaker } from "./roomCircuitBreaker";
+import { handleQuarantineControlRequest } from "./quarantineControl";
 export { PresenceServer } from "./presenceServer";
 
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
@@ -203,20 +193,7 @@ export class PartyServer extends YServer {
   private cachedSharedPerms: Record<string, SharedElementPermissions> | null =
     null;
   private persistenceMode: PersistenceMode = { kind: "available" };
-  // Set when this room must never hydrate or persist its document. Loaded from
-  // storage at the top of onLoad, before any hydration work happens.
-  private quarantine: QuarantineState | null = null;
-  // Set by buildCompactedDocument when the document is too large to rebuild in
-  // memory. Callers turn this into a parked compaction schedule and one loud log.
-  private compactionTooLargeBytes: number | null = null;
-  // Deadline of an active load-backoff window. While set, this isolate never
-  // hydrated, so every request is refused rather than served an empty document.
-  private loadDeferredUntil: number | null = null;
-  // Guards against logging the same quarantine twice when it is both applied
-  // from the control plane and resumed from durable storage in one start.
-  private hasLoggedQuarantine = false;
-  // Single-flight guard for an in-place re-load attempt at the deadline.
-  private inFlightReload: Promise<boolean> | null = null;
+  private roomCircuitBreakerInstance: RoomCircuitBreaker | null = null;
   // Tracks the two startup phases separately because a deferred room hydrates
   // after the platform's one-time onStart hook has already returned.
   private realtimeSyncStarted = false;
@@ -240,6 +217,54 @@ export class PartyServer extends YServer {
   private observersAttached = false;
   private adminHandler = new AdminHandler(this);
 
+  get circuitBreaker(): RoomCircuitBreaker {
+    if (!this.roomCircuitBreakerInstance) {
+      this.roomCircuitBreakerInstance = new RoomCircuitBreaker({
+        roomName: this.name,
+        storage: this.ctx.storage,
+        getQuarantineControl: () => env.QUARANTINE_CONTROL ?? null,
+        readPositiveNumber: readPositiveNumberEnv,
+        defaults: {
+          documentWarningBytes: DEFAULT_QUARANTINE_DOCUMENT_BYTES,
+          maxInDurableObjectBytes: DEFAULT_COMPACTION_MAX_IN_DO_BYTES,
+          failureThreshold: DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
+          failureBackoffMs: DEFAULT_FAILURE_BACKOFF_MS,
+          failureBackoffMaxMs: DEFAULT_FAILURE_BACKOFF_MAX_MS,
+        },
+        activateTransientPersistence: (quarantine) => {
+          this.persistenceMode = {
+            kind: "transient",
+            reason: `room quarantined (${quarantine.reason})`,
+            failedAt: quarantine.quarantinedAt,
+          };
+        },
+        startRealtimeSync: () => this.startRealtimeSync(),
+        reloadRoom: async () => {
+          this.documentLoadCompleted = false;
+          if (this.realtimeSyncStarted) {
+            await this.onLoad();
+          } else {
+            await this.startRealtimeSync();
+          }
+
+          const remainingFailures =
+            await this.circuitBreaker.getFailureCount("load");
+          if (remainingFailures !== 0 || !this.documentLoadCompleted) {
+            return false;
+          }
+
+          await this.completeRoomStartup();
+          return true;
+        },
+        prepareGuardedReload: () => {
+          this.documentLoadCompleted = false;
+        },
+        clearCompactionSchedule: () => this.clearEmptyRoomCompactAfter(),
+      });
+    }
+    return this.roomCircuitBreakerInstance;
+  }
+
   /**
    * Every entry path (fetch, websocket, alarm) funnels through the platform's
    * initialization, which calls onStart() -> onLoad() and hydrates. So this is
@@ -251,16 +276,16 @@ export class PartyServer extends YServer {
     // Operator control plane first: a room that crashes during hydration can
     // never be reached by an admin route, so an external flag is the only way to
     // take it out of service.
-    await this.applyExternalQuarantineFlag();
+    await this.circuitBreaker.applyExternalQuarantineFlag();
 
-    if (this.isQuarantined()) {
-      await this.enterQuarantineRuntimeState();
+    if (this.circuitBreaker.isQuarantined()) {
+      await this.circuitBreaker.enterQuarantineRuntimeState();
       await this.startRealtimeSync();
       return;
     }
 
     // Load backoff, evaluated before hydration for the same reason.
-    if (await this.shouldDeferLoad()) {
+    if (await this.circuitBreaker.shouldDeferLoad()) {
       return;
     }
 
@@ -278,92 +303,6 @@ export class PartyServer extends YServer {
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
     await this.ensureAlarmScheduled();
-  }
-
-  /**
-   * Decides whether this start may hydrate, and records the consequences.
-   * Returns true when the room must not load.
-   *
-   * Runs before hydration so it also protects the alarm path, where the platform
-   * initializes the room before invoking onAlarm.
-   */
-  private async shouldDeferLoad(): Promise<boolean> {
-    const previousFailures = await this.getFailureCount("load");
-    if (previousFailures === 0) return false;
-
-    const failureThreshold = this.getQuarantineFailureThreshold();
-    if (
-      shouldQuarantineForFailures({
-        failureCount: previousFailures,
-        failureThreshold,
-      })
-    ) {
-      await this.enterQuarantine({
-        reason: "repeated-failures",
-        detail: `load work failed ${previousFailures} times in a row`,
-        failureKind: "load",
-        failureCount: previousFailures,
-      });
-      return true;
-    }
-
-    const retryAfter = await this.getFailureRetryAfter("load");
-
-    // A recorded failure with no deadline yet: this is the first strike, so open
-    // the window now rather than letting the platform retry immediately.
-    if (retryAfter === null) {
-      const firstRetryAt = getFailureRetryAt({
-        failureCount: previousFailures,
-        baseMs: this.getFailureBackoffBaseMs(),
-        maxMs: this.getFailureBackoffMaxMs(),
-        now: Date.now(),
-      });
-      await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
-      this.deferLoad(firstRetryAt, previousFailures);
-      return true;
-    }
-
-    if (!isRetryDue({ retryAfter, now: Date.now() })) {
-      this.deferLoad(retryAfter, previousFailures);
-      return true;
-    }
-
-    // The deadline has arrived. Exactly one attempt is allowed through: the next
-    // deadline is committed BEFORE hydrating, so requests racing the boundary in
-    // a fresh isolate see a future deadline rather than all retrying at once.
-    const nextRetryAt = getFailureRetryAt({
-      failureCount: previousFailures + 1,
-      baseMs: this.getFailureBackoffBaseMs(),
-      maxMs: this.getFailureBackoffMaxMs(),
-      now: Date.now(),
-    });
-    await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
-
-    // Logged at error level immediately before the risky attempt: if hydration
-    // kills the isolate, this is the last record that it was tried at all.
-    console.error(
-      formatFailureBackoffLog({
-        roomName: this.name,
-        failureKind: "load",
-        failureCount: previousFailures,
-        retryAt: nextRetryAt,
-        failureThreshold,
-      }) + " Attempting hydration now."
-    );
-    return false;
-  }
-
-  private deferLoad(retryAt: number, failureCount: number): void {
-    this.loadDeferredUntil = retryAt;
-    console.error(
-      formatFailureBackoffLog({
-        roomName: this.name,
-        failureKind: "load",
-        failureCount,
-        retryAt,
-        failureThreshold: this.getQuarantineFailureThreshold(),
-      }) + " Serving 503 until the deadline; the document was not read."
-    );
   }
 
   async getSubscribers(): Promise<Subscriber[]> {
@@ -547,7 +486,7 @@ export class PartyServer extends YServer {
   markPersistenceAvailable(): void {
     // A quarantined room's transient mode IS the write park. Lifting it here
     // would re-enable autosave against a document that was never hydrated.
-    if (this.isQuarantined()) return;
+    if (this.circuitBreaker.isQuarantined()) return;
 
     if (this.persistenceMode.kind === "transient") {
       console.log(
@@ -579,607 +518,6 @@ export class PartyServer extends YServer {
         error,
       })
     );
-  }
-
-  private getQuarantineDocumentBytes(): number {
-    return readPositiveNumberEnv(
-      "QUARANTINE_DOCUMENT_BYTES",
-      DEFAULT_QUARANTINE_DOCUMENT_BYTES
-    );
-  }
-
-  getCompactionMaxInDurableObjectBytes(): number {
-    return readPositiveNumberEnv(
-      "COMPACTION_MAX_IN_DO_BYTES",
-      DEFAULT_COMPACTION_MAX_IN_DO_BYTES
-    );
-  }
-
-  private getQuarantineFailureThreshold(): number {
-    return readPositiveNumberEnv(
-      "QUARANTINE_FAILURE_THRESHOLD",
-      DEFAULT_QUARANTINE_FAILURE_THRESHOLD
-    );
-  }
-
-  private getFailureBackoffBaseMs(): number {
-    return readPositiveNumberEnv(
-      "FAILURE_BACKOFF_MS",
-      DEFAULT_FAILURE_BACKOFF_MS
-    );
-  }
-
-  private getFailureBackoffMaxMs(): number {
-    return readPositiveNumberEnv(
-      "FAILURE_BACKOFF_MAX_MS",
-      DEFAULT_FAILURE_BACKOFF_MAX_MS
-    );
-  }
-
-  isQuarantined(): boolean {
-    return this.quarantine !== null;
-  }
-
-  getQuarantineState(): QuarantineState | null {
-    return this.quarantine;
-  }
-
-  private failureKeyFor(kind: FailureKind): string {
-    return kind === "load"
-      ? STORAGE_KEYS.quarantineLoadAttempts
-      : STORAGE_KEYS.alarmFailureAttempts;
-  }
-
-  async getFailureCount(kind: FailureKind): Promise<number> {
-    const value = await this.ctx.storage.get(this.failureKeyFor(kind));
-    return typeof value === "number" ? value : 0;
-  }
-
-  private retryKeyFor(kind: FailureKind): string {
-    return kind === "load"
-      ? STORAGE_KEYS.loadRetryAfter
-      : STORAGE_KEYS.alarmRetryAfter;
-  }
-
-  async getFailureRetryAfter(kind: FailureKind): Promise<number | null> {
-    const value = await this.ctx.storage.get(this.retryKeyFor(kind));
-    return typeof value === "number" ? value : null;
-  }
-
-  async getCompactionParkedBytes(): Promise<number | null> {
-    const value = await this.ctx.storage.get(STORAGE_KEYS.compactionParked);
-    return typeof value === "number" ? value : null;
-  }
-
-  /**
-   * Records that a risky operation is starting. The write is awaited so that an
-   * isolate killed mid-operation leaves the increment behind: that is the only
-   * evidence an out-of-memory crash ever produces.
-   *
-   * Note for log readers: any mid-work isolate kill counts as a strike, including
-   * routine ones like a deploy evicting the isolate. Those are harmless and
-   * self-heal, since the next successful run clears the counter. A single strike
-   * appearing right after a deploy is expected and is not evidence of an OOM.
-   */
-  private async beginRiskyOperation(kind: FailureKind): Promise<number> {
-    const attempt = (await this.getFailureCount(kind)) + 1;
-    await this.ctx.storage.put(this.failureKeyFor(kind), attempt);
-    return attempt;
-  }
-
-  /**
-   * Marks a risky operation as completed. Clearing the counter is what makes
-   * failures self-healing: once the underlying cause clears, the room returns to
-   * its normal cadence without any operator action.
-   */
-  private async completeRiskyOperation(kind: FailureKind): Promise<void> {
-    await this.ctx.storage.delete(this.failureKeyFor(kind));
-    // Only this operation's deadline is cleared: a healthy load must not erase
-    // the alarm's backoff, or compaction would start crash-looping again.
-    await this.ctx.storage.delete(this.retryKeyFor(kind));
-  }
-
-  /**
-   * Reacts to a previous attempt that started and never finished. Backoff comes
-   * first so the platform's rapid alarm retry cannot spin; quarantine is the
-   * last resort once the whole ladder has been exhausted.
-   */
-  private async handleRepeatedFailures({
-    kind,
-    failureCount,
-    retryFailureCount = failureCount,
-  }: {
-    kind: FailureKind;
-    failureCount: number;
-    retryFailureCount?: number;
-  }): Promise<{ quarantined: boolean; retryAt: number }> {
-    const failureThreshold = this.getQuarantineFailureThreshold();
-
-    if (shouldQuarantineForFailures({ failureCount, failureThreshold })) {
-      await this.enterQuarantine({
-        reason: "repeated-failures",
-        detail: `${kind} work failed ${failureCount} times in a row`,
-        failureKind: kind,
-        failureCount,
-      });
-      return { quarantined: true, retryAt: 0 };
-    }
-
-    const retryAt = getFailureRetryAt({
-      failureCount: retryFailureCount,
-      baseMs: this.getFailureBackoffBaseMs(),
-      maxMs: this.getFailureBackoffMaxMs(),
-      now: Date.now(),
-    });
-    await this.ctx.storage.put(this.retryKeyFor(kind), retryAt);
-
-    console.error(
-      formatFailureBackoffLog({
-        roomName: this.name,
-        failureKind: kind,
-        failureCount,
-        retryAt,
-        failureThreshold,
-      })
-    );
-
-    return { quarantined: false, retryAt };
-  }
-
-  private async readStoredQuarantine(): Promise<QuarantineState | null> {
-    const value = await this.ctx.storage.get(STORAGE_KEYS.quarantine);
-    return (value as QuarantineState | undefined) ?? null;
-  }
-
-  /**
-   * Enters quarantine: the persisted document is never hydrated and never
-   * overwritten. The room keeps serving visitors through the existing transient
-   * mode, which already suppresses autosave, admin writes, and bridge flushes.
-   * Pending alarms are canceled so the platform stops retrying the work that
-   * killed the isolate.
-   */
-  async enterQuarantine({
-    reason,
-    detail,
-    failureKind,
-    failureCount,
-    skipExternalWrite = false,
-  }: {
-    reason: QuarantineReason;
-    detail: string;
-    failureKind: FailureKind | null;
-    failureCount: number;
-    skipExternalWrite?: boolean;
-  }): Promise<void> {
-    const quarantine: QuarantineState = {
-      reason,
-      detail,
-      failureKind,
-      failureCount,
-      quarantinedAt: Date.now(),
-    };
-    this.quarantine = quarantine;
-    await this.ctx.storage.put(STORAGE_KEYS.quarantine, quarantine);
-
-    // Local safety FIRST: transient mode, canceled alarms, and the runbook log
-    // must not depend on a best-effort external write. A KV failure used to
-    // leave the room writable with its alarms still armed and nothing logged.
-    await this.enterQuarantineRuntimeState();
-
-    // KV is the pre-hydration authority; DO storage is the local record. Both
-    // are written so a quarantine survives a room that cannot start.
-    if (!skipExternalWrite) {
-      await this.writeExternalQuarantineFlag(detail);
-    }
-
-    await this.startRealtimeSync();
-  }
-
-  /**
-   * Applies the runtime consequences of quarantine. Split out because it must
-   * run identically whether quarantine was just entered, resumed from durable
-   * storage, or resumed from the external control plane.
-   */
-  private async enterQuarantineRuntimeState(): Promise<void> {
-    const quarantine = ensureExists(this.quarantine);
-
-    // Transient mode is the existing ephemeral-only path: realtime sync keeps
-    // working, autosave and persistence writes are refused.
-    this.persistenceMode = {
-      kind: "transient",
-      reason: `room quarantined (${quarantine.reason})`,
-      failedAt: quarantine.quarantinedAt,
-    };
-    // Quarantine intentionally serves an ephemeral collaborative room instead
-    // of refusing traffic behind the load-backoff gate.
-    this.loadDeferredUntil = null;
-
-    await this.cancelAlarmForQuarantine();
-
-    if (this.hasLoggedQuarantine) return;
-    this.hasLoggedQuarantine = true;
-    console.error(
-      formatQuarantineLog({
-        roomName: this.name,
-        reason: quarantine.reason,
-        detail: quarantine.detail,
-        failureKind: quarantine.failureKind,
-        failureCount: quarantine.failureCount,
-      })
-    );
-  }
-
-  private async cancelAlarmForQuarantine(): Promise<void> {
-    await this.ctx.storage.deleteAlarm?.();
-  }
-
-  isLoadDeferred(): boolean {
-    return this.loadDeferredUntil !== null;
-  }
-
-  private getQuarantineControlKv(): KVNamespace | null {
-    // Absent in tests and in any deployment where the binding is not configured.
-    return env.QUARANTINE_CONTROL ?? null;
-  }
-
-  private getQuarantineControlKey(): string {
-    return `quarantine:${this.name}`;
-  }
-
-  /**
-   * Reads the external quarantine flag before hydration. This is the only
-   * quarantine path that works for a room which crashes on start, because every
-   * admin route runs after hydration has already happened.
-   *
-   * Fails OPEN: a KV outage must not take rooms offline. Manual quarantine is an
-   * operator tool, not a correctness gate.
-   */
-  private async applyExternalQuarantineFlag(): Promise<void> {
-    const kv = this.getQuarantineControlKv();
-    if (kv === null) return;
-
-    let flag: string | null;
-    try {
-      flag = await kv.get(this.getQuarantineControlKey());
-    } catch (error) {
-      console.warn(
-        `[PartyServer] Quarantine control lookup failed for room=${this.name}; proceeding normally. ` +
-          `reason=${getErrorMessage(error)}`
-      );
-      return;
-    }
-
-    if (flag === null) return;
-
-    await this.enterQuarantine({
-      reason: "manual",
-      detail: flag || "no reason given",
-      failureKind: null,
-      failureCount: 0,
-      // KV is already the source of truth here; writing back would be a no-op.
-      skipExternalWrite: true,
-    });
-  }
-
-  private async writeExternalQuarantineFlag(
-    detail: string | null
-  ): Promise<void> {
-    const kv = this.getQuarantineControlKv();
-    if (kv === null) return;
-
-    const key = this.getQuarantineControlKey();
-    try {
-      if (detail === null) {
-        await kv.delete(key);
-      } else {
-        await kv.put(key, detail);
-      }
-    } catch (error) {
-      // Surfaced loudly: the operator needs to know the pre-hydration flag did
-      // not stick, because that is the copy that survives a crashing room.
-      console.error(
-        `[PartyServer] Quarantine control write FAILED for room=${this.name}; ` +
-          `the pre-hydration flag is NOT set and will not survive a restart. ` +
-          `reason=${getErrorMessage(error)}`
-      );
-      throw error;
-    }
-  }
-
-  /**
-   * Response for a room inside its load-backoff window. This is deliberately a
-   * hard failure rather than transient mode: the document was never read, so
-   * serving the empty live doc would look like data loss to a visitor. Quarantine
-   * is the opposite trade-off, where an operator has accepted ephemeral service.
-   */
-  async getLoadDeferredResponse(): Promise<Response | null> {
-    if (this.loadDeferredUntil === null) return null;
-
-    // The isolate can outlive the deadline: onStart only runs once, so without
-    // this a live isolate would serve 503 forever while client retries kept it
-    // alive. Re-evaluate in place when the deadline passes.
-    if (Date.now() >= this.loadDeferredUntil) {
-      const recovered = await this.attemptDeferredReload();
-      if (recovered) return null;
-    }
-
-    if (this.loadDeferredUntil === null) return null;
-
-    const retryAfterSeconds = Math.max(
-      1,
-      Math.ceil((this.loadDeferredUntil - Date.now()) / 1000)
-    );
-
-    return new Response(
-      JSON.stringify({
-        error: "room_load_deferred",
-        message:
-          "This room failed to load and is waiting before trying again. Its data is intact and was not read or modified.",
-        roomId: this.name,
-        retryAfterSeconds,
-        retryAt: new Date(this.loadDeferredUntil).toISOString(),
-      }),
-      {
-        status: 503,
-        headers: {
-          "content-type": "application/json",
-          "retry-after": String(retryAfterSeconds),
-          "Access-Control-Allow-Origin": "*",
-        },
-      }
-    );
-  }
-
-  /**
-   * Retries hydration in place once a deferral deadline has passed, so a live
-   * isolate recovers on its own instead of serving 503 until it is evicted.
-   *
-   * Single-flight: concurrent requests arriving at the deadline share one
-   * attempt. The next deadline is committed before hydrating, exactly as in the
-   * pre-hydration path, so a crash here still lands the room in a longer window.
-   *
-   * Returns true when the room is serving again.
-   */
-  private async attemptDeferredReload(): Promise<boolean> {
-    if (this.inFlightReload) return this.inFlightReload;
-
-    const attempt = (async () => {
-      try {
-        const previousFailures = await this.getFailureCount("load");
-        const failureThreshold = this.getQuarantineFailureThreshold();
-
-        if (
-          shouldQuarantineForFailures({
-            failureCount: previousFailures,
-            failureThreshold,
-          })
-        ) {
-          await this.enterQuarantine({
-            reason: "repeated-failures",
-            detail: `load work failed ${previousFailures} times in a row`,
-            failureKind: "load",
-            failureCount: previousFailures,
-          });
-          this.loadDeferredUntil = null;
-          return false;
-        }
-
-        const nextRetryAt = getFailureRetryAt({
-          failureCount: previousFailures + 1,
-          baseMs: this.getFailureBackoffBaseMs(),
-          maxMs: this.getFailureBackoffMaxMs(),
-          now: Date.now(),
-        });
-        await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
-
-        if (previousFailures === 0) {
-          console.log(
-            `[PartyServer] Starting guarded hydration after quarantine clear: room=${this.name}`
-          );
-        } else {
-          console.error(
-            formatFailureBackoffLog({
-              roomName: this.name,
-              failureKind: "load",
-              failureCount: previousFailures,
-              retryAt: nextRetryAt,
-              failureThreshold,
-            }) + " Retrying hydration in place now."
-          );
-        }
-
-        // Clear the flag so the guarded load does not short-circuit on it.
-        this.loadDeferredUntil = null;
-        this.documentLoadCompleted = false;
-        if (this.realtimeSyncStarted) {
-          await this.onLoad();
-        } else {
-          await this.startRealtimeSync();
-        }
-
-        // onLoad clears the counter on success.
-        const remainingFailures = await this.getFailureCount("load");
-        if (remainingFailures === 0 && this.documentLoadCompleted) {
-          await this.completeRoomStartup();
-          console.log(
-            `[PartyServer] Room recovered after deferral: room=${this.name}`
-          );
-          return true;
-        }
-
-        this.loadDeferredUntil = nextRetryAt;
-        return false;
-      } catch (error) {
-        // An observed throw is not the OOM case the counter infers, but the room
-        // still cannot serve, so it stays deferred.
-        console.error(
-          `[PartyServer] Deferred reload failed for room=${this.name}:`,
-          error
-        );
-        this.loadDeferredUntil = await this.getFailureRetryAfter("load");
-        return false;
-      } finally {
-        this.inFlightReload = null;
-      }
-    })();
-
-    this.inFlightReload = attempt;
-    return attempt;
-  }
-
-  /**
-   * Handles a compaction attempt that was refused because the document is too
-   * large to rebuild in memory. The compaction schedule is parked so the alarm
-   * stops retrying doomed work, and the room is otherwise untouched: it loads,
-   * serves visitors, and persists normally. This is not a quarantine.
-   *
-   * Returns true when a skip was recorded, so callers can stop.
-   */
-  private async parkCompactionIfTooLarge(): Promise<boolean> {
-    const documentBytes = this.compactionTooLargeBytes;
-    this.compactionTooLargeBytes = null;
-    if (documentBytes === null) return false;
-
-    const alreadyParked = await this.getCompactionParkedBytes();
-    await this.ctx.storage.put(STORAGE_KEYS.compactionParked, documentBytes);
-    // Parking clears the pending compaction request so the alarm does not keep
-    // waking the room to retry work that cannot succeed.
-    await this.clearEmptyRoomCompactAfter();
-
-    // One loud log per room, not one per alarm.
-    if (alreadyParked === null) {
-      console.error(
-        formatCompactionSkipLog({
-          roomName: this.name,
-          documentBytes,
-          maxBytes: this.getCompactionMaxInDurableObjectBytes(),
-        })
-      );
-    }
-    return true;
-  }
-
-  private async assertCanCompactDocument(documentBytes: number): Promise<void> {
-    const maxBytes = this.getCompactionMaxInDurableObjectBytes();
-    if (
-      !isTooLargeToCompactInDurableObject({
-        documentBytes,
-        maxBytes,
-      })
-    ) {
-      return;
-    }
-
-    this.compactionTooLargeBytes = documentBytes;
-    await this.parkCompactionIfTooLarge();
-    throw new ExternalCompactionRequiredError(documentBytes, maxBytes);
-  }
-
-  /**
-   * Enforces the quarantine data-safety invariant at the write functions rather
-   * than at the admin routes. A quarantined room never hydrated its persisted
-   * document, so its live doc is empty and every document write derived from it
-   * would destroy real data. Rebuilding the persisted document is just as
-   * dangerous: applying that update is the OOM this breaker exists to prevent.
-   */
-  private assertNotQuarantined(operation: string): void {
-    if (!this.isQuarantined()) return;
-    throw new Error(
-      `Refusing to ${operation} for quarantined room ${this.name}: the persisted document was never hydrated, so this would overwrite or reload data that is known to crash the room. Clear quarantine only after shrinking or repairing the document.`
-    );
-  }
-
-  // Clears quarantine along with the failure history that caused it, so the room
-  // starts from a clean slate rather than re-quarantining on the next failure.
-  /**
-   * Clears quarantine and the failure ledger behind it. Returns what was
-   * actually reset, because this endpoint also doubles as "unstick this room"
-   * and silently wiping counters while reporting "nothing to clear" hides real
-   * state from whoever is running it.
-   */
-  async clearQuarantine(): Promise<{
-    wasQuarantined: boolean;
-    loadFailures: number;
-    alarmFailures: number;
-    wasLoadDeferred: boolean;
-  }> {
-    const summary = {
-      wasQuarantined: this.quarantine !== null,
-      loadFailures: await this.getFailureCount("load"),
-      alarmFailures: await this.getFailureCount("alarm"),
-      wasLoadDeferred: this.loadDeferredUntil !== null,
-    };
-    const needsGuardedReload =
-      summary.wasQuarantined || summary.wasLoadDeferred;
-
-    // Clear the external flag first: if it survived while local state did not,
-    // the room would silently re-quarantine on its next start.
-    await this.writeExternalQuarantineFlag(null);
-
-    this.quarantine = null;
-    this.hasLoggedQuarantine = false;
-    this.documentLoadCompleted = false;
-    // The persisted document was not necessarily loaded in this isolate. Keep
-    // normal traffic gated until the next guarded load proves it is safe.
-    this.loadDeferredUntil = needsGuardedReload ? Date.now() : null;
-    await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
-    await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
-    await this.ctx.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
-    await this.ctx.storage.delete(STORAGE_KEYS.loadRetryAfter);
-    await this.ctx.storage.delete(STORAGE_KEYS.alarmRetryAfter);
-    console.log(
-      `[PartyServer] Quarantine cleared for room=${this.name}: ` +
-        `wasQuarantined=${summary.wasQuarantined}, ` +
-        `loadFailuresReset=${summary.loadFailures}, ` +
-        `alarmFailuresReset=${summary.alarmFailures}, ` +
-        `wasLoadDeferred=${summary.wasLoadDeferred}, ` +
-        `recoveryPending=${needsGuardedReload}.`
-    );
-    return summary;
-  }
-
-  // Lets an operator re-enable in-DO compaction after shrinking a document
-  // externally.
-  async clearCompactionPark(): Promise<void> {
-    await this.ctx.storage.delete(STORAGE_KEYS.compactionParked);
-  }
-
-  /**
-   * Reads the external flag for reporting. Distinguishes "no flag" from "could
-   * not check", because those mean very different things when an operator is
-   * deciding whether a quarantine actually took effect.
-   */
-  async readExternalQuarantineFlag(): Promise<
-    { available: true; value: string | null } | { available: false }
-  > {
-    const kv = this.getQuarantineControlKv();
-    if (kv === null) return { available: false };
-    try {
-      return { available: true, value: await kv.get(this.getQuarantineControlKey()) };
-    } catch {
-      return { available: false };
-    }
-  }
-
-  hasQuarantineControlPlane(): boolean {
-    return this.getQuarantineControlKv() !== null;
-  }
-
-  async getQuarantineStatusBody() {
-    return createQuarantineStatusBody({
-      roomName: this.name,
-      quarantine: this.quarantine,
-      documentWarningBytes: this.getQuarantineDocumentBytes(),
-      maxInDurableObjectBytes: this.getCompactionMaxInDurableObjectBytes(),
-      failureThreshold: this.getQuarantineFailureThreshold(),
-      loadFailures: await this.getFailureCount("load"),
-      alarmFailures: await this.getFailureCount("alarm"),
-      loadRetryAfter: await this.getFailureRetryAfter("load"),
-      alarmRetryAfter: await this.getFailureRetryAfter("alarm"),
-      compactionParkedBytes: await this.getCompactionParkedBytes(),
-      loadDeferredUntil: this.loadDeferredUntil,
-      externalFlag: await this.readExternalQuarantineFlag(),
-    });
   }
 
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
@@ -1267,14 +605,15 @@ export class PartyServer extends YServer {
     // faithful measure available here.
     const sourceBase64 = sourceDocumentBase64 ?? encodeDocToBase64(doc);
     const beforeSize = sourceBase64.length;
-    const maxInDurableObjectBytes = this.getCompactionMaxInDurableObjectBytes();
+    const maxInDurableObjectBytes =
+      this.circuitBreaker.getCompactionMaxInDurableObjectBytes();
     if (
       isTooLargeToCompactInDurableObject({
         documentBytes: beforeSize,
         maxBytes: maxInDurableObjectBytes,
       })
     ) {
-      this.compactionTooLargeBytes = beforeSize;
+      this.circuitBreaker.markCompactionTooLarge(beforeSize);
       return null;
     }
 
@@ -1321,7 +660,7 @@ export class PartyServer extends YServer {
   }
 
   private async saveDocumentBase64(documentBase64: string): Promise<void> {
-    this.assertNotQuarantined("persist document");
+    this.circuitBreaker.assertNotQuarantined("persist document");
 
     const { error } = await supabase.from("documents").upsert(
       {
@@ -1575,7 +914,7 @@ export class PartyServer extends YServer {
     // room legitimately accepts, because it is how an oversized document gets
     // repaired. Callers opt in explicitly so no other path inherits it.
     if (!options?.allowQuarantined) {
-      this.assertNotQuarantined("restore a snapshot");
+      this.circuitBreaker.assertNotQuarantined("restore a snapshot");
     }
 
     const roomId = this.name;
@@ -1699,8 +1038,8 @@ export class PartyServer extends YServer {
   private async scheduleNextAlarm(): Promise<void> {
     // A quarantined room must not schedule work that wakes it up: every wake is
     // another chance to retry the load that killed the isolate.
-    if (this.isQuarantined()) {
-      await this.cancelAlarmForQuarantine();
+    if (this.circuitBreaker.isQuarantined()) {
+      await this.circuitBreaker.cancelAlarm();
       return;
     }
 
@@ -1731,7 +1070,7 @@ export class PartyServer extends YServer {
     if (this.getOpenConnectionCount() !== 0) return;
     // Parked rooms must never be re-scheduled by a later disconnect, or the
     // alarm would keep waking the room to retry work that cannot succeed.
-    if ((await this.getCompactionParkedBytes()) !== null) return;
+    if ((await this.circuitBreaker.getCompactionParkedBytes()) !== null) return;
 
     const compactAfter = Date.now() + DEFAULT_EMPTY_ROOM_COMPACT_DELAY_MS;
     await this.setEmptyRoomCompactAfter(compactAfter);
@@ -2066,19 +1405,9 @@ export class PartyServer extends YServer {
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
 
-    // Inside a load-backoff window the live document is empty because it was
-    // never read. Joining a visitor to it would look like their data vanished,
-    // so the socket is closed instead. Past the deadline this recovers in place
-    // rather than refusing forever.
-    if (this.loadDeferredUntil !== null && Date.now() >= this.loadDeferredUntil) {
-      await this.attemptDeferredReload();
-    }
-
-    if (this.loadDeferredUntil !== null) {
-      const retryAfterSeconds = Math.max(
-        1,
-        Math.ceil((this.loadDeferredUntil - Date.now()) / 1000)
-      );
+    const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
+    if (loadDeferred) {
+      const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
       console.warn(
         `[PartyServer] Refusing connection to deferred room=${this.name}: ` +
           `connectionId=${connection.id}, retryAfterSeconds=${retryAfterSeconds}`
@@ -2276,17 +1605,17 @@ export class PartyServer extends YServer {
    */
   override async onLoad(): Promise<void> {
     this.documentLoadCompleted = false;
-    this.quarantine = await this.readStoredQuarantine();
-    if (this.quarantine !== null) {
-      await this.enterQuarantineRuntimeState();
+    await this.circuitBreaker.loadStoredQuarantine();
+    if (this.circuitBreaker.isQuarantined()) {
+      await this.circuitBreaker.enterQuarantineRuntimeState();
       return;
     }
 
-    if (this.loadDeferredUntil !== null) return;
+    if (this.circuitBreaker.isLoadDeferred()) return;
 
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
-    const loadAttempts = await this.beginRiskyOperation("load");
+    const loadAttempts = await this.circuitBreaker.beginRiskyOperation("load");
 
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
@@ -2324,7 +1653,7 @@ export class PartyServer extends YServer {
       // and succeeds well past this threshold; it is compaction that multiplies
       // memory, so that is where the hard ceiling lives.
       const documentBytes = result.data.document.length;
-      const thresholdBytes = this.getQuarantineDocumentBytes();
+      const thresholdBytes = this.circuitBreaker.getDocumentWarningBytes();
       if (isDocumentOversized({ documentBytes, thresholdBytes })) {
         console.warn(
           `[PartyServer] Large document load for room=${this.name}: ` +
@@ -2355,7 +1684,7 @@ export class PartyServer extends YServer {
 
     // Hydration completed without killing the isolate, so the failure history
     // and any pending backoff are cleared.
-    await this.completeRiskyOperation("load");
+    await this.circuitBreaker.completeRiskyOperation("load");
     this.documentLoadCompleted = true;
   }
 
@@ -2363,16 +1692,7 @@ export class PartyServer extends YServer {
   // attempted. Attempts that DID reach hydration stay counted, so the failure
   // history keeps its evidence even if Supabase is flaky in between.
   private async releaseLoadAttempt(loadAttempts: number): Promise<void> {
-    const remaining = loadAttempts - 1;
-    if (remaining <= 0) {
-      await this.completeRiskyOperation("load");
-      return;
-    }
-    await this.ctx.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
-    // The deadline was written speculatively before this attempt. Hydration was
-    // never reached, so roll it back too or the room stays deferred for a
-    // backoff rung it did not earn.
-    await this.ctx.storage.delete(STORAGE_KEYS.loadRetryAfter);
+    await this.circuitBreaker.releaseLoadAttempt(loadAttempts);
   }
 
   override async onSave(): Promise<void> {
@@ -2395,7 +1715,7 @@ export class PartyServer extends YServer {
     if (compactedDocument === null) {
       // Too large to rebuild in memory: park the schedule and report the
       // external-compaction runbook rather than retrying on every autosave.
-      if (await this.parkCompactionIfTooLarge()) {
+      if (await this.circuitBreaker.parkCompactionIfTooLarge()) {
         await setRecheckAfter(recheckAfter);
         return null;
       }
@@ -2727,7 +2047,8 @@ export class PartyServer extends YServer {
           "/admin/quarantine-clear",
         ].some((path) => url.pathname.includes(path));
         if (!isLoadControlRoute) {
-          const loadDeferred = await this.getLoadDeferredResponse();
+          const loadDeferred =
+            await this.circuitBreaker.getLoadDeferredResponse();
           if (loadDeferred) return loadDeferred;
         }
         // Awaited so a rejection lands in this method's catch rather than
@@ -2736,7 +2057,7 @@ export class PartyServer extends YServer {
       }
 
       // The document was never read, so there is nothing to serve.
-      const loadDeferred = await this.getLoadDeferredResponse();
+      const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
       if (loadDeferred) return loadDeferred;
 
       if (request.method !== "POST") {
@@ -3012,7 +2333,7 @@ export class PartyServer extends YServer {
     // A hard reset derives its new document from the live doc, which is empty
     // for a quarantined room, and falls back to re-reading the persisted one.
     // Both outcomes are exactly what quarantine exists to prevent.
-    this.assertNotQuarantined("hard reset");
+    this.circuitBreaker.assertNotQuarantined("hard reset");
 
     const roomId = this.name;
     console.log(`[Hard Reset] Starting for room: ${roomId}`);
@@ -3026,7 +2347,7 @@ export class PartyServer extends YServer {
       console.log(`[Hard Reset] Successfully retrieved live Y.Doc`);
 
       let beforeSize = encodeDocToBase64(liveYDoc).length;
-      await this.assertCanCompactDocument(beforeSize);
+      await this.circuitBreaker.assertCanCompactDocument(beforeSize);
 
       // Extract current state as JSON
       let currentPlayData = docToJson(liveYDoc);
@@ -3056,7 +2377,7 @@ export class PartyServer extends YServer {
 
         if (dbRow?.document) {
           beforeSize = dbRow.document.length;
-          await this.assertCanCompactDocument(beforeSize);
+          await this.circuitBreaker.assertCanCompactDocument(beforeSize);
           const fallbackDoc = new Y.Doc();
           try {
             Y.applyUpdate(
@@ -3224,7 +2545,7 @@ export class PartyServer extends YServer {
         // Distinguishes "nothing to compact" from "too large to compact here":
         // the latter parks the schedule and reports the external-compaction
         // runbook.
-        if (await this.parkCompactionIfTooLarge()) return;
+        if (await this.circuitBreaker.parkCompactionIfTooLarge()) return;
         await this.clearEmptyRoomCompactAfter();
         return;
       }
@@ -3301,48 +2622,10 @@ export class PartyServer extends YServer {
 
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
-    if (this.isQuarantined()) {
-      console.warn(
-        `[PartyServer] Alarm skipped for quarantined room=${this.name}; canceling pending alarms.`
-      );
-      await this.cancelAlarmForQuarantine();
-      return;
-    }
-
-    // A previous alarm started risky work and never finished it, which is what
-    // an out-of-memory crash looks like from here. Back off instead of letting
-    // the platform's rapid retry turn one crash into a permanent loop.
-    const previousFailures = await this.getFailureCount("alarm");
-    if (previousFailures > 0) {
-      // Check the existing window BEFORE recording a new one, otherwise a retry
-      // that has come due would be pushed out again and never run.
-      const retryAfter = await this.getFailureRetryAfter("alarm");
-      if (!isRetryDue({ retryAfter, now: Date.now() })) {
-        // Not yet time to retry: re-arm at the backoff time and do no work.
-        await this.ctx.storage.setAlarm?.(ensureExists(retryAfter));
-        return;
-      }
-
-      const outcome = await this.handleRepeatedFailures({
-        kind: "alarm",
-        failureCount: previousFailures,
-        // The current deadline has elapsed, so this is the retry attempt. Store
-        // the following rung before risky work in case this attempt also OOMs.
-        retryFailureCount:
-          retryAfter === null ? previousFailures : previousFailures + 1,
-      });
-      if (outcome.quarantined) return;
-
-      // A fresh backoff was just recorded for this failure count. Honour it
-      // unless this attempt is the one allowed to proceed.
-      if (retryAfter === null) {
-        await this.ctx.storage.setAlarm?.(outcome.retryAt);
-        return;
-      }
-    }
+    if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
     // Durable BEFORE the risky work, mirroring the load path.
-    await this.beginRiskyOperation("alarm");
+    await this.circuitBreaker.beginRiskyOperation("alarm");
 
     try {
       const compactAfter = await this.getEmptyRoomCompactAfter();
@@ -3356,14 +2639,14 @@ export class PartyServer extends YServer {
 
       await this.pruneBridgeLeases();
       // Reached only if the risky work above did not kill the isolate.
-      await this.completeRiskyOperation("alarm");
+      await this.circuitBreaker.completeRiskyOperation("alarm");
     } catch (error) {
       // An exception we can observe is NOT the failure mode this counter infers.
       // The counter exists to detect work that vanished mid-flight (an OOM kills
       // the isolate, so nothing gets to log). A caught throw means the isolate
       // survived, so it is cleared: otherwise a long Supabase outage would march
       // healthy rooms all the way to quarantine and mislabel them as OOM.
-      await this.completeRiskyOperation("alarm");
+      await this.circuitBreaker.completeRiskyOperation("alarm");
       console.error(
         `[PartyServer] Alarm work failed for room=${this.name} (observed exception, not a vanish):`,
         error
@@ -3523,70 +2806,11 @@ export default {
   // Set up your fetch handler to use configured Servers
   async fetch(request: Request, workerEnv: Env): Promise<Response> {
     try {
-      const url = new URL(request.url);
-      if (url.pathname === "/admin/quarantines") {
-        if (request.method === "OPTIONS") {
-          return new Response(null, {
-            status: 200,
-            headers: {
-              "Access-Control-Allow-Origin": "*",
-              "Access-Control-Allow-Methods": "GET, OPTIONS",
-              "Access-Control-Allow-Headers":
-                "Content-Type, Authorization",
-            },
-          });
-        }
-
-        if (request.method !== "GET") {
-          return new Response("Method Not Allowed", {
-            status: 405,
-            headers: { Allow: "GET, OPTIONS" },
-          });
-        }
-
-        const authError = getAdminAuthError(
-          request,
-          workerEnv.ADMIN_TOKEN
-        );
-        if (authError) return authError;
-
-        try {
-          const rooms = await listQuarantinedRooms(
-            workerEnv.QUARANTINE_CONTROL
-          );
-          return new Response(
-            JSON.stringify({
-              available: true,
-              count: rooms.length,
-              rooms,
-            }),
-            {
-              headers: {
-                "content-type": "application/json",
-                "Access-Control-Allow-Origin": "*",
-              },
-            }
-          );
-        } catch (error) {
-          console.error(
-            "[PartyServer] Failed to list quarantined rooms:",
-            error
-          );
-          return new Response(
-            JSON.stringify({
-              available: false,
-              error: "Failed to read the quarantine control plane",
-            }),
-            {
-              status: 503,
-              headers: {
-                "content-type": "application/json",
-                "Access-Control-Allow-Origin": "*",
-              },
-            }
-          );
-        }
-      }
+      const quarantineResponse = await handleQuarantineControlRequest(request, {
+        adminToken: workerEnv.ADMIN_TOKEN,
+        quarantineControl: workerEnv.QUARANTINE_CONTROL,
+      });
+      if (quarantineResponse) return quarantineResponse;
 
       return (
         (await routePartykitRequest(request, workerEnv)) ||

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -211,6 +211,11 @@ export class PartyServer extends YServer {
   // Deadline of an active load-backoff window. While set, this isolate never
   // hydrated, so every request is refused rather than served an empty document.
   private loadDeferredUntil: number | null = null;
+  // Guards against logging the same quarantine twice when it is both applied
+  // from the control plane and resumed from durable storage in one start.
+  private hasLoggedQuarantine = false;
+  // Single-flight guard for an in-place re-load attempt at the deadline.
+  private inFlightReload: Promise<boolean> | null = null;
 
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -230,17 +235,119 @@ export class PartyServer extends YServer {
   private observersAttached = false;
   private adminHandler = new AdminHandler(this);
 
+  /**
+   * Every entry path (fetch, websocket, alarm) funnels through the platform's
+   * initialization, which calls onStart() -> onLoad() and hydrates. So this is
+   * the ONLY place a guard can sit and still run before hydration. Guards placed
+   * in onAlarm are downstream of the crash they are meant to prevent and never
+   * execute for a room that dies during hydration.
+   */
   override async onStart(): Promise<void> {
-    // Read the operator control plane BEFORE super.onStart(), which hydrates.
-    // A room that crashes during hydration can never be reached by an admin
-    // route, so the only way to take it out of service is an external flag
-    // consulted before the crash happens.
+    // Operator control plane first: a room that crashes during hydration can
+    // never be reached by an admin route, so an external flag is the only way to
+    // take it out of service.
     await this.applyExternalQuarantineFlag();
+
+    if (this.isQuarantined()) {
+      await this.enterQuarantineRuntimeState();
+      return;
+    }
+
+    // Load backoff, evaluated before hydration for the same reason.
+    if (await this.shouldDeferLoad()) {
+      return;
+    }
 
     await super.onStart();
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
     await this.ensureAlarmScheduled();
+  }
+
+  /**
+   * Decides whether this start may hydrate, and records the consequences.
+   * Returns true when the room must not load.
+   *
+   * Runs before hydration so it also protects the alarm path, where the platform
+   * initializes the room before invoking onAlarm.
+   */
+  private async shouldDeferLoad(): Promise<boolean> {
+    const previousFailures = await this.getFailureCount("load");
+    if (previousFailures === 0) return false;
+
+    const failureThreshold = this.getQuarantineFailureThreshold();
+    if (
+      shouldQuarantineForFailures({
+        failureCount: previousFailures,
+        failureThreshold,
+      })
+    ) {
+      await this.enterQuarantine({
+        reason: "repeated-failures",
+        detail: `load work failed ${previousFailures} times in a row`,
+        failureKind: "load",
+        failureCount: previousFailures,
+      });
+      return true;
+    }
+
+    const retryAfter = await this.getFailureRetryAfter("load");
+
+    // A recorded failure with no deadline yet: this is the first strike, so open
+    // the window now rather than letting the platform retry immediately.
+    if (retryAfter === null) {
+      const firstRetryAt = getFailureRetryAt({
+        failureCount: previousFailures,
+        baseMs: this.getFailureBackoffBaseMs(),
+        maxMs: this.getFailureBackoffMaxMs(),
+        now: Date.now(),
+      });
+      await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
+      this.deferLoad(firstRetryAt, previousFailures);
+      return true;
+    }
+
+    if (!isRetryDue({ retryAfter, now: Date.now() })) {
+      this.deferLoad(retryAfter, previousFailures);
+      return true;
+    }
+
+    // The deadline has arrived. Exactly one attempt is allowed through: the next
+    // deadline is committed BEFORE hydrating, so requests racing the boundary in
+    // a fresh isolate see a future deadline rather than all retrying at once.
+    const nextRetryAt = getFailureRetryAt({
+      failureCount: previousFailures + 1,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
+
+    // Logged at error level immediately before the risky attempt: if hydration
+    // kills the isolate, this is the last record that it was tried at all.
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.name,
+        failureKind: "load",
+        failureCount: previousFailures,
+        retryAt: nextRetryAt,
+        failureThreshold,
+      }) + " Attempting hydration now."
+    );
+    return false;
+  }
+
+  private deferLoad(retryAt: number, failureCount: number): void {
+    this.loadDeferredUntil = retryAt;
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.name,
+        failureKind: "load",
+        failureCount,
+        retryAt,
+        failureThreshold: this.getQuarantineFailureThreshold(),
+      }) + " Serving 503 until the deadline; the document was not read."
+    );
   }
 
   async getSubscribers(): Promise<Subscriber[]> {
@@ -422,6 +529,10 @@ export class PartyServer extends YServer {
   }
 
   markPersistenceAvailable(): void {
+    // A quarantined room's transient mode IS the write park. Lifting it here
+    // would re-enable autosave against a document that was never hydrated.
+    if (this.isQuarantined()) return;
+
     if (this.persistenceMode.kind === "transient") {
       console.log(
         `[PartyServer] Supabase persistence restored for room=${this.name}; leaving transient mode.`
@@ -461,7 +572,7 @@ export class PartyServer extends YServer {
     );
   }
 
-  private getCompactionMaxInDurableObjectBytes(): number {
+  getCompactionMaxInDurableObjectBytes(): number {
     return readPositiveNumberEnv(
       "COMPACTION_MAX_IN_DO_BYTES",
       DEFAULT_COMPACTION_MAX_IN_DO_BYTES
@@ -528,6 +639,11 @@ export class PartyServer extends YServer {
    * Records that a risky operation is starting. The write is awaited so that an
    * isolate killed mid-operation leaves the increment behind: that is the only
    * evidence an out-of-memory crash ever produces.
+   *
+   * Note for log readers: any mid-work isolate kill counts as a strike, including
+   * routine ones like a deploy evicting the isolate. Those are harmless and
+   * self-heal, since the next successful run clears the counter. A single strike
+   * appearing right after a deploy is expected and is not evidence of an OOM.
    */
   private async beginRiskyOperation(kind: FailureKind): Promise<number> {
     const attempt = (await this.getFailureCount(kind)) + 1;
@@ -629,29 +745,45 @@ export class PartyServer extends YServer {
     this.quarantine = quarantine;
     await this.ctx.storage.put(STORAGE_KEYS.quarantine, quarantine);
 
+    // Local safety FIRST: transient mode, canceled alarms, and the runbook log
+    // must not depend on a best-effort external write. A KV failure used to
+    // leave the room writable with its alarms still armed and nothing logged.
+    await this.enterQuarantineRuntimeState();
+
     // KV is the pre-hydration authority; DO storage is the local record. Both
     // are written so a quarantine survives a room that cannot start.
     if (!skipExternalWrite) {
       await this.writeExternalQuarantineFlag(detail);
     }
+  }
+
+  /**
+   * Applies the runtime consequences of quarantine. Split out because it must
+   * run identically whether quarantine was just entered, resumed from durable
+   * storage, or resumed from the external control plane.
+   */
+  private async enterQuarantineRuntimeState(): Promise<void> {
+    const quarantine = ensureExists(this.quarantine);
 
     // Transient mode is the existing ephemeral-only path: realtime sync keeps
     // working, autosave and persistence writes are refused.
     this.persistenceMode = {
       kind: "transient",
-      reason: `room quarantined (${reason})`,
+      reason: `room quarantined (${quarantine.reason})`,
       failedAt: quarantine.quarantinedAt,
     };
 
     await this.cancelAlarmForQuarantine();
 
+    if (this.hasLoggedQuarantine) return;
+    this.hasLoggedQuarantine = true;
     console.error(
       formatQuarantineLog({
         roomName: this.name,
-        reason,
-        detail,
-        failureKind,
-        failureCount,
+        reason: quarantine.reason,
+        detail: quarantine.detail,
+        failureKind: quarantine.failureKind,
+        failureCount: quarantine.failureCount,
       })
     );
   }
@@ -739,7 +871,17 @@ export class PartyServer extends YServer {
    * serving the empty live doc would look like data loss to a visitor. Quarantine
    * is the opposite trade-off, where an operator has accepted ephemeral service.
    */
-  getLoadDeferredResponse(): Response | null {
+  async getLoadDeferredResponse(): Promise<Response | null> {
+    if (this.loadDeferredUntil === null) return null;
+
+    // The isolate can outlive the deadline: onStart only runs once, so without
+    // this a live isolate would serve 503 forever while client retries kept it
+    // alive. Re-evaluate in place when the deadline passes.
+    if (Date.now() >= this.loadDeferredUntil) {
+      const recovered = await this.attemptDeferredReload();
+      if (recovered) return null;
+    }
+
     if (this.loadDeferredUntil === null) return null;
 
     const retryAfterSeconds = Math.max(
@@ -765,6 +907,91 @@ export class PartyServer extends YServer {
         },
       }
     );
+  }
+
+  /**
+   * Retries hydration in place once a deferral deadline has passed, so a live
+   * isolate recovers on its own instead of serving 503 until it is evicted.
+   *
+   * Single-flight: concurrent requests arriving at the deadline share one
+   * attempt. The next deadline is committed before hydrating, exactly as in the
+   * pre-hydration path, so a crash here still lands the room in a longer window.
+   *
+   * Returns true when the room is serving again.
+   */
+  private async attemptDeferredReload(): Promise<boolean> {
+    if (this.inFlightReload) return this.inFlightReload;
+
+    const attempt = (async () => {
+      try {
+        const previousFailures = await this.getFailureCount("load");
+        const failureThreshold = this.getQuarantineFailureThreshold();
+
+        if (
+          shouldQuarantineForFailures({
+            failureCount: previousFailures,
+            failureThreshold,
+          })
+        ) {
+          await this.enterQuarantine({
+            reason: "repeated-failures",
+            detail: `load work failed ${previousFailures} times in a row`,
+            failureKind: "load",
+            failureCount: previousFailures,
+          });
+          this.loadDeferredUntil = null;
+          return false;
+        }
+
+        const nextRetryAt = getFailureRetryAt({
+          failureCount: previousFailures + 1,
+          baseMs: this.getFailureBackoffBaseMs(),
+          maxMs: this.getFailureBackoffMaxMs(),
+          now: Date.now(),
+        });
+        await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
+
+        console.error(
+          formatFailureBackoffLog({
+            roomName: this.name,
+            failureKind: "load",
+            failureCount: previousFailures,
+            retryAt: nextRetryAt,
+            failureThreshold,
+          }) + " Retrying hydration in place now."
+        );
+
+        // Clear the flag so onLoad does not short-circuit on it.
+        this.loadDeferredUntil = null;
+        await this.onLoad();
+
+        // onLoad clears the counter on success.
+        const remainingFailures = await this.getFailureCount("load");
+        if (remainingFailures === 0) {
+          console.log(
+            `[PartyServer] Room recovered after deferral: room=${this.name}`
+          );
+          return true;
+        }
+
+        this.loadDeferredUntil = nextRetryAt;
+        return false;
+      } catch (error) {
+        // An observed throw is not the OOM case the counter infers, but the room
+        // still cannot serve, so it stays deferred.
+        console.error(
+          `[PartyServer] Deferred reload failed for room=${this.name}:`,
+          error
+        );
+        this.loadDeferredUntil = await this.getFailureRetryAfter("load");
+        return false;
+      } finally {
+        this.inFlightReload = null;
+      }
+    })();
+
+    this.inFlightReload = attempt;
+    return attempt;
   }
 
   /**
@@ -831,26 +1058,73 @@ export class PartyServer extends YServer {
 
   // Clears quarantine along with the failure history that caused it, so the room
   // starts from a clean slate rather than re-quarantining on the next failure.
-  async clearQuarantine(): Promise<void> {
+  /**
+   * Clears quarantine and the failure ledger behind it. Returns what was
+   * actually reset, because this endpoint also doubles as "unstick this room"
+   * and silently wiping counters while reporting "nothing to clear" hides real
+   * state from whoever is running it.
+   */
+  async clearQuarantine(): Promise<{
+    wasQuarantined: boolean;
+    loadFailures: number;
+    alarmFailures: number;
+    wasLoadDeferred: boolean;
+  }> {
+    const summary = {
+      wasQuarantined: this.quarantine !== null,
+      loadFailures: await this.getFailureCount("load"),
+      alarmFailures: await this.getFailureCount("alarm"),
+      wasLoadDeferred: this.loadDeferredUntil !== null,
+    };
+
     // Clear the external flag first: if it survived while local state did not,
     // the room would silently re-quarantine on its next start.
     await this.writeExternalQuarantineFlag(null);
 
     this.quarantine = null;
+    this.hasLoggedQuarantine = false;
+    // Otherwise status would report a healthy room while requests still 503.
+    this.loadDeferredUntil = null;
     await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
     await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
     await this.ctx.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
     await this.ctx.storage.delete(STORAGE_KEYS.loadRetryAfter);
     await this.ctx.storage.delete(STORAGE_KEYS.alarmRetryAfter);
     console.log(
-      `[PartyServer] Quarantine cleared for room=${this.name}; the next load will attempt hydration again.`
+      `[PartyServer] Quarantine cleared for room=${this.name}: ` +
+        `wasQuarantined=${summary.wasQuarantined}, ` +
+        `loadFailuresReset=${summary.loadFailures}, ` +
+        `alarmFailuresReset=${summary.alarmFailures}, ` +
+        `wasLoadDeferred=${summary.wasLoadDeferred}. The next load will attempt hydration again.`
     );
+    return summary;
   }
 
   // Lets an operator re-enable in-DO compaction after shrinking a document
   // externally.
   async clearCompactionPark(): Promise<void> {
     await this.ctx.storage.delete(STORAGE_KEYS.compactionParked);
+  }
+
+  /**
+   * Reads the external flag for reporting. Distinguishes "no flag" from "could
+   * not check", because those mean very different things when an operator is
+   * deciding whether a quarantine actually took effect.
+   */
+  async readExternalQuarantineFlag(): Promise<
+    { available: true; value: string | null } | { available: false }
+  > {
+    const kv = this.getQuarantineControlKv();
+    if (kv === null) return { available: false };
+    try {
+      return { available: true, value: await kv.get(this.getQuarantineControlKey()) };
+    } catch {
+      return { available: false };
+    }
+  }
+
+  hasQuarantineControlPlane(): boolean {
+    return this.getQuarantineControlKv() !== null;
   }
 
   async getQuarantineStatusBody() {
@@ -865,6 +1139,8 @@ export class PartyServer extends YServer {
       loadRetryAfter: await this.getFailureRetryAfter("load"),
       alarmRetryAfter: await this.getFailureRetryAfter("alarm"),
       compactionParkedBytes: await this.getCompactionParkedBytes(),
+      loadDeferredUntil: this.loadDeferredUntil,
+      externalFlag: await this.readExternalQuarantineFlag(),
     });
   }
 
@@ -1754,7 +2030,12 @@ export class PartyServer extends YServer {
 
     // Inside a load-backoff window the live document is empty because it was
     // never read. Joining a visitor to it would look like their data vanished,
-    // so the socket is closed instead.
+    // so the socket is closed instead. Past the deadline this recovers in place
+    // rather than refusing forever.
+    if (this.loadDeferredUntil !== null && Date.now() >= this.loadDeferredUntil) {
+      await this.attemptDeferredReload();
+    }
+
     if (this.loadDeferredUntil !== null) {
       const retryAfterSeconds = Math.max(
         1,
@@ -1947,80 +2228,22 @@ export class PartyServer extends YServer {
     );
   }
 
+  /**
+   * Hydration itself. The decision about WHETHER to hydrate lives in onStart(),
+   * which is the only hook that runs before the platform initializes the room on
+   * every entry path. Reaching this method means that decision said yes.
+   *
+   * onLoad is still reachable directly (y-partyserver calls it from onStart), so
+   * the quarantine check is repeated here as a cheap safety net.
+   */
   override async onLoad(): Promise<void> {
-    // A quarantined room never hydrates. Quarantine is an operator decision or a
-    // last resort after the retry backoff has been exhausted; it is never
-    // entered just because a document is large.
     this.quarantine = await this.readStoredQuarantine();
     if (this.quarantine !== null) {
-      await this.resumeQuarantine();
+      await this.enterQuarantineRuntimeState();
       return;
     }
 
-    // Evidence of previous loads that started and never finished.
-    const previousFailures = await this.getFailureCount("load");
-    if (previousFailures > 0) {
-      const failureThreshold = this.getQuarantineFailureThreshold();
-      if (
-        shouldQuarantineForFailures({
-          failureCount: previousFailures,
-          failureThreshold,
-        })
-      ) {
-        await this.enterQuarantine({
-          reason: "repeated-failures",
-          detail: `load work failed ${previousFailures} times in a row`,
-          failureKind: "load",
-          failureCount: previousFailures,
-        });
-        return;
-      }
-
-      // Inside the backoff window the room serves nothing at all: hydration is
-      // what crashes it, and an un-hydrated room would otherwise hand visitors
-      // an empty document as if it were their data. Requests get a 503 with
-      // Retry-After instead, and Supabase is never queried.
-      const retryAfter = await this.getFailureRetryAfter("load");
-      if (!isRetryDue({ retryAfter, now: Date.now() })) {
-        this.loadDeferredUntil = ensureExists(retryAfter);
-        console.warn(
-          `[PartyServer] Load deferred for room=${this.name}: ` +
-            `consecutiveFailures=${previousFailures}, ` +
-            `retryAt=${new Date(this.loadDeferredUntil).toISOString()}. ` +
-            "Serving 503 until the retry deadline; the document was not read."
-        );
-        return;
-      }
-
-      if (retryAfter === null) {
-        const firstRetryAt = getFailureRetryAt({
-          failureCount: previousFailures,
-          baseMs: this.getFailureBackoffBaseMs(),
-          maxMs: this.getFailureBackoffMaxMs(),
-          now: Date.now(),
-        });
-        await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
-        this.loadDeferredUntil = firstRetryAt;
-        console.warn(
-          `[PartyServer] Load deferred for room=${this.name}: ` +
-            `consecutiveFailures=${previousFailures}, ` +
-            `retryAt=${new Date(firstRetryAt).toISOString()}. ` +
-            "Serving 503 until the retry deadline; the document was not read."
-        );
-        return;
-      }
-
-      // The deadline has arrived. Exactly one attempt is allowed through: record
-      // the next backoff BEFORE hydrating, so requests racing the deadline in a
-      // fresh isolate see a future deadline rather than all retrying at once.
-      const nextRetryAt = getFailureRetryAt({
-        failureCount: previousFailures + 1,
-        baseMs: this.getFailureBackoffBaseMs(),
-        maxMs: this.getFailureBackoffMaxMs(),
-        now: Date.now(),
-      });
-      await this.ctx.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
-    }
+    if (this.loadDeferredUntil !== null) return;
 
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
@@ -2106,27 +2329,10 @@ export class PartyServer extends YServer {
       return;
     }
     await this.ctx.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
-  }
-
-  // A room that was already quarantined on a previous start re-enters transient
-  // mode without touching Supabase at all.
-  private async resumeQuarantine(): Promise<void> {
-    const quarantine = ensureExists(this.quarantine);
-    this.persistenceMode = {
-      kind: "transient",
-      reason: `room quarantined (${quarantine.reason})`,
-      failedAt: quarantine.quarantinedAt,
-    };
-    await this.cancelAlarmForQuarantine();
-    console.error(
-      formatQuarantineLog({
-        roomName: this.name,
-        reason: quarantine.reason,
-        detail: quarantine.detail,
-        failureKind: quarantine.failureKind,
-        failureCount: quarantine.failureCount,
-      })
-    );
+    // The deadline was written speculatively before this attempt. Hydration was
+    // never reached, so roll it back too or the room stays deferred for a
+    // backoff rung it did not earn.
+    await this.ctx.storage.delete(STORAGE_KEYS.loadRetryAfter);
   }
 
   override async onSave(): Promise<void> {
@@ -2480,13 +2686,15 @@ export class PartyServer extends YServer {
           "/admin/quarantine-set",
           "/admin/quarantine-clear",
         ].some((path) => url.pathname.includes(path));
-        const loadDeferred = this.getLoadDeferredResponse();
+        const loadDeferred = await this.getLoadDeferredResponse();
         if (loadDeferred && !isLoadControlRoute) return loadDeferred;
-        return this.adminHandler.handleRequest(request);
+        // Awaited so a rejection lands in this method's catch rather than
+        // escaping as a bare platform 500 with no CORS headers and no log.
+        return await this.adminHandler.handleRequest(request);
       }
 
       // The document was never read, so there is nothing to serve.
-      const loadDeferred = this.getLoadDeferredResponse();
+      const loadDeferred = await this.getLoadDeferredResponse();
       if (loadDeferred) return loadDeferred;
 
       if (request.method !== "POST") {
@@ -3107,7 +3315,20 @@ export class PartyServer extends YServer {
       await this.pruneBridgeLeases();
       // Reached only if the risky work above did not kill the isolate.
       await this.completeRiskyOperation("alarm");
+    } catch (error) {
+      // An exception we can observe is NOT the failure mode this counter infers.
+      // The counter exists to detect work that vanished mid-flight (an OOM kills
+      // the isolate, so nothing gets to log). A caught throw means the isolate
+      // survived, so it is cleared: otherwise a long Supabase outage would march
+      // healthy rooms all the way to quarantine and mislabel them as OOM.
+      await this.completeRiskyOperation("alarm");
+      console.error(
+        `[PartyServer] Alarm work failed for room=${this.name} (observed exception, not a vanish):`,
+        error
+      );
     } finally {
+      // scheduleNextAlarm's quarantine guard is what stops a room quarantined
+      // moments ago inside this try block from having its alarm re-armed here.
       await this.scheduleNextAlarm();
     }
   }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_MESSAGE_RATE_LIMIT,
   DEFAULT_MESSAGE_RATE_WINDOW_MS,
   DEFAULT_PERSISTED_DOCUMENT_COMPACT_BYTES,
+  DEFAULT_QUARANTINE_DOCUMENT_BYTES,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
@@ -92,6 +93,15 @@ import {
   type PersistenceMode,
 } from "./persistenceMode";
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
+import {
+  createQuarantineStatusBody,
+  formatQuarantineLog,
+  shouldQuarantineForDocumentSize,
+  shouldQuarantineForLoadAttempts,
+  DEFAULT_QUARANTINE_LOAD_ATTEMPTS,
+  type QuarantineReason,
+  type QuarantineState,
+} from "./quarantinePolicy";
 export { PresenceServer } from "./presenceServer";
 
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
@@ -182,6 +192,9 @@ export class PartyServer extends YServer {
   private cachedSharedPerms: Record<string, SharedElementPermissions> | null =
     null;
   private persistenceMode: PersistenceMode = { kind: "available" };
+  // Set when this room must never hydrate or persist its document. Loaded from
+  // storage at the top of onLoad, before any hydration work happens.
+  private quarantine: QuarantineState | null = null;
 
   // Pending bridge flush timer — batches bridge fan-out across rapid updates
   private bridgeFlushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -419,6 +432,123 @@ export class PartyServer extends YServer {
     );
   }
 
+  private getQuarantineDocumentBytes(): number {
+    return readPositiveNumberEnv(
+      "QUARANTINE_DOCUMENT_BYTES",
+      DEFAULT_QUARANTINE_DOCUMENT_BYTES
+    );
+  }
+
+  private getQuarantineMaxLoadAttempts(): number {
+    return readPositiveNumberEnv(
+      "QUARANTINE_LOAD_ATTEMPTS",
+      DEFAULT_QUARANTINE_LOAD_ATTEMPTS
+    );
+  }
+
+  isQuarantined(): boolean {
+    return this.quarantine !== null;
+  }
+
+  getQuarantineState(): QuarantineState | null {
+    return this.quarantine;
+  }
+
+  async getQuarantineLoadAttempts(): Promise<number> {
+    const value = await this.ctx.storage.get(
+      STORAGE_KEYS.quarantineLoadAttempts
+    );
+    return typeof value === "number" ? value : 0;
+  }
+
+  private async readStoredQuarantine(): Promise<QuarantineState | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.quarantine);
+    return (value as QuarantineState | undefined) ?? null;
+  }
+
+  /**
+   * Enters quarantine: the persisted document is never hydrated and never
+   * overwritten. The room keeps serving visitors through the existing transient
+   * mode, which already suppresses autosave, admin writes, and bridge flushes.
+   * Pending alarms are canceled so Cloudflare stops retrying the load that
+   * killed the isolate.
+   */
+  private async enterQuarantine({
+    reason,
+    documentBytes,
+    loadAttempts,
+  }: {
+    reason: QuarantineReason;
+    documentBytes: number | null;
+    loadAttempts: number;
+  }): Promise<void> {
+    const quarantine: QuarantineState = {
+      reason,
+      documentBytes,
+      loadAttempts,
+      quarantinedAt: Date.now(),
+    };
+    this.quarantine = quarantine;
+    await this.ctx.storage.put(STORAGE_KEYS.quarantine, quarantine);
+
+    // Transient mode is the existing ephemeral-only path: realtime sync keeps
+    // working, autosave and persistence writes are refused.
+    this.persistenceMode = {
+      kind: "transient",
+      reason: `room quarantined (${reason})`,
+      failedAt: quarantine.quarantinedAt,
+    };
+
+    await this.cancelAlarmForQuarantine();
+
+    console.error(
+      formatQuarantineLog({
+        roomName: this.name,
+        reason,
+        documentBytes,
+        thresholdBytes: this.getQuarantineDocumentBytes(),
+        loadAttempts,
+      })
+    );
+  }
+
+  private async cancelAlarmForQuarantine(): Promise<void> {
+    await this.ctx.storage.deleteAlarm?.();
+  }
+
+  /**
+   * Enforces the quarantine data-safety invariant at the write functions rather
+   * than at the admin routes. A quarantined room never hydrated its persisted
+   * document, so its live doc is empty and every document write derived from it
+   * would destroy real data. Rebuilding the persisted document is just as
+   * dangerous: applying that update is the OOM this breaker exists to prevent.
+   */
+  private assertNotQuarantined(operation: string): void {
+    if (!this.isQuarantined()) return;
+    throw new Error(
+      `Refusing to ${operation} for quarantined room ${this.name}: the persisted document was never hydrated, so this would overwrite or reload data that is known to crash the room. Clear quarantine only after shrinking or repairing the document.`
+    );
+  }
+
+  async clearQuarantine(): Promise<void> {
+    this.quarantine = null;
+    await this.ctx.storage.delete(STORAGE_KEYS.quarantine);
+    await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+    console.log(
+      `[PartyServer] Quarantine cleared for room=${this.name}; the next load will attempt hydration again.`
+    );
+  }
+
+  getQuarantineStatusBody(loadAttempts: number) {
+    return createQuarantineStatusBody({
+      roomName: this.name,
+      quarantine: this.quarantine,
+      thresholdBytes: this.getQuarantineDocumentBytes(),
+      maxLoadAttempts: this.getQuarantineMaxLoadAttempts(),
+      loadAttempts,
+    });
+  }
+
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
     const limits = this.getServerLimits();
     const contentLength = request.headers.get("content-length");
@@ -543,6 +673,8 @@ export class PartyServer extends YServer {
   }
 
   private async saveDocumentBase64(documentBase64: string): Promise<void> {
+    this.assertNotQuarantined("persist document");
+
     const { error } = await supabase.from("documents").upsert(
       {
         name: this.name,
@@ -785,12 +917,19 @@ export class PartyServer extends YServer {
    */
   async restoreFromSnapshot(
     snapshotBase64: string,
-    options?: { bumpEpoch?: boolean }
+    options?: { bumpEpoch?: boolean; allowQuarantined?: boolean }
   ): Promise<{
     documentSize: number;
     resetEpoch: number;
     closedConnections: number;
   }> {
+    // Restoring an operator-supplied snapshot is the one write a quarantined
+    // room legitimately accepts, because it is how an oversized document gets
+    // repaired. Callers opt in explicitly so no other path inherits it.
+    if (!options?.allowQuarantined) {
+      this.assertNotQuarantined("restore a snapshot");
+    }
+
     const roomId = this.name;
     console.log(`[Restore Snapshot] Starting for room: ${roomId}`);
 
@@ -910,6 +1049,13 @@ export class PartyServer extends YServer {
   }
 
   private async scheduleNextAlarm(): Promise<void> {
+    // A quarantined room must not schedule work that wakes it up: every wake is
+    // another chance to retry the load that killed the isolate.
+    if (this.isQuarantined()) {
+      await this.cancelAlarmForQuarantine();
+      return;
+    }
+
     const now = Date.now();
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
@@ -1448,6 +1594,39 @@ export class PartyServer extends YServer {
   }
 
   override async onLoad(): Promise<void> {
+    // The crash-loop breaker and size gate both run before any hydration work.
+    // A room whose document OOMs the isolate never reaches the end of this
+    // method, so anything protective has to be durable before that point.
+    this.quarantine = await this.readStoredQuarantine();
+    if (this.quarantine !== null) {
+      await this.resumeQuarantine();
+      return;
+    }
+
+    const maxLoadAttempts = this.getQuarantineMaxLoadAttempts();
+    const previousAttempts = await this.getQuarantineLoadAttempts();
+    if (
+      shouldQuarantineForLoadAttempts({
+        loadAttempts: previousAttempts,
+        maxLoadAttempts,
+      })
+    ) {
+      await this.enterQuarantine({
+        reason: "crash-loop",
+        documentBytes: null,
+        loadAttempts: previousAttempts,
+      });
+      return;
+    }
+
+    // Durable BEFORE the risky work: if hydration kills the isolate, this
+    // increment survives and the next start counts it.
+    const loadAttempts = previousAttempts + 1;
+    await this.ctx.storage.put(
+      STORAGE_KEYS.quarantineLoadAttempts,
+      loadAttempts
+    );
+
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
     const query = supabase
@@ -1464,23 +1643,85 @@ export class PartyServer extends YServer {
     });
 
     if (result === null) {
+      // Supabase is unreachable, so hydration never ran. Roll the attempt back
+      // rather than zeroing it: a sub-threshold document that OOMs mid-hydration
+      // must still be able to accumulate evidence across an outage.
+      await this.releaseLoadAttempt(loadAttempts);
       return;
     }
 
     if (result.error) {
       this.enterTransientPersistenceMode(new Error(result.error.message));
+      await this.releaseLoadAttempt(loadAttempts);
       return;
     }
 
     this.markPersistenceAvailable();
 
     if (result.data) {
+      // Size gate. The download itself is safe; Y.applyUpdate is what OOMs the
+      // Durable Object, so the check sits between the two.
+      const documentBytes = result.data.document.length;
+      if (
+        shouldQuarantineForDocumentSize({
+          documentBytes,
+          thresholdBytes: this.getQuarantineDocumentBytes(),
+        })
+      ) {
+        await this.enterQuarantine({
+          reason: "document-size",
+          documentBytes,
+          loadAttempts,
+        });
+        return;
+      }
+
       this.markDocumentPersisted(result.data.document);
       Y.applyUpdate(
         this.document,
         new Uint8Array(Buffer.from(result.data.document, "base64"))
       );
     }
+
+    // Hydration completed without killing the isolate.
+    await this.clearLoadAttempts();
+  }
+
+  private async clearLoadAttempts(): Promise<void> {
+    await this.ctx.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+  }
+
+  // Undoes this start's increment when the load ended before hydration could be
+  // attempted. Attempts that DID reach hydration stay counted, so the crash-loop
+  // breaker keeps its evidence even if Supabase is flaky in between.
+  private async releaseLoadAttempt(loadAttempts: number): Promise<void> {
+    const remaining = loadAttempts - 1;
+    if (remaining <= 0) {
+      await this.clearLoadAttempts();
+      return;
+    }
+    await this.ctx.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
+  }
+
+  // A room that was already quarantined on a previous start re-enters transient
+  // mode without touching Supabase at all.
+  private async resumeQuarantine(): Promise<void> {
+    const quarantine = ensureExists(this.quarantine);
+    this.persistenceMode = {
+      kind: "transient",
+      reason: `room quarantined (${quarantine.reason})`,
+      failedAt: quarantine.quarantinedAt,
+    };
+    await this.cancelAlarmForQuarantine();
+    console.error(
+      formatQuarantineLog({
+        roomName: this.name,
+        reason: quarantine.reason,
+        documentBytes: quarantine.documentBytes,
+        thresholdBytes: this.getQuarantineDocumentBytes(),
+        loadAttempts: quarantine.loadAttempts,
+      })
+    );
   }
 
   override async onSave(): Promise<void> {
@@ -2092,6 +2333,11 @@ export class PartyServer extends YServer {
     resetEpoch: number;
     closedConnections: number;
   }> {
+    // A hard reset derives its new document from the live doc, which is empty
+    // for a quarantined room, and falls back to re-reading the persisted one.
+    // Both outcomes are exactly what quarantine exists to prevent.
+    this.assertNotQuarantined("hard reset");
+
     const roomId = this.name;
     console.log(`[Hard Reset] Starting for room: ${roomId}`);
 
@@ -2356,6 +2602,14 @@ export class PartyServer extends YServer {
 
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
+    if (this.isQuarantined()) {
+      console.warn(
+        `[PartyServer] Alarm skipped for quarantined room=${this.name}; canceling pending alarms.`
+      );
+      await this.cancelAlarmForQuarantine();
+      return;
+    }
+
     try {
       const compactAfter = await this.getEmptyRoomCompactAfter();
       if (compactAfter !== null && compactAfter <= Date.now()) {

--- a/partykit/quarantineControl.ts
+++ b/partykit/quarantineControl.ts
@@ -1,0 +1,44 @@
+// ABOUTME: Lists room quarantine flags from the Worker KV control plane.
+// ABOUTME: Keeps global admin reads independent from Durable Object hydration.
+const QUARANTINE_KEY_PREFIX = "quarantine:";
+
+export type QuarantinedRoomEntry = {
+  roomId: string;
+  detail: string;
+};
+
+export async function listQuarantinedRooms(
+  kv: KVNamespace
+): Promise<QuarantinedRoomEntry[]> {
+  const rooms: QuarantinedRoomEntry[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await kv.list({
+      prefix: QUARANTINE_KEY_PREFIX,
+      ...(cursor ? { cursor } : {}),
+    });
+    const pageRooms = await Promise.all(
+      page.keys.map(async ({ name }) => {
+        const detail = await kv.get(name);
+        if (detail === null) return null;
+
+        return {
+          roomId: name.slice(QUARANTINE_KEY_PREFIX.length),
+          detail,
+        };
+      })
+    );
+
+    rooms.push(
+      ...pageRooms.filter(
+        (room): room is QuarantinedRoomEntry => room !== null
+      )
+    );
+
+    if (page.list_complete) break;
+    cursor = page.cursor;
+  } while (cursor);
+
+  return rooms.sort((a, b) => a.roomId.localeCompare(b.roomId));
+}

--- a/partykit/quarantineControl.ts
+++ b/partykit/quarantineControl.ts
@@ -1,5 +1,7 @@
 // ABOUTME: Lists room quarantine flags from the Worker KV control plane.
 // ABOUTME: Keeps global admin reads independent from Durable Object hydration.
+import { getAdminAuthError } from "./adminAuth";
+
 const QUARANTINE_KEY_PREFIX = "quarantine:";
 
 export type QuarantinedRoomEntry = {
@@ -31,9 +33,7 @@ export async function listQuarantinedRooms(
     );
 
     rooms.push(
-      ...pageRooms.filter(
-        (room): room is QuarantinedRoomEntry => room !== null
-      )
+      ...pageRooms.filter((room): room is QuarantinedRoomEntry => room !== null)
     );
 
     if (page.list_complete) break;
@@ -41,4 +41,71 @@ export async function listQuarantinedRooms(
   } while (cursor);
 
   return rooms.sort((a, b) => a.roomId.localeCompare(b.roomId));
+}
+
+export async function handleQuarantineControlRequest(
+  request: Request,
+  {
+    adminToken,
+    quarantineControl,
+  }: {
+    adminToken: string | undefined;
+    quarantineControl: KVNamespace;
+  }
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (url.pathname !== "/admin/quarantines") return null;
+
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      },
+    });
+  }
+
+  if (request.method !== "GET") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: { Allow: "GET, OPTIONS" },
+    });
+  }
+
+  const authError = getAdminAuthError(request, adminToken);
+  if (authError) return authError;
+
+  try {
+    const rooms = await listQuarantinedRooms(quarantineControl);
+    return new Response(
+      JSON.stringify({
+        available: true,
+        count: rooms.length,
+        rooms,
+      }),
+      {
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  } catch (error) {
+    console.error("[PartyServer] Failed to list quarantined rooms:", error);
+    return new Response(
+      JSON.stringify({
+        available: false,
+        error: "Failed to read the quarantine control plane",
+      }),
+      {
+        status: 503,
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
 }

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -200,6 +200,8 @@ export function createQuarantineStatusBody({
   loadRetryAfter,
   alarmRetryAfter,
   compactionParkedBytes,
+  loadDeferredUntil = null,
+  externalFlag = { available: false },
 }: {
   roomName: string;
   quarantine: QuarantineState | null;
@@ -211,6 +213,8 @@ export function createQuarantineStatusBody({
   loadRetryAfter: number | null;
   alarmRetryAfter: number | null;
   compactionParkedBytes: number | null;
+  loadDeferredUntil?: number | null;
+  externalFlag?: { available: true; value: string | null } | { available: false };
 }) {
   return {
     roomId: roomName,
@@ -238,6 +242,20 @@ export function createQuarantineStatusBody({
       documentBytes: compactionParkedBytes,
       maxInDurableObjectBytes,
     },
+    // Whether this isolate is currently refusing requests, which can differ from
+    // the stored deadline after an in-place recovery.
+    loadDeferred: {
+      active: loadDeferredUntil !== null,
+      until:
+        loadDeferredUntil === null
+          ? null
+          : new Date(loadDeferredUntil).toISOString(),
+    },
+    // The pre-hydration flag. "kvUnavailable" means it could not be checked,
+    // which is not the same as no flag being set.
+    externalQuarantineFlag: externalFlag.available
+      ? externalFlag.value
+      : "kvUnavailable",
     documentWarningBytes,
   };
 }

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -1,32 +1,26 @@
-// ABOUTME: Decides when a room must skip hydration to avoid load-time OOM crash loops.
-// ABOUTME: Keeps quarantine reasons, counters, and operator logs deterministic and testable.
-export type QuarantineReason = "document-size" | "crash-loop";
+// ABOUTME: Decides how a room reacts to oversized documents and repeated OOM failures.
+// ABOUTME: Owns retry backoff, compaction skips, and the last-resort quarantine threshold.
+export type QuarantineReason = "manual" | "repeated-failures";
+
+// Which risky operation a failure counter tracks. Load and alarm failures are
+// counted separately because they fail for different reasons, and only the
+// alarm path can be rescheduled.
+export type FailureKind = "load" | "alarm";
 
 export type QuarantineState = {
   reason: QuarantineReason;
-  // Persisted document size in base64 bytes at the time quarantine was entered.
-  // Null when the crash-loop breaker fired before the document was measured.
-  documentBytes: number | null;
-  loadAttempts: number;
+  // Operator-supplied note for a manual quarantine, or the failing operation
+  // for an automatic one.
+  detail: string;
+  failureKind: FailureKind | null;
+  failureCount: number;
   quarantinedAt: number;
 };
 
-// A room is quarantined before hydration when a previous load never reported
-// success. The counter is written durably before hydration and cleared after,
-// so an isolate that dies inside Y.applyUpdate leaves the increment behind.
-export const DEFAULT_QUARANTINE_LOAD_ATTEMPTS = 3;
-
-export function shouldQuarantineForLoadAttempts({
-  loadAttempts,
-  maxLoadAttempts,
-}: {
-  loadAttempts: number;
-  maxLoadAttempts: number;
-}): boolean {
-  return loadAttempts >= maxLoadAttempts;
-}
-
-export function shouldQuarantineForDocumentSize({
+// Size alone never blocks a load or quarantines a room: healthy production rooms
+// live in the same size band as rooms that have OOMed. Oversized documents are
+// only reported, so they can be compacted before they become a problem.
+export function isDocumentOversized({
   documentBytes,
   thresholdBytes,
 }: {
@@ -36,61 +30,194 @@ export function shouldQuarantineForDocumentSize({
   return documentBytes > thresholdBytes;
 }
 
+// In-DO compaction holds the live doc, its JSON projection, and the rebuilt copy
+// at once, so its ceiling is far below the load ceiling. Above it, compaction is
+// doomed work: it would crash the isolate without producing a smaller document.
+export function isTooLargeToCompactInDurableObject({
+  documentBytes,
+  maxBytes,
+}: {
+  documentBytes: number;
+  maxBytes: number;
+}): boolean {
+  return documentBytes > maxBytes;
+}
+
+export function shouldQuarantineForFailures({
+  failureCount,
+  failureThreshold,
+}: {
+  failureCount: number;
+  failureThreshold: number;
+}): boolean {
+  return failureCount >= failureThreshold;
+}
+
+/**
+ * Exponential backoff for work that keeps failing. Cloudflare retries a failed
+ * alarm within seconds, which is what turns a single OOM into a permanent crash
+ * loop, so the alarm is rescheduled onto this ladder instead. A room whose
+ * failure was environmental (isolate co-tenancy, memory pressure) gets room to
+ * recover on its own.
+ */
+export function getFailureBackoffMs({
+  failureCount,
+  baseMs,
+  maxMs,
+}: {
+  failureCount: number;
+  baseMs: number;
+  maxMs: number;
+}): number {
+  if (failureCount <= 0) return 0;
+  // 1min, 5min, 20min, 1h, 6h against the default base, then doubling to the cap.
+  const ladder = [1, 5, 20, 60, 360];
+  const multiplier =
+    failureCount <= ladder.length
+      ? ladder[failureCount - 1]
+      : ladder[ladder.length - 1] * 2 ** (failureCount - ladder.length);
+  return Math.min(baseMs * multiplier, maxMs);
+}
+
+export function getFailureRetryAt({
+  failureCount,
+  baseMs,
+  maxMs,
+  now,
+}: {
+  failureCount: number;
+  baseMs: number;
+  maxMs: number;
+  now: number;
+}): number {
+  return now + getFailureBackoffMs({ failureCount, baseMs, maxMs });
+}
+
+export function isRetryDue({
+  retryAfter,
+  now,
+}: {
+  retryAfter: number | null;
+  now: number;
+}): boolean {
+  return retryAfter === null || retryAfter <= now;
+}
+
+export function formatCompactionSkipLog({
+  roomName,
+  documentBytes,
+  maxBytes,
+}: {
+  roomName: string;
+  documentBytes: number;
+  maxBytes: number;
+}): string {
+  return [
+    `[PartyServer] ROOM REQUIRES EXTERNAL COMPACTION: room=${roomName}`,
+    `documentBytes=${documentBytes}`,
+    `maxInDurableObjectBytes=${maxBytes}`,
+    "Compacting this document inside the room would rebuild it in memory and crash the room, so in-DO compaction is disabled for it and the compaction schedule is parked.",
+    "The room still loads and runs normally; only automatic shrinking is off.",
+    `To recover: GET admin/raw-data for room=${roomName}, compact the document offline, then POST admin/restore-raw-document.`,
+  ].join(" ");
+}
+
+export function formatFailureBackoffLog({
+  roomName,
+  failureKind,
+  failureCount,
+  retryAt,
+  failureThreshold,
+}: {
+  roomName: string;
+  failureKind: FailureKind;
+  failureCount: number;
+  retryAt: number;
+  failureThreshold: number;
+}): string {
+  return [
+    `[PartyServer] ROOM WORK FAILING: room=${roomName}`,
+    `operation=${failureKind}`,
+    `consecutiveFailures=${failureCount}`,
+    `retryAt=${new Date(retryAt).toISOString()}`,
+    `quarantineAfter=${failureThreshold}`,
+    "The previous attempt started and never completed, most likely an out-of-memory crash. Retries are backing off instead of looping.",
+    "This clears itself if the next attempt succeeds.",
+  ].join(" ");
+}
+
 export function formatQuarantineLog({
   roomName,
   reason,
-  documentBytes,
-  thresholdBytes,
-  loadAttempts,
+  detail,
+  failureKind,
+  failureCount,
 }: {
   roomName: string;
   reason: QuarantineReason;
-  documentBytes: number | null;
-  thresholdBytes: number;
-  loadAttempts: number;
+  detail: string;
+  failureKind: FailureKind | null;
+  failureCount: number;
 }): string {
   const cause =
-    reason === "document-size"
-      ? `persisted document is too large to hydrate (documentBytes=${documentBytes}, thresholdBytes=${thresholdBytes})`
-      : `hydration failed ${loadAttempts} times without completing, so loading it again would keep crashing the isolate`;
+    reason === "manual"
+      ? `an operator quarantined it (${detail})`
+      : `${failureKind} work failed ${failureCount} times in a row and exhausted the retry backoff, so the room cannot recover on its own`;
 
   return [
     `[PartyServer] ROOM QUARANTINED: room=${roomName}`,
     `reason=${reason}`,
-    `documentBytes=${documentBytes ?? "unknown"}`,
-    `thresholdBytes=${thresholdBytes}`,
-    `loadAttempts=${loadAttempts}`,
+    `operation=${failureKind ?? "none"}`,
+    `consecutiveFailures=${failureCount}`,
     `cause=${cause}.`,
-    "The persisted document was NOT loaded and will NOT be overwritten.",
-    "Entering TRANSIENT MODE: visitors sync live with each other, nothing persists, alarms are canceled.",
-    `To recover: shrink or repair the persisted document, then POST admin/quarantine-clear for room=${roomName}.`,
+    "The persisted document is NOT loaded and will NOT be overwritten.",
+    "The room runs in TRANSIENT MODE: visitors sync live with each other, nothing persists, alarms are parked.",
+    `To recover: repair or shrink the document (GET admin/raw-data, compact offline, POST admin/restore-raw-document), then POST admin/quarantine-clear for room=${roomName}.`,
   ].join(" ");
 }
 
 export function createQuarantineStatusBody({
   roomName,
   quarantine,
-  thresholdBytes,
-  maxLoadAttempts,
-  loadAttempts,
+  documentWarningBytes,
+  maxInDurableObjectBytes,
+  failureThreshold,
+  loadFailures,
+  alarmFailures,
+  retryAfter,
+  compactionParkedBytes,
 }: {
   roomName: string;
   quarantine: QuarantineState | null;
-  thresholdBytes: number;
-  maxLoadAttempts: number;
-  loadAttempts: number;
+  documentWarningBytes: number;
+  maxInDurableObjectBytes: number;
+  failureThreshold: number;
+  loadFailures: number;
+  alarmFailures: number;
+  retryAfter: number | null;
+  compactionParkedBytes: number | null;
 }) {
   return {
     roomId: roomName,
     quarantined: quarantine !== null,
     reason: quarantine?.reason ?? null,
-    documentBytes: quarantine?.documentBytes ?? null,
+    detail: quarantine?.detail ?? null,
     quarantinedAt:
       quarantine === null
         ? null
         : new Date(quarantine.quarantinedAt).toISOString(),
-    loadAttempts,
-    thresholdBytes,
-    maxLoadAttempts,
+    failures: {
+      load: loadFailures,
+      alarm: alarmFailures,
+      quarantineAfter: failureThreshold,
+      retryAfter:
+        retryAfter === null ? null : new Date(retryAfter).toISOString(),
+    },
+    compaction: {
+      parked: compactionParkedBytes !== null,
+      documentBytes: compactionParkedBytes,
+      maxInDurableObjectBytes,
+    },
+    documentWarningBytes,
   };
 }

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -184,7 +184,8 @@ export function createQuarantineStatusBody({
   failureThreshold,
   loadFailures,
   alarmFailures,
-  retryAfter,
+  loadRetryAfter,
+  alarmRetryAfter,
   compactionParkedBytes,
 }: {
   roomName: string;
@@ -194,7 +195,8 @@ export function createQuarantineStatusBody({
   failureThreshold: number;
   loadFailures: number;
   alarmFailures: number;
-  retryAfter: number | null;
+  loadRetryAfter: number | null;
+  alarmRetryAfter: number | null;
   compactionParkedBytes: number | null;
 }) {
   return {
@@ -210,8 +212,13 @@ export function createQuarantineStatusBody({
       load: loadFailures,
       alarm: alarmFailures,
       quarantineAfter: failureThreshold,
-      retryAfter:
-        retryAfter === null ? null : new Date(retryAfter).toISOString(),
+      // Separate deadlines: a healthy load must not imply the alarm is healthy.
+      loadRetryAfter:
+        loadRetryAfter === null ? null : new Date(loadRetryAfter).toISOString(),
+      alarmRetryAfter:
+        alarmRetryAfter === null
+          ? null
+          : new Date(alarmRetryAfter).toISOString(),
     },
     compaction: {
       parked: compactionParkedBytes !== null,

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Decides how a room reacts to oversized documents and repeated OOM failures.
-// ABOUTME: Owns retry backoff, compaction skips, and the last-resort quarantine threshold.
+// ABOUTME: Decides how a room reacts to repeated load, alarm, and compaction failures.
+// ABOUTME: Owns retry backoff and last-resort failure thresholds.
 export type QuarantineReason = "manual" | "repeated-failures";
 
 // Which risky operation a failure counter tracks. Load and alarm failures are
@@ -17,19 +17,6 @@ export type QuarantineState = {
   quarantinedAt: number;
 };
 
-export class ExternalCompactionRequiredError extends Error {
-  constructor(
-    public readonly documentBytes: number,
-    public readonly maxBytes: number
-  ) {
-    super(
-      `Document is too large to compact safely in the room: ` +
-        `${documentBytes} bytes exceeds the ${maxBytes} byte limit`
-    );
-    this.name = "ExternalCompactionRequiredError";
-  }
-}
-
 // Size alone never blocks a load or quarantines a room: healthy production rooms
 // live in the same size band as rooms that have OOMed. Oversized documents are
 // only reported, so they can be compacted before they become a problem.
@@ -41,19 +28,6 @@ export function isDocumentOversized({
   thresholdBytes: number;
 }): boolean {
   return documentBytes > thresholdBytes;
-}
-
-// In-DO compaction holds the live doc, its JSON projection, and the rebuilt copy
-// at once, so its ceiling is far below the load ceiling. Above it, compaction is
-// doomed work: it would crash the isolate without producing a smaller document.
-export function isTooLargeToCompactInDurableObject({
-  documentBytes,
-  maxBytes,
-}: {
-  documentBytes: number;
-  maxBytes: number;
-}): boolean {
-  return documentBytes > maxBytes;
 }
 
 export function shouldQuarantineForFailures({
@@ -116,22 +90,56 @@ export function isRetryDue({
   return retryAfter === null || retryAfter <= now;
 }
 
-export function formatCompactionSkipLog({
+export function getCompactionRetryDelayMs({
+  failureCount,
+  retryDelaysMs,
+}: {
+  failureCount: number;
+  retryDelaysMs: readonly number[];
+}): number | null {
+  return retryDelaysMs[failureCount - 1] ?? null;
+}
+
+export function shouldDisableCompaction({
+  failureCount,
+  disableAfter,
+}: {
+  failureCount: number;
+  disableAfter: number;
+}): boolean {
+  return failureCount >= disableAfter;
+}
+
+export function formatCompactionBackoffLog({
   roomName,
-  documentBytes,
-  maxBytes,
+  failureCount,
+  retryAt,
 }: {
   roomName: string;
-  documentBytes: number;
-  maxBytes: number;
+  failureCount: number;
+  retryAt: number;
 }): string {
   return [
-    `[PartyServer] ROOM REQUIRES EXTERNAL COMPACTION: room=${roomName}`,
-    `documentBytes=${documentBytes}`,
-    `maxInDurableObjectBytes=${maxBytes}`,
-    "Compacting this document inside the room would rebuild it in memory and crash the room, so in-DO compaction is disabled for it and the compaction schedule is parked.",
-    "The room still loads and runs normally; only automatic shrinking is off.",
-    `To recover: GET admin/raw-data for room=${roomName}, compact the document offline, then POST admin/restore-raw-document.`,
+    `[PartyServer] AUTOMATIC COMPACTION BACKOFF: room=${roomName}`,
+    `vanishedAttempts=${failureCount}`,
+    `retryAt=${new Date(retryAt).toISOString()}`,
+    "The previous compaction started but never completed, most likely because the isolate ran out of memory.",
+    "The room continues loading, syncing, and persisting normally while compaction waits.",
+  ].join(" ");
+}
+
+export function formatCompactionDisabledLog({
+  roomName,
+  failureCount,
+}: {
+  roomName: string;
+  failureCount: number;
+}): string {
+  return [
+    `[PartyServer] AUTOMATIC COMPACTION DISABLED: room=${roomName}`,
+    `vanishedAttempts=${failureCount}`,
+    "Compaction vanished three times in a row, so automatic compaction is disabled without affecting room service or persistence.",
+    `To retry: POST admin/compaction-retry for room=${roomName}.`,
   ].join(" ");
 }
 
@@ -193,26 +201,30 @@ export function createQuarantineStatusBody({
   roomName,
   quarantine,
   documentWarningBytes,
-  maxInDurableObjectBytes,
   failureThreshold,
   loadFailures,
   alarmFailures,
   loadRetryAfter,
   alarmRetryAfter,
-  compactionParkedBytes,
+  compactionFailures,
+  compactionRetryAfter,
+  compactionDisabledAt,
+  compactionDisableAfter,
   loadDeferredUntil = null,
   externalFlag = { available: false },
 }: {
   roomName: string;
   quarantine: QuarantineState | null;
   documentWarningBytes: number;
-  maxInDurableObjectBytes: number;
   failureThreshold: number;
   loadFailures: number;
   alarmFailures: number;
   loadRetryAfter: number | null;
   alarmRetryAfter: number | null;
-  compactionParkedBytes: number | null;
+  compactionFailures: number;
+  compactionRetryAfter: number | null;
+  compactionDisabledAt: number | null;
+  compactionDisableAfter: number;
   loadDeferredUntil?: number | null;
   externalFlag?: { available: true; value: string | null } | { available: false };
 }) {
@@ -238,9 +250,17 @@ export function createQuarantineStatusBody({
           : new Date(alarmRetryAfter).toISOString(),
     },
     compaction: {
-      parked: compactionParkedBytes !== null,
-      documentBytes: compactionParkedBytes,
-      maxInDurableObjectBytes,
+      disabled: compactionDisabledAt !== null,
+      disabledAt:
+        compactionDisabledAt === null
+          ? null
+          : new Date(compactionDisabledAt).toISOString(),
+      failures: compactionFailures,
+      disableAfter: compactionDisableAfter,
+      retryAfter:
+        compactionRetryAfter === null
+          ? null
+          : new Date(compactionRetryAfter).toISOString(),
     },
     // Whether this isolate is currently refusing requests, which can differ from
     // the stored deadline after an in-place recovery.

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Decides when a room must skip hydration to avoid load-time OOM crash loops.
+// ABOUTME: Keeps quarantine reasons, counters, and operator logs deterministic and testable.
+export type QuarantineReason = "document-size" | "crash-loop";
+
+export type QuarantineState = {
+  reason: QuarantineReason;
+  // Persisted document size in base64 bytes at the time quarantine was entered.
+  // Null when the crash-loop breaker fired before the document was measured.
+  documentBytes: number | null;
+  loadAttempts: number;
+  quarantinedAt: number;
+};
+
+// A room is quarantined before hydration when a previous load never reported
+// success. The counter is written durably before hydration and cleared after,
+// so an isolate that dies inside Y.applyUpdate leaves the increment behind.
+export const DEFAULT_QUARANTINE_LOAD_ATTEMPTS = 3;
+
+export function shouldQuarantineForLoadAttempts({
+  loadAttempts,
+  maxLoadAttempts,
+}: {
+  loadAttempts: number;
+  maxLoadAttempts: number;
+}): boolean {
+  return loadAttempts >= maxLoadAttempts;
+}
+
+export function shouldQuarantineForDocumentSize({
+  documentBytes,
+  thresholdBytes,
+}: {
+  documentBytes: number;
+  thresholdBytes: number;
+}): boolean {
+  return documentBytes > thresholdBytes;
+}
+
+export function formatQuarantineLog({
+  roomName,
+  reason,
+  documentBytes,
+  thresholdBytes,
+  loadAttempts,
+}: {
+  roomName: string;
+  reason: QuarantineReason;
+  documentBytes: number | null;
+  thresholdBytes: number;
+  loadAttempts: number;
+}): string {
+  const cause =
+    reason === "document-size"
+      ? `persisted document is too large to hydrate (documentBytes=${documentBytes}, thresholdBytes=${thresholdBytes})`
+      : `hydration failed ${loadAttempts} times without completing, so loading it again would keep crashing the isolate`;
+
+  return [
+    `[PartyServer] ROOM QUARANTINED: room=${roomName}`,
+    `reason=${reason}`,
+    `documentBytes=${documentBytes ?? "unknown"}`,
+    `thresholdBytes=${thresholdBytes}`,
+    `loadAttempts=${loadAttempts}`,
+    `cause=${cause}.`,
+    "The persisted document was NOT loaded and will NOT be overwritten.",
+    "Entering TRANSIENT MODE: visitors sync live with each other, nothing persists, alarms are canceled.",
+    `To recover: shrink or repair the persisted document, then POST admin/quarantine-clear for room=${roomName}.`,
+  ].join(" ");
+}
+
+export function createQuarantineStatusBody({
+  roomName,
+  quarantine,
+  thresholdBytes,
+  maxLoadAttempts,
+  loadAttempts,
+}: {
+  roomName: string;
+  quarantine: QuarantineState | null;
+  thresholdBytes: number;
+  maxLoadAttempts: number;
+  loadAttempts: number;
+}) {
+  return {
+    roomId: roomName,
+    quarantined: quarantine !== null,
+    reason: quarantine?.reason ?? null,
+    documentBytes: quarantine?.documentBytes ?? null,
+    quarantinedAt:
+      quarantine === null
+        ? null
+        : new Date(quarantine.quarantinedAt).toISOString(),
+    loadAttempts,
+    thresholdBytes,
+    maxLoadAttempts,
+  };
+}

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -17,6 +17,19 @@ export type QuarantineState = {
   quarantinedAt: number;
 };
 
+export class ExternalCompactionRequiredError extends Error {
+  constructor(
+    public readonly documentBytes: number,
+    public readonly maxBytes: number
+  ) {
+    super(
+      `Document is too large to compact safely in the room: ` +
+        `${documentBytes} bytes exceeds the ${maxBytes} byte limit`
+    );
+    this.name = "ExternalCompactionRequiredError";
+  }
+}
+
 // Size alone never blocks a load or quarantines a room: healthy production rooms
 // live in the same size band as rooms that have OOMed. Oversized documents are
 // only reported, so they can be compacted before they become a problem.

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -1,0 +1,675 @@
+// ABOUTME: Owns room quarantine, retry backoff, and compaction parking state.
+// ABOUTME: Keeps failure recovery policy separate from PartyServer synchronization.
+import { STORAGE_KEYS } from "./const";
+import { getErrorMessage } from "./persistenceMode";
+import {
+  createQuarantineStatusBody,
+  ExternalCompactionRequiredError,
+  formatCompactionSkipLog,
+  formatFailureBackoffLog,
+  formatQuarantineLog,
+  getFailureRetryAt,
+  isRetryDue,
+  isTooLargeToCompactInDurableObject,
+  shouldQuarantineForFailures,
+  type FailureKind,
+  type QuarantineReason,
+  type QuarantineState,
+} from "./quarantinePolicy";
+
+type RoomStorage = {
+  get(key: string): Promise<unknown>;
+  put(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<unknown>;
+  setAlarm?(scheduledTime: number | Date): Promise<void>;
+  deleteAlarm?(): Promise<void>;
+};
+
+type RoomCircuitBreakerOptions = {
+  roomName: string;
+  storage: RoomStorage;
+  getQuarantineControl: () => KVNamespace | null;
+  readPositiveNumber: (name: string, fallback: number) => number;
+  defaults: {
+    documentWarningBytes: number;
+    maxInDurableObjectBytes: number;
+    failureThreshold: number;
+    failureBackoffMs: number;
+    failureBackoffMaxMs: number;
+  };
+  activateTransientPersistence: (quarantine: QuarantineState) => void;
+  startRealtimeSync: () => Promise<void>;
+  reloadRoom: () => Promise<boolean>;
+  prepareGuardedReload: () => void;
+  clearCompactionSchedule: () => Promise<void>;
+};
+
+export type EnterQuarantineOptions = {
+  reason: QuarantineReason;
+  detail: string;
+  failureKind: FailureKind | null;
+  failureCount: number;
+  skipExternalWrite?: boolean;
+};
+
+export type QuarantineResetSummary = {
+  wasQuarantined: boolean;
+  loadFailures: number;
+  alarmFailures: number;
+  wasLoadDeferred: boolean;
+};
+
+export class RoomCircuitBreaker {
+  private quarantine: QuarantineState | null = null;
+  private compactionTooLargeBytes: number | null = null;
+  private loadDeferredUntil: number | null = null;
+  private hasLoggedQuarantine = false;
+  private inFlightReload: Promise<boolean> | null = null;
+
+  constructor(private options: RoomCircuitBreakerOptions) {}
+
+  private get roomName(): string {
+    return this.options.roomName;
+  }
+
+  private get storage(): RoomStorage {
+    return this.options.storage;
+  }
+
+  getDocumentWarningBytes(): number {
+    return this.options.readPositiveNumber(
+      "QUARANTINE_DOCUMENT_BYTES",
+      this.options.defaults.documentWarningBytes
+    );
+  }
+
+  getCompactionMaxInDurableObjectBytes(): number {
+    return this.options.readPositiveNumber(
+      "COMPACTION_MAX_IN_DO_BYTES",
+      this.options.defaults.maxInDurableObjectBytes
+    );
+  }
+
+  private getFailureThreshold(): number {
+    return this.options.readPositiveNumber(
+      "QUARANTINE_FAILURE_THRESHOLD",
+      this.options.defaults.failureThreshold
+    );
+  }
+
+  private getFailureBackoffBaseMs(): number {
+    return this.options.readPositiveNumber(
+      "FAILURE_BACKOFF_MS",
+      this.options.defaults.failureBackoffMs
+    );
+  }
+
+  private getFailureBackoffMaxMs(): number {
+    return this.options.readPositiveNumber(
+      "FAILURE_BACKOFF_MAX_MS",
+      this.options.defaults.failureBackoffMaxMs
+    );
+  }
+
+  isQuarantined(): boolean {
+    return this.quarantine !== null;
+  }
+
+  getQuarantineState(): QuarantineState | null {
+    return this.quarantine;
+  }
+
+  isLoadDeferred(): boolean {
+    return this.loadDeferredUntil !== null;
+  }
+
+  setLoadDeferredUntil(retryAt: number | null): void {
+    this.loadDeferredUntil = retryAt;
+  }
+
+  private failureKeyFor(kind: FailureKind): string {
+    return kind === "load"
+      ? STORAGE_KEYS.quarantineLoadAttempts
+      : STORAGE_KEYS.alarmFailureAttempts;
+  }
+
+  private retryKeyFor(kind: FailureKind): string {
+    return kind === "load"
+      ? STORAGE_KEYS.loadRetryAfter
+      : STORAGE_KEYS.alarmRetryAfter;
+  }
+
+  async getFailureCount(kind: FailureKind): Promise<number> {
+    const value = await this.storage.get(this.failureKeyFor(kind));
+    return typeof value === "number" ? value : 0;
+  }
+
+  async getFailureRetryAfter(kind: FailureKind): Promise<number | null> {
+    const value = await this.storage.get(this.retryKeyFor(kind));
+    return typeof value === "number" ? value : null;
+  }
+
+  async getCompactionParkedBytes(): Promise<number | null> {
+    const value = await this.storage.get(STORAGE_KEYS.compactionParked);
+    return typeof value === "number" ? value : null;
+  }
+
+  /**
+   * Records that risky work is starting before the operation can kill the
+   * isolate. A successful or observed failure clears this evidence.
+   */
+  async beginRiskyOperation(kind: FailureKind): Promise<number> {
+    const attempt = (await this.getFailureCount(kind)) + 1;
+    await this.storage.put(this.failureKeyFor(kind), attempt);
+    return attempt;
+  }
+
+  async completeRiskyOperation(kind: FailureKind): Promise<void> {
+    await this.storage.delete(this.failureKeyFor(kind));
+    await this.storage.delete(this.retryKeyFor(kind));
+  }
+
+  async releaseLoadAttempt(loadAttempts: number): Promise<void> {
+    const remaining = loadAttempts - 1;
+    if (remaining <= 0) {
+      await this.completeRiskyOperation("load");
+      return;
+    }
+
+    await this.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
+    await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
+  }
+
+  private async handleRepeatedFailures({
+    kind,
+    failureCount,
+    retryFailureCount = failureCount,
+  }: {
+    kind: FailureKind;
+    failureCount: number;
+    retryFailureCount?: number;
+  }): Promise<{ quarantined: boolean; retryAt: number }> {
+    const failureThreshold = this.getFailureThreshold();
+
+    if (shouldQuarantineForFailures({ failureCount, failureThreshold })) {
+      await this.enterQuarantine({
+        reason: "repeated-failures",
+        detail: `${kind} work failed ${failureCount} times in a row`,
+        failureKind: kind,
+        failureCount,
+      });
+      return { quarantined: true, retryAt: 0 };
+    }
+
+    const retryAt = getFailureRetryAt({
+      failureCount: retryFailureCount,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.storage.put(this.retryKeyFor(kind), retryAt);
+
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.roomName,
+        failureKind: kind,
+        failureCount,
+        retryAt,
+        failureThreshold,
+      })
+    );
+
+    return { quarantined: false, retryAt };
+  }
+
+  async shouldDeferLoad(): Promise<boolean> {
+    const previousFailures = await this.getFailureCount("load");
+    if (previousFailures === 0) return false;
+
+    const failureThreshold = this.getFailureThreshold();
+    if (
+      shouldQuarantineForFailures({
+        failureCount: previousFailures,
+        failureThreshold,
+      })
+    ) {
+      await this.enterQuarantine({
+        reason: "repeated-failures",
+        detail: `load work failed ${previousFailures} times in a row`,
+        failureKind: "load",
+        failureCount: previousFailures,
+      });
+      return true;
+    }
+
+    const retryAfter = await this.getFailureRetryAfter("load");
+    if (retryAfter === null) {
+      const firstRetryAt = getFailureRetryAt({
+        failureCount: previousFailures,
+        baseMs: this.getFailureBackoffBaseMs(),
+        maxMs: this.getFailureBackoffMaxMs(),
+        now: Date.now(),
+      });
+      await this.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
+      this.deferLoad(firstRetryAt, previousFailures);
+      return true;
+    }
+
+    if (!isRetryDue({ retryAfter, now: Date.now() })) {
+      this.deferLoad(retryAfter, previousFailures);
+      return true;
+    }
+
+    const nextRetryAt = getFailureRetryAt({
+      failureCount: previousFailures + 1,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
+
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.roomName,
+        failureKind: "load",
+        failureCount: previousFailures,
+        retryAt: nextRetryAt,
+        failureThreshold,
+      }) + " Attempting hydration now."
+    );
+    return false;
+  }
+
+  private deferLoad(retryAt: number, failureCount: number): void {
+    this.loadDeferredUntil = retryAt;
+    console.error(
+      formatFailureBackoffLog({
+        roomName: this.roomName,
+        failureKind: "load",
+        failureCount,
+        retryAt,
+        failureThreshold: this.getFailureThreshold(),
+      }) + " Serving 503 until the deadline; the document was not read."
+    );
+  }
+
+  async loadStoredQuarantine(): Promise<void> {
+    const value = await this.storage.get(STORAGE_KEYS.quarantine);
+    this.quarantine = (value as QuarantineState | undefined) ?? null;
+  }
+
+  async enterQuarantine({
+    reason,
+    detail,
+    failureKind,
+    failureCount,
+    skipExternalWrite = false,
+  }: EnterQuarantineOptions): Promise<void> {
+    const quarantine: QuarantineState = {
+      reason,
+      detail,
+      failureKind,
+      failureCount,
+      quarantinedAt: Date.now(),
+    };
+    this.quarantine = quarantine;
+    await this.storage.put(STORAGE_KEYS.quarantine, quarantine);
+
+    await this.enterQuarantineRuntimeState();
+
+    if (!skipExternalWrite) {
+      await this.writeExternalQuarantineFlag(detail);
+    }
+
+    await this.options.startRealtimeSync();
+  }
+
+  async enterQuarantineRuntimeState(): Promise<void> {
+    const quarantine = this.quarantine;
+    if (quarantine === null) {
+      throw new Error(
+        "Cannot enter quarantine runtime state without a quarantine"
+      );
+    }
+
+    this.options.activateTransientPersistence(quarantine);
+    this.loadDeferredUntil = null;
+    await this.cancelAlarm();
+
+    if (this.hasLoggedQuarantine) return;
+    this.hasLoggedQuarantine = true;
+    console.error(
+      formatQuarantineLog({
+        roomName: this.roomName,
+        reason: quarantine.reason,
+        detail: quarantine.detail,
+        failureKind: quarantine.failureKind,
+        failureCount: quarantine.failureCount,
+      })
+    );
+  }
+
+  async cancelAlarm(): Promise<void> {
+    await this.storage.deleteAlarm?.();
+  }
+
+  private getQuarantineControlKey(): string {
+    return `quarantine:${this.roomName}`;
+  }
+
+  async applyExternalQuarantineFlag(): Promise<void> {
+    const kv = this.options.getQuarantineControl();
+    if (kv === null) return;
+
+    let flag: string | null;
+    try {
+      flag = await kv.get(this.getQuarantineControlKey());
+    } catch (error) {
+      console.warn(
+        `[PartyServer] Quarantine control lookup failed for room=${this.roomName}; proceeding normally. ` +
+          `reason=${getErrorMessage(error)}`
+      );
+      return;
+    }
+
+    if (flag === null) return;
+
+    await this.enterQuarantine({
+      reason: "manual",
+      detail: flag || "no reason given",
+      failureKind: null,
+      failureCount: 0,
+      skipExternalWrite: true,
+    });
+  }
+
+  private async writeExternalQuarantineFlag(
+    detail: string | null
+  ): Promise<void> {
+    const kv = this.options.getQuarantineControl();
+    if (kv === null) return;
+
+    const key = this.getQuarantineControlKey();
+    try {
+      if (detail === null) {
+        await kv.delete(key);
+      } else {
+        await kv.put(key, detail);
+      }
+    } catch (error) {
+      console.error(
+        `[PartyServer] Quarantine control write FAILED for room=${this.roomName}; ` +
+          `the pre-hydration flag is NOT set and will not survive a restart. ` +
+          `reason=${getErrorMessage(error)}`
+      );
+      throw error;
+    }
+  }
+
+  async getLoadDeferredResponse(): Promise<Response | null> {
+    if (this.loadDeferredUntil === null) return null;
+
+    if (Date.now() >= this.loadDeferredUntil) {
+      const recovered = await this.attemptDeferredReload();
+      if (recovered) return null;
+    }
+
+    if (this.loadDeferredUntil === null) return null;
+
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((this.loadDeferredUntil - Date.now()) / 1000)
+    );
+
+    return new Response(
+      JSON.stringify({
+        error: "room_load_deferred",
+        message:
+          "This room failed to load and is waiting before trying again. Its data is intact and was not read or modified.",
+        roomId: this.roomName,
+        retryAfterSeconds,
+        retryAt: new Date(this.loadDeferredUntil).toISOString(),
+      }),
+      {
+        status: 503,
+        headers: {
+          "content-type": "application/json",
+          "retry-after": String(retryAfterSeconds),
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
+
+  private async attemptDeferredReload(): Promise<boolean> {
+    if (this.inFlightReload) return this.inFlightReload;
+
+    const attempt = (async () => {
+      try {
+        const previousFailures = await this.getFailureCount("load");
+        const failureThreshold = this.getFailureThreshold();
+
+        if (
+          shouldQuarantineForFailures({
+            failureCount: previousFailures,
+            failureThreshold,
+          })
+        ) {
+          await this.enterQuarantine({
+            reason: "repeated-failures",
+            detail: `load work failed ${previousFailures} times in a row`,
+            failureKind: "load",
+            failureCount: previousFailures,
+          });
+          this.loadDeferredUntil = null;
+          return false;
+        }
+
+        const nextRetryAt = getFailureRetryAt({
+          failureCount: previousFailures + 1,
+          baseMs: this.getFailureBackoffBaseMs(),
+          maxMs: this.getFailureBackoffMaxMs(),
+          now: Date.now(),
+        });
+        await this.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
+
+        if (previousFailures === 0) {
+          console.log(
+            `[PartyServer] Starting guarded hydration after quarantine clear: room=${this.roomName}`
+          );
+        } else {
+          console.error(
+            formatFailureBackoffLog({
+              roomName: this.roomName,
+              failureKind: "load",
+              failureCount: previousFailures,
+              retryAt: nextRetryAt,
+              failureThreshold,
+            }) + " Retrying hydration in place now."
+          );
+        }
+
+        this.loadDeferredUntil = null;
+        const recovered = await this.options.reloadRoom();
+        if (recovered) {
+          console.log(
+            `[PartyServer] Room recovered after deferral: room=${this.roomName}`
+          );
+          return true;
+        }
+
+        this.loadDeferredUntil = nextRetryAt;
+        return false;
+      } catch (error) {
+        console.error(
+          `[PartyServer] Deferred reload failed for room=${this.roomName}:`,
+          error
+        );
+        this.loadDeferredUntil = await this.getFailureRetryAfter("load");
+        return false;
+      } finally {
+        this.inFlightReload = null;
+      }
+    })();
+
+    this.inFlightReload = attempt;
+    return attempt;
+  }
+
+  markCompactionTooLarge(documentBytes: number): void {
+    this.compactionTooLargeBytes = documentBytes;
+  }
+
+  async parkCompactionIfTooLarge(): Promise<boolean> {
+    const documentBytes = this.compactionTooLargeBytes;
+    this.compactionTooLargeBytes = null;
+    if (documentBytes === null) return false;
+
+    const alreadyParked = await this.getCompactionParkedBytes();
+    await this.storage.put(STORAGE_KEYS.compactionParked, documentBytes);
+    await this.options.clearCompactionSchedule();
+
+    if (alreadyParked === null) {
+      console.error(
+        formatCompactionSkipLog({
+          roomName: this.roomName,
+          documentBytes,
+          maxBytes: this.getCompactionMaxInDurableObjectBytes(),
+        })
+      );
+    }
+    return true;
+  }
+
+  async assertCanCompactDocument(documentBytes: number): Promise<void> {
+    const maxBytes = this.getCompactionMaxInDurableObjectBytes();
+    if (
+      !isTooLargeToCompactInDurableObject({
+        documentBytes,
+        maxBytes,
+      })
+    ) {
+      return;
+    }
+
+    this.compactionTooLargeBytes = documentBytes;
+    await this.parkCompactionIfTooLarge();
+    throw new ExternalCompactionRequiredError(documentBytes, maxBytes);
+  }
+
+  assertNotQuarantined(operation: string): void {
+    if (!this.isQuarantined()) return;
+    throw new Error(
+      `Refusing to ${operation} for quarantined room ${this.roomName}: the persisted document was never hydrated, so this would overwrite or reload data that is known to crash the room. Clear quarantine only after shrinking or repairing the document.`
+    );
+  }
+
+  async clearQuarantine(): Promise<QuarantineResetSummary> {
+    const summary = {
+      wasQuarantined: this.quarantine !== null,
+      loadFailures: await this.getFailureCount("load"),
+      alarmFailures: await this.getFailureCount("alarm"),
+      wasLoadDeferred: this.loadDeferredUntil !== null,
+    };
+    const needsGuardedReload =
+      summary.wasQuarantined || summary.wasLoadDeferred;
+
+    await this.writeExternalQuarantineFlag(null);
+
+    this.quarantine = null;
+    this.hasLoggedQuarantine = false;
+    this.options.prepareGuardedReload();
+    this.loadDeferredUntil = needsGuardedReload ? Date.now() : null;
+    await this.storage.delete(STORAGE_KEYS.quarantine);
+    await this.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+    await this.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
+    await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
+    await this.storage.delete(STORAGE_KEYS.alarmRetryAfter);
+    console.log(
+      `[PartyServer] Quarantine cleared for room=${this.roomName}: ` +
+        `wasQuarantined=${summary.wasQuarantined}, ` +
+        `loadFailuresReset=${summary.loadFailures}, ` +
+        `alarmFailuresReset=${summary.alarmFailures}, ` +
+        `wasLoadDeferred=${summary.wasLoadDeferred}, ` +
+        `recoveryPending=${needsGuardedReload}.`
+    );
+    return summary;
+  }
+
+  async clearCompactionPark(): Promise<void> {
+    await this.storage.delete(STORAGE_KEYS.compactionParked);
+  }
+
+  async readExternalQuarantineFlag(): Promise<
+    { available: true; value: string | null } | { available: false }
+  > {
+    const kv = this.options.getQuarantineControl();
+    if (kv === null) return { available: false };
+    try {
+      return {
+        available: true,
+        value: await kv.get(this.getQuarantineControlKey()),
+      };
+    } catch {
+      return { available: false };
+    }
+  }
+
+  hasQuarantineControlPlane(): boolean {
+    return this.options.getQuarantineControl() !== null;
+  }
+
+  async getQuarantineStatusBody() {
+    return createQuarantineStatusBody({
+      roomName: this.roomName,
+      quarantine: this.quarantine,
+      documentWarningBytes: this.getDocumentWarningBytes(),
+      maxInDurableObjectBytes: this.getCompactionMaxInDurableObjectBytes(),
+      failureThreshold: this.getFailureThreshold(),
+      loadFailures: await this.getFailureCount("load"),
+      alarmFailures: await this.getFailureCount("alarm"),
+      loadRetryAfter: await this.getFailureRetryAfter("load"),
+      alarmRetryAfter: await this.getFailureRetryAfter("alarm"),
+      compactionParkedBytes: await this.getCompactionParkedBytes(),
+      loadDeferredUntil: this.loadDeferredUntil,
+      externalFlag: await this.readExternalQuarantineFlag(),
+    });
+  }
+
+  async shouldRunAlarm(): Promise<boolean> {
+    if (this.isQuarantined()) {
+      console.warn(
+        `[PartyServer] Alarm skipped for quarantined room=${this.roomName}; canceling pending alarms.`
+      );
+      await this.cancelAlarm();
+      return false;
+    }
+
+    const previousFailures = await this.getFailureCount("alarm");
+    if (previousFailures === 0) return true;
+
+    const retryAfter = await this.getFailureRetryAfter("alarm");
+    if (!isRetryDue({ retryAfter, now: Date.now() })) {
+      if (retryAfter === null) {
+        throw new Error("Alarm retry was deferred without a retry deadline");
+      }
+      await this.storage.setAlarm?.(retryAfter);
+      return false;
+    }
+
+    const outcome = await this.handleRepeatedFailures({
+      kind: "alarm",
+      failureCount: previousFailures,
+      retryFailureCount:
+        retryAfter === null ? previousFailures : previousFailures + 1,
+    });
+    if (outcome.quarantined) return false;
+
+    if (retryAfter === null) {
+      await this.storage.setAlarm?.(outcome.retryAt);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -1,16 +1,21 @@
-// ABOUTME: Owns room quarantine, retry backoff, and compaction parking state.
+// ABOUTME: Owns room quarantine and retry state for load, alarm, and compaction work.
 // ABOUTME: Keeps failure recovery policy separate from PartyServer synchronization.
-import { STORAGE_KEYS } from "./const";
+import {
+  DEFAULT_COMPACTION_DISABLE_AFTER,
+  DEFAULT_COMPACTION_RETRY_DELAYS_MS,
+  STORAGE_KEYS,
+} from "./const";
 import { getErrorMessage } from "./persistenceMode";
 import {
   createQuarantineStatusBody,
-  ExternalCompactionRequiredError,
-  formatCompactionSkipLog,
+  formatCompactionBackoffLog,
+  formatCompactionDisabledLog,
   formatFailureBackoffLog,
   formatQuarantineLog,
+  getCompactionRetryDelayMs,
   getFailureRetryAt,
   isRetryDue,
-  isTooLargeToCompactInDurableObject,
+  shouldDisableCompaction,
   shouldQuarantineForFailures,
   type FailureKind,
   type QuarantineReason,
@@ -32,7 +37,6 @@ type RoomCircuitBreakerOptions = {
   readPositiveNumber: (name: string, fallback: number) => number;
   defaults: {
     documentWarningBytes: number;
-    maxInDurableObjectBytes: number;
     failureThreshold: number;
     failureBackoffMs: number;
     failureBackoffMaxMs: number;
@@ -59,9 +63,19 @@ export type QuarantineResetSummary = {
   wasLoadDeferred: boolean;
 };
 
+export type CompactionAdmission =
+  | { kind: "run" }
+  | { kind: "defer"; retryAt: number }
+  | { kind: "disabled"; disabledAt: number };
+
+export type CompactionResetSummary = {
+  failures: number;
+  retryAfter: number | null;
+  disabledAt: number | null;
+};
+
 export class RoomCircuitBreaker {
   private quarantine: QuarantineState | null = null;
-  private compactionTooLargeBytes: number | null = null;
   private loadDeferredUntil: number | null = null;
   private hasLoggedQuarantine = false;
   private inFlightReload: Promise<boolean> | null = null;
@@ -80,13 +94,6 @@ export class RoomCircuitBreaker {
     return this.options.readPositiveNumber(
       "QUARANTINE_DOCUMENT_BYTES",
       this.options.defaults.documentWarningBytes
-    );
-  }
-
-  getCompactionMaxInDurableObjectBytes(): number {
-    return this.options.readPositiveNumber(
-      "COMPACTION_MAX_IN_DO_BYTES",
-      this.options.defaults.maxInDurableObjectBytes
     );
   }
 
@@ -149,9 +156,117 @@ export class RoomCircuitBreaker {
     return typeof value === "number" ? value : null;
   }
 
-  async getCompactionParkedBytes(): Promise<number | null> {
-    const value = await this.storage.get(STORAGE_KEYS.compactionParked);
+  async getCompactionFailureCount(): Promise<number> {
+    const value = await this.storage.get(STORAGE_KEYS.compactionAttempts);
+    return typeof value === "number" ? value : 0;
+  }
+
+  async getCompactionRetryAfter(): Promise<number | null> {
+    const value = await this.storage.get(STORAGE_KEYS.compactionRetryAfter);
     return typeof value === "number" ? value : null;
+  }
+
+  async getCompactionDisabledAt(): Promise<number | null> {
+    const value = await this.storage.get(STORAGE_KEYS.compactionDisabledAt);
+    return typeof value === "number" ? value : null;
+  }
+
+  async beginCompactionAttempt(): Promise<number> {
+    const attempt = (await this.getCompactionFailureCount()) + 1;
+    await this.storage.put(STORAGE_KEYS.compactionAttempts, attempt);
+    return attempt;
+  }
+
+  async completeCompactionAttempt(): Promise<void> {
+    await this.storage.delete(STORAGE_KEYS.compactionAttempts);
+    await this.storage.delete(STORAGE_KEYS.compactionRetryAfter);
+    await this.storage.delete(STORAGE_KEYS.compactionDisabledAt);
+  }
+
+  async getCompactionAdmission(): Promise<CompactionAdmission> {
+    const disabledAt = await this.getCompactionDisabledAt();
+    if (disabledAt !== null) {
+      return { kind: "disabled", disabledAt };
+    }
+
+    const failures = await this.getCompactionFailureCount();
+    if (
+      shouldDisableCompaction({
+        failureCount: failures,
+        disableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
+      })
+    ) {
+      const now = Date.now();
+      await this.storage.put(STORAGE_KEYS.compactionDisabledAt, now);
+      await this.storage.delete(STORAGE_KEYS.compactionRetryAfter);
+      await this.options.clearCompactionSchedule();
+      console.error(
+        formatCompactionDisabledLog({
+          roomName: this.roomName,
+          failureCount: failures,
+        })
+      );
+      return { kind: "disabled", disabledAt: now };
+    }
+
+    if (failures === 0) return { kind: "run" };
+
+    const retryAfter = await this.getCompactionRetryAfter();
+    if (retryAfter !== null && !isRetryDue({ retryAfter, now: Date.now() })) {
+      return { kind: "defer", retryAt: retryAfter };
+    }
+
+    if (retryAfter === null) {
+      const delayMs = getCompactionRetryDelayMs({
+        failureCount: failures,
+        retryDelaysMs: DEFAULT_COMPACTION_RETRY_DELAYS_MS,
+      });
+      if (delayMs === null) {
+        throw new Error(
+          `Missing compaction retry delay for failure ${failures}`
+        );
+      }
+      const firstRetryAt = Date.now() + delayMs;
+      await this.storage.put(STORAGE_KEYS.compactionRetryAfter, firstRetryAt);
+      console.error(
+        formatCompactionBackoffLog({
+          roomName: this.roomName,
+          failureCount: failures,
+          retryAt: firstRetryAt,
+        })
+      );
+      return { kind: "defer", retryAt: firstRetryAt };
+    }
+
+    const nextDelayMs = getCompactionRetryDelayMs({
+      failureCount: failures + 1,
+      retryDelaysMs: DEFAULT_COMPACTION_RETRY_DELAYS_MS,
+    });
+    if (nextDelayMs === null) {
+      await this.storage.delete(STORAGE_KEYS.compactionRetryAfter);
+    } else {
+      await this.storage.put(
+        STORAGE_KEYS.compactionRetryAfter,
+        Date.now() + nextDelayMs
+      );
+    }
+    return { kind: "run" };
+  }
+
+  async clearCompactionFailure(): Promise<CompactionResetSummary> {
+    const summary = {
+      failures: await this.getCompactionFailureCount(),
+      retryAfter: await this.getCompactionRetryAfter(),
+      disabledAt: await this.getCompactionDisabledAt(),
+    };
+    await this.completeCompactionAttempt();
+    console.log(
+      `[PartyServer] Automatic compaction re-enabled for room=${this.roomName}: ` +
+        `failuresReset=${summary.failures}, ` +
+        `retryAfterReset=${summary.retryAfter ?? "none"}, ` +
+        `wasDisabled=${summary.disabledAt !== null}.`
+    );
+    return summary;
   }
 
   /**
@@ -516,47 +631,6 @@ export class RoomCircuitBreaker {
     return attempt;
   }
 
-  markCompactionTooLarge(documentBytes: number): void {
-    this.compactionTooLargeBytes = documentBytes;
-  }
-
-  async parkCompactionIfTooLarge(): Promise<boolean> {
-    const documentBytes = this.compactionTooLargeBytes;
-    this.compactionTooLargeBytes = null;
-    if (documentBytes === null) return false;
-
-    const alreadyParked = await this.getCompactionParkedBytes();
-    await this.storage.put(STORAGE_KEYS.compactionParked, documentBytes);
-    await this.options.clearCompactionSchedule();
-
-    if (alreadyParked === null) {
-      console.error(
-        formatCompactionSkipLog({
-          roomName: this.roomName,
-          documentBytes,
-          maxBytes: this.getCompactionMaxInDurableObjectBytes(),
-        })
-      );
-    }
-    return true;
-  }
-
-  async assertCanCompactDocument(documentBytes: number): Promise<void> {
-    const maxBytes = this.getCompactionMaxInDurableObjectBytes();
-    if (
-      !isTooLargeToCompactInDurableObject({
-        documentBytes,
-        maxBytes,
-      })
-    ) {
-      return;
-    }
-
-    this.compactionTooLargeBytes = documentBytes;
-    await this.parkCompactionIfTooLarge();
-    throw new ExternalCompactionRequiredError(documentBytes, maxBytes);
-  }
-
   assertNotQuarantined(operation: string): void {
     if (!this.isQuarantined()) return;
     throw new Error(
@@ -596,10 +670,6 @@ export class RoomCircuitBreaker {
     return summary;
   }
 
-  async clearCompactionPark(): Promise<void> {
-    await this.storage.delete(STORAGE_KEYS.compactionParked);
-  }
-
   async readExternalQuarantineFlag(): Promise<
     { available: true; value: string | null } | { available: false }
   > {
@@ -624,13 +694,15 @@ export class RoomCircuitBreaker {
       roomName: this.roomName,
       quarantine: this.quarantine,
       documentWarningBytes: this.getDocumentWarningBytes(),
-      maxInDurableObjectBytes: this.getCompactionMaxInDurableObjectBytes(),
       failureThreshold: this.getFailureThreshold(),
       loadFailures: await this.getFailureCount("load"),
       alarmFailures: await this.getFailureCount("alarm"),
       loadRetryAfter: await this.getFailureRetryAfter("load"),
       alarmRetryAfter: await this.getFailureRetryAfter("alarm"),
-      compactionParkedBytes: await this.getCompactionParkedBytes(),
+      compactionFailures: await this.getCompactionFailureCount(),
+      compactionRetryAfter: await this.getCompactionRetryAfter(),
+      compactionDisabledAt: await this.getCompactionDisabledAt(),
+      compactionDisableAfter: DEFAULT_COMPACTION_DISABLE_AFTER,
       loadDeferredUntil: this.loadDeferredUntil,
       externalFlag: await this.readExternalQuarantineFlag(),
     });

--- a/partykit/worker-configuration.d.ts
+++ b/partykit/worker-configuration.d.ts
@@ -8,6 +8,7 @@ declare namespace Cloudflare {
     durableNamespaces: "PartyServer" | "PresenceServer";
   }
   interface StagingEnv {
+    QUARANTINE_CONTROL: KVNamespace;
     SUPABASE_URL: string;
     SUPABASE_KEY: string;
     ADMIN_TOKEN: string;
@@ -15,6 +16,7 @@ declare namespace Cloudflare {
     Presence: DurableObjectNamespace<import("./partykit/party").PresenceServer>;
   }
   interface Env {
+    QUARANTINE_CONTROL: KVNamespace;
     SUPABASE_URL: string;
     SUPABASE_KEY: string;
     ADMIN_TOKEN: string;

--- a/partykit/wrangler.jsonc
+++ b/partykit/wrangler.jsonc
@@ -21,6 +21,15 @@
   "secrets": {
     "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
   },
+  // Operator control plane for room quarantine. Read before hydration, so a room
+  // that crashes on start can still be taken out of service.
+  "kv_namespaces": [
+    {
+      "binding": "QUARANTINE_CONTROL",
+      "id": "ca43215f51df4d699551fea9ed684e87",
+      "preview_id": "b40ca25277454bf59cfbc0a17bc0098f"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {
@@ -63,6 +72,13 @@
       "secrets": {
         "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
       },
+      "kv_namespaces": [
+        {
+          "binding": "QUARANTINE_CONTROL",
+          "id": "b0d93abaea7d40adae9fced738e54155",
+          "preview_id": "b40ca25277454bf59cfbc0a17bc0098f"
+        }
+      ],
       "durable_objects": {
         "bindings": [
           {

--- a/website/admin.scss
+++ b/website/admin.scss
@@ -70,6 +70,171 @@
   gap: 30px;
 }
 
+.quarantine-overview {
+  border-color: #feb2b2;
+}
+
+.quarantine-overview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+
+  h2 {
+    margin-bottom: 4px;
+  }
+
+  p {
+    margin: 0;
+    color: #718096;
+    font-size: 0.9rem;
+  }
+}
+
+.quarantine-refresh {
+  border: 1px solid #cbd5e0;
+  border-radius: 6px;
+  background: white;
+  color: #2d3748;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 8px 12px;
+
+  &:hover:not(:disabled) {
+    background: #edf2f7;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+}
+
+.quarantine-overview-empty {
+  margin-top: 16px;
+  border: 1px solid #9ae6b4;
+  border-radius: 6px;
+  background: #f0fff4;
+  color: #22543d;
+  padding: 12px;
+}
+
+.quarantine-overview-error {
+  margin-top: 16px;
+  border: 1px solid #fc8181;
+  border-radius: 6px;
+  background: #fff5f5;
+  color: #c53030;
+  padding: 12px;
+}
+
+.quarantine-room-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.quarantine-room-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  border: 1px solid #feb2b2;
+  border-radius: 8px;
+  background: #fff5f5;
+  color: #2d3748;
+  cursor: pointer;
+  padding: 12px;
+  text-align: left;
+
+  &:hover {
+    border-color: #fc8181;
+    background: #fed7d7;
+  }
+
+  span:first-child {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+  }
+
+  code {
+    overflow: hidden;
+    color: #718096;
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  span:last-child {
+    color: #c53030;
+    font-size: 0.85rem;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+}
+
+.room-quarantine-panel {
+  margin: 16px 0;
+  border: 1px solid #9ae6b4;
+  border-radius: 8px;
+  background: #f0fff4;
+  padding: 14px;
+
+  &.danger {
+    border-color: #fc8181;
+    background: #fff5f5;
+  }
+
+  &.warning {
+    border-color: #f6e05e;
+    background: #fffff0;
+  }
+}
+
+.room-quarantine-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+
+  span {
+    border-radius: 999px;
+    background: #c6f6d5;
+    color: #22543d;
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 4px 9px;
+  }
+
+  .danger & span {
+    background: #fed7d7;
+    color: #9b2c2c;
+  }
+
+  .warning & span {
+    background: #fefcbf;
+    color: #744210;
+  }
+}
+
+.room-quarantine-details {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+
+  div {
+    display: grid;
+    grid-template-columns: 140px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  span {
+    overflow-wrap: anywhere;
+  }
+}
+
 section {
   background: white;
   border: 1px solid #e2e8f0;
@@ -834,6 +999,25 @@ section {
 
   .comparison-data-grid {
     grid-template-columns: 1fr;
+  }
+
+  .quarantine-overview-header,
+  .room-quarantine-title {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .quarantine-room-row {
+    grid-template-columns: 1fr;
+
+    span:last-child {
+      white-space: normal;
+    }
+  }
+
+  .room-quarantine-details div {
+    grid-template-columns: 1fr;
+    gap: 2px;
   }
 }
 

--- a/website/admin.tsx
+++ b/website/admin.tsx
@@ -26,6 +26,12 @@ import {
   formatAdminResetWarning,
 } from "./adminMessages";
 import { HOSTS, type EnvName } from "./adminHosts";
+import {
+  QuarantinedRoomsOverview,
+  RoomQuarantinePanel,
+  type QuarantineOverviewState,
+  type RoomQuarantineStatus,
+} from "./adminQuarantine";
 
 // Types from the original admin.ts
 interface RoomData {
@@ -43,6 +49,7 @@ interface RoomData {
   timestamp?: string;
   roomId?: string;
   documentSize?: number;
+  quarantine?: RoomQuarantineStatus;
 }
 
 interface DebugLog {
@@ -678,6 +685,8 @@ const AdminConsole: React.FC = () => {
   const [urlInput, setUrlInput] = useState<string>("");
   const [roomData, setRoomData] = useState<RoomData | null>(null);
   const [adminToken, setAdminToken] = useState<string | null>(null);
+  const [quarantineOverview, setQuarantineOverview] =
+    useState<QuarantineOverviewState>({ state: "loading", rooms: [] });
   // Auto-detect environment - cannot be changed
   const hostEnv = detectEnvironment();
   const [roomStatus, setRoomStatus] = useState<{
@@ -1213,6 +1222,58 @@ const AdminConsole: React.FC = () => {
 
     return await response.json();
   };
+
+  const loadQuarantinedRooms = useCallback(async () => {
+    if (!adminToken) return;
+
+    setQuarantineOverview((previous) => ({
+      state: "loading",
+      rooms: previous.rooms,
+    }));
+
+    try {
+      const response = await fetch(
+        `${HOSTS[hostEnv]}/admin/quarantines?token=${encodeURIComponent(
+          adminToken
+        )}`
+      );
+      const body = await response.json();
+
+      if (response.status === 401) {
+        setAdminToken(null);
+        localStorage.removeItem("playhtml-admin-token");
+        throw new Error(
+          "Authentication failed. Please re-authenticate with a valid token."
+        );
+      }
+
+      if (!response.ok || body.available !== true) {
+        throw new Error(
+          body.error ||
+            `Failed to read quarantines: ${response.status} ${response.statusText}`
+        );
+      }
+
+      setQuarantineOverview({
+        state: "ready",
+        rooms: body.rooms,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setQuarantineOverview((previous) => ({
+        state: "error",
+        rooms: previous.rooms,
+        message,
+      }));
+      addLog("error", `Failed to list quarantined rooms: ${message}`);
+    }
+  }, [addLog, adminToken, hostEnv]);
+
+  useEffect(() => {
+    if (adminToken) {
+      void loadQuarantinedRooms();
+    }
+  }, [adminToken, loadQuarantinedRooms]);
 
   const exportRoomData = async () => {
     if (!roomData || !currentRoomId) return;
@@ -2292,6 +2353,15 @@ const AdminConsole: React.FC = () => {
       </header>
 
       <div className="admin-content">
+        <QuarantinedRoomsOverview
+          overview={quarantineOverview}
+          onRefresh={() => void loadQuarantinedRooms()}
+          onSelectRoom={(roomId) => {
+            setCurrentRoomId(roomId);
+            void loadRoom(roomId);
+          }}
+        />
+
         <section className="room-inspector">
           <h2>Room Inspector</h2>
           <div className="input-group">
@@ -2322,6 +2392,10 @@ const AdminConsole: React.FC = () => {
             <div className={`status-display ${roomStatus.type}`}>
               {roomStatus.message}
             </div>
+          )}
+
+          {roomData?.quarantine && (
+            <RoomQuarantinePanel status={roomData.quarantine} />
           )}
 
           {roomData && (

--- a/website/adminQuarantine.tsx
+++ b/website/adminQuarantine.tsx
@@ -1,0 +1,185 @@
+// ABOUTME: Renders global and per-room quarantine state in the admin console.
+// ABOUTME: Gives operators a read-only path from the quarantine index to room details.
+import React from "react";
+
+export interface RoomQuarantineStatus {
+  roomId: string;
+  quarantined: boolean;
+  reason: "manual" | "repeated-failures" | null;
+  detail: string | null;
+  quarantinedAt: string | null;
+  failures: {
+    load: number;
+    alarm: number;
+    quarantineAfter: number;
+    loadRetryAt: string | null;
+    alarmRetryAt: string | null;
+  };
+  compaction: {
+    parked: boolean;
+    documentBytes: number | null;
+    maxInDurableObjectBytes: number;
+  };
+  loadDeferred: {
+    active: boolean;
+    until: string | null;
+  };
+  externalQuarantineFlag: string | null;
+}
+
+export interface QuarantinedRoomSummary {
+  roomId: string;
+  detail: string;
+}
+
+export type QuarantineOverviewState =
+  | { state: "loading"; rooms: QuarantinedRoomSummary[] }
+  | { state: "ready"; rooms: QuarantinedRoomSummary[] }
+  | { state: "error"; rooms: QuarantinedRoomSummary[]; message: string };
+
+function formatRoomId(roomId: string): string {
+  try {
+    return decodeURIComponent(roomId);
+  } catch {
+    return roomId;
+  }
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "Unknown";
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function formatDate(timestamp: string | null): string {
+  if (timestamp === null) return "Not set";
+  return new Date(timestamp).toLocaleString();
+}
+
+export const QuarantinedRoomsOverview: React.FC<{
+  overview: QuarantineOverviewState;
+  onRefresh: () => void;
+  onSelectRoom: (roomId: string) => void;
+}> = ({ overview, onRefresh, onSelectRoom }) => (
+  <section className="quarantine-overview" aria-labelledby="quarantine-heading">
+    <div className="quarantine-overview-header">
+      <div>
+        <h2 id="quarantine-heading">Quarantined rooms</h2>
+        <p>
+          Rooms currently stopped by the production quarantine control plane.
+        </p>
+      </div>
+      <button
+        type="button"
+        className="quarantine-refresh"
+        onClick={onRefresh}
+        disabled={overview.state === "loading"}
+      >
+        {overview.state === "loading" ? "Refreshing…" : "Refresh"}
+      </button>
+    </div>
+
+    {overview.state === "error" && (
+      <div className="quarantine-overview-error" role="alert">
+        {overview.message}
+      </div>
+    )}
+
+    {overview.state === "ready" && overview.rooms.length === 0 && (
+      <div className="quarantine-overview-empty">
+        No rooms are currently quarantined.
+      </div>
+    )}
+
+    {overview.rooms.length > 0 && (
+      <div className="quarantine-room-list">
+        {overview.rooms.map((room) => (
+          <button
+            type="button"
+            className="quarantine-room-row"
+            key={room.roomId}
+            onClick={() => onSelectRoom(room.roomId)}
+          >
+            <span>
+              <strong>{formatRoomId(room.roomId)}</strong>
+              <code>{room.roomId}</code>
+            </span>
+            <span>{room.detail}</span>
+            <span aria-hidden="true">View room →</span>
+          </button>
+        ))}
+      </div>
+    )}
+  </section>
+);
+
+export const RoomQuarantinePanel: React.FC<{
+  status: RoomQuarantineStatus;
+}> = ({ status }) => {
+  const state = status.quarantined
+    ? {
+        label:
+          status.reason === "repeated-failures"
+            ? "Automatically quarantined"
+            : "Manually quarantined",
+        tone: "danger",
+      }
+    : status.loadDeferred.active
+      ? { label: "Load deferred", tone: "warning" }
+      : status.compaction.parked
+        ? { label: "External compaction required", tone: "warning" }
+        : { label: "Healthy", tone: "healthy" };
+
+  return (
+    <div className={`room-quarantine-panel ${state.tone}`}>
+      <div className="room-quarantine-title">
+        <strong>Room safety state</strong>
+        <span>{state.label}</span>
+      </div>
+
+      {(status.quarantined ||
+        status.loadDeferred.active ||
+        status.compaction.parked) && (
+        <div className="room-quarantine-details">
+          {status.detail && (
+            <div>
+              <strong>Reason</strong>
+              <span>{status.detail}</span>
+            </div>
+          )}
+          {status.quarantinedAt && (
+            <div>
+              <strong>Quarantined at</strong>
+              <span>{formatDate(status.quarantinedAt)}</span>
+            </div>
+          )}
+          <div>
+            <strong>Failure ledger</strong>
+            <span>
+              {status.failures.load} load / {status.failures.alarm} alarm
+              failures; quarantine at {status.failures.quarantineAfter}
+            </span>
+          </div>
+          {status.loadDeferred.active && (
+            <div>
+              <strong>Next load retry</strong>
+              <span>{formatDate(status.loadDeferred.until)}</span>
+            </div>
+          )}
+          {status.compaction.parked && (
+            <div>
+              <strong>Compaction</strong>
+              <span>
+                Parked at {formatBytes(status.compaction.documentBytes)}; in-room
+                limit {formatBytes(status.compaction.maxInDurableObjectBytes)}
+              </span>
+            </div>
+          )}
+          <div>
+            <strong>External control flag</strong>
+            <span>{status.externalQuarantineFlag ?? "Not set"}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/website/adminQuarantine.tsx
+++ b/website/adminQuarantine.tsx
@@ -12,13 +12,15 @@ export interface RoomQuarantineStatus {
     load: number;
     alarm: number;
     quarantineAfter: number;
-    loadRetryAt: string | null;
-    alarmRetryAt: string | null;
+    loadRetryAfter: string | null;
+    alarmRetryAfter: string | null;
   };
   compaction: {
-    parked: boolean;
-    documentBytes: number | null;
-    maxInDurableObjectBytes: number;
+    disabled: boolean;
+    disabledAt: string | null;
+    failures: number;
+    disableAfter: number;
+    retryAfter: string | null;
   };
   loadDeferred: {
     active: boolean;
@@ -43,11 +45,6 @@ function formatRoomId(roomId: string): string {
   } catch {
     return roomId;
   }
-}
-
-function formatBytes(bytes: number | null): string {
-  if (bytes === null) return "Unknown";
-  return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
 }
 
 function formatDate(timestamp: string | null): string {
@@ -125,9 +122,11 @@ export const RoomQuarantinePanel: React.FC<{
       }
     : status.loadDeferred.active
       ? { label: "Load deferred", tone: "warning" }
-      : status.compaction.parked
-        ? { label: "External compaction required", tone: "warning" }
-        : { label: "Healthy", tone: "healthy" };
+      : status.compaction.disabled
+        ? { label: "Automatic compaction disabled", tone: "warning" }
+        : status.compaction.retryAfter
+          ? { label: "Compaction retry delayed", tone: "warning" }
+          : { label: "Healthy", tone: "healthy" };
 
   return (
     <div className={`room-quarantine-panel ${state.tone}`}>
@@ -138,7 +137,8 @@ export const RoomQuarantinePanel: React.FC<{
 
       {(status.quarantined ||
         status.loadDeferred.active ||
-        status.compaction.parked) && (
+        status.compaction.disabled ||
+        status.compaction.retryAfter) && (
         <div className="room-quarantine-details">
           {status.detail && (
             <div>
@@ -165,13 +165,25 @@ export const RoomQuarantinePanel: React.FC<{
               <span>{formatDate(status.loadDeferred.until)}</span>
             </div>
           )}
-          {status.compaction.parked && (
+          {(status.compaction.disabled || status.compaction.retryAfter) && (
             <div>
               <strong>Compaction</strong>
               <span>
-                Parked at {formatBytes(status.compaction.documentBytes)}; in-room
-                limit {formatBytes(status.compaction.maxInDurableObjectBytes)}
+                {status.compaction.failures} vanished attempts; disable after{" "}
+                {status.compaction.disableAfter}
               </span>
+            </div>
+          )}
+          {status.compaction.retryAfter && (
+            <div>
+              <strong>Next compaction retry</strong>
+              <span>{formatDate(status.compaction.retryAfter)}</span>
+            </div>
+          )}
+          {status.compaction.disabledAt && (
+            <div>
+              <strong>Compaction disabled at</strong>
+              <span>{formatDate(status.compaction.disabledAt)}</span>
             </div>
           )}
           <div>

--- a/website/test/adminQuarantine.test.tsx
+++ b/website/test/adminQuarantine.test.tsx
@@ -1,0 +1,122 @@
+// ABOUTME: Verifies quarantine visibility in the browser admin console.
+// ABOUTME: Covers the global room index and detailed selected-room safety state.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import {
+  QuarantinedRoomsOverview,
+  RoomQuarantinePanel,
+  type RoomQuarantineStatus,
+} from "../adminQuarantine";
+
+const AUTOMATIC_QUARANTINE: RoomQuarantineStatus = {
+  roomId: "playhtml.fun-%2Fweek%2F2",
+  quarantined: true,
+  reason: "repeated-failures",
+  detail: "load work failed 8 times in a row",
+  quarantinedAt: "2026-07-29T05:00:00.000Z",
+  failures: {
+    load: 8,
+    alarm: 0,
+    quarantineAfter: 8,
+    loadRetryAt: null,
+    alarmRetryAt: null,
+  },
+  compaction: {
+    parked: true,
+    documentBytes: 6 * 1024 * 1024,
+    maxInDurableObjectBytes: 4 * 1024 * 1024,
+  },
+  loadDeferred: {
+    active: false,
+    until: null,
+  },
+  externalQuarantineFlag: "load work failed 8 times in a row",
+};
+
+describe("QuarantinedRoomsOverview", () => {
+  test("shows every room and opens the selected room", () => {
+    const onSelectRoom = vi.fn();
+
+    render(
+      <QuarantinedRoomsOverview
+        overview={{
+          state: "ready",
+          rooms: [
+            {
+              roomId: "playhtml.fun-%2Fweek%2F2",
+              detail: "load work failed 8 times in a row",
+            },
+            {
+              roomId: "playhtml.fun-%2Fbunny",
+              detail: "operator investigation",
+            },
+          ],
+        }}
+        onRefresh={() => {}}
+        onSelectRoom={onSelectRoom}
+      />
+    );
+
+    expect(screen.getByText("playhtml.fun-/week/2")).toBeTruthy();
+    expect(screen.getByText("playhtml.fun-/bunny")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /playhtml\.fun-\/week\/2/i,
+      })
+    );
+    expect(onSelectRoom).toHaveBeenCalledWith(
+      "playhtml.fun-%2Fweek%2F2"
+    );
+  });
+
+  test("only claims the list is empty after a successful read", () => {
+    const { rerender } = render(
+      <QuarantinedRoomsOverview
+        overview={{ state: "ready", rooms: [] }}
+        onRefresh={() => {}}
+        onSelectRoom={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByText("No rooms are currently quarantined.")
+    ).toBeTruthy();
+
+    rerender(
+      <QuarantinedRoomsOverview
+        overview={{
+          state: "error",
+          rooms: [],
+          message: "Failed to read the quarantine control plane",
+        }}
+        onRefresh={() => {}}
+        onSelectRoom={() => {}}
+      />
+    );
+
+    expect(
+      screen.queryByText("No rooms are currently quarantined.")
+    ).toBeNull();
+    expect(
+      screen.getByText("Failed to read the quarantine control plane")
+    ).toBeTruthy();
+  });
+});
+
+describe("RoomQuarantinePanel", () => {
+  test("shows automatic quarantine and the failure ledger", () => {
+    render(<RoomQuarantinePanel status={AUTOMATIC_QUARANTINE} />);
+
+    expect(screen.getByText("Automatically quarantined")).toBeTruthy();
+    expect(
+      screen.getAllByText("load work failed 8 times in a row", {
+        selector: ".room-quarantine-details span",
+      })
+    ).toHaveLength(2);
+    expect(
+      screen.getByText(/8 load \/ 0 alarm failures; quarantine at 8/)
+    ).toBeTruthy();
+    expect(screen.getByText(/Parked at 6\.00 MB/)).toBeTruthy();
+  });
+});

--- a/website/test/adminQuarantine.test.tsx
+++ b/website/test/adminQuarantine.test.tsx
@@ -18,13 +18,15 @@ const AUTOMATIC_QUARANTINE: RoomQuarantineStatus = {
     load: 8,
     alarm: 0,
     quarantineAfter: 8,
-    loadRetryAt: null,
-    alarmRetryAt: null,
+    loadRetryAfter: null,
+    alarmRetryAfter: null,
   },
   compaction: {
-    parked: true,
-    documentBytes: 6 * 1024 * 1024,
-    maxInDurableObjectBytes: 4 * 1024 * 1024,
+    disabled: true,
+    disabledAt: "2026-07-29T05:01:00.000Z",
+    failures: 3,
+    disableAfter: 3,
+    retryAfter: null,
   },
   loadDeferred: {
     active: false,
@@ -117,6 +119,40 @@ describe("RoomQuarantinePanel", () => {
     expect(
       screen.getByText(/8 load \/ 0 alarm failures; quarantine at 8/)
     ).toBeTruthy();
-    expect(screen.getByText(/Parked at 6\.00 MB/)).toBeTruthy();
+    expect(
+      screen.getByText(/3 vanished attempts; disable after 3/)
+    ).toBeTruthy();
+    expect(screen.getByText("Compaction disabled at")).toBeTruthy();
+  });
+
+  test("shows a delayed compaction retry without calling the room unhealthy", () => {
+    render(
+      <RoomQuarantinePanel
+        status={{
+          ...AUTOMATIC_QUARANTINE,
+          quarantined: false,
+          reason: null,
+          detail: null,
+          quarantinedAt: null,
+          failures: {
+            ...AUTOMATIC_QUARANTINE.failures,
+            load: 0,
+          },
+          compaction: {
+            disabled: false,
+            disabledAt: null,
+            failures: 1,
+            disableAfter: 3,
+            retryAfter: "2026-07-29T05:00:15.000Z",
+          },
+          externalQuarantineFlag: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText("Compaction retry delayed")).toBeTruthy();
+    expect(
+      screen.getByText(/1 vanished attempts; disable after 3/)
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Incident context

Three rooms with oversized persisted docs (7-13MB base64) put their Durable Objects into a permanent OOM crash loop: the empty-room compaction alarm loads the doc, `buildCompactedDocument` holds 3-5 representations at once, the isolate OOMs, and Cloudflare auto-retries the failed alarm within seconds. Because the memory limit is per-isolate (shared by many co-located rooms), each reset also killed unrelated rooms' connections — including the playhtml.fun homepage's presence socket, which is how it surfaced. Two of the three rooms were fixed by external compaction (13MB→152KB and 7.8MB→488KB, lossless-verified); the remaining two hold mostly real content and still crash-loop today. This PR makes the server structurally immune to the loop.

## Policy (as decided in review)

| Trigger | Response | Room state |
|---|---|---|
| Doc > 10MB at load | Warn only, hydrate anyway | Normal |
| Doc > 4MB at compaction | Skip in-DO compaction, park schedule, log external runbook once (durable once-guard) | **Normal** — loads, serves, persists |
| Risky work fails (load/alarm) | Durable counters + exponential backoff (1m → 5m → 20m → 1h → 6h → 24h cap); deferred rooms 503 + Retry-After, zero Supabase reads, single-flight in-place retry at deadline | Deferred, self-heals |
| 8 consecutive vanished-mid-work failures | Auto-quarantine (last resort) | Transient: serves visitors ephemeral-only, all persistence writes blocked, alarms parked |
| `POST admin/quarantine-set` / `-clear` (+ Cloudflare KV flag, checked BEFORE hydration) | Manual quarantine — the primary path | Transient |
| `POST admin/restore-raw-document` | Replaces doc; auto-clears park/quarantine only if the new doc is under the ceiling | Normal |

Size alone never blocks a load or quarantines a room (four healthy production rooms sit in the 6-8MB band). Quarantine never touches the persisted document — data-safety is enforced at every Supabase write function (`assertNotQuarantined`), enumerated and verified in review.

## Key design points

- **The gate runs in `onStart` BEFORE `super.onStart()`** — partyserver's `alarm()`/`fetch`/websocket paths all hydrate via `ensureInitialized → onStart → onLoad` before any handler runs, so this is the only placement that intercepts every entry path. Caught in fresh review (guards originally in `onAlarm` were unreachable for hydration-OOM rooms); regression-proofed by a new test class that drives the real platform entry points (`server.alarm()`, `server.fetch()`) instead of calling hooks directly.
- **Manual quarantine works on rooms that can't start**: the flag lives in Cloudflare KV (namespaces created for prod/preview/staging, ids wired in wrangler.jsonc) and is read pre-hydration. KV reads fail open (operator tool, not a correctness gate); presence of the key quarantines even with an empty value (fail-safe — release by deleting the key, not writing empty). Emergency stop for an unreachable room: `bunx wrangler kv key put --binding QUARANTINE_CONTROL "quarantine:<room-id>" "reason" --remote`.
- **Observed exceptions are not OOM evidence**: the failure counters only accumulate on true vanished-mid-work attempts, so a Supabase outage logs loudly at normal cadence instead of slowly quarantining healthy rooms.
- Backoff deadlines/counters are durably written before risky work, which is what absorbs Cloudflare's seconds-apart alarm retries.

## Review process

Implemented against a live incident, then hardened through: Spencer's line-level review (4 required changes incl. the 503 contract and KV control plane), a fresh DO-lifecycle review (caught the F1 entry-path blocker + 7 more), and a silent-failure audit (caught the eternal-503 trap, the un-awaited admin router swallowing errors, and 8 more). Every finding fixed or explicitly documented in code; each mechanism mutation-tested.

## Verification

- 198 tests across 17 partykit files, run from the branch worktree; `tsc -p partykit` clean
- Data-safety: persisted-row byte-identity asserted across autosave, compaction, hard reset, restore, and force-save under quarantine
- Platform-entry tests: alarm on a deferred room performs zero Supabase reads; KV-flagged room never hydrates; 5 concurrent requests at a deferral deadline produce exactly 1 read

No packages/ changes — server-only, no changeset. Deploy: staging first (`bun deploy-server:staging`), verify, then `bun deploy-server`. On production deploy the two remaining crash-looping rooms stop looping immediately (compaction-skip parks their alarms); they then need one external compaction each (runbook in the parked-room log line).