### PR TITLE
Synchronize Internet Commute riders and add install entry point

### DIFF
--- a/extension/src/__tests__/content-lifecycle.test.ts
+++ b/extension/src/__tests__/content-lifecycle.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies bfcache pageshow restores collaboration and listeners are not one-shot.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EXTENSION_INSTALL_ATTRIBUTE } from "../utils/extensionInstallMarker";
 
 const storageGet = vi.hoisted(() => vi.fn());
 const storageSet = vi.hoisted(() => vi.fn());
@@ -64,6 +65,7 @@ describe("content page-lifecycle wiring", () => {
     vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     document.body.innerHTML = "";
+    document.documentElement.removeAttribute(EXTENSION_INSTALL_ATTRIBUTE);
     // Present native playhtml so setupPresence takes the identity-injection
     // branch, which re-dispatches "playhtml:configure-identity" every time
     // presence setup runs — the observable signal we assert on.
@@ -108,6 +110,9 @@ describe("content page-lifecycle wiring", () => {
         .default as { main: () => void };
 
       contentScript.main();
+      expect(
+        document.documentElement.getAttribute(EXTENSION_INSTALL_ATTRIBUTE),
+      ).toBe("installed");
 
       // Initial presence setup dispatches identity once.
       await vi.waitFor(() => {

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
@@ -47,10 +47,10 @@ describe("CommuteInstallPrompt", () => {
       vi.advanceTimersByTime(800);
     });
 
-    expect(container.textContent).toContain(
-      "make your browsing part of the line",
-    );
-    expect(container.querySelectorAll("a")).toHaveLength(3);
+    expect(container.textContent).toContain("get the extension");
+    const link = container.querySelector("a");
+    expect(link?.href).toBe("https://wewere.online/");
+    expect(link?.target).toBe("_blank");
     act(() => root.unmount());
   });
 

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
@@ -47,6 +47,7 @@ describe("CommuteInstallPrompt", () => {
       vi.advanceTimersByTime(800);
     });
 
+    expect(container.textContent).toContain("internet transit pass");
     expect(container.textContent).toContain("get the extension");
     const link = container.querySelector("a");
     expect(link?.href).toBe("https://wewere.online/");

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
@@ -1,0 +1,84 @@
+// ABOUTME: Verifies the commute install ticket only appears without the extension.
+// ABOUTME: Covers delayed display and late content-script detection.
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EXTENSION_INSTALL_ATTRIBUTE,
+  markExtensionInstalled,
+} from "../../utils/extensionInstallMarker";
+import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
+
+async function renderPrompt(): Promise<{
+  container: HTMLDivElement;
+  root: Root;
+}> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<CommuteInstallPrompt />);
+  });
+
+  return { container, root };
+}
+
+describe("CommuteInstallPrompt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.documentElement.removeAttribute(EXTENSION_INSTALL_ATTRIBUTE);
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("appears after the extension detection window", async () => {
+    const { container, root } = await renderPrompt();
+
+    expect(container.querySelector(".commute-install-cta")).toBeNull();
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(container.textContent).toContain(
+      "make your browsing part of the line",
+    );
+    expect(container.querySelectorAll("a")).toHaveLength(3);
+    act(() => root.unmount());
+  });
+
+  it("stays hidden when the extension is already installed", async () => {
+    markExtensionInstalled(document.documentElement);
+    const { container, root } = await renderPrompt();
+
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(container.querySelector(".commute-install-cta")).toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("disappears when the content script arrives after the page", async () => {
+    const { container, root } = await renderPrompt();
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(container.querySelector(".commute-install-cta")).not.toBeNull();
+
+    await act(async () => {
+      markExtensionInstalled(document.documentElement);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector(".commute-install-cta")).toBeNull();
+    act(() => root.unmount());
+  });
+});

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
@@ -70,12 +70,13 @@ export function CommuteInstallPrompt() {
       rel="noreferrer"
       aria-label="Visit we were online to download the extension"
     >
+      <span className="commute-install-cta__icon" aria-hidden="true" />
       <span className="commute-install-cta__copy">
+        <span className="commute-install-cta__label">
+          internet transit pass
+        </span>
         <strong>add your stops</strong>
         <span>get the extension →</span>
-      </span>
-      <span className="commute-install-cta__ticket" aria-hidden="true">
-        WWO
       </span>
     </a>
   );

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
@@ -1,8 +1,7 @@
-// ABOUTME: Shows browser-store links on the public commute when the extension is absent.
+// ABOUTME: Links the public commute to the extension homepage when installation is absent.
 // ABOUTME: Waits for the content-script marker so installed riders do not see the prompt.
 
 import { useEffect, useState } from "react";
-import { DOWNLOAD_LINKS } from "@movement/downloadLinks";
 import {
   EXTENSION_INSTALL_ATTRIBUTE,
   isExtensionInstalled,
@@ -64,25 +63,20 @@ export function CommuteInstallPrompt() {
   if (installState !== "missing") return null;
 
   return (
-    <aside
+    <a
       className="commute-install-cta"
-      aria-label="Download the we were online extension"
+      href="https://wewere.online/"
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Visit we were online to download the extension"
     >
-      <span className="commute-install-cta__ticket" aria-hidden="true">
-        ADD YOUR STOP
-      </span>
       <span className="commute-install-cta__copy">
-        <strong>make your browsing part of the line</strong>
-        <span>get the extension to leave stops for future riders</span>
+        <strong>add your stops</strong>
+        <span>get the extension →</span>
       </span>
-      <span className="commute-install-cta__links">
-        <span>download:</span>
-        {DOWNLOAD_LINKS.map(({ browser, url }) => (
-          <a key={browser} href={url} target="_blank" rel="noreferrer">
-            {browser}
-          </a>
-        ))}
+      <span className="commute-install-cta__ticket" aria-hidden="true">
+        WWO
       </span>
-    </aside>
+    </a>
   );
 }

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
@@ -1,0 +1,88 @@
+// ABOUTME: Shows browser-store links on the public commute when the extension is absent.
+// ABOUTME: Waits for the content-script marker so installed riders do not see the prompt.
+
+import { useEffect, useState } from "react";
+import { DOWNLOAD_LINKS } from "@movement/downloadLinks";
+import {
+  EXTENSION_INSTALL_ATTRIBUTE,
+  isExtensionInstalled,
+} from "../../utils/extensionInstallMarker";
+
+const EXTENSION_DETECTION_MS = 800;
+
+type InstallState = "checking" | "installed" | "missing";
+
+function isPublicWebPage(): boolean {
+  return (
+    window.location.protocol === "http:" ||
+    window.location.protocol === "https:"
+  );
+}
+
+function useExtensionInstallState(): InstallState {
+  const [state, setState] = useState<InstallState>(() => {
+    if (!isPublicWebPage()) return "installed";
+    return isExtensionInstalled(document.documentElement)
+      ? "installed"
+      : "checking";
+  });
+
+  useEffect(() => {
+    if (!isPublicWebPage()) return;
+
+    const root = document.documentElement;
+    if (isExtensionInstalled(root)) {
+      setState("installed");
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (isExtensionInstalled(root)) {
+        setState("installed");
+      }
+    });
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: [EXTENSION_INSTALL_ATTRIBUTE],
+    });
+
+    const timer = window.setTimeout(() => {
+      setState((current) => (current === "checking" ? "missing" : current));
+    }, EXTENSION_DETECTION_MS);
+
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return state;
+}
+
+export function CommuteInstallPrompt() {
+  const installState = useExtensionInstallState();
+  if (installState !== "missing") return null;
+
+  return (
+    <aside
+      className="commute-install-cta"
+      aria-label="Download the we were online extension"
+    >
+      <span className="commute-install-cta__ticket" aria-hidden="true">
+        ADD YOUR STOP
+      </span>
+      <span className="commute-install-cta__copy">
+        <strong>make your browsing part of the line</strong>
+        <span>get the extension to leave stops for future riders</span>
+      </span>
+      <span className="commute-install-cta__links">
+        <span>download:</span>
+        {DOWNLOAD_LINKS.map(({ browser, url }) => (
+          <a key={browser} href={url} target="_blank" rel="noreferrer">
+            {browser}
+          </a>
+        ))}
+      </span>
+    </aside>
+  );
+}

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -263,28 +263,6 @@ button {
   animation-play-state: paused;
 }
 
-.landscape--arriving {
-  .landscape-track--clouds {
-    animation-duration: 120s;
-  }
-
-  .landscape-track--mountain {
-    animation-duration: 42s;
-  }
-
-  .landscape-track--foreground {
-    animation-duration: 24s;
-  }
-
-  .landscape-track--water {
-    animation-duration: 15s;
-  }
-
-  .landscape-track--lower-trees {
-    animation-duration: 20s;
-  }
-}
-
 .landscape-cloud {
   fill: none;
   stroke: $landscape-ink;
@@ -618,6 +596,51 @@ button {
   &--right {
     right: 3px;
   }
+
+  &--joining {
+    border-color: rgba($accent-gold, 0.75);
+    background:
+      repeating-linear-gradient(
+        90deg,
+        rgba($accent-gold, 0.18) 0 2px,
+        transparent 2px 5px
+      ),
+      #4e5351;
+    box-shadow:
+      inset -2px 0 rgba($bg, 0.65),
+      0 0 0 3px rgba($accent-gold, 0.2);
+    animation: side-door-welcome 1.4s ease both;
+  }
+}
+
+.train-joiner {
+  position: absolute;
+  top: 140px;
+  left: 5px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  pointer-events: none;
+  animation: carriage-entry 1.4s cubic-bezier(0.2, 0.8, 0.3, 1) both;
+
+  .cursor-rider {
+    position: relative;
+    top: auto;
+    left: auto;
+  }
+}
+
+.train-joiner__message {
+  padding: 3px 6px;
+  color: $text;
+  border: 1px solid rgba($text, 0.25);
+  border-radius: 4px;
+  background: rgba($bg, 0.94);
+  box-shadow: 0 1px 4px rgba($text, 0.18);
+  font-family: $font-mono;
+  font-size: 8px;
+  white-space: nowrap;
 }
 
 .train-door {
@@ -642,7 +665,10 @@ button {
   }
 
   &--exit {
-    cursor: pointer;
+    cursor:
+      url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='28' height='28' viewBox='0 0 28 28'%3E%3Crect x='2' y='3' width='13' height='21' rx='2' fill='%23faf7f2' stroke='%235a4e41' stroke-width='2'/%3E%3Cpath d='M10 14h15m-5-5 5 5-5 5' fill='none' stroke='%23c56d4f' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+        14 14,
+      alias;
 
     &::after {
       content: "";
@@ -654,7 +680,20 @@ button {
     }
 
     .train-door__label {
-      opacity: 1;
+      opacity: 0;
+    }
+
+    &:hover,
+    &:focus-visible {
+      .train-door__panel {
+        border-color: rgba($accent-gold, 0.9);
+        box-shadow: 0 0 0 2px rgba($accent-gold, 0.18);
+      }
+
+      .train-door__label {
+        opacity: 1;
+        transform: translate(-50%, 2px);
+      }
     }
   }
 }
@@ -688,7 +727,9 @@ button {
   font-weight: 600;
   opacity: 0;
   transform: translateX(-50%);
-  transition: opacity 0.5s;
+  transition:
+    opacity 0.2s,
+    transform 0.2s;
   white-space: nowrap;
 }
 
@@ -1012,6 +1053,53 @@ button {
 
   50% {
     box-shadow: 0 0 0 6px rgba($accent-gold, 0.35);
+  }
+}
+
+@keyframes side-door-welcome {
+  0%,
+  100% {
+    border-color: rgba(90, 78, 65, 0.35);
+    background: $car-metal;
+    box-shadow: none;
+    filter: brightness(1);
+  }
+
+  35%,
+  70% {
+    border-color: rgba($accent-gold, 0.75);
+    background:
+      repeating-linear-gradient(
+        90deg,
+        rgba($accent-gold, 0.18) 0 2px,
+        transparent 2px 5px
+      ),
+      #4e5351;
+    box-shadow:
+      inset -2px 0 rgba($bg, 0.65),
+      0 0 0 3px rgba($accent-gold, 0.2);
+    filter: brightness(1.35);
+  }
+}
+
+@keyframes carriage-entry {
+  0% {
+    opacity: 0;
+    transform: translateX(-30px);
+  }
+
+  18% {
+    opacity: 1;
+  }
+
+  72% {
+    opacity: 1;
+    transform: translateX(76px);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateX(96px);
   }
 }
 

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -116,14 +116,15 @@ button {
   right: 14px;
   bottom: 14px;
   z-index: 30;
-  min-width: 174px;
-  padding: 8px 8px 8px 11px;
+  min-width: 198px;
+  min-height: 64px;
+  padding: 9px 11px 8px 8px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
+  overflow: hidden;
   border: 1px dashed rgba($text, 0.32);
-  border-radius: 7px;
+  border-radius: 10px 6px 6px 10px;
   background:
     repeating-linear-gradient(
       90deg,
@@ -131,7 +132,9 @@ button {
       transparent 1px 5px
     ),
     rgba($surface, 0.96);
-  box-shadow: 0 2px 8px rgba($text, 0.14);
+  box-shadow:
+    inset 0 3px $accent-teal,
+    0 2px 8px rgba($text, 0.14);
   text-decoration: none;
   transition:
     border-color 0.15s,
@@ -141,31 +144,53 @@ button {
   &:hover,
   &:focus-visible {
     border-color: rgba($accent-teal, 0.72);
-    box-shadow: 0 3px 12px rgba($text, 0.18);
+    box-shadow:
+      inset 0 3px $accent-teal,
+      0 3px 12px rgba($text, 0.18);
     outline: none;
     transform: translateY(-1px);
   }
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    left: 61px;
+    width: 9px;
+    height: 9px;
+    border: 1px dashed rgba($text, 0.28);
+    border-radius: 50%;
+    background: $bg;
+  }
+
+  &::before {
+    top: -5px;
+  }
+
+  &::after {
+    bottom: -5px;
+  }
 }
 
-.commute-install-cta__ticket {
-  width: 28px;
-  height: 28px;
-  display: grid;
-  place-items: center;
+.commute-install-cta__icon {
+  width: 44px;
+  height: 44px;
   flex: 0 0 auto;
-  color: $bg;
-  border-radius: 4px;
-  background: $accent-rust;
-  font-family: $font-mono;
-  font-size: 8px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  border: 1px solid rgba($text, 0.18);
+  border-radius: 6px;
+  background-color: $bg;
+  background-image: url("../../../public/icon/128.png");
+  background-position: center;
+  background-size: cover;
+  box-shadow: inset 0 0 0 1px rgba($bg, 0.7);
 }
 
 .commute-install-cta__copy {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  border-left: 1px dashed rgba($text, 0.25);
+  padding-left: 5px;
 
   strong {
     font-size: 12px;
@@ -175,6 +200,14 @@ button {
     color: $text-muted;
     font-family: $font-mono;
     font-size: 8px;
+  }
+
+  .commute-install-cta__label {
+    color: $accent-rust;
+    font-size: 7px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 }
 

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -111,6 +111,89 @@ button {
   text-align: center;
 }
 
+.commute-install-cta {
+  width: 100%;
+  min-height: 62px;
+  margin: 0 0 14px;
+  padding: 9px 14px 9px 10px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  border: 1px dashed rgba($text, 0.32);
+  border-left: 5px solid $accent-gold;
+  border-radius: 8px;
+  background:
+    repeating-linear-gradient(
+      90deg,
+      rgba($accent-gold, 0.04) 0 1px,
+      transparent 1px 5px
+    ),
+    rgba($surface, 0.9);
+  box-shadow: 0 1px 4px rgba($text, 0.08);
+}
+
+.commute-install-cta__ticket {
+  padding: 8px 9px;
+  color: $bg;
+  border-radius: 5px;
+  background: $accent-rust;
+  font-family: $font-mono;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.commute-install-cta__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+
+  strong {
+    font-size: 15px;
+  }
+
+  span {
+    color: $text-muted;
+    font-size: 11px;
+  }
+}
+
+.commute-install-cta__links {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: $font-mono;
+  font-size: 10px;
+
+  > span {
+    color: $text-muted;
+  }
+
+  a {
+    padding: 6px 8px;
+    border: 1px solid rgba($accent-teal, 0.45);
+    border-radius: 5px;
+    background: rgba($bg, 0.72);
+    color: $text;
+    text-decoration: none;
+    transition:
+      border-color 0.15s,
+      background 0.15s,
+      transform 0.15s;
+
+    &:hover,
+    &:focus-visible {
+      border-color: $accent-teal;
+      background: rgba($accent-teal, 0.12);
+      outline: none;
+      transform: translateY(-1px);
+    }
+  }
+}
+
 .commute-banner {
   width: 100%;
   min-height: 50px;

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -706,17 +706,6 @@ button {
   }
 
   &--joining {
-    border-color: rgba($accent-gold, 0.75);
-    background:
-      repeating-linear-gradient(
-        90deg,
-        rgba($accent-gold, 0.18) 0 2px,
-        transparent 2px 5px
-      ),
-      #4e5351;
-    box-shadow:
-      inset -2px 0 rgba($bg, 0.65),
-      0 0 0 3px rgba($accent-gold, 0.2);
     animation: side-door-welcome 1.4s ease both;
   }
 }
@@ -729,6 +718,7 @@ button {
   display: flex;
   align-items: center;
   gap: 5px;
+  opacity: 0;
   pointer-events: none;
   animation: carriage-entry 1.4s cubic-bezier(0.2, 0.8, 0.3, 1) both;
 

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -112,85 +112,77 @@ button {
 }
 
 .commute-install-cta {
-  width: 100%;
-  min-height: 62px;
-  margin: 0 0 14px;
-  padding: 9px 14px 9px 10px;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  position: fixed;
+  right: 14px;
+  bottom: 14px;
+  z-index: 30;
+  min-width: 174px;
+  padding: 8px 8px 8px 11px;
+  display: flex;
   align-items: center;
-  gap: 14px;
+  justify-content: space-between;
+  gap: 10px;
   border: 1px dashed rgba($text, 0.32);
-  border-left: 5px solid $accent-gold;
-  border-radius: 8px;
+  border-radius: 7px;
   background:
     repeating-linear-gradient(
       90deg,
       rgba($accent-gold, 0.04) 0 1px,
       transparent 1px 5px
     ),
-    rgba($surface, 0.9);
-  box-shadow: 0 1px 4px rgba($text, 0.08);
+    rgba($surface, 0.96);
+  box-shadow: 0 2px 8px rgba($text, 0.14);
+  text-decoration: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    border-color: rgba($accent-teal, 0.72);
+    box-shadow: 0 3px 12px rgba($text, 0.18);
+    outline: none;
+    transform: translateY(-1px);
+  }
 }
 
 .commute-install-cta__ticket {
-  padding: 8px 9px;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
   color: $bg;
-  border-radius: 5px;
+  border-radius: 4px;
   background: $accent-rust;
   font-family: $font-mono;
-  font-size: 9px;
+  font-size: 8px;
   font-weight: 600;
   letter-spacing: 0.08em;
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
 }
 
 .commute-install-cta__copy {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 
   strong {
-    font-size: 15px;
+    font-size: 12px;
   }
 
   span {
     color: $text-muted;
-    font-size: 11px;
+    font-family: $font-mono;
+    font-size: 8px;
   }
 }
 
-.commute-install-cta__links {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-family: $font-mono;
-  font-size: 10px;
-
-  > span {
-    color: $text-muted;
-  }
-
-  a {
-    padding: 6px 8px;
-    border: 1px solid rgba($accent-teal, 0.45);
-    border-radius: 5px;
-    background: rgba($bg, 0.72);
-    color: $text;
-    text-decoration: none;
-    transition:
-      border-color 0.15s,
-      background 0.15s,
-      transform 0.15s;
-
-    &:hover,
-    &:focus-visible {
-      border-color: $accent-teal;
-      background: rgba($accent-teal, 0.12);
-      outline: none;
-      transform: translateY(-1px);
-    }
+@media (max-width: 600px) {
+  .commute-install-cta {
+    right: auto;
+    bottom: 8px;
+    left: 8px;
   }
 }
 

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -7,6 +7,7 @@ import {
   PlayProvider,
   useCursorZone,
   usePlayContext,
+  usePresence,
   useUsers,
   withSharedState,
 } from "@playhtml/react";
@@ -21,7 +22,18 @@ import {
   type CommuteStop,
 } from "./commuteStops";
 import {
+  COMMUTE_SERVICE_CHANNEL,
+  COMMUTE_SERVICE_DISCOVERY_MS,
+  createCommuteService,
+  estimateServerTimeOffset,
+  selectCommuteService,
+  type CommuteService,
+  type CommuteServicePresence,
+} from "./commuteService";
+import {
+  DEPARTURE_SECONDS,
   getCommuteTiming,
+  INITIAL_PLATFORM_SECONDS,
   type CommutePhase,
 } from "./commuteTiming";
 import { ProceduralLandscape } from "./landscape";
@@ -48,6 +60,7 @@ interface CommuteCarProps {
   currentStop: CommuteStop;
   phase: CommutePhase;
   atOrigin: boolean;
+  isJoining: boolean;
   onSeatStateChange: (hasSeat: boolean) => void;
 }
 
@@ -55,6 +68,7 @@ interface RecentRoute {
   stops: CommuteStop[];
   sceneryStops: CommuteStop[];
   activePeople: number;
+  serverTimeOffsetMs: number | null;
   status: "loading" | "live" | "empty" | "error";
 }
 
@@ -81,12 +95,14 @@ const SEATS: SeatDefinition[] = ["top", "bottom"].flatMap((row) =>
 
 const DOORS = [276, 696];
 const COMMUTE_REFRESH_MS = 30_000;
+const COMMUTE_ROUTE_TIMEOUT_MS = 5_000;
 
 function useRecentRoute(): RecentRoute {
   const [route, setRoute] = useState<RecentRoute>({
     stops: [],
     sceneryStops: [],
     activePeople: 0,
+    serverTimeOffsetMs: null,
     status: "loading",
   });
 
@@ -96,6 +112,7 @@ function useRecentRoute(): RecentRoute {
 
     const load = async () => {
       try {
+        const requestStartedAt = Date.now();
         const response = await fetch(COMMUTE_RECENT_URL, {
           signal: controller.signal,
         });
@@ -104,19 +121,26 @@ function useRecentRoute(): RecentRoute {
         }
 
         const commute = parseCommuteResponse(await response.json());
-        setRoute((current) => {
-          if (hasLoadedRoute) {
-            return { ...current, activePeople: commute.activePeople };
-          }
-
+        const responseReceivedAt = Date.now();
+        if (hasLoadedRoute) {
+          setRoute((current) => ({
+            ...current,
+            activePeople: commute.activePeople,
+          }));
+        } else {
           hasLoadedRoute = true;
-          return {
+          setRoute({
             stops: commute.stops,
             sceneryStops: commute.sceneryStops,
             activePeople: commute.activePeople,
+            serverTimeOffsetMs: estimateServerTimeOffset(
+              commute.generatedAt,
+              requestStartedAt,
+              responseReceivedAt,
+            ),
             status: commute.stops.length > 0 ? "live" : "empty",
-          };
-        });
+          });
+        }
       } catch (error) {
         if (controller.signal.aborted) return;
         console.warn("[internet commute] recent route unavailable:", error);
@@ -125,6 +149,7 @@ function useRecentRoute(): RecentRoute {
             stops: [],
             sceneryStops: [],
             activePeople: 0,
+            serverTimeOffsetMs: 0,
             status: "error",
           });
         }
@@ -132,14 +157,137 @@ function useRecentRoute(): RecentRoute {
     };
 
     void load();
+    const routeTimeout = window.setTimeout(() => {
+      if (hasLoadedRoute) return;
+      setRoute((current) =>
+        current.status === "loading"
+          ? {
+              ...current,
+              serverTimeOffsetMs: 0,
+              status: "error",
+            }
+          : current,
+      );
+    }, COMMUTE_ROUTE_TIMEOUT_MS);
     const refreshTimer = window.setInterval(() => void load(), COMMUTE_REFRESH_MS);
     return () => {
       controller.abort();
+      window.clearTimeout(routeTimeout);
       window.clearInterval(refreshTimer);
     };
   }, []);
 
   return route;
+}
+
+interface CommuteServiceConnection {
+  joinedExistingService: boolean;
+  service: CommuteService | null;
+}
+
+function presenceWithService(service: CommuteService): Record<string, unknown> {
+  return {
+    [COMMUTE_SERVICE_CHANNEL]: {
+      joinedAt: service.startedAt,
+      service,
+    },
+  };
+}
+
+function useCommuteService(
+  availableStops: CommuteStop[],
+  routeStatus: RecentRoute["status"],
+  serverTimeOffsetMs: number | null,
+): CommuteServiceConnection {
+  const { presences, setMyPresence, myIdentity } =
+    usePresence<CommuteServicePresence>(COMMUTE_SERVICE_CHANNEL);
+  const [connection, setConnection] = useState<CommuteServiceConnection>({
+    joinedExistingService: false,
+    service: null,
+  });
+  const presencesRef = useRef(presences);
+
+  useEffect(() => {
+    presencesRef.current = presences;
+  }, [presences]);
+
+  useEffect(() => {
+    if (connection.service || !myIdentity) {
+      return;
+    }
+
+    const discoveryTimer = window.setTimeout(() => {
+      const existingService = selectCommuteService(
+        presencesRef.current.values(),
+      );
+      if (
+        existingService === null &&
+        (routeStatus === "loading" || serverTimeOffsetMs === null)
+      ) {
+        return;
+      }
+
+      const serverNow = Date.now() + (serverTimeOffsetMs ?? 0);
+      const service =
+        existingService ??
+        createCommuteService(serverNow, myIdentity.publicKey, availableStops);
+      const presence: CommuteServicePresence = {
+        joinedAt: serverNow,
+        service,
+      };
+
+      setConnection({
+        joinedExistingService: existingService !== null,
+        service,
+      });
+      setMyPresence(presence);
+    }, COMMUTE_SERVICE_DISCOVERY_MS);
+
+    return () => window.clearTimeout(discoveryTimer);
+  }, [
+    availableStops,
+    connection.service,
+    myIdentity,
+    routeStatus,
+    serverTimeOffsetMs,
+    setMyPresence,
+  ]);
+
+  const canonicalService = useMemo(() => {
+    const candidates: unknown[] = [...presences.values()];
+    if (connection.service) {
+      candidates.push(presenceWithService(connection.service));
+    }
+    return selectCommuteService(candidates);
+  }, [connection.service, presences]);
+
+  useEffect(() => {
+    if (
+      !connection.service ||
+      !canonicalService ||
+      canonicalService.id === connection.service.id ||
+      serverTimeOffsetMs === null
+    ) {
+      return;
+    }
+
+    const presence: CommuteServicePresence = {
+      joinedAt: Date.now() + serverTimeOffsetMs,
+      service: canonicalService,
+    };
+    setConnection({
+      joinedExistingService: true,
+      service: canonicalService,
+    });
+    setMyPresence(presence);
+  }, [
+    canonicalService,
+    connection.service,
+    serverTimeOffsetMs,
+    setMyPresence,
+  ]);
+
+  return connection;
 }
 
 function StopFavicon({
@@ -283,14 +431,16 @@ function Platform({
 
 function LandscapeWindow({
   currentStop,
+  platformStop,
   phase,
-  atOrigin,
+  platformAtOrigin,
   edge,
   stops,
 }: {
   currentStop: CommuteStop;
+  platformStop: CommuteStop;
   phase: CommutePhase;
-  atOrigin: boolean;
+  platformAtOrigin: boolean;
   edge: "upper" | "lower";
   stops: CommuteStop[];
 }) {
@@ -326,9 +476,9 @@ function LandscapeWindow({
           </span>
         ))}
       <Platform
-        currentStop={currentStop}
+        currentStop={platformStop}
         visible={stationVisible}
-        atOrigin={atOrigin}
+        atOrigin={platformAtOrigin}
       />
     </div>
   );
@@ -373,7 +523,7 @@ function TrainDoor({
       <span className="train-door__panel train-door__panel--left" />
       <span className="train-door__panel train-door__panel--right" />
       <span className="train-door__label" aria-hidden={!canExit}>
-        click door to get off
+        leave this train →
       </span>
     </button>
   );
@@ -389,7 +539,13 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     },
   }),
   ({ awarenessByStableId, myAwareness, setMyAwareness, ref }, props) => {
-    const { cursors } = usePlayContext();
+    const { onSeatStateChange } = props;
+    const {
+      configureCursors,
+      cursors,
+      getMyPlayerIdentity,
+      isLoading,
+    } = usePlayContext();
     const [toast, setToast] = useState<string | null>(null);
     const toastTimer = useRef<number | undefined>(undefined);
     useCursorZone(ref);
@@ -407,6 +563,33 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     }, [awarenessByStableId]);
 
     const mySeatId = myAwareness?.seatId ?? null;
+    const seatedRiderIds = useMemo(() => {
+      const riderIds = new Set<string>();
+      for (const [stableId, awareness] of awarenessByStableId) {
+        if (awareness.seatId !== null) riderIds.add(stableId);
+      }
+      if (mySeatId !== null) {
+        const myPlayerId = getMyPlayerIdentity()?.publicKey;
+        if (myPlayerId) riderIds.add(myPlayerId);
+      }
+      return riderIds;
+    }, [awarenessByStableId, getMyPlayerIdentity, mySeatId]);
+
+    useEffect(() => {
+      if (isLoading) return;
+
+      configureCursors({
+        shouldRenderCursor: (presence) => {
+          const playerId = presence.playerIdentity?.publicKey;
+          return playerId === undefined || !seatedRiderIds.has(playerId);
+        },
+      });
+
+      return () => {
+        configureCursors({ shouldRenderCursor: () => true });
+      };
+    }, [configureCursors, isLoading, seatedRiderIds]);
+
     const displayedRiders = useMemo(() => {
       const riders = new Map(ridersBySeat);
       if (mySeatId !== null) {
@@ -424,8 +607,8 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     ]);
 
     useEffect(() => {
-      props.onSeatStateChange(mySeatId !== null);
-    }, [mySeatId, props.onSeatStateChange]);
+      onSeatStateChange(mySeatId !== null);
+    }, [mySeatId, onSeatStateChange]);
 
     useEffect(
       () => () => {
@@ -484,8 +667,24 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
           <span className="train-car__edge train-car__edge--bottom" />
           <span className="train-car__edge train-car__edge--left" />
           <span className="train-car__edge train-car__edge--right" />
-          <span className="train-car__side-door train-car__side-door--left" />
+          <span
+            className={`train-car__side-door train-car__side-door--left ${
+              props.isJoining ? "train-car__side-door--joining" : ""
+            }`}
+          />
           <span className="train-car__side-door train-car__side-door--right" />
+          {props.isJoining && (
+            <span className="train-joiner" aria-hidden>
+              <CursorRider
+                color={cursors.color || "#5b8db8"}
+                label="you"
+                isYou
+              />
+              <span className="train-joiner__message">
+                joining from the next carriage
+              </span>
+            </span>
+          )}
 
           {DOORS.map((x) => (
             <TrainDoor
@@ -556,7 +755,9 @@ function Banner({
     message = `now arriving at ${stopName}`;
     aside = `last visited ${formatStopAge(currentStop)} ago`;
   } else {
-    message = `${secondsLeft} seconds until next stop`;
+    message = `${secondsLeft} ${
+      secondsLeft === 1 ? "second" : "seconds"
+    } until next stop`;
     aside = `next stop: ${stopName}`;
     if (!hasSeat) instruction = "click an empty seat to sit";
   }
@@ -577,29 +778,64 @@ function Banner({
 function InternetCommute() {
   const riders = useUsers();
   const recentRoute = useRecentRoute();
-  const stops =
+  const availableStops =
     recentRoute.status === "live" ? recentRoute.stops : SAMPLE_STOPS;
+  const serviceConnection = useCommuteService(
+    availableStops,
+    recentRoute.status,
+    recentRoute.serverTimeOffsetMs,
+  );
+  const stops = serviceConnection.service?.stops ?? availableStops;
   const sceneryStops =
     recentRoute.sceneryStops.length > 0
       ? recentRoute.sceneryStops
       : SAMPLE_STOPS;
   const browsingCount = recentRoute.activePeople;
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const [clockNow, setClockNow] = useState(() => Date.now());
   const [hasSeat, setHasSeat] = useState(false);
 
   useEffect(() => {
-    const startedAt = Date.now();
     const timer = window.setInterval(() => {
-      setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+      setClockNow(Date.now());
     }, 250);
     return () => window.clearInterval(timer);
   }, []);
 
+  const elapsedSeconds = serviceConnection.service
+    ? Math.max(
+        0,
+        Math.floor(
+          (clockNow +
+            (recentRoute.serverTimeOffsetMs ?? 0) -
+            serviceConnection.service.startedAt) /
+            1000,
+        ),
+      )
+    : 0;
   const timing = getCommuteTiming(elapsedSeconds, stops.length);
   const currentStop = stops[timing.stopIndex];
+  const departingOrigin =
+    timing.phase === "riding" &&
+    elapsedSeconds < INITIAL_PLATFORM_SECONDS + DEPARTURE_SECONDS;
+  const platformStop =
+    timing.departureStopIndex === null
+      ? currentStop
+      : stops[timing.departureStopIndex];
+  const platformAtOrigin = timing.atOrigin || departingOrigin;
 
   return (
-    <main className="commute-page">
+    <main
+      className="commute-page"
+      data-service-id={serviceConnection.service?.id}
+      data-service-started-at={serviceConnection.service?.startedAt}
+      data-service-elapsed-seconds={elapsedSeconds}
+      data-joined-existing-service={serviceConnection.joinedExistingService}
+      data-joining-service={
+        serviceConnection.joinedExistingService
+          ? serviceConnection.service?.id
+          : undefined
+      }
+    >
       <div className="commute-shell">
         <header className="commute-header">
           <a
@@ -628,8 +864,9 @@ function InternetCommute() {
 
         <LandscapeWindow
           currentStop={currentStop}
+          platformStop={platformStop}
           phase={timing.phase}
-          atOrigin={timing.atOrigin}
+          platformAtOrigin={platformAtOrigin}
           edge="upper"
           stops={sceneryStops}
         />
@@ -638,12 +875,14 @@ function InternetCommute() {
           currentStop={currentStop}
           phase={timing.phase}
           atOrigin={timing.atOrigin}
+          isJoining={serviceConnection.joinedExistingService}
           onSeatStateChange={setHasSeat}
         />
         <LandscapeWindow
           currentStop={currentStop}
+          platformStop={platformStop}
           phase={timing.phase}
-          atOrigin={timing.atOrigin}
+          platformAtOrigin={platformAtOrigin}
           edge="lower"
           stops={sceneryStops}
         />

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -25,7 +25,8 @@ import {
   COMMUTE_SERVICE_CHANNEL,
   COMMUTE_SERVICE_DISCOVERY_MS,
   createCommuteService,
-  estimateServerTimeOffset,
+  getCommuteServicesFromPresences,
+  getCommuteStops,
   selectCommuteService,
   type CommuteService,
   type CommuteServicePresence,
@@ -113,7 +114,6 @@ function useRecentRoute(): RecentRoute {
 
     const load = async () => {
       try {
-        const requestStartedAt = Date.now();
         const response = await fetch(COMMUTE_RECENT_URL, {
           signal: controller.signal,
         });
@@ -122,7 +122,6 @@ function useRecentRoute(): RecentRoute {
         }
 
         const commute = parseCommuteResponse(await response.json());
-        const responseReceivedAt = Date.now();
         if (hasLoadedRoute) {
           setRoute((current) => ({
             ...current,
@@ -134,11 +133,7 @@ function useRecentRoute(): RecentRoute {
             stops: commute.stops,
             sceneryStops: commute.sceneryStops,
             activePeople: commute.activePeople,
-            serverTimeOffsetMs: estimateServerTimeOffset(
-              commute.generatedAt,
-              requestStartedAt,
-              responseReceivedAt,
-            ),
+            serverTimeOffsetMs: commute.generatedAt - Date.now(),
             status: commute.stops.length > 0 ? "live" : "empty",
           });
         }
@@ -186,15 +181,6 @@ interface CommuteServiceConnection {
   service: CommuteService | null;
 }
 
-function presenceWithService(service: CommuteService): Record<string, unknown> {
-  return {
-    [COMMUTE_SERVICE_CHANNEL]: {
-      joinedAt: service.startedAt,
-      service,
-    },
-  };
-}
-
 function useCommuteService(
   availableStops: CommuteStop[],
   routeStatus: RecentRoute["status"],
@@ -219,7 +205,7 @@ function useCommuteService(
 
     const discoveryTimer = window.setTimeout(() => {
       const existingService = selectCommuteService(
-        presencesRef.current.values(),
+        getCommuteServicesFromPresences(presencesRef.current.values()),
       );
       if (
         existingService === null &&
@@ -233,7 +219,6 @@ function useCommuteService(
         existingService ??
         createCommuteService(serverNow, myIdentity.publicKey, availableStops);
       const presence: CommuteServicePresence = {
-        joinedAt: serverNow,
         service,
       };
 
@@ -255,9 +240,9 @@ function useCommuteService(
   ]);
 
   const canonicalService = useMemo(() => {
-    const candidates: unknown[] = [...presences.values()];
+    const candidates = getCommuteServicesFromPresences(presences.values());
     if (connection.service) {
-      candidates.push(presenceWithService(connection.service));
+      candidates.push(connection.service);
     }
     return selectCommuteService(candidates);
   }, [connection.service, presences]);
@@ -266,14 +251,12 @@ function useCommuteService(
     if (
       !connection.service ||
       !canonicalService ||
-      canonicalService.id === connection.service.id ||
-      serverTimeOffsetMs === null
+      canonicalService.id === connection.service.id
     ) {
       return;
     }
 
     const presence: CommuteServicePresence = {
-      joinedAt: Date.now() + serverTimeOffsetMs,
       service: canonicalService,
     };
     setConnection({
@@ -284,7 +267,6 @@ function useCommuteService(
   }, [
     canonicalService,
     connection.service,
-    serverTimeOffsetMs,
     setMyPresence,
   ]);
 
@@ -786,7 +768,13 @@ function InternetCommute() {
     recentRoute.status,
     recentRoute.serverTimeOffsetMs,
   );
-  const stops = serviceConnection.service?.stops ?? availableStops;
+  const stops = useMemo(
+    () =>
+      serviceConnection.service
+        ? getCommuteStops(serviceConnection.service)
+        : availableStops,
+    [availableStops, serviceConnection.service],
+  );
   const sceneryStops =
     recentRoute.sceneryStops.length > 0
       ? recentRoute.sceneryStops

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -36,6 +36,7 @@ import {
   INITIAL_PLATFORM_SECONDS,
   type CommutePhase,
 } from "./commuteTiming";
+import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
 import { ProceduralLandscape } from "./landscape";
 import "./commute.scss";
 
@@ -853,6 +854,8 @@ function InternetCommute() {
           a slow train through the recent web — stops are pages other riders
           visited lately
         </p>
+
+        <CommuteInstallPrompt />
 
         <Banner
           phase={timing.phase}

--- a/extension/src/entrypoints/commute/commuteService.test.ts
+++ b/extension/src/entrypoints/commute/commuteService.test.ts
@@ -6,7 +6,8 @@ import { SAMPLE_STOPS } from "./commuteStops";
 import {
   COMMUTE_SERVICE_CHANNEL,
   createCommuteService,
-  estimateServerTimeOffset,
+  getCommuteServicesFromPresences,
+  getCommuteStops,
   getCommuteServiceFromPresence,
   selectCommuteService,
 } from "./commuteService";
@@ -14,7 +15,6 @@ import {
 function presenceFor(service: ReturnType<typeof createCommuteService>) {
   return {
     [COMMUTE_SERVICE_CHANNEL]: {
-      joinedAt: service.startedAt,
       service,
     },
   };
@@ -25,10 +25,10 @@ describe("Internet Commute service", () => {
     const stops = SAMPLE_STOPS.slice(0, 2).map((stop) => ({ ...stop }));
     const service = createCommuteService(1_000, "rider-a", stops);
 
-    stops[0].domain = "changed.example";
+    stops[0].title = "changed title";
 
     expect(service.id).toBe("1000:rider-a");
-    expect(service.stops[0].domain).toBe(SAMPLE_STOPS[0].domain);
+    expect(service.stops[0].title).toBe(SAMPLE_STOPS[0].title);
   });
 
   it("selects the earliest valid active service", () => {
@@ -36,11 +36,7 @@ describe("Internet Commute service", () => {
     const later = createCommuteService(1_100, "rider-b", SAMPLE_STOPS);
 
     expect(
-      selectCommuteService([
-        presenceFor(later),
-        { [COMMUTE_SERVICE_CHANNEL]: { service: null } },
-        presenceFor(first),
-      ]),
+      selectCommuteService([later, first]),
     ).toEqual(first);
   });
 
@@ -49,14 +45,14 @@ describe("Internet Commute service", () => {
     const serviceA = createCommuteService(1_000, "rider-a", SAMPLE_STOPS);
 
     expect(
-      selectCommuteService([presenceFor(serviceB), presenceFor(serviceA)])?.id,
+      selectCommuteService([serviceB, serviceA])?.id,
     ).toBe(serviceA.id);
   });
 
   it("ignores malformed route data from presence", () => {
+    const valid = createCommuteService(1_000, "rider-a", SAMPLE_STOPS);
     const malformed = {
       [COMMUTE_SERVICE_CHANNEL]: {
-        joinedAt: 1_000,
         service: {
           id: "bad",
           startedAt: 1_000,
@@ -66,16 +62,49 @@ describe("Internet Commute service", () => {
     };
 
     expect(getCommuteServiceFromPresence(malformed)).toBeNull();
-    expect(selectCommuteService([malformed])).toBeNull();
+    expect(
+      getCommuteServicesFromPresences([malformed, presenceFor(valid)]),
+    ).toEqual([valid]);
   });
 
-  it("calibrates from receipt because generatedAt is set after route work", () => {
-    expect(estimateServerTimeOffset(10_100, 9_900, 10_150)).toBe(-50);
+  it("reconstructs display stops from the compact service route", () => {
+    const service = createCommuteService(1_000, "rider-a", [
+      {
+        ...SAMPLE_STOPS[0],
+        url: "https://www.example.com/a-page",
+        title: "A page",
+      },
+    ]);
+
+    expect(getCommuteStops(service)[0]).toMatchObject({
+      id: "https://www.example.com/a-page",
+      domain: "example.com",
+      path: "/a-page",
+      title: "A page",
+      source: "sample",
+    });
   });
 
-  it("rejects an inverted request interval", () => {
-    expect(() => estimateServerTimeOffset(10_000, 10_100, 10_000)).toThrow(
-      "Internet Commute response preceded its request",
+  it("keeps a ten-stop route below the PlayHTML presence value limit", () => {
+    const stops = Array.from({ length: 10 }, (_, index) => ({
+      ...SAMPLE_STOPS[0],
+      url: `https://destination-${index}.example/${"path/".repeat(20)}`,
+      title: "T".repeat(100),
+      visitedAt: 1_000 + index,
+      sampleAge: null,
+      source: "live" as const,
+    }));
+    const service = createCommuteService(
+      1_000,
+      `pk_${"a".repeat(130)}`,
+      stops,
     );
+    const wireValue = {
+      at: 1_000,
+      value: { service },
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(wireValue)).byteLength;
+
+    expect(bytes).toBeLessThanOrEqual(4_096);
   });
 });

--- a/extension/src/entrypoints/commute/commuteService.test.ts
+++ b/extension/src/entrypoints/commute/commuteService.test.ts
@@ -1,0 +1,81 @@
+// ABOUTME: Verifies Internet Commute riders converge on one ephemeral train service.
+// ABOUTME: Covers canonical selection, malformed presence, route snapshots, and clock offset.
+
+import { describe, expect, it } from "vitest";
+import { SAMPLE_STOPS } from "./commuteStops";
+import {
+  COMMUTE_SERVICE_CHANNEL,
+  createCommuteService,
+  estimateServerTimeOffset,
+  getCommuteServiceFromPresence,
+  selectCommuteService,
+} from "./commuteService";
+
+function presenceFor(service: ReturnType<typeof createCommuteService>) {
+  return {
+    [COMMUTE_SERVICE_CHANNEL]: {
+      joinedAt: service.startedAt,
+      service,
+    },
+  };
+}
+
+describe("Internet Commute service", () => {
+  it("creates a route snapshot that does not follow later local mutations", () => {
+    const stops = SAMPLE_STOPS.slice(0, 2).map((stop) => ({ ...stop }));
+    const service = createCommuteService(1_000, "rider-a", stops);
+
+    stops[0].domain = "changed.example";
+
+    expect(service.id).toBe("1000:rider-a");
+    expect(service.stops[0].domain).toBe(SAMPLE_STOPS[0].domain);
+  });
+
+  it("selects the earliest valid active service", () => {
+    const first = createCommuteService(1_000, "rider-a", SAMPLE_STOPS);
+    const later = createCommuteService(1_100, "rider-b", SAMPLE_STOPS);
+
+    expect(
+      selectCommuteService([
+        presenceFor(later),
+        { [COMMUTE_SERVICE_CHANNEL]: { service: null } },
+        presenceFor(first),
+      ]),
+    ).toEqual(first);
+  });
+
+  it("uses the service id as a deterministic simultaneous-start tiebreaker", () => {
+    const serviceB = createCommuteService(1_000, "rider-b", SAMPLE_STOPS);
+    const serviceA = createCommuteService(1_000, "rider-a", SAMPLE_STOPS);
+
+    expect(
+      selectCommuteService([presenceFor(serviceB), presenceFor(serviceA)])?.id,
+    ).toBe(serviceA.id);
+  });
+
+  it("ignores malformed route data from presence", () => {
+    const malformed = {
+      [COMMUTE_SERVICE_CHANNEL]: {
+        joinedAt: 1_000,
+        service: {
+          id: "bad",
+          startedAt: 1_000,
+          stops: [{ id: "missing-fields" }],
+        },
+      },
+    };
+
+    expect(getCommuteServiceFromPresence(malformed)).toBeNull();
+    expect(selectCommuteService([malformed])).toBeNull();
+  });
+
+  it("calibrates from receipt because generatedAt is set after route work", () => {
+    expect(estimateServerTimeOffset(10_100, 9_900, 10_150)).toBe(-50);
+  });
+
+  it("rejects an inverted request interval", () => {
+    expect(() => estimateServerTimeOffset(10_000, 10_100, 10_000)).toThrow(
+      "Internet Commute response preceded its request",
+    );
+  });
+});

--- a/extension/src/entrypoints/commute/commuteService.ts
+++ b/extension/src/entrypoints/commute/commuteService.ts
@@ -6,14 +6,22 @@ import type { CommuteStop } from "./commuteStops";
 export const COMMUTE_SERVICE_CHANNEL = "internet-commute-service";
 export const COMMUTE_SERVICE_DISCOVERY_MS = 1_500;
 
+export interface CommuteServiceStop {
+  url: string;
+  title: string | null;
+  visitedAt: number | null;
+  sampleAge: string | null;
+  hue: string;
+  source: "live" | "sample";
+}
+
 export interface CommuteService {
   id: string;
   startedAt: number;
-  stops: CommuteStop[];
+  stops: CommuteServiceStop[];
 }
 
 export interface CommuteServicePresence extends Record<string, unknown> {
-  joinedAt: number;
   service: CommuteService;
 }
 
@@ -25,18 +33,23 @@ function isNullableString(value: unknown): value is string | null {
   return value === null || typeof value === "string";
 }
 
-function isCommuteStop(value: unknown): value is CommuteStop {
+function isWebUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function isCommuteServiceStop(value: unknown): value is CommuteServiceStop {
   if (!isRecord(value)) return false;
 
   return (
-    typeof value.id === "string" &&
-    typeof value.url === "string" &&
-    typeof value.domain === "string" &&
-    typeof value.path === "string" &&
+    isWebUrl(value.url) &&
     isNullableString(value.title) &&
-    isNullableString(value.faviconUrl) &&
-    typeof value.recentDomainVisits === "number" &&
-    typeof value.visitedBy === "string" &&
     (value.visitedAt === null || typeof value.visitedAt === "number") &&
     isNullableString(value.sampleAge) &&
     typeof value.hue === "string" &&
@@ -55,7 +68,7 @@ export function isCommuteService(value: unknown): value is CommuteService {
     value.startedAt > 0 &&
     Array.isArray(value.stops) &&
     value.stops.length > 0 &&
-    value.stops.every(isCommuteStop)
+    value.stops.every(isCommuteServiceStop)
   );
 }
 
@@ -72,15 +85,25 @@ export function getCommuteServiceFromPresence(
   return channelValue.service;
 }
 
-export function selectCommuteService(
+export function getCommuteServicesFromPresences(
   presences: Iterable<unknown>,
+): CommuteService[] {
+  const services: CommuteService[] = [];
+
+  for (const presence of presences) {
+    const service = getCommuteServiceFromPresence(presence);
+    if (service) services.push(service);
+  }
+
+  return services;
+}
+
+export function selectCommuteService(
+  services: Iterable<CommuteService>,
 ): CommuteService | null {
   let selected: CommuteService | null = null;
 
-  for (const presence of presences) {
-    const candidate = getCommuteServiceFromPresence(presence);
-    if (!candidate) continue;
-
+  for (const candidate of services) {
     if (
       selected === null ||
       candidate.startedAt < selected.startedAt ||
@@ -112,18 +135,36 @@ export function createCommuteService(
   return {
     id: `${Math.floor(startedAt)}:${creatorId}`,
     startedAt,
-    stops: stops.map((stop) => ({ ...stop })),
+    stops: stops.map(
+      ({ url, title, visitedAt, sampleAge, hue, source }) => ({
+        url,
+        title,
+        visitedAt,
+        sampleAge,
+        hue,
+        source,
+      }),
+    ),
   };
 }
 
-export function estimateServerTimeOffset(
-  generatedAt: number,
-  requestStartedAt: number,
-  responseReceivedAt: number,
-): number {
-  if (responseReceivedAt < requestStartedAt) {
-    throw new Error("Internet Commute response preceded its request");
-  }
+export function getCommuteStops(service: CommuteService): CommuteStop[] {
+  return service.stops.map((stop) => {
+    const url = new URL(stop.url);
 
-  return generatedAt - responseReceivedAt;
+    return {
+      id: stop.url,
+      url: stop.url,
+      domain: url.hostname.replace(/^www\./, ""),
+      path: url.pathname || "/",
+      title: stop.title,
+      faviconUrl: null,
+      recentDomainVisits: 1,
+      visitedBy: "another rider",
+      visitedAt: stop.visitedAt,
+      sampleAge: stop.sampleAge,
+      hue: stop.hue,
+      source: stop.source,
+    };
+  });
 }

--- a/extension/src/entrypoints/commute/commuteService.ts
+++ b/extension/src/entrypoints/commute/commuteService.ts
@@ -1,0 +1,129 @@
+// ABOUTME: Selects the ephemeral shared service followed by every Internet Commute rider.
+// ABOUTME: Uses server-calibrated time and active presence so an empty train resets at Home.
+
+import type { CommuteStop } from "./commuteStops";
+
+export const COMMUTE_SERVICE_CHANNEL = "internet-commute-service";
+export const COMMUTE_SERVICE_DISCOVERY_MS = 1_500;
+
+export interface CommuteService {
+  id: string;
+  startedAt: number;
+  stops: CommuteStop[];
+}
+
+export interface CommuteServicePresence extends Record<string, unknown> {
+  joinedAt: number;
+  service: CommuteService;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isCommuteStop(value: unknown): value is CommuteStop {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.id === "string" &&
+    typeof value.url === "string" &&
+    typeof value.domain === "string" &&
+    typeof value.path === "string" &&
+    isNullableString(value.title) &&
+    isNullableString(value.faviconUrl) &&
+    typeof value.recentDomainVisits === "number" &&
+    typeof value.visitedBy === "string" &&
+    (value.visitedAt === null || typeof value.visitedAt === "number") &&
+    isNullableString(value.sampleAge) &&
+    typeof value.hue === "string" &&
+    (value.source === "live" || value.source === "sample")
+  );
+}
+
+export function isCommuteService(value: unknown): value is CommuteService {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    typeof value.startedAt === "number" &&
+    Number.isFinite(value.startedAt) &&
+    value.startedAt > 0 &&
+    Array.isArray(value.stops) &&
+    value.stops.length > 0 &&
+    value.stops.every(isCommuteStop)
+  );
+}
+
+export function getCommuteServiceFromPresence(
+  presence: unknown,
+): CommuteService | null {
+  if (!isRecord(presence)) return null;
+
+  const channelValue = presence[COMMUTE_SERVICE_CHANNEL];
+  if (!isRecord(channelValue) || !isCommuteService(channelValue.service)) {
+    return null;
+  }
+
+  return channelValue.service;
+}
+
+export function selectCommuteService(
+  presences: Iterable<unknown>,
+): CommuteService | null {
+  let selected: CommuteService | null = null;
+
+  for (const presence of presences) {
+    const candidate = getCommuteServiceFromPresence(presence);
+    if (!candidate) continue;
+
+    if (
+      selected === null ||
+      candidate.startedAt < selected.startedAt ||
+      (candidate.startedAt === selected.startedAt &&
+        candidate.id.localeCompare(selected.id) < 0)
+    ) {
+      selected = candidate;
+    }
+  }
+
+  return selected;
+}
+
+export function createCommuteService(
+  startedAt: number,
+  creatorId: string,
+  stops: CommuteStop[],
+): CommuteService {
+  if (!Number.isFinite(startedAt) || startedAt <= 0) {
+    throw new Error("Internet Commute requires a valid service start time");
+  }
+  if (creatorId.length === 0) {
+    throw new Error("Internet Commute requires a service creator");
+  }
+  if (stops.length === 0) {
+    throw new Error("Internet Commute requires at least one service stop");
+  }
+
+  return {
+    id: `${Math.floor(startedAt)}:${creatorId}`,
+    startedAt,
+    stops: stops.map((stop) => ({ ...stop })),
+  };
+}
+
+export function estimateServerTimeOffset(
+  generatedAt: number,
+  requestStartedAt: number,
+  responseReceivedAt: number,
+): number {
+  if (responseReceivedAt < requestStartedAt) {
+    throw new Error("Internet Commute response preceded its request");
+  }
+
+  return generatedAt - responseReceivedAt;
+}

--- a/extension/src/entrypoints/commute/commuteStops.test.ts
+++ b/extension/src/entrypoints/commute/commuteStops.test.ts
@@ -245,6 +245,7 @@ describe("parseCommuteResponse", () => {
       }),
     ).toEqual({
       activePeople: 4,
+      generatedAt: 1_000,
       sceneryStops: [
         expect.objectContaining({
           domain: "docs.google.com",

--- a/extension/src/entrypoints/commute/commuteStops.ts
+++ b/extension/src/entrypoints/commute/commuteStops.ts
@@ -428,6 +428,7 @@ function destinationToStop(
 
 export function parseCommuteResponse(payload: unknown): {
   activePeople: number;
+  generatedAt: number;
   sceneryStops: CommuteStop[];
   stops: CommuteStop[];
 } {
@@ -445,6 +446,7 @@ export function parseCommuteResponse(payload: unknown): {
 
   return {
     activePeople: payload.activePeople,
+    generatedAt: payload.generatedAt,
     sceneryStops: payload.scenery.map(sceneryItemToStop),
     stops: payload.destinations.map(destinationToStop),
   };

--- a/extension/src/entrypoints/commute/commuteTiming.test.ts
+++ b/extension/src/entrypoints/commute/commuteTiming.test.ts
@@ -10,32 +10,85 @@ describe("getCommuteTiming", () => {
       phase: "stopped",
       secondsLeft: 10,
       stopIndex: 0,
+      departureStopIndex: null,
       atOrigin: true,
     });
   });
 
-  it("moves through travel, arrival, and the destination platform", () => {
-    expect(getCommuteTiming(10, 5).phase).toBe("riding");
-    expect(getCommuteTiming(25, 5)).toEqual({
-      phase: "arriving",
-      secondsLeft: 4,
-      stopIndex: 0,
-      atOrigin: false,
-    });
-    expect(getCommuteTiming(29, 5)).toEqual({
+  it("keeps the initial Home Station platform open for ten seconds", () => {
+    expect(getCommuteTiming(9.999, 5)).toMatchObject({
       phase: "stopped",
-      secondsLeft: 10,
       stopIndex: 0,
+      departureStopIndex: null,
+      atOrigin: true,
+    });
+    expect(getCommuteTiming(9.999, 5).secondsLeft).toBeCloseTo(0.001);
+    expect(getCommuteTiming(10, 5)).toEqual({
+      phase: "riding",
+      secondsLeft: 15,
+      stopIndex: 0,
+      departureStopIndex: null,
       atOrigin: false,
     });
   });
 
-  it("advances to the next route stop after the platform dwell", () => {
-    expect(getCommuteTiming(39, 5)).toEqual({
+  it("moves through travel, arrival, and a five-second destination dwell", () => {
+    expect(getCommuteTiming(24.999, 5)).toMatchObject({
+      phase: "riding",
+      stopIndex: 0,
+      departureStopIndex: null,
+    });
+    expect(getCommuteTiming(25, 5)).toEqual({
+      phase: "arriving",
+      secondsLeft: 4,
+      stopIndex: 0,
+      departureStopIndex: null,
+      atOrigin: false,
+    });
+    expect(getCommuteTiming(28.999, 5)).toMatchObject({
+      phase: "arriving",
+      stopIndex: 0,
+      departureStopIndex: null,
+    });
+    expect(getCommuteTiming(29, 5)).toEqual({
+      phase: "stopped",
+      secondsLeft: 5,
+      stopIndex: 0,
+      departureStopIndex: null,
+      atOrigin: false,
+    });
+    expect(getCommuteTiming(33.999, 5)).toMatchObject({
+      phase: "stopped",
+      stopIndex: 0,
+      departureStopIndex: null,
+    });
+  });
+
+  it("keeps showing the departed stop through the platform departure", () => {
+    expect(getCommuteTiming(34, 5)).toEqual({
       phase: "riding",
       secondsLeft: 15,
       stopIndex: 1,
+      departureStopIndex: 0,
       atOrigin: false,
+    });
+    expect(getCommuteTiming(36.599, 5)).toMatchObject({
+      phase: "riding",
+      stopIndex: 1,
+      departureStopIndex: 0,
+    });
+    expect(getCommuteTiming(36.6, 5)).toMatchObject({
+      phase: "riding",
+      stopIndex: 1,
+      departureStopIndex: null,
+    });
+  });
+
+  it("identifies the previous stop when the route loops", () => {
+    expect(getCommuteTiming(58, 2)).toMatchObject({
+      phase: "riding",
+      stopIndex: 0,
+      departureStopIndex: 1,
     });
   });
 

--- a/extension/src/entrypoints/commute/commuteTiming.ts
+++ b/extension/src/entrypoints/commute/commuteTiming.ts
@@ -4,7 +4,8 @@
 export const INITIAL_PLATFORM_SECONDS = 10;
 export const TRAVEL_SECONDS = 15;
 export const ARRIVAL_SECONDS = 4;
-export const PLATFORM_SECONDS = 10;
+export const PLATFORM_SECONDS = 5;
+export const DEPARTURE_SECONDS = 2.6;
 
 export type CommutePhase = "stopped" | "riding" | "arriving";
 
@@ -12,6 +13,7 @@ export interface CommuteTiming {
   phase: CommutePhase;
   secondsLeft: number;
   stopIndex: number;
+  departureStopIndex: number | null;
   atOrigin: boolean;
 }
 
@@ -28,6 +30,7 @@ export function getCommuteTiming(
       phase: "stopped",
       secondsLeft: INITIAL_PLATFORM_SECONDS - elapsedSeconds,
       stopIndex: 0,
+      departureStopIndex: null,
       atOrigin: true,
     };
   }
@@ -35,14 +38,18 @@ export function getCommuteTiming(
   const cycleSeconds = TRAVEL_SECONDS + ARRIVAL_SECONDS + PLATFORM_SECONDS;
   const elapsedAfterOrigin = elapsedSeconds - INITIAL_PLATFORM_SECONDS;
   const cyclePosition = elapsedAfterOrigin % cycleSeconds;
-  const stopIndex =
-    Math.floor(elapsedAfterOrigin / cycleSeconds) % stopCount;
+  const completedCycles = Math.floor(elapsedAfterOrigin / cycleSeconds);
+  const stopIndex = completedCycles % stopCount;
 
   if (cyclePosition < TRAVEL_SECONDS) {
     return {
       phase: "riding",
       secondsLeft: TRAVEL_SECONDS - cyclePosition,
       stopIndex,
+      departureStopIndex:
+        completedCycles === 0 || cyclePosition >= DEPARTURE_SECONDS
+          ? null
+          : (stopIndex - 1 + stopCount) % stopCount,
       atOrigin: false,
     };
   }
@@ -52,6 +59,7 @@ export function getCommuteTiming(
       phase: "arriving",
       secondsLeft: TRAVEL_SECONDS + ARRIVAL_SECONDS - cyclePosition,
       stopIndex,
+      departureStopIndex: null,
       atOrigin: false,
     };
   }
@@ -60,6 +68,7 @@ export function getCommuteTiming(
     phase: "stopped",
     secondsLeft: cycleSeconds - cyclePosition,
     stopIndex,
+    departureStopIndex: null,
     atOrigin: false,
   };
 }

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -23,6 +23,7 @@ import { VERBOSE } from "../config";
 import { getFaviconUrl, getPageTitle } from "../utils/pageMetadata";
 import { FLAGS } from "../flags";
 import { shouldStartExtensionPresence } from "./content/presencePolicy";
+import { markExtensionInstalled } from "../utils/extensionInstallMarker";
 
 async function internalDevFeaturesEnabled(): Promise<boolean> {
   try {
@@ -53,6 +54,8 @@ export default defineContentScript({
     if (proto === "chrome-extension:" || proto === "moz-extension:") {
       return;
     }
+
+    markExtensionInstalled(document.documentElement);
 
     let currentPresenceCount = 0;
 

--- a/extension/src/utils/extensionInstallMarker.test.ts
+++ b/extension/src/utils/extensionInstallMarker.test.ts
@@ -1,0 +1,27 @@
+// ABOUTME: Verifies the DOM marker shared between the extension and public pages.
+// ABOUTME: Covers both writing and detecting the installed-extension signal.
+
+import { describe, expect, it } from "vitest";
+import {
+  EXTENSION_INSTALL_ATTRIBUTE,
+  isExtensionInstalled,
+  markExtensionInstalled,
+} from "./extensionInstallMarker";
+
+describe("extension install marker", () => {
+  it("marks the page when the extension content script is running", () => {
+    const root = document.createElement("html");
+
+    markExtensionInstalled(root);
+
+    expect(root.getAttribute(EXTENSION_INSTALL_ATTRIBUTE)).toBe("installed");
+    expect(isExtensionInstalled(root)).toBe(true);
+  });
+
+  it("does not treat unrelated attribute values as installed", () => {
+    const root = document.createElement("html");
+    root.setAttribute(EXTENSION_INSTALL_ATTRIBUTE, "unknown");
+
+    expect(isExtensionInstalled(root)).toBe(false);
+  });
+});

--- a/extension/src/utils/extensionInstallMarker.ts
+++ b/extension/src/utils/extensionInstallMarker.ts
@@ -1,0 +1,12 @@
+// ABOUTME: Exposes extension installation to public pages through a DOM marker.
+// ABOUTME: Lets website features hide installation prompts when the content script is present.
+
+export const EXTENSION_INSTALL_ATTRIBUTE = "data-we-were-online-extension";
+
+export function markExtensionInstalled(root: Element): void {
+  root.setAttribute(EXTENSION_INSTALL_ATTRIBUTE, "installed");
+}
+
+export function isExtensionInstalled(root: Element): boolean {
+  return root.getAttribute(EXTENSION_INSTALL_ATTRIBUTE) === "installed";
+}

--- a/extension/website/shared/downloadLinks.ts
+++ b/extension/website/shared/downloadLinks.ts
@@ -1,0 +1,17 @@
+// ABOUTME: Defines the public browser-store links for installing we were online.
+// ABOUTME: Keeps every website download surface pointed at the same listings.
+
+export const DOWNLOAD_LINKS = [
+  {
+    browser: "Chrome",
+    url: "https://chromewebstore.google.com/detail/we-were-online/bhkdblmogjkgeipehaphdocclmijnkhc?authuser=0&hl=en",
+  },
+  {
+    browser: "Firefox",
+    url: "https://addons.mozilla.org/en-US/firefox/addon/we-were-online/",
+  },
+  {
+    browser: "Edge",
+    url: "https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl",
+  },
+] as const;

--- a/extension/website/src/components/DownloadGate.tsx
+++ b/extension/website/src/components/DownloadGate.tsx
@@ -3,20 +3,8 @@
 
 import { useState, useEffect } from 'react';
 import { WORKER_URL } from '@movement/config';
+import { DOWNLOAD_LINKS } from '@movement/downloadLinks';
 import styles from './DownloadGate.module.scss';
-
-const CHROME_DOWNLOAD_URL =
-  'https://chromewebstore.google.com/detail/we-were-online/bhkdblmogjkgeipehaphdocclmijnkhc?authuser=0&hl=en';
-const FIREFOX_DOWNLOAD_URL =
-  'https://addons.mozilla.org/en-US/firefox/addon/we-were-online/';
-const EDGE_DOWNLOAD_URL =
-  'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
-
-const DOWNLOAD_LINKS = [
-  { browser: 'Chrome', url: CHROME_DOWNLOAD_URL },
-  { browser: 'Firefox', url: FIREFOX_DOWNLOAD_URL },
-  { browser: 'Edge', url: EDGE_DOWNLOAD_URL },
-];
 
 const SUBSCRIBED_KEY = 'wewere.subscribed';
 


### PR DESCRIPTION
## Summary

- Keep riders on the same ephemeral Internet Commute service, including people who join after the train has started.
- Align the platform, departure, and arrival states with the train animation. Riders now enter from the neighboring carriage, leave through a door affordance, and stop showing a free cursor while seated.
- Add a compact transit-pass install link to the public commute. The prompt uses the extension icon and stays hidden when the extension is installed.
- Share the Chrome, Firefox, and Edge listing URLs across the commute and website download surfaces.

## Validation

- `bun run --cwd extension test -- --run` (499 tests)
- `bun run --cwd extension/website build`
- `bun run build-extension`
- Scoped ESLint check for the commute install prompt
- Desktop and 390 × 844 browser verification on `/commute/`

## Screenshots

Desktop and phone-width captures are attached in the PR Evidence comment.
