### PR TITLE
playhtml: reevaluate cursor render predicates

### DIFF
--- a/.changeset/refresh-cursor-render-filters.md
+++ b/.changeset/refresh-cursor-render-filters.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Reevaluate current remote cursors when `shouldRenderCursor` changes so visibility updates do not wait for another peer cursor event.

--- a/packages/playhtml/src/cursors/__tests__/configure-render-filter.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/configure-render-filter.test.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Verifies cursor render filters reevaluate current remote presences.
+// ABOUTME: Predicate changes apply without waiting for another peer update.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Y from "yjs";
+import { CursorClientAwareness } from "../cursor-client";
+
+function makeFakeProvider() {
+  const doc = new Y.Doc();
+  const listeners: Array<(args: any) => void> = [];
+  const awareness: any = {
+    _states: new Map<number, Record<string, unknown>>(),
+    getStates() {
+      return this._states;
+    },
+    setLocalStateField(field: string, value: unknown) {
+      const local =
+        (this._states.get(this.clientID) as Record<string, unknown>) ?? {};
+      local[field] = value;
+      this._states.set(this.clientID, local);
+    },
+    getLocalState() {
+      return this._states.get(this.clientID) ?? null;
+    },
+    on(_event: string, callback: (args: any) => void) {
+      listeners.push(callback);
+    },
+    off() {},
+    emit(args: any) {
+      listeners.forEach((callback) => callback(args));
+    },
+    clientID: 1,
+    doc,
+  };
+
+  return { doc, awareness, on() {}, off() {} } as any;
+}
+
+function addRemoteCursor(provider: ReturnType<typeof makeFakeProvider>) {
+  const remoteClientId = 42;
+  provider.awareness._states.set(remoteClientId, {
+    __playhtml_cursors__: {
+      cursor: { x: 10, y: 20, pointer: "default" },
+      page: "/",
+      playerIdentity: {
+        publicKey: "remote-key",
+        playerStyle: { colorPalette: ["#00ff00"] },
+      },
+      lastSeen: Date.now(),
+    },
+  });
+  provider.awareness.emit({
+    added: [remoteClientId],
+    updated: [],
+    removed: [],
+  });
+}
+
+function makeClient(
+  provider: ReturnType<typeof makeFakeProvider>,
+  shouldRenderCursor?: () => boolean,
+) {
+  return new CursorClientAwareness(provider, {
+    enabled: true,
+    playerIdentity: {
+      publicKey: "local-key",
+      playerStyle: { colorPalette: ["#ff0000"] },
+    } as any,
+    shouldRenderCursor,
+  });
+}
+
+describe("configure({ shouldRenderCursor })", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    document.head
+      .querySelectorAll("#playhtml-cursor-styles")
+      .forEach((node) => node.remove());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("filters a rendered cursor without another peer update", () => {
+    const provider = makeFakeProvider();
+    const client = makeClient(provider);
+    addRemoteCursor(provider);
+
+    const cursor = document.querySelector(".playhtml-cursor-other");
+    expect(cursor).not.toBeNull();
+
+    client.configure({ shouldRenderCursor: () => false });
+
+    expect(cursor?.classList.contains("playhtml-cursor-fade-out")).toBe(true);
+    vi.advanceTimersByTime(300);
+    expect(document.querySelector(".playhtml-cursor-other")).toBeNull();
+
+    client.destroy();
+  });
+
+  it("renders a previously filtered cursor without another peer update", () => {
+    const provider = makeFakeProvider();
+    const client = makeClient(provider, () => false);
+    addRemoteCursor(provider);
+
+    expect(document.querySelector(".playhtml-cursor-other")).toBeNull();
+
+    client.configure({ shouldRenderCursor: () => true });
+
+    expect(document.querySelector(".playhtml-cursor-other")).not.toBeNull();
+
+    client.destroy();
+  });
+});

--- a/packages/playhtml/src/cursors/cursor-client.ts
+++ b/packages/playhtml/src/cursors/cursor-client.ts
@@ -2119,6 +2119,12 @@ export class CursorClientAwareness {
     // Update options object
     Object.assign(this.options, options);
 
+    if ("shouldRenderCursor" in options) {
+      for (const [stableId, presence] of this.activeCursorPresenceEntries()) {
+        this.updateCursor(stableId, presence);
+      }
+    }
+
     // Update visibility threshold if changed
     if (options.visibilityThreshold !== undefined) {
       this.visibilityThreshold = options.visibilityThreshold;


### PR DESCRIPTION
## Summary

- Reevaluate every current remote cursor when `shouldRenderCursor` changes.
- Reuse the existing cursor update path so filtered cursors are removed and newly allowed cursors are recreated without waiting for another peer event.
- Add focused regression coverage for both visibility directions and a `playhtml` patch changeset.

## Root cause

`CursorClientAwareness.configure()` updated the stored cursor options, but `shouldRenderCursor` was only read by `updateCursor()`. Existing remote cursor DOM was therefore left in its prior state until that peer published another cursor update.

## Validation

- `bun run test -- src/cursors/__tests__/configure-render-filter.test.ts` (2 tests)
- `bun run test` in `packages/playhtml` (51 files, 501 tests)
- `bun run build` in `packages/common`
- `bun run build` in `packages/playhtml`
- `bunx tsc --noEmit` in `packages/playhtml`
- Real-browser validation with two independent clients: a current remote cursor disappears when the predicate filters it and reappears when the predicate allows it, with no new peer movement.

## Docs and starters

No docs change is needed because the documented `shouldRenderCursor` signature and usage are unchanged. The fix makes `configure()` honor the existing contract immediately. No starter update is needed because imports, options, markup, and CSS are unchanged.