### PR TITLE
Restore presence compatibility for legacy identities

### DIFF
--- a/partykit/__tests__/presenceServer.test.ts
+++ b/partykit/__tests__/presenceServer.test.ts
@@ -1,8 +1,87 @@
-// ABOUTME: Verifies generic presence server lifecycle diagnostics.
-// ABOUTME: Keeps expected WebSocket closes from polluting Worker logs.
+// ABOUTME: Verifies presence message compatibility and server lifecycle behavior.
+// ABOUTME: Covers public identity projection, state persistence, and close diagnostics.
 import { describe, expect, it } from "bun:test";
+import { validatePresenceClientMessage } from "@playhtml/common";
 import { getConnectionCloseDiagnostic } from "../connectionDiagnostics";
-import { persistPresenceConnectionState } from "../presenceMessage";
+import {
+  persistPresenceConnectionState,
+  projectPresenceClientIdentity,
+} from "../presenceMessage";
+
+describe("presence message compatibility", () => {
+  it("projects legacy join identities to public fields before validation", () => {
+    const message = validatePresenceClientMessage(
+      projectPresenceClientIdentity({
+        type: "presence-join",
+        identity: {
+          publicKey: "pk_1",
+          name: "Reader",
+          playerStyle: {
+            colorPalette: ["red"],
+            cursorStyle: "default",
+            privateStyle: "secret",
+          },
+          createdAt: 123,
+          discoveredSites: ["example.com"],
+          privateKey: { d: "secret" },
+        },
+      }),
+    );
+
+    expect(message).toEqual({
+      type: "presence-join",
+      identity: {
+        publicKey: "pk_1",
+        name: "Reader",
+        playerStyle: {
+          colorPalette: ["red"],
+          cursorStyle: "default",
+        },
+        createdAt: 123,
+      },
+    });
+  });
+
+  it("projects legacy identity-channel updates to public fields", () => {
+    const message = validatePresenceClientMessage(
+      projectPresenceClientIdentity({
+        type: "presence-update",
+        channel: "identity",
+        value: {
+          publicKey: "pk_1",
+          playerStyle: { colorPalette: ["red"] },
+          discoveredSites: ["example.com"],
+        },
+      }),
+    );
+
+    expect(message).toEqual({
+      type: "presence-update",
+      channel: "identity",
+      value: {
+        publicKey: "pk_1",
+        playerStyle: { colorPalette: ["red"] },
+      },
+    });
+  });
+
+  it("preserves invalid public identity fields for strict validation", () => {
+    expect(() =>
+      validatePresenceClientMessage(
+        projectPresenceClientIdentity({
+          type: "presence-join",
+          identity: {
+            publicKey: "pk_1",
+            playerStyle: { colorPalette: [] },
+            discoveredSites: ["example.com"],
+          },
+        }),
+      ),
+    ).toThrow(
+      "identity.playerStyle.colorPalette[0] must be a non-empty string",
+    );
+  });
+});
 
 describe("presence connection state persistence", () => {
   it("restores the previous state after a rejected attachment write", () => {

--- a/partykit/presenceMessage.ts
+++ b/partykit/presenceMessage.ts
@@ -9,6 +9,8 @@ const PUBLIC_IDENTITY_FIELDS = [
 ] as const;
 const PUBLIC_PLAYER_STYLE_FIELDS = ["colorPalette", "cursorStyle"] as const;
 
+// Compatibility for playhtml@2.11.1–2.13.1, which sent profile fields in
+// presence identities. Remove when those published clients no longer need support.
 export function projectPresenceClientIdentity(value: unknown): unknown {
   if (!isRecord(value)) return value;
 

--- a/partykit/presenceMessage.ts
+++ b/partykit/presenceMessage.ts
@@ -1,5 +1,67 @@
 // ABOUTME: Persists presence connection state through the hosting platform.
-// ABOUTME: Restores hibernation state when platform attachment writes are rejected.
+// ABOUTME: Prepares compatible client messages and restores rejected attachment writes.
+
+const PUBLIC_IDENTITY_FIELDS = [
+  "publicKey",
+  "name",
+  "playerStyle",
+  "createdAt",
+] as const;
+const PUBLIC_PLAYER_STYLE_FIELDS = ["colorPalette", "cursorStyle"] as const;
+
+export function projectPresenceClientIdentity(value: unknown): unknown {
+  if (!isRecord(value)) return value;
+
+  if (value.type === "presence-join" && isRecord(value.identity)) {
+    return {
+      ...value,
+      identity: projectPlayerIdentity(value.identity),
+    };
+  }
+
+  if (
+    value.type === "presence-update" &&
+    value.channel === "identity" &&
+    isRecord(value.value)
+  ) {
+    return {
+      ...value,
+      value: projectPlayerIdentity(value.value),
+    };
+  }
+
+  return value;
+}
+
+function projectPlayerIdentity(
+  identity: Record<string, unknown>,
+): Record<string, unknown> {
+  const projected = pickFields(identity, PUBLIC_IDENTITY_FIELDS);
+  if (isRecord(projected.playerStyle)) {
+    projected.playerStyle = pickFields(
+      projected.playerStyle,
+      PUBLIC_PLAYER_STYLE_FIELDS,
+    );
+  }
+  return projected;
+}
+
+function pickFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const projected: Record<string, unknown> = {};
+  for (const field of fields) {
+    if (Object.prototype.hasOwnProperty.call(value, field)) {
+      projected[field] = value[field];
+    }
+  }
+  return projected;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
 export function persistPresenceConnectionState<T>(
   previous: T,

--- a/partykit/presenceServer.ts
+++ b/partykit/presenceServer.ts
@@ -24,7 +24,10 @@ import {
   takePresenceChanges,
 } from "./presencePolicy";
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
-import { persistPresenceConnectionState } from "./presenceMessage";
+import {
+  persistPresenceConnectionState,
+  projectPresenceClientIdentity,
+} from "./presenceMessage";
 
 const PRESENCE_CHANNELS_STATE_KEY = "__playhtmlPresenceChannels";
 const PRESENCE_OPENED_AT_STATE_KEY = "__playhtmlPresenceOpenedAt";
@@ -74,7 +77,9 @@ export class PresenceServer extends Server<Env> {
 
     let parsed: PresenceClientMessage;
     try {
-      parsed = validatePresenceClientMessage(JSON.parse(message));
+      parsed = validatePresenceClientMessage(
+        projectPresenceClientIdentity(JSON.parse(message)),
+      );
     } catch (error) {
       this.sendError(connection, getErrorMessage(error));
       return;


### PR DESCRIPTION
## Summary

- Project incoming join and identity-channel payloads to the public identity fields before validation.
- Keep strict validation for every allowed public field.
- Persist and broadcast only the projected identity.
- Cover legacy joins, identity updates, nested private fields, and malformed public data.

## Why

Published `playhtml@2.11.1` through `2.13.1` clients send `discoveredSites` in their default identity. The server's strict public-identity boundary rejects that field, which breaks online counts, remote cursor identity and rendering, and other identity-keyed presence features for those clients.

The server now removes fields outside the public identity contract before invoking the existing validator. Invalid public fields still fail validation. Shared element state, persisted data, and the WebSocket transport are unchanged.

## Validation

- `bun test partykit/__tests__` (209 tests)
- `bunx tsc -p partykit --noEmit`
- `git diff --check`

No changeset or public documentation update is needed because this changes only server compatibility behavior and does not change the package API.