### PR TITLE
Add circular cursor gesture collection and redraw mode

### DIFF
--- a/extension/website/circle-draw/circle-draw.scss
+++ b/extension/website/circle-draw/circle-draw.scss
@@ -1,0 +1,134 @@
+// ABOUTME: Styles the circle collection page as an open full-screen drawing field.
+// ABOUTME: Keeps guides faint while the visitor's live cursor trail stays legible.
+
+:root {
+  font-family: "Martian Mono", monospace;
+  color: #2f2b27;
+  background: #faf7f2;
+  font-synthesis: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  overflow: hidden;
+}
+
+.circle-page {
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 22% 32%, rgb(246 228 211 / 55%), transparent 36%),
+    radial-gradient(circle at 76% 72%, rgb(225 236 218 / 55%), transparent 38%),
+    #faf7f2;
+}
+
+.circle-header {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px 24px;
+  pointer-events: none;
+
+  h1 {
+    margin: 0;
+    font-family: "Source Serif 4", Georgia, serif;
+    font-size: clamp(28px, 3.5vw, 54px);
+    font-style: italic;
+    font-weight: 200;
+    line-height: 1;
+  }
+
+  p {
+    margin: 10px 0 0;
+    color: #756d64;
+    font-size: clamp(9px, 1vw, 12px);
+    letter-spacing: 0.02em;
+  }
+
+  a {
+    color: #2f2b27;
+    font-size: 10px;
+    pointer-events: auto;
+  }
+}
+
+.circle-guides {
+  position: absolute;
+  inset: 0;
+}
+
+.circle-guide {
+  position: absolute;
+  aspect-ratio: 1;
+  border: 2px dashed rgb(85 76 68 / 22%);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 10px rgb(255 255 255 / 22%),
+    inset 0 0 45px rgb(255 255 255 / 28%);
+}
+
+.local-trail {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+
+  path {
+    fill: none;
+    stroke: #201d1a;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2.5;
+  }
+}
+
+footer {
+  position: absolute;
+  z-index: 3;
+  right: 24px;
+  bottom: 20px;
+  max-width: 430px;
+  color: #756d64;
+  font-size: 10px;
+  line-height: 1.6;
+  text-align: right;
+  pointer-events: none;
+}
+
+@media (max-width: 720px) {
+  .circle-header {
+    display: block;
+    padding: 18px;
+
+    a {
+      display: inline-block;
+      margin-top: 12px;
+    }
+  }
+
+  .circle-guide:nth-child(3),
+  .circle-guide:nth-child(6) {
+    display: none;
+  }
+
+  footer {
+    right: 18px;
+    bottom: 16px;
+    left: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .local-trail {
+    display: none;
+  }
+}

--- a/extension/website/circle-draw/circle-draw.tsx
+++ b/extension/website/circle-draw/circle-draw.tsx
@@ -1,0 +1,101 @@
+// ABOUTME: Presents large circle guides for deliberate cursor-trail collection.
+// ABOUTME: Echoes the visitor's current gesture while the extension records it.
+
+import React, { useEffect, useRef } from "react";
+import ReactDOM from "react-dom/client";
+import "./circle-draw.scss";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+const GUIDE_LAYOUT = [
+  { left: "4%", top: "8%", width: "34vmin" },
+  { left: "34%", top: "5%", width: "45vmin" },
+  { right: "3%", top: "13%", width: "31vmin" },
+  { left: "12%", bottom: "4%", width: "39vmin" },
+  { left: "45%", bottom: "3%", width: "32vmin" },
+  { right: "6%", bottom: "7%", width: "43vmin" },
+];
+
+function pointsToPath(points: Point[]): string {
+  return points
+    .map((point, index) => `${index === 0 ? "M" : "L"}${point.x},${point.y}`)
+    .join(" ");
+}
+
+const CircleDraw = () => {
+  const trailRef = useRef<SVGPathElement>(null);
+  const pointsRef = useRef<Point[]>([]);
+  const frameRef = useRef<number | null>(null);
+  const clearTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const renderTrail = () => {
+      frameRef.current = null;
+      trailRef.current?.setAttribute("d", pointsToPath(pointsRef.current));
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      pointsRef.current.push({ x: event.clientX, y: event.clientY });
+      if (pointsRef.current.length > 800) {
+        pointsRef.current.splice(0, pointsRef.current.length - 800);
+      }
+      if (frameRef.current === null) {
+        frameRef.current = requestAnimationFrame(renderTrail);
+      }
+      if (clearTimerRef.current !== null) {
+        window.clearTimeout(clearTimerRef.current);
+      }
+      clearTimerRef.current = window.setTimeout(() => {
+        pointsRef.current = [];
+        trailRef.current?.setAttribute("d", "");
+      }, 1800);
+    };
+
+    window.addEventListener("pointermove", handlePointerMove, { passive: true });
+    return () => {
+      window.removeEventListener("pointermove", handlePointerMove);
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+      if (clearTimerRef.current !== null) {
+        window.clearTimeout(clearTimerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <main className="circle-page">
+      <header className="circle-header">
+        <div>
+          <h1>draw circles with us</h1>
+          <p>trace slowly · follow a ring all the way around · loop once or twice</p>
+        </div>
+        <a href="/redraw/?mode=circles">watch the drawing →</a>
+      </header>
+
+      <div className="circle-guides" aria-hidden="true">
+        {GUIDE_LAYOUT.map((guide, index) => (
+          <div
+            className="circle-guide"
+            key={index}
+            style={guide}
+          />
+        ))}
+      </div>
+
+      <svg className="local-trail" aria-hidden="true">
+        <path ref={trailRef} />
+      </svg>
+
+      <footer>
+        with the <em>we were online</em> extension installed, your cursor trail
+        becomes part of the collective drawing
+      </footer>
+    </main>
+  );
+};
+
+ReactDOM.createRoot(
+  document.getElementById("reactContent") as HTMLElement,
+).render(<CircleDraw />);

--- a/extension/website/circle-draw/index.html
+++ b/extension/website/circle-draw/index.html
@@ -1,0 +1,25 @@
+<!-- ABOUTME: Entry page for collecting deliberate circular cursor gestures. -->
+<!-- ABOUTME: Loads the full-screen circle tracing experience at /circle-draw/. -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Trace circles with your cursor to contribute to a collective drawing."
+    />
+
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@1,8..60,200&family=Martian+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>draw circles — we were online</title>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./circle-draw.tsx"></script>
+  </body>
+</html>

--- a/extension/website/redraw/__tests__/circles.test.ts
+++ b/extension/website/redraw/__tests__/circles.test.ts
@@ -93,6 +93,34 @@ describe("detectCircularGestures", () => {
     ).toEqual([]);
   });
 
+  it("rejects closed loops with long straight sides", () => {
+    const top = Array.from({ length: 8 }, (_, index) => ({
+      x: 100 + index * 35,
+      y: 100,
+    }));
+    const roundedEnd = Array.from({ length: 12 }, (_, index) => {
+      const angle = -Math.PI / 2 + (index / 11) * Math.PI;
+      return {
+        x: 345 + Math.cos(angle) * 150,
+        y: 250 + Math.sin(angle) * 150,
+      };
+    });
+    const bottom = Array.from({ length: 8 }, (_, index) => ({
+      x: 345 - index * 35,
+      y: 400,
+    }));
+    const left = Array.from({ length: 10 }, (_, index) => ({
+      x: 100,
+      y: 400 - index * (300 / 9),
+    }));
+
+    expect(
+      detectCircularGestures([
+        trail([...top, ...roundedEnd, ...bottom, ...left], "flat-loop"),
+      ]),
+    ).toEqual([]);
+  });
+
   it("selects two non-overlapping circles from one continuous trail", () => {
     const points = [
       ...circlePoints({ centerX: 220, centerY: 240 }),

--- a/extension/website/redraw/__tests__/circles.test.ts
+++ b/extension/website/redraw/__tests__/circles.test.ts
@@ -1,0 +1,151 @@
+// ABOUTME: Verifies rough-circle detection inside longer cursor paths.
+// ABOUTME: Covers false positives, multiple gestures, and deterministic arrangement.
+
+import { describe, expect, it } from "vitest";
+import {
+  arrangeCircularGestures,
+  detectCircularGestures,
+} from "../circles";
+import { LibraryItem } from "../draw";
+
+function circlePoints({
+  centerX = 300,
+  centerY = 220,
+  radiusX = 120,
+  radiusY = 105,
+  samples = 25,
+  startAngle = 0,
+}: {
+  centerX?: number;
+  centerY?: number;
+  radiusX?: number;
+  radiusY?: number;
+  samples?: number;
+  startAngle?: number;
+} = {}) {
+  return Array.from({ length: samples }, (_, index) => {
+    const angle = startAngle + (index / (samples - 1)) * Math.PI * 2;
+    const wobble = index % 3 === 0 ? 4 : -2;
+    return {
+      x: centerX + Math.cos(angle) * (radiusX + wobble),
+      y: centerY + Math.sin(angle) * (radiusY - wobble),
+    };
+  });
+}
+
+function trail(points: Array<{ x: number; y: number }>, id = "trail"): LibraryItem {
+  return { points, color: "#ef476f", id };
+}
+
+describe("detectCircularGestures", () => {
+  it("finds a rough ellipse embedded between approach and exit movements", () => {
+    const points = [
+      { x: 20, y: 20 },
+      { x: 80, y: 80 },
+      ...circlePoints(),
+      { x: 500, y: 400 },
+      { x: 560, y: 460 },
+    ];
+
+    const detected = detectCircularGestures([trail(points)]);
+
+    expect(detected).toHaveLength(1);
+    expect(detected[0].score).toBeGreaterThan(0.58);
+    expect(detected[0].points.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("finds a circle from sparse archival samples", () => {
+    const detected = detectCircularGestures([
+      trail(circlePoints({ samples: 10 })),
+    ]);
+
+    expect(detected).toHaveLength(1);
+  });
+
+  it("rejects open arcs, rectangles, and back-and-forth browsing motion", () => {
+    const arc = circlePoints({ samples: 20 }).slice(0, 12);
+    const rectangle = [
+      { x: 100, y: 100 },
+      { x: 200, y: 100 },
+      { x: 300, y: 100 },
+      { x: 400, y: 100 },
+      { x: 400, y: 200 },
+      { x: 400, y: 300 },
+      { x: 400, y: 400 },
+      { x: 300, y: 400 },
+      { x: 200, y: 400 },
+      { x: 100, y: 400 },
+      { x: 100, y: 300 },
+      { x: 100, y: 200 },
+      { x: 100, y: 100 },
+    ];
+    const zigzag = Array.from({ length: 30 }, (_, index) => ({
+      x: 40 + index * 18,
+      y: index % 2 === 0 ? 80 : 260,
+    }));
+
+    expect(
+      detectCircularGestures([
+        trail(arc, "arc"),
+        trail(rectangle, "rectangle"),
+        trail(zigzag, "zigzag"),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("selects two non-overlapping circles from one continuous trail", () => {
+    const points = [
+      ...circlePoints({ centerX: 220, centerY: 240 }),
+      { x: 400, y: 240 },
+      { x: 520, y: 240 },
+      ...circlePoints({
+        centerX: 650,
+        centerY: 240,
+        radiusX: 105,
+        radiusY: 115,
+        startAngle: Math.PI,
+      }),
+    ];
+
+    const detected = detectCircularGestures([trail(points)]);
+
+    expect(detected).toHaveLength(2);
+  });
+});
+
+describe("arrangeCircularGestures", () => {
+  it("keeps detected shapes distinct while clustering their centers", () => {
+    const detected = detectCircularGestures([
+      trail(circlePoints(), "one"),
+      trail(
+        circlePoints({
+          centerX: 600,
+          centerY: 400,
+          radiusX: 95,
+          radiusY: 110,
+        }),
+        "two",
+      ),
+    ]);
+
+    const arranged = arrangeCircularGestures(detected, {
+      width: 1200,
+      height: 800,
+    }, {
+      maxCircles: 2,
+      spatialOverlap: 1,
+    });
+
+    expect(arranged).toHaveLength(2);
+    for (const item of arranged) {
+      const centerX =
+        item.points.reduce((total, point) => total + point.x, 0) /
+        item.points.length;
+      const centerY =
+        item.points.reduce((total, point) => total + point.y, 0) /
+        item.points.length;
+      expect(Math.abs(centerX - 600)).toBeLessThan(4);
+      expect(Math.abs(centerY - 400)).toBeLessThan(4);
+    }
+  });
+});

--- a/extension/website/redraw/circles.ts
+++ b/extension/website/redraw/circles.ts
@@ -11,7 +11,10 @@ const DEFAULT_MIN_POINTS = 9;
 const DEFAULT_MAX_WINDOW_POINTS = 64;
 const DEFAULT_MIN_DIAMETER = 70;
 const DEFAULT_MIN_SCORE = 0.58;
-const MAX_CLOSURE_RATIO = 0.4;
+const MAX_CLOSURE_RATIO = 0.25;
+const MAX_ANGLE_STEP_VARIATION = 0.75;
+const MAX_TURN_VARIATION = 0.8;
+const MIN_CIRCULARITY = 0.55;
 
 export interface CircularGesture extends LibraryItem {
   score: number;
@@ -35,6 +38,16 @@ function distance(a: Point, b: Point): number {
 
 function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
+}
+
+function coefficientOfVariation(values: number[]): number {
+  if (values.length === 0) return Infinity;
+  const mean = values.reduce((total, value) => total + value, 0) / values.length;
+  if (mean === 0) return Infinity;
+  const variance =
+    values.reduce((total, value) => total + (value - mean) ** 2, 0) /
+    values.length;
+  return Math.sqrt(variance) / mean;
 }
 
 function circularDelta(from: number, to: number): number {
@@ -62,6 +75,37 @@ function tangentTurnConcentration(points: Point[]): number {
   const meanTurn = turns.reduce((total, turn) => total + turn, 0) / turns.length;
   const ninetiethPercentile = turns[Math.floor(turns.length * 0.9)];
   return meanTurn === 0 ? Infinity : ninetiethPercentile / meanTurn;
+}
+
+function tangentTurnVariation(points: Point[]): number {
+  const turns: number[] = [];
+  for (let index = 2; index < points.length - 2; index++) {
+    const incoming = Math.atan2(
+      points[index].y - points[index - 2].y,
+      points[index].x - points[index - 2].x,
+    );
+    const outgoing = Math.atan2(
+      points[index + 2].y - points[index].y,
+      points[index + 2].x - points[index].x,
+    );
+    turns.push(Math.abs(circularDelta(incoming, outgoing)));
+  }
+  if (turns.length === 0) return Infinity;
+
+  return coefficientOfVariation(turns);
+}
+
+function polygonCircularity(points: Point[]): number {
+  let twiceArea = 0;
+  let perimeter = 0;
+  for (let index = 0; index < points.length; index++) {
+    const point = points[index];
+    const next = points[(index + 1) % points.length];
+    twiceArea += point.x * next.y - next.x * point.y;
+    perimeter += distance(point, next);
+  }
+  if (perimeter === 0) return 0;
+  return (2 * Math.PI * Math.abs(twiceArea)) / perimeter ** 2;
 }
 
 function analyzeCircle(points: Point[], minDiameter: number): CircleMetrics | null {
@@ -111,11 +155,13 @@ function analyzeCircle(points: Point[], minDiameter: number): CircleMetrics | nu
   );
   let netTurn = 0;
   let totalTurn = 0;
+  const angleSteps: number[] = [];
   const visitedAngleBins = new Set<number>();
   for (let index = 1; index < angles.length; index++) {
     const delta = circularDelta(angles[index - 1], angles[index]);
     netTurn += delta;
     totalTurn += Math.abs(delta);
+    angleSteps.push(Math.abs(delta));
   }
   for (const angle of angles) {
     const normalized = (angle + Math.PI) / (Math.PI * 2);
@@ -125,14 +171,20 @@ function analyzeCircle(points: Point[], minDiameter: number): CircleMetrics | nu
   const turnCoverage = Math.abs(netTurn) / (Math.PI * 2);
   const directionConsistency =
     totalTurn === 0 ? 0 : Math.abs(netTurn) / totalTurn;
+  const angleStepVariation = coefficientOfVariation(angleSteps);
   const angleCoverage = visitedAngleBins.size / 12;
   const turnConcentration = tangentTurnConcentration(sampled);
+  const turnVariation = tangentTurnVariation(sampled);
+  const circularity = polygonCircularity(sampled);
   if (
     turnCoverage < 0.68 ||
     turnCoverage > 1.45 ||
     directionConsistency < 0.62 ||
+    angleStepVariation > MAX_ANGLE_STEP_VARIATION ||
     angleCoverage < 0.67 ||
-    turnConcentration > 4.5
+    turnConcentration > 4.5 ||
+    turnVariation > MAX_TURN_VARIATION ||
+    circularity < MIN_CIRCULARITY
   ) {
     return null;
   }

--- a/extension/website/redraw/circles.ts
+++ b/extension/website/redraw/circles.ts
@@ -1,0 +1,340 @@
+// ABOUTME: Detects rough circular gestures inside archived cursor trails.
+// ABOUTME: Arranges the detected gestures into an overlapping circle composition.
+
+import { Trail } from "../shared/types";
+import { resampleUniform } from "../shared/utils/styleUtils";
+import { LibraryItem } from "./draw";
+import { Point } from "./image";
+
+const RESAMPLED_POINTS = 32;
+const DEFAULT_MIN_POINTS = 9;
+const DEFAULT_MAX_WINDOW_POINTS = 64;
+const DEFAULT_MIN_DIAMETER = 70;
+const DEFAULT_MIN_SCORE = 0.58;
+const MAX_CLOSURE_RATIO = 0.4;
+
+export interface CircularGesture extends LibraryItem {
+  score: number;
+}
+
+interface CircleCandidate extends CircularGesture {
+  sourceIndex: number;
+  startIndex: number;
+  endIndex: number;
+}
+
+interface CircleMetrics {
+  score: number;
+  centroid: Point;
+  diameter: number;
+}
+
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function circularDelta(from: number, to: number): number {
+  let delta = to - from;
+  while (delta > Math.PI) delta -= Math.PI * 2;
+  while (delta < -Math.PI) delta += Math.PI * 2;
+  return delta;
+}
+
+function tangentTurnConcentration(points: Point[]): number {
+  const turns: number[] = [];
+  for (let index = 1; index < points.length - 1; index++) {
+    const incoming = Math.atan2(
+      points[index].y - points[index - 1].y,
+      points[index].x - points[index - 1].x,
+    );
+    const outgoing = Math.atan2(
+      points[index + 1].y - points[index].y,
+      points[index + 1].x - points[index].x,
+    );
+    turns.push(Math.abs(circularDelta(incoming, outgoing)));
+  }
+  if (turns.length === 0) return Infinity;
+  turns.sort((a, b) => a - b);
+  const meanTurn = turns.reduce((total, turn) => total + turn, 0) / turns.length;
+  const ninetiethPercentile = turns[Math.floor(turns.length * 0.9)];
+  return meanTurn === 0 ? Infinity : ninetiethPercentile / meanTurn;
+}
+
+function analyzeCircle(points: Point[], minDiameter: number): CircleMetrics | null {
+  if (points.length < DEFAULT_MIN_POINTS) return null;
+
+  const sampled = resampleUniform(points, RESAMPLED_POINTS);
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  let centroidX = 0;
+  let centroidY = 0;
+
+  for (const point of sampled) {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+    centroidX += point.x;
+    centroidY += point.y;
+  }
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const diameter = Math.max(width, height);
+  if (diameter < minDiameter || Math.min(width, height) < diameter * 0.5) {
+    return null;
+  }
+
+  const centroid = {
+    x: centroidX / sampled.length,
+    y: centroidY / sampled.length,
+  };
+  const radii = sampled.map((point) => distance(point, centroid));
+  const meanRadius =
+    radii.reduce((total, radius) => total + radius, 0) / radii.length;
+  const radiusVariance =
+    radii.reduce(
+      (total, radius) => total + (radius - meanRadius) ** 2,
+      0,
+    ) / radii.length;
+  const radialVariation = Math.sqrt(radiusVariance) / meanRadius;
+  if (radialVariation > 0.42) return null;
+
+  const angles = sampled.map((point) =>
+    Math.atan2(point.y - centroid.y, point.x - centroid.x),
+  );
+  let netTurn = 0;
+  let totalTurn = 0;
+  const visitedAngleBins = new Set<number>();
+  for (let index = 1; index < angles.length; index++) {
+    const delta = circularDelta(angles[index - 1], angles[index]);
+    netTurn += delta;
+    totalTurn += Math.abs(delta);
+  }
+  for (const angle of angles) {
+    const normalized = (angle + Math.PI) / (Math.PI * 2);
+    visitedAngleBins.add(Math.min(11, Math.floor(normalized * 12)));
+  }
+
+  const turnCoverage = Math.abs(netTurn) / (Math.PI * 2);
+  const directionConsistency =
+    totalTurn === 0 ? 0 : Math.abs(netTurn) / totalTurn;
+  const angleCoverage = visitedAngleBins.size / 12;
+  const turnConcentration = tangentTurnConcentration(sampled);
+  if (
+    turnCoverage < 0.68 ||
+    turnCoverage > 1.45 ||
+    directionConsistency < 0.62 ||
+    angleCoverage < 0.67 ||
+    turnConcentration > 4.5
+  ) {
+    return null;
+  }
+
+  const closure = distance(sampled[0], sampled[sampled.length - 1]) / diameter;
+  if (closure > MAX_CLOSURE_RATIO) return null;
+
+  const aspectRatio = Math.min(width, height) / diameter;
+  const closureScore = 1 - clamp01(closure / MAX_CLOSURE_RATIO);
+  const radialScore = 1 - clamp01(radialVariation / 0.42);
+  const turnScore = 1 - clamp01(Math.abs(1 - turnCoverage) / 0.45);
+  const score =
+    closureScore * 0.3 +
+    radialScore * 0.25 +
+    turnScore * 0.2 +
+    directionConsistency * 0.15 +
+    aspectRatio * 0.05 +
+    angleCoverage * 0.05;
+
+  return { score, centroid, diameter };
+}
+
+function removeNearbyPoints(points: Point[]): Point[] {
+  if (points.length === 0) return [];
+  const filtered = [points[0]];
+  for (let index = 1; index < points.length; index++) {
+    if (distance(filtered[filtered.length - 1], points[index]) >= 4) {
+      filtered.push(points[index]);
+    }
+  }
+  return filtered;
+}
+
+function rangesOverlap(a: CircleCandidate, b: CircleCandidate): boolean {
+  if (a.sourceIndex !== b.sourceIndex) return false;
+  const overlap =
+    Math.min(a.endIndex, b.endIndex) - Math.max(a.startIndex, b.startIndex);
+  if (overlap <= 0) return false;
+  const shorterLength = Math.min(
+    a.endIndex - a.startIndex,
+    b.endIndex - b.startIndex,
+  );
+  return overlap / shorterLength > 0.45;
+}
+
+export function detectCircularGestures(
+  trails: LibraryItem[],
+  {
+    maxGestures = 120,
+    minDiameter = DEFAULT_MIN_DIAMETER,
+    minScore = DEFAULT_MIN_SCORE,
+  }: {
+    maxGestures?: number;
+    minDiameter?: number;
+    minScore?: number;
+  } = {},
+): CircularGesture[] {
+  const candidates: CircleCandidate[] = [];
+
+  trails.forEach((trail, sourceIndex) => {
+    const points = removeNearbyPoints(trail.points);
+    for (
+      let startIndex = 0;
+      startIndex <= points.length - DEFAULT_MIN_POINTS;
+      startIndex += 3
+    ) {
+      const maxEndIndex = Math.min(
+        points.length - 1,
+        startIndex + DEFAULT_MAX_WINDOW_POINTS,
+      );
+      let minX = points[startIndex].x;
+      let maxX = minX;
+      let minY = points[startIndex].y;
+      let maxY = minY;
+      let pathLength = 0;
+
+      for (
+        let endIndex = startIndex + 1;
+        endIndex <= maxEndIndex;
+        endIndex++
+      ) {
+        const point = points[endIndex];
+        pathLength += distance(points[endIndex - 1], point);
+        minX = Math.min(minX, point.x);
+        maxX = Math.max(maxX, point.x);
+        minY = Math.min(minY, point.y);
+        maxY = Math.max(maxY, point.y);
+        if (endIndex - startIndex + 1 < DEFAULT_MIN_POINTS) continue;
+        if (
+          (endIndex - startIndex - (DEFAULT_MIN_POINTS - 1)) % 2 !== 0 &&
+          endIndex !== maxEndIndex
+        ) {
+          continue;
+        }
+
+        const diameter = Math.max(maxX - minX, maxY - minY);
+        if (
+          diameter < minDiameter ||
+          distance(points[startIndex], point) > diameter * MAX_CLOSURE_RATIO
+        ) {
+          continue;
+        }
+
+        const pathToDiameterRatio = pathLength / diameter;
+        if (pathToDiameterRatio < 2.2 || pathToDiameterRatio > 5.5) {
+          continue;
+        }
+
+        const candidatePoints = points.slice(startIndex, endIndex + 1);
+        const metrics = analyzeCircle(candidatePoints, minDiameter);
+        if (!metrics || metrics.score < minScore) continue;
+        candidates.push({
+          points: candidatePoints,
+          color: trail.color,
+          id: `${trail.id}-circle-${startIndex}-${endIndex}`,
+          score: metrics.score,
+          sourceIndex,
+          startIndex,
+          endIndex,
+        });
+      }
+    }
+  });
+
+  candidates.sort((a, b) => b.score - a.score);
+  const selected: CircleCandidate[] = [];
+  for (const candidate of candidates) {
+    if (selected.some((existing) => rangesOverlap(candidate, existing))) {
+      continue;
+    }
+    selected.push(candidate);
+    if (selected.length >= maxGestures) break;
+  }
+
+  return selected.map(({ points, color, id, score }) => ({
+    points,
+    color,
+    id,
+    score,
+  }));
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function hashFraction(value: string): number {
+  return hashString(value) / 0xffffffff;
+}
+
+export function arrangeCircularGestures(
+  gestures: CircularGesture[],
+  viewport: { width: number; height: number },
+  {
+    maxCircles,
+    spatialOverlap,
+  }: {
+    maxCircles: number;
+    spatialOverlap: number;
+  },
+): Trail[] {
+  const selected = gestures.slice(0, maxCircles);
+  const minViewportDimension = Math.min(viewport.width, viewport.height);
+  const spread = 1 - clamp01(spatialOverlap);
+
+  return selected.flatMap((gesture, index) => {
+    const metrics = analyzeCircle(gesture.points, 0);
+    if (!metrics) return [];
+
+    const angle = index * Math.PI * (3 - Math.sqrt(5));
+    const ringFraction =
+      selected.length <= 1 ? 0 : Math.sqrt(index / (selected.length - 1));
+    const horizontalRadius = viewport.width * 0.42 * spread * ringFraction;
+    const verticalRadius = viewport.height * 0.35 * spread * ringFraction;
+    const center = {
+      x: viewport.width / 2 + Math.cos(angle) * horizontalRadius,
+      y: viewport.height / 2 + Math.sin(angle) * verticalRadius,
+    };
+    const sizeVariation = 0.44 + hashFraction(gesture.id) * 0.48;
+    const targetDiameter = minViewportDimension * sizeVariation;
+    const scale = targetDiameter / metrics.diameter;
+    const points = gesture.points.map((point, pointIndex) => ({
+      x: center.x + (point.x - metrics.centroid.x) * scale,
+      y: center.y + (point.y - metrics.centroid.y) * scale,
+      ts: pointIndex,
+    }));
+
+    return [
+      {
+        points,
+        color: gesture.color,
+        opacity: 1,
+        id: `arranged-${gesture.id}`,
+        startTime: 0,
+        endTime: Math.max(1, points.length - 1),
+        clicks: [],
+      },
+    ];
+  });
+}

--- a/extension/website/redraw/redraw.tsx
+++ b/extension/website/redraw/redraw.tsx
@@ -25,7 +25,6 @@ import {
 } from "./circles";
 
 const MAX_POOL_EVENTS = 100000;
-const CIRCLE_POOL_EVENTS = 20000;
 const IMAGE_MAX_SIZE = 640;
 const LIBRARY_CHUNK_POINTS = 120;
 const LIBRARY_MIN_CHUNK_POINTS = 8;
@@ -35,6 +34,7 @@ const CIRCLE_SOURCE_DOMAIN = window.location.hostname.replace(/^www\./, "");
 const CIRCLE_SOURCE_PATH = "/circle-draw";
 
 type Mode = "mosaic" | "warp" | "inplace" | "circles";
+type CircleSource = "archive" | "guided";
 
 const styles = {
   page: {
@@ -124,7 +124,7 @@ const CursorRedraw = () => {
   );
   const { events, loading, deepening, error: poolError } = useCursorEventPool(
     "",
-    mode === "circles" ? CIRCLE_POOL_EVENTS : MAX_POOL_EVENTS,
+    MAX_POOL_EVENTS,
   );
   const [error, setError] = useState<string | null>(null);
 
@@ -145,6 +145,7 @@ const CursorRedraw = () => {
   const [maxCircles, setMaxCircles] = useState(80);
   const [circleMinScore, setCircleMinScore] = useState(0.58);
   const [spatialOverlap, setSpatialOverlap] = useState(0.72);
+  const [circleSource, setCircleSource] = useState<CircleSource>("archive");
 
   const [viewportSize, setViewportSize] = useState(() => ({
     width: window.innerWidth,
@@ -190,7 +191,7 @@ const CursorRedraw = () => {
     () => ({
       randomizeColors: false,
       filters:
-        mode === "circles"
+        mode === "circles" && circleSource === "guided"
           ? [{ domain: CIRCLE_SOURCE_DOMAIN, path: CIRCLE_SOURCE_PATH }]
           : [],
       pidFilter: "",
@@ -204,7 +205,7 @@ const CursorRedraw = () => {
       minGapBetweenTrails: 0.3,
       documentSpace: false,
     }),
-    [mode],
+    [circleSource, mode],
   );
 
   const { trailStates } = useCursorTrails(events, viewportSize, cursorSettings);
@@ -385,7 +386,10 @@ const CursorRedraw = () => {
     : displayError
       ? displayError
       : mode === "circles"
-        ? `${detectedCircles.length} circular gestures detected from ${events.length} events`
+        ? `${detectedCircles.length} circular gestures detected from ${
+            circleSource === "archive" ? "all pages" : "the guided page"
+          } while scanning ${events.length} archived events` +
+          (deepening ? " — scanning older events..." : "")
         : (!image
           ? `${library.length} gestures in the library`
           : `${drawnTrails.length} strokes from ${library.length} gestures`) +
@@ -402,9 +406,14 @@ const CursorRedraw = () => {
         </div>
       )}
 
-      {mode === "circles" && detectedCircles.length === 0 && !loading && (
+      {mode === "circles" &&
+        detectedCircles.length === 0 &&
+        !loading &&
+        !deepening && (
         <div style={styles.dropPrompt}>
-          waiting for circles drawn at {CIRCLE_SOURCE_DOMAIN}/circle-draw
+          {circleSource === "archive"
+            ? `no circular gestures found in ${events.length} archived events`
+            : `waiting for circles drawn at ${CIRCLE_SOURCE_DOMAIN}/circle-draw`}
         </div>
       )}
 
@@ -426,7 +435,7 @@ const CursorRedraw = () => {
 
       {sequence.trailStates.length > 0 && (
         <AnimatedTrails
-          key={`${mode}-${threshold}-${maxStrokes}-${allowRotation}-${warpStrength}-${corridor}-${maxCircles}-${circleMinScore}-${spatialOverlap}-${image?.objectUrl}`}
+          key={`${mode}-${threshold}-${maxStrokes}-${allowRotation}-${warpStrength}-${corridor}-${circleSource}-${maxCircles}-${circleMinScore}-${spatialOverlap}-${image?.objectUrl}`}
           trailStates={sequence.trailStates}
           timeRange={timeRange}
           windowSize={sequence.trailStates.length}
@@ -544,6 +553,24 @@ const CursorRedraw = () => {
           )}
           {mode === "circles" && (
             <>
+              <div style={styles.row}>
+                <label htmlFor="circle-source">source</label>
+                <select
+                  id="circle-source"
+                  value={circleSource}
+                  onChange={(e) =>
+                    setCircleSource(e.target.value as CircleSource)
+                  }
+                  style={{
+                    width: 140,
+                    fontFamily: "'Martian Mono', monospace",
+                    fontSize: 9,
+                  }}
+                >
+                  <option value="archive">all archive</option>
+                  <option value="guided">guided page only</option>
+                </select>
+              </div>
               <div style={styles.row}>
                 <span>circles: {maxCircles}</span>
                 <input

--- a/extension/website/redraw/redraw.tsx
+++ b/extension/website/redraw/redraw.tsx
@@ -19,6 +19,10 @@ import { DEFAULT_SETTINGS } from "../shared/components/settingsDefaults";
 import { scheduleTrailSequence } from "../shared/utils/trailSequence";
 import { dilateMask, extractStrokes, loadImageData, Point } from "./image";
 import { LibraryItem, inPlaceTrails, mosaicTrails, warpTrails } from "./draw";
+import {
+  arrangeCircularGestures,
+  detectCircularGestures,
+} from "./circles";
 
 const MAX_POOL_EVENTS = 100000;
 const IMAGE_MAX_SIZE = 640;
@@ -26,8 +30,10 @@ const LIBRARY_CHUNK_POINTS = 120;
 const LIBRARY_MIN_CHUNK_POINTS = 8;
 const LIBRARY_MAX_ITEMS = 1500;
 const CANVAS_FIT = 0.85;
+const CIRCLE_SOURCE_DOMAIN = "wewere.online";
+const CIRCLE_SOURCE_PATH = "/circle-draw";
 
-type Mode = "mosaic" | "warp" | "inplace";
+type Mode = "mosaic" | "warp" | "inplace" | "circles";
 
 const styles = {
   page: {
@@ -87,6 +93,7 @@ const styles = {
   } as React.CSSProperties,
   row: {
     display: "flex",
+    flexWrap: "wrap",
     alignItems: "center",
     justifyContent: "space-between",
     gap: "8px",
@@ -109,8 +116,13 @@ const styles = {
 
 const CursorRedraw = () => {
   const chromeHidden = useChromeToggle();
+  const [mode, setMode] = useState<Mode>(() =>
+    new URLSearchParams(window.location.search).get("mode") === "circles"
+      ? "circles"
+      : "mosaic",
+  );
   const { events, loading, deepening, error: poolError } = useCursorEventPool(
-    "",
+    mode === "circles" ? CIRCLE_SOURCE_DOMAIN : "",
     MAX_POOL_EVENTS,
   );
   const [error, setError] = useState<string | null>(null);
@@ -120,7 +132,6 @@ const CursorRedraw = () => {
     objectUrl: string;
   } | null>(null);
 
-  const [mode, setMode] = useState<Mode>("mosaic");
   const [threshold, setThreshold] = useState(60);
   const [maxStrokes, setMaxStrokes] = useState(160);
   const [allowRotation, setAllowRotation] = useState(false);
@@ -130,6 +141,9 @@ const CursorRedraw = () => {
   const [pxPerSecond, setPxPerSecond] = useState(1400);
   const [overlap, setOverlap] = useState(0.85);
   const [showUnderlay, setShowUnderlay] = useState(true);
+  const [maxCircles, setMaxCircles] = useState(80);
+  const [circleMinScore, setCircleMinScore] = useState(0.58);
+  const [spatialOverlap, setSpatialOverlap] = useState(0.72);
 
   const [viewportSize, setViewportSize] = useState(() => ({
     width: window.innerWidth,
@@ -174,7 +188,10 @@ const CursorRedraw = () => {
   const cursorSettings: CursorTrailSettings = useMemo(
     () => ({
       randomizeColors: false,
-      filters: [],
+      filters:
+        mode === "circles"
+          ? [{ domain: CIRCLE_SOURCE_DOMAIN, path: CIRCLE_SOURCE_PATH }]
+          : [],
       pidFilter: "",
       eventFilter: { move: true, click: true, hold: true, cursor_change: true },
       // Straight keeps the genuine gesture shapes for matching.
@@ -186,7 +203,7 @@ const CursorRedraw = () => {
       minGapBetweenTrails: 0.3,
       documentSpace: false,
     }),
-    [],
+    [mode],
   );
 
   const { trailStates } = useCursorTrails(events, viewportSize, cursorSettings);
@@ -253,6 +270,15 @@ const CursorRedraw = () => {
     [trailStates],
   );
 
+  const detectedCircles = useMemo(
+    () =>
+      detectCircularGestures(fullTrails, {
+        maxGestures: Math.max(maxCircles, 120),
+        minScore: circleMinScore,
+      }),
+    [circleMinScore, fullTrails, maxCircles],
+  );
+
   const corridorMask = useMemo(() => {
     if (!imageStrokes || mode !== "inplace") return null;
     return dilateMask(
@@ -264,6 +290,12 @@ const CursorRedraw = () => {
   }, [imageStrokes, mode, corridor]);
 
   const drawnTrails = useMemo(() => {
+    if (mode === "circles") {
+      return arrangeCircularGestures(detectedCircles, viewportSize, {
+        maxCircles,
+        spatialOverlap,
+      });
+    }
     if (!canvasStrokes || library.length === 0) return [];
     if (mode === "mosaic") {
       return mosaicTrails(canvasStrokes.strokes, library, allowRotation);
@@ -294,6 +326,10 @@ const CursorRedraw = () => {
     fit,
     fullTrails,
     maxStrokes,
+    detectedCircles,
+    viewportSize,
+    maxCircles,
+    spatialOverlap,
   ]);
 
   const sequence = useMemo(() => {
@@ -347,7 +383,9 @@ const CursorRedraw = () => {
     ? "loading cursor events..."
     : displayError
       ? displayError
-      : (!image
+      : mode === "circles"
+        ? `${detectedCircles.length} circular gestures detected from ${events.length} events`
+        : (!image
           ? `${library.length} gestures in the library`
           : `${drawnTrails.length} strokes from ${library.length} gestures`) +
         (deepening ? ` — deepening pool (${events.length} events)...` : "");
@@ -357,13 +395,19 @@ const CursorRedraw = () => {
       {!chromeHidden && <div style={styles.title}>cursor redraw</div>}
       {!chromeHidden && <div style={styles.status}>{statusText}</div>}
 
-      {!image && !loading && (
+      {mode !== "circles" && !image && !loading && (
         <div style={styles.dropPrompt}>
           drop an image anywhere to draw it with cursor trails
         </div>
       )}
 
-      {image && fit && showUnderlay && (
+      {mode === "circles" && detectedCircles.length === 0 && !loading && (
+        <div style={styles.dropPrompt}>
+          waiting for circles drawn at wewere.online/circle-draw
+        </div>
+      )}
+
+      {mode !== "circles" && image && fit && showUnderlay && (
         <img
           src={image.objectUrl}
           alt=""
@@ -381,7 +425,7 @@ const CursorRedraw = () => {
 
       {sequence.trailStates.length > 0 && (
         <AnimatedTrails
-          key={`${mode}-${threshold}-${maxStrokes}-${allowRotation}-${warpStrength}-${corridor}-${image?.objectUrl}`}
+          key={`${mode}-${threshold}-${maxStrokes}-${allowRotation}-${warpStrength}-${corridor}-${maxCircles}-${circleMinScore}-${spatialOverlap}-${image?.objectUrl}`}
           trailStates={sequence.trailStates}
           timeRange={timeRange}
           windowSize={sequence.trailStates.length}
@@ -411,42 +455,52 @@ const CursorRedraw = () => {
             >
               in place
             </button>
+            <button
+              style={styles.modeButton(mode === "circles")}
+              onClick={() => setMode("circles")}
+            >
+              circles
+            </button>
           </div>
-          <div style={styles.row}>
-            <span>image</span>
-            <input
-              type="file"
-              accept="image/*"
-              style={{ width: 130, fontSize: 9 }}
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) handleFile(file);
-              }}
-            />
-          </div>
-          <div style={styles.row}>
-            <span>edges: {threshold}</span>
-            <input
-              type="range"
-              min={20}
-              max={200}
-              value={threshold}
-              onChange={(e) => setThreshold(Number(e.target.value))}
-              style={styles.slider}
-            />
-          </div>
-          <div style={styles.row}>
-            <span>strokes: {maxStrokes}</span>
-            <input
-              type="range"
-              min={20}
-              max={400}
-              step={10}
-              value={maxStrokes}
-              onChange={(e) => setMaxStrokes(Number(e.target.value))}
-              style={styles.slider}
-            />
-          </div>
+          {mode !== "circles" && (
+            <>
+              <div style={styles.row}>
+                <span>image</span>
+                <input
+                  type="file"
+                  accept="image/*"
+                  style={{ width: 130, fontSize: 9 }}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) handleFile(file);
+                  }}
+                />
+              </div>
+              <div style={styles.row}>
+                <span>edges: {threshold}</span>
+                <input
+                  type="range"
+                  min={20}
+                  max={200}
+                  value={threshold}
+                  onChange={(e) => setThreshold(Number(e.target.value))}
+                  style={styles.slider}
+                />
+              </div>
+              <div style={styles.row}>
+                <span>strokes: {maxStrokes}</span>
+                <input
+                  type="range"
+                  min={20}
+                  max={400}
+                  step={10}
+                  value={maxStrokes}
+                  onChange={(e) => setMaxStrokes(Number(e.target.value))}
+                  style={styles.slider}
+                />
+              </div>
+            </>
+          )}
           {mode === "mosaic" && (
             <div style={styles.row}>
               <label>
@@ -487,6 +541,52 @@ const CursorRedraw = () => {
               />
             </div>
           )}
+          {mode === "circles" && (
+            <>
+              <div style={styles.row}>
+                <span>circles: {maxCircles}</span>
+                <input
+                  type="range"
+                  min={5}
+                  max={120}
+                  step={5}
+                  value={maxCircles}
+                  onChange={(e) => setMaxCircles(Number(e.target.value))}
+                  style={styles.slider}
+                />
+              </div>
+              <div style={styles.row}>
+                <span>confidence: {circleMinScore.toFixed(2)}</span>
+                <input
+                  type="range"
+                  min={0.5}
+                  max={0.85}
+                  step={0.01}
+                  value={circleMinScore}
+                  onChange={(e) => setCircleMinScore(Number(e.target.value))}
+                  style={styles.slider}
+                />
+              </div>
+              <div style={styles.row}>
+                <span>spatial overlap: {spatialOverlap.toFixed(2)}</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={1}
+                  step={0.02}
+                  value={spatialOverlap}
+                  onChange={(e) => setSpatialOverlap(Number(e.target.value))}
+                  style={styles.slider}
+                />
+              </div>
+              <a
+                href="/circle-draw/"
+                style={{ color: "#3d3833", textAlign: "right" }}
+              >
+                collect more circles →
+              </a>
+            </>
+          )}
           <div style={styles.row}>
             <span>pace: {pxPerSecond}px/s</span>
             <input
@@ -500,7 +600,7 @@ const CursorRedraw = () => {
             />
           </div>
           <div style={styles.row}>
-            <span>overlap: {overlap.toFixed(2)}</span>
+            <span>timing overlap: {overlap.toFixed(2)}</span>
             <input
               type="range"
               min={0}
@@ -523,17 +623,19 @@ const CursorRedraw = () => {
               style={styles.slider}
             />
           </div>
-          <div style={styles.row}>
-            <label>
-              <input
-                type="checkbox"
-                checked={showUnderlay}
-                onChange={(e) => setShowUnderlay(e.target.checked)}
-                style={{ marginRight: 6 }}
-              />
-              show image underlay
-            </label>
-          </div>
+          {mode !== "circles" && (
+            <div style={styles.row}>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={showUnderlay}
+                  onChange={(e) => setShowUnderlay(e.target.checked)}
+                  style={{ marginRight: 6 }}
+                />
+                show image underlay
+              </label>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/extension/website/redraw/redraw.tsx
+++ b/extension/website/redraw/redraw.tsx
@@ -25,6 +25,7 @@ import {
 } from "./circles";
 
 const MAX_POOL_EVENTS = 100000;
+const CIRCLE_POOL_EVENTS = 20000;
 const IMAGE_MAX_SIZE = 640;
 const LIBRARY_CHUNK_POINTS = 120;
 const LIBRARY_MIN_CHUNK_POINTS = 8;
@@ -122,8 +123,8 @@ const CursorRedraw = () => {
       : "mosaic",
   );
   const { events, loading, deepening, error: poolError } = useCursorEventPool(
-    mode === "circles" ? CIRCLE_SOURCE_DOMAIN : "",
-    MAX_POOL_EVENTS,
+    "",
+    mode === "circles" ? CIRCLE_POOL_EVENTS : MAX_POOL_EVENTS,
   );
   const [error, setError] = useState<string | null>(null);
 

--- a/extension/website/redraw/redraw.tsx
+++ b/extension/website/redraw/redraw.tsx
@@ -31,7 +31,7 @@ const LIBRARY_CHUNK_POINTS = 120;
 const LIBRARY_MIN_CHUNK_POINTS = 8;
 const LIBRARY_MAX_ITEMS = 1500;
 const CANVAS_FIT = 0.85;
-const CIRCLE_SOURCE_DOMAIN = "wewere.online";
+const CIRCLE_SOURCE_DOMAIN = window.location.hostname.replace(/^www\./, "");
 const CIRCLE_SOURCE_PATH = "/circle-draw";
 
 type Mode = "mosaic" | "warp" | "inplace" | "circles";

--- a/extension/website/redraw/redraw.tsx
+++ b/extension/website/redraw/redraw.tsx
@@ -404,7 +404,7 @@ const CursorRedraw = () => {
 
       {mode === "circles" && detectedCircles.length === 0 && !loading && (
         <div style={styles.dropPrompt}>
-          waiting for circles drawn at wewere.online/circle-draw
+          waiting for circles drawn at {CIRCLE_SOURCE_DOMAIN}/circle-draw
         </div>
       )}
 


### PR DESCRIPTION
## Summary

- Add `/circle-draw/`, a guided page where extension users can trace large circles slowly enough for archival cursor sampling.
- Add a Circles mode to `/redraw/` that reads cursor events from `wewere.online/circle-draw`, detects rough circular gestures inside longer trails, and arranges them into an overlapping composition.
- Add controls for gesture confidence, circle count, spatial overlap, timing overlap, pace, and stroke width.
- Link both surfaces directly to each other.

## Detection

The detector scores closed trail windows using radial consistency, angular coverage, turn direction, aspect ratio, and distributed curvature. It rejects open arcs, back-and-forth movement, and corner-dominated rectangles. Detected paths retain their original gesture shape when they are translated and uniformly scaled into the composition.

## Validation

- `bunx vitest run redraw/__tests__/circles.test.ts` (5 tests)
- `bunx tsc --noEmit --pretty false`
- Targeted ESLint on the changed TypeScript files
- `bun run build`
- Browser verification of `/circle-draw/` and `/redraw/?mode=circles` with clean console logs
- Synthetic browser fixture: 24 of 24 circular gestures detected from 648 cursor events

The screenshot fixture uses generated cursor paths to exercise the production detector and renderer. It is not archived user data.

No changeset, starter-template update, or developer-doc update is needed because this change is confined to the extension website and does not change a package API.