### PR TITLE
Keep Grok out of Internet Commute stops

### DIFF
--- a/extension/worker/src/__tests__/commutePolicy.test.ts
+++ b/extension/worker/src/__tests__/commutePolicy.test.ts
@@ -185,6 +185,43 @@ describe('buildCommuteResponse', () => {
     ]);
   });
 
+  it('keeps Grok as scenery while allowing Archive.org item pages as stops', () => {
+    const response = buildCommuteResponse(
+      [
+        event(
+          'grok',
+          'navigation',
+          'https://grok.com/',
+          200,
+          'grok-rider',
+          'Grok',
+        ),
+        event(
+          'archive-item',
+          'navigation',
+          'https://archive.org/details/computerchronicles',
+          100,
+          'archive-rider',
+          'Computer Chronicles',
+        ),
+      ],
+      [],
+      1_000,
+    );
+
+    expect(response.scenery.map((item) => item.domain)).toEqual([
+      'grok.com',
+      'archive.org',
+    ]);
+    expect(response.destinations).toEqual([
+      expect.objectContaining({
+        domain: 'archive.org',
+        title: 'Computer Chronicles',
+        url: 'https://archive.org/details/computerchronicles',
+      }),
+    ]);
+  });
+
   it('keeps user-bound surfaces as scenery but excludes them from destinations', () => {
     const response = buildCommuteResponse(
       [

--- a/extension/worker/src/routes/commutePolicy.ts
+++ b/extension/worker/src/routes/commutePolicy.ts
@@ -23,6 +23,7 @@ const NEVER_LAND_DOMAINS = [
   'docs.superhuman.com',
   'drive.google.com',
   'gemini.google.com',
+  'grok.com',
   'mail.google.com',
   'outlook.cloud.microsoft',
   'outlook.live.com',


### PR DESCRIPTION
## Summary

- Keep `grok.com` visible as domain-only scenery but exclude it from landing destinations.
- Add coverage confirming that Archive.org item pages remain valid stops.

## Rationale

Generic AI application homepages are not useful Internet Commute destinations. Archive.org item pages are public, standalone resources and should remain eligible.

## Validation

- `bun run --cwd extension/worker test` (62 tests passed)
- `bunx tsc --noEmit --project extension/worker/tsconfig.json`
- `git diff --check`

Screenshots are not applicable because this changes the worker's destination response policy without changing the interface.