### PR TITLE
Refine Internet Commute destination curation

### DIFF
--- a/extension/worker/src/__tests__/commutePolicy.test.ts
+++ b/extension/worker/src/__tests__/commutePolicy.test.ts
@@ -109,6 +109,82 @@ describe('buildCommuteResponse', () => {
     ]);
   });
 
+  it('keeps large documentation and authentication surfaces as scenery only', () => {
+    const response = buildCommuteResponse(
+      [
+        event(
+          'superhuman-docs',
+          'navigation',
+          'https://docs.superhuman.com/help/article',
+          300,
+          'docs-rider',
+          'Superhuman Help Center',
+        ),
+        event(
+          'saml-callback',
+          'navigation',
+          'https://idpproxy.illinois.edu/simplesaml/module.php/saml/sp/saml2-acs.php/saml-sp',
+          200,
+          'auth-rider',
+          'Sign in',
+        ),
+        event(
+          'saml-callback-path',
+          'navigation',
+          'https://university.example/simplesaml/module.php/saml/sp/saml2-acs.php/service',
+          150,
+          'callback-rider',
+          'University login',
+        ),
+        event(
+          'article',
+          'navigation',
+          'https://garden.example/essays/moss',
+          100,
+          'article-rider',
+          'Notes on moss',
+        ),
+      ],
+      [],
+      1_000,
+    );
+
+    expect(response.scenery.map((item) => item.domain)).toEqual([
+      'docs.superhuman.com',
+      'idpproxy.illinois.edu',
+      'university.example',
+      'garden.example',
+    ]);
+    expect(
+      response.destinations.map((destination) => destination.domain),
+    ).toEqual(['garden.example']);
+  });
+
+  it('keeps IMDb entity pages while removing tracking queries', () => {
+    const response = buildCommuteResponse(
+      [
+        event(
+          'imdb-title',
+          'navigation',
+          'https://www.imdb.com/title/tt0133093/?ref_=nv_sr_srsg_0_tt_8_nm_0_in_0_q_matrix',
+          200,
+          'movie-rider',
+          'The Matrix (1999) - IMDb',
+        ),
+      ],
+      [],
+      1_000,
+    );
+
+    expect(response.destinations).toEqual([
+      expect.objectContaining({
+        domain: 'imdb.com',
+        title: 'The Matrix (1999) - IMDb',
+        url: 'https://www.imdb.com/title/tt0133093',
+      }),
+    ]);
+  });
+
   it('keeps user-bound surfaces as scenery but excludes them from destinations', () => {
     const response = buildCommuteResponse(
       [

--- a/extension/worker/src/routes/commutePolicy.ts
+++ b/extension/worker/src/routes/commutePolicy.ts
@@ -20,6 +20,7 @@ const NEVER_LAND_DOMAINS = [
   'chatgpt.com',
   'discord.com',
   'docs.google.com',
+  'docs.superhuman.com',
   'drive.google.com',
   'gemini.google.com',
   'mail.google.com',
@@ -34,6 +35,7 @@ const NEVER_LAND_DOMAINS = [
 
 const TITLE_REQUIRED_DOMAINS = [
   'github.com',
+  'imdb.com',
   'instagram.com',
   'itch.io',
   'pinterest.com',
@@ -60,8 +62,11 @@ const NEVER_LAND_SUBDOMAIN_LABELS = new Set([
   'auth',
   'candidate',
   'dashboard',
+  'idp',
+  'idpproxy',
   'login',
   'mail',
+  'sso',
 ]);
 
 const NEVER_LAND_PATH_SEGMENTS = new Set([
@@ -92,6 +97,13 @@ const NEVER_LAND_PATH_PREFIXES = [
     domain: 'nytimes.com',
     prefixes: ['/puzzles/stats'],
   },
+];
+
+const AUTHENTICATION_PATH_MARKERS = [
+  'oauth2callback',
+  'saml2acs',
+  'signinoidc',
+  'simplesaml',
 ];
 
 const GENERIC_TITLES = new Set([
@@ -171,9 +183,13 @@ function hasBlockedPath(pathname: string, domain: string): boolean {
     return true;
   }
 
-  return pathname
-    .split('/')
-    .some((segment) => NEVER_LAND_PATH_SEGMENTS.has(comparableLabel(segment)));
+  return pathname.split('/').some((segment) => {
+    const label = comparableLabel(segment);
+    return (
+      NEVER_LAND_PATH_SEGMENTS.has(label) ||
+      AUTHENTICATION_PATH_MARKERS.some((marker) => label.includes(marker))
+    );
+  });
 }
 
 function getMeaningfulTitle(
@@ -239,6 +255,14 @@ function sanitizePublicDestinationUrl(rawUrl: string): string | null {
       const videoId = url.pathname.replace(/^\/+/, '').split('/')[0];
       if (!/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
       return `https://youtu.be/${videoId}`;
+    }
+
+    if (
+      domainMatches(domain, 'imdb.com') &&
+      /^\/(?:title\/tt\d+|name\/nm\d+)(?:\/|$)/.test(url.pathname)
+    ) {
+      url.search = '';
+      return url.toString();
     }
 
     if (url.searchParams.size > 0) return null;


### PR DESCRIPTION
## Summary

- Keep `docs.superhuman.com` and identity-provider callback pages as domain-only scenery.
- Detect common IdP subdomains and SAML/OAuth callback path markers.
- Allow IMDb title and name pages to become stops after removing tracking query parameters.
- Require a meaningful title for IMDb stops.

## Why

Internet Commute should favor independent public pages without excluding useful public content from larger sites. Authentication callbacks and large product documentation are poor destinations, while an IMDb title page is useful when its tracking query is removed.

A strict domain allowlist would exclude the long-tail web that the commute is intended to surface. This keeps the existing hybrid model: broad domain-only scenery, generic privacy and authentication filters, a small denylist, and narrow normalization rules for public content sites.

## Validation

- `bun run --cwd extension/worker test` (61 tests)
- `bunx tsc --noEmit --project extension/worker/tsconfig.json`
- `git diff --check`

## Screenshots

Not applicable. This changes the worker's destination response policy without changing the commute interface.