### PR TITLE
react: type usePresence channels by name

### DIFF
--- a/.changeset/type-presence-channel.md
+++ b/.changeset/type-presence-channel.md
@@ -1,0 +1,9 @@
+---
+"@playhtml/react": patch
+---
+
+Correct `usePresence` types so the channel name and payload match the returned
+presence view. Pass the channel literal first and the payload second, such as
+`usePresence<"status", StatusPresence>("status")`. Channel values are available
+under their channel key, while `setMyPresence` continues to accept the channel
+payload.

--- a/apps/docs/src/content/docs/data/presence/index.mdx
+++ b/apps/docs/src/content/docs/data/presence/index.mdx
@@ -50,7 +50,10 @@ import { usePresence } from "@playhtml/react";
 function StatusList() {
   // presences is the live map (keyed by stable id); setMyPresence writes
   // your own; myIdentity is your name/colors/publicKey.
-  const { presences, setMyPresence, myIdentity } = usePresence<{ text: string }>("status");
+  const { presences, setMyPresence, myIdentity } = usePresence<
+    "status",
+    { text: string }
+  >("status");
 
   return (
     <>
@@ -61,7 +64,7 @@ function StatusList() {
 }
 ```
 
-The hook subscribes and unsubscribes with the component lifecycle. Your channel value lives under the channel name (`p.status`), not flattened onto the view.
+The hook subscribes and unsubscribes with the component lifecycle. Your channel value lives under the channel name (`p.status`), not directly on the view. The value is optional because a peer may not have published to that channel.
   </TabItem>
 </Tabs>
 

--- a/apps/docs/src/content/docs/reference/react-api.md
+++ b/apps/docs/src/content/docs/reference/react-api.md
@@ -322,15 +322,24 @@ All hooks must be used inside a `PlayProvider`. Each is safe to call before play
 Subscribe to a custom [presence](/docs/data/presence/) channel. Returns the live map of everyone's presence, a setter for your own, and your identity.
 
 ```tsx
-function usePresence<T = Record<string, unknown>>(channel: string): {
-  presences: Map<string, PresenceView<T>>;
-  setMyPresence: (data: T) => void;
+function usePresence<
+  Channel extends string,
+  Payload extends Record<string, unknown> = Record<string, unknown>,
+>(channel: Channel): {
+  presences: Map<
+    string,
+    PresenceView<Partial<Record<Channel, Payload>>>
+  >;
+  setMyPresence: (data: Payload) => void;
   myIdentity: PlayerIdentity | null;
 };
 ```
 
 ```tsx
-const { presences, setMyPresence } = usePresence<{ text: string }>("status");
+const { presences, setMyPresence } = usePresence<
+  "status",
+  { text: string }
+>("status");
 setMyPresence({ text: "focused" });
 // presences is keyed by stable id; each value has isMe, playerIdentity, cursor,
 // plus your channel data nested under the channel name:
@@ -340,7 +349,7 @@ for (const [, p] of presences) {
 }
 ```
 
-The type parameter is an assertion about your channel's shape; no runtime validation is performed. Note your data lives under the channel key (`p.status`), not flattened onto the view.
+The type parameters describe the channel name and its payload. No runtime validation is performed. The channel property is optional because a peer may not have published a value. Your data lives under the channel key (`p.status`), not directly on the view.
 
 ### `usePageData`
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,8 @@
   },
   "scripts": {
     "build": "tsc && vite build",
-    "test": "vitest run --no-typecheck && vitest run --no-typecheck --config vitest.integration.config.ts",
+    "test": "bun run test:types && vitest run --no-typecheck && vitest run --no-typecheck --config vitest.integration.config.ts",
+    "test:types": "tsc --noEmit -p tsconfig.type-tests.json",
     "test:watch": "vitest --no-typecheck"
   },
   "publishConfig": {

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -49,10 +49,12 @@ describe("usePresence", () => {
 
   it("setMyPresence is a no-op pre-sync, works post-sync", async () => {
     const warnSpy = vi.spyOn(console, "warn");
-    let captured: ReturnType<typeof usePresence> | null = null;
+    let captured:
+      | ReturnType<typeof usePresence<"selection", { x: number }>>
+      | null = null;
 
     function TestComponent() {
-      captured = usePresence("selection");
+      captured = usePresence<"selection", { x: number }>("selection");
       return <div />;
     }
 
@@ -78,10 +80,18 @@ describe("usePresence", () => {
     act(() => {
       captured!.setMyPresence({ x: 2 });
     });
+    expect(playhtml.presence.setMyPresence).toHaveBeenLastCalledWith("selection", {
+      x: 2,
+    });
 
     await waitFor(() => {
       expect(captured!.presences.size).toBeGreaterThan(0);
+      expect(captured!.presences.get("me")).toMatchObject({
+        selection: { x: 2 },
+        isMe: true,
+      });
     });
+    expect(captured!.presences.get("me")).not.toHaveProperty("x");
   });
 });
 

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -121,7 +121,17 @@ const mockedPlayhtml = {
   handleNavigation: vi.fn().mockResolvedValue(undefined),
   presence: {
     setMyPresence: vi.fn((channel: string, data: unknown) => {
-      mockPresences.set("me", { ...data, isMe: true, cursor: null });
+      const view: Record<string, unknown> = {
+        ...(mockPresences.get("me") as Record<string, unknown> | undefined),
+        isMe: true,
+        cursor: null,
+      };
+      if (data === null) {
+        delete view[channel];
+      } else {
+        view[channel] = data;
+      }
+      mockPresences.set("me", view);
       const listeners = presenceListeners.get(channel);
       if (listeners) for (const cb of listeners) cb(new Map(mockPresences));
     }),

--- a/packages/react/src/__tests__/usePresence.types.ts
+++ b/packages/react/src/__tests__/usePresence.types.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Checks the public usePresence channel and payload type contract.
+// ABOUTME: Ensures presence reads are nested while writes accept the channel payload.
+
+import { usePresence } from "../index";
+
+type StatusPresence = {
+  text: string;
+};
+
+export function verifyUsePresenceTypes(): void {
+  const { presences, setMyPresence } = usePresence<
+    "status",
+    StatusPresence
+  >("status");
+  const peer = presences.get("peer");
+
+  if (peer) {
+    const status: StatusPresence | undefined = peer.status;
+    void status;
+
+    // @ts-expect-error The payload is stored under the selected channel.
+    peer.text;
+    // @ts-expect-error Other presence channels do not share the selected payload type.
+    peer.activity;
+  }
+
+  setMyPresence({ text: "focused" });
+
+  // @ts-expect-error setMyPresence accepts the payload without the channel wrapper.
+  setMyPresence({ status: { text: "focused" } });
+  // @ts-expect-error The type-level channel must match the subscribed channel.
+  usePresence<"status", StatusPresence>("activity");
+  // @ts-expect-error The first type argument is the channel name.
+  usePresence<StatusPresence>("status");
+}

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -15,6 +15,15 @@ import {
 } from "playhtml";
 import type { CursorZoneOptions } from "playhtml";
 
+type SelectedPresenceView<
+  Channel extends string,
+  Payload extends Record<string, unknown>,
+> = PresenceView<Partial<Record<Channel, Payload>>>;
+type SelectedPresences<
+  Channel extends string,
+  Payload extends Record<string, unknown>,
+> = Map<string, SelectedPresenceView<Channel, Payload>>;
+
 function warnPreInit(call: string): void {
   console.warn(`[@playhtml/react] ${call} called before init — ignored.`);
 }
@@ -84,31 +93,36 @@ export function useCursorZone(
  * returns an empty map, a setter that warns and no-ops, and `null` identity
  * until sync completes — then wires up automatically.
  *
- * Type parameter `T` is an assertion about the shape of presence values; no
- * runtime validation is performed.
+ * Type parameters describe the selected channel and its payload. No runtime
+ * validation is performed.
  */
-export function usePresence<T extends Record<string, unknown> = Record<string, unknown>>(
-  channel: string,
+export function usePresence<
+  Channel extends string,
+  Payload extends Record<string, unknown> = Record<string, unknown>,
+>(
+  channel: Channel,
 ): {
-  presences: Map<string, PresenceView<T>>;
-  setMyPresence: (data: T) => void;
+  presences: SelectedPresences<Channel, Payload>;
+  setMyPresence: (data: Payload) => void;
   myIdentity: PlayerIdentity | null;
 } {
   const { isLoading } = useContext(PlayContext);
   const presences = usePlayhtmlSubscription(
     isLoading,
-    () => new Map<string, PresenceView<T>>(),
+    () => new Map() as SelectedPresences<Channel, Payload>,
     (setPresences) => {
-      setPresences(playhtml.presence.getPresences() as Map<string, PresenceView<T>>);
+      setPresences(
+        playhtml.presence.getPresences() as SelectedPresences<Channel, Payload>,
+      );
       return playhtml.presence.onPresenceChange(channel, (next) => {
-        setPresences(new Map(next) as Map<string, PresenceView<T>>);
+        setPresences(new Map(next) as SelectedPresences<Channel, Payload>);
       });
     },
     [channel],
   );
 
   const setMyPresence = useCallback(
-    (data: T) => {
+    (data: Payload) => {
       if (isLoading) {
         warnPreInit(`usePresence("${channel}").setMyPresence`);
         return;

--- a/packages/react/tsconfig.type-tests.json
+++ b/packages/react/tsconfig.type-tests.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/__tests__/usePresence.types.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- type `usePresence` with the selected channel name and its payload
- keep `setMyPresence` accepting the channel payload while exposing peer data under the channel key
- add compile-only contract coverage and a focused nested-shape runtime test
- update the React presence docs and add a package changeset

## Root cause

`usePresence<T>(channel)` returned `PresenceView<T>`, which described `T` as fields directly on each presence view. The runtime stores the payload at `presence[channel]`, so consumers could not use the supplied payload type to read the selected channel.

The corrected signature uses `usePresence<Channel, Payload>(channel)` and returns `PresenceView<Partial<Record<Channel, Payload>>>`. The channel property is optional because a peer may not have published a value.

## Developer impact

Typed calls now name both parts of the contract:

```tsx
const { presences, setMyPresence } = usePresence<
  "status",
  { text: string }
>("status");

setMyPresence({ text: "focused" });
presences.get("peer")?.status?.text;
```

## Verification

- `bun run test` in `packages/react` (50 unit tests, 1 integration test)
- `bunx vitest run --no-typecheck src/__tests__/presence-client.test.ts` in `packages/playhtml` (24 tests)
- `bun run build` in `packages/react`
- `bun run test` in `apps/docs` (41 tests)
- `bun build-site`
- generated `packages/react/dist/main.d.ts` inspection
- `git diff --check`

`bun run lint` still reports existing errors in website, extension, and Worker files outside this diff. The React package typecheck and build pass.

## Docs and starters

Updated the React API reference and presence guide. The starter templates do not use `usePresence`, so no starter changes are needed.

## Visual evidence

See the PR Evidence comment for the rendered `usePresence` reference section.