### PR TITLE
Rotate Internet Commute scenery between stops

### DIFF
--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -15,6 +15,7 @@ import { COMMUTE_RECENT_URL } from "@movement/config";
 import {
   formatStopAge,
   getFaviconUrl,
+  getPassingSceneryStops,
   getStopDisplayDetail,
   getStopDisplayName,
   parseCommuteResponse,
@@ -419,6 +420,7 @@ function LandscapeWindow({
   platformAtOrigin,
   edge,
   stops,
+  stopIndex,
 }: {
   currentStop: CommuteStop;
   platformStop: CommuteStop;
@@ -426,10 +428,13 @@ function LandscapeWindow({
   platformAtOrigin: boolean;
   edge: "upper" | "lower";
   stops: CommuteStop[];
+  stopIndex: number;
 }) {
-  const passingSites = stops
-    .filter((stop) => stop.id !== currentStop.id)
-    .slice(0, 4);
+  const passingSites = getPassingSceneryStops(
+    stops,
+    currentStop.domain,
+    stopIndex,
+  );
   const stationVisible = phase === "stopped" || phase === "arriving";
 
   return (
@@ -860,6 +865,7 @@ function InternetCommute() {
           platformAtOrigin={platformAtOrigin}
           edge="upper"
           stops={sceneryStops}
+          stopIndex={timing.stopIndex}
         />
         <CommuteCar
           id="internet-commute-car"
@@ -876,6 +882,7 @@ function InternetCommute() {
           platformAtOrigin={platformAtOrigin}
           edge="lower"
           stops={sceneryStops}
+          stopIndex={timing.stopIndex}
         />
 
         <div className="commute-counts">

--- a/extension/src/entrypoints/commute/commuteStops.test.ts
+++ b/extension/src/entrypoints/commute/commuteStops.test.ts
@@ -8,6 +8,7 @@ import {
   deriveRecentStops,
   formatStopAge,
   getFaviconUrl,
+  getPassingSceneryStops,
   getStopDisplayDetail,
   getStopDisplayName,
   parseCommuteResponse,
@@ -54,6 +55,38 @@ function commuteStop(
     ...overrides,
   };
 }
+
+describe("getPassingSceneryStops", () => {
+  it("rotates the visible domains for each stop and omits the current domain", () => {
+    const stops = [
+      commuteStop("current.example"),
+      ...Array.from({ length: 9 }, (_, index) =>
+        commuteStop(`scenery-${index}.example`),
+      ),
+    ];
+
+    expect(
+      getPassingSceneryStops(stops, "current.example", 0).map(
+        (stop) => stop.domain,
+      ),
+    ).toEqual([
+      "scenery-0.example",
+      "scenery-1.example",
+      "scenery-2.example",
+      "scenery-3.example",
+    ]);
+    expect(
+      getPassingSceneryStops(stops, "current.example", 1).map(
+        (stop) => stop.domain,
+      ),
+    ).toEqual([
+      "scenery-4.example",
+      "scenery-5.example",
+      "scenery-6.example",
+      "scenery-7.example",
+    ]);
+  });
+});
 
 describe("deriveRecentStops", () => {
   it("returns the newest unique web pages without query strings or hashes", () => {

--- a/extension/src/entrypoints/commute/commuteStops.ts
+++ b/extension/src/entrypoints/commute/commuteStops.ts
@@ -19,6 +19,23 @@ export interface CommuteStop {
   source: "live" | "sample";
 }
 
+const PASSING_SCENERY_COUNT = 4;
+
+export function getPassingSceneryStops(
+  stops: CommuteStop[],
+  currentDomain: string,
+  stopIndex: number,
+): CommuteStop[] {
+  const candidates = stops.filter((stop) => stop.domain !== currentDomain);
+  if (candidates.length <= PASSING_SCENERY_COUNT) return candidates;
+
+  const start = (stopIndex * PASSING_SCENERY_COUNT) % candidates.length;
+  return [...candidates, ...candidates].slice(
+    start,
+    start + PASSING_SCENERY_COUNT,
+  );
+}
+
 export const SAMPLE_STOPS: CommuteStop[] = [
   {
     id: "html-energy",


### PR DESCRIPTION
## Summary

- Rotate the four visible scenery domains with the shared stop index.
- Exclude the current station domain from the passing scenery.
- Keep every rider on the same deterministic scenery set.

## Root cause

Each landscape window always rendered the first four entries from the scenery response. The current-stop filter compared incompatible destination and scenery IDs, so it usually excluded nothing.

## Validation

- `bunx vitest run src/entrypoints/commute/commuteStops.test.ts`
- `bun run build` in `extension/website`
- Verified multiple consecutive stop transitions on `http://127.0.0.1:5173/commute/`

The full extension TypeScript check still reports existing errors outside the files changed here.