### PR TITLE
React: keep presence room hooks safe during navigation

### DIFF
--- a/.changeset/polite-presence-rooms.md
+++ b/.changeset/polite-presence-rooms.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Keep `usePresenceRoom()` returning `null` instead of throwing when React renders ahead of PlayHTML readiness during navigation or provider remount timing.

--- a/packages/react/src/__tests__/binding.integration.test.tsx
+++ b/packages/react/src/__tests__/binding.integration.test.tsx
@@ -1,10 +1,10 @@
-// ABOUTME: Tests React element binding lifecycle against the real playhtml core.
-// ABOUTME: Verifies data-source changes remove handlers created after asynchronous ID assignment.
+// ABOUTME: Tests React hooks and element bindings against the real playhtml core.
+// ABOUTME: Verifies binding cleanup and presence-room readiness across navigation.
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { elementHandlers, playhtml, resetPlayHTML, TagType } from "playhtml";
-import { withSharedState } from "../index";
+import { PlayProvider, usePresenceRoom, withSharedState } from "../index";
 
 describe("CanPlayElement binding lifecycle", () => {
   beforeEach(async () => {
@@ -58,5 +58,73 @@ describe("CanPlayElement binding lifecycle", () => {
     ).toBe(false);
 
     unmount();
+  });
+});
+
+describe("usePresenceRoom navigation readiness", () => {
+  const originalPath = window.location.pathname + window.location.search;
+
+  beforeEach(async () => {
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDER_THROW = false;
+    (globalThis as any).PLAYHTML_TEST_PROVIDERS = [];
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+    history.replaceState(null, "", "/presence-room-a");
+    await playhtml.init({});
+  });
+
+  afterEach(async () => {
+    cleanup();
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = false;
+    history.replaceState(null, "", originalPath);
+    await resetPlayHTML();
+    document.body.innerHTML = "";
+  });
+
+  it("recovers when the provider remounts while the next page is syncing", async () => {
+    function RoomStatus() {
+      const room = usePresenceRoom("chat");
+      return <div data-testid="room">{room ? "ready" : "loading"}</div>;
+    }
+
+    const firstRender = render(
+      <PlayProvider>
+        <RoomStatus />
+      </PlayProvider>,
+    );
+    await waitFor(() => {
+      expect(firstRender.getByTestId("room").textContent).toBe("ready");
+    });
+
+    (globalThis as any).PLAYHTML_TEST_DISABLE_AUTO_SYNC = true;
+    history.replaceState(null, "", "/presence-room-b");
+
+    let navigation!: Promise<void>;
+    act(() => {
+      navigation = playhtml.handleNavigation();
+    });
+    firstRender.unmount();
+
+    const secondRender = render(
+      <PlayProvider>
+        <RoomStatus />
+      </PlayProvider>,
+    );
+    expect(secondRender.getByTestId("room").textContent).toBe("loading");
+
+    const providers = (globalThis as any).PLAYHTML_TEST_PROVIDERS as Array<{
+      emit: (type: string, value: boolean) => void;
+    }>;
+    act(() => {
+      providers.at(-1)?.emit("sync", true);
+    });
+    await act(async () => {
+      await navigation;
+    });
+
+    await waitFor(() => {
+      expect(secondRender.getByTestId("room").textContent).toBe("ready");
+    });
   });
 });

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -18,6 +18,16 @@ import {
 } from "../index";
 import type { PlayerIdentity } from "playhtml";
 
+const mockedPlayhtml = (globalThis as any).MOCKED_PLAYHTML as {
+  isLoading: boolean;
+  init: ReturnType<typeof vi.fn>;
+  ready: Promise<void>;
+  resetReady: () => void;
+  resolveReady: () => void;
+  createPresenceRoom: ReturnType<typeof vi.fn>;
+  presence: unknown;
+};
+
 describe("usePresence", () => {
   beforeEach(() => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -171,6 +181,92 @@ describe("usePresenceRoom", () => {
 
     expect(seen[0]).toBe(false);
     await waitFor(() => expect(seen.at(-1)).toBe(true));
+  });
+
+  it("keeps returning null when the provider is briefly ahead of core readiness", async () => {
+    mockedPlayhtml.resetReady();
+    mockedPlayhtml.isLoading = false;
+    mockedPlayhtml.init.mockImplementation(() => mockedPlayhtml.ready);
+    mockedPlayhtml.createPresenceRoom.mockClear();
+
+    const room = {
+      presence: mockedPlayhtml.presence,
+      destroy: vi.fn(),
+    };
+    mockedPlayhtml.createPresenceRoom
+      .mockImplementationOnce(() => {
+        throw new Error("playhtml.createPresenceRoom is not available before init()");
+      })
+      .mockImplementation(() => room);
+
+    function TestComponent() {
+      const room = usePresenceRoom("voice");
+      return <div data-testid="room">{room ? "ready" : "loading"}</div>;
+    }
+
+    const { getByTestId } = render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    expect(getByTestId("room")).toHaveTextContent("loading");
+    await waitFor(() => {
+      expect(mockedPlayhtml.createPresenceRoom).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      document.dispatchEvent(new CustomEvent("playhtml:navigated"));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("room")).toHaveTextContent("ready");
+    });
+  });
+
+  it("retries the current room name when readiness resolves", async () => {
+    mockedPlayhtml.resetReady();
+    mockedPlayhtml.isLoading = false;
+    mockedPlayhtml.init.mockImplementation(() => mockedPlayhtml.ready);
+    mockedPlayhtml.createPresenceRoom.mockClear();
+
+    let coreReady = false;
+    mockedPlayhtml.createPresenceRoom.mockImplementation((name: string) => {
+      if (!coreReady) {
+        throw new Error("playhtml.createPresenceRoom is not available before init()");
+      }
+      return {
+        name,
+        presence: mockedPlayhtml.presence,
+        destroy: vi.fn(),
+      };
+    });
+
+    function TestComponent({ name }: { name: string }) {
+      const room = usePresenceRoom(name) as { name: string } | null;
+      return <div data-testid="room">{room?.name ?? "loading"}</div>;
+    }
+
+    const { getByTestId, rerender } = render(
+      <PlayProvider>
+        <TestComponent name="first" />
+      </PlayProvider>,
+    );
+    expect(getByTestId("room")).toHaveTextContent("loading");
+
+    rerender(
+      <PlayProvider>
+        <TestComponent name="second" />
+      </PlayProvider>,
+    );
+    coreReady = true;
+    act(() => {
+      mockedPlayhtml.resolveReady();
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("room")).toHaveTextContent("second");
+    });
   });
 });
 

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -87,6 +87,14 @@ function resetMockReady() {
     mockReadyResolve();
     return mockReady;
   });
+  mockedPlayhtml.createPresenceRoom.mockImplementation(createMockPresenceRoom);
+}
+
+function createMockPresenceRoom(_name: string) {
+  return {
+    presence: mockedPlayhtml.presence,
+    destroy: vi.fn(),
+  };
 }
 
 const mockedPlayhtml = {
@@ -166,10 +174,7 @@ const mockedPlayhtml = {
       destroy: vi.fn(),
     };
   }),
-  createPresenceRoom: vi.fn((_name: string) => ({
-    presence: mockedPlayhtml.presence,
-    destroy: vi.fn(),
-  })),
+  createPresenceRoom: vi.fn(createMockPresenceRoom),
 };
 
 resetMockReady();

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -45,6 +45,13 @@ function usePlayhtmlSubscription<T>(
   return value;
 }
 
+function isPresenceRoomNotReadyError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message === "playhtml.createPresenceRoom is not available before init()"
+  );
+}
+
 /**
  * Hook to access cursor presences from the playhtml context
  * Returns a Map of stable ID -> CursorPresenceView
@@ -194,16 +201,55 @@ export function usePageData<T>(
  */
 export function usePresenceRoom(name: string): PresenceRoom | null {
   const { isLoading } = useContext(PlayContext);
-  return usePlayhtmlSubscription<PresenceRoom | null>(
-    isLoading,
-    () => null,
-    (setRoom) => {
-      const room = playhtml.createPresenceRoom(name);
-      setRoom(room);
-      return () => room.destroy();
-    },
-    [name],
-  );
+  const [room, setRoom] = useState<PresenceRoom | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const readyRetryRef = useRef<{
+    name: string;
+    ready: Promise<void>;
+  } | null>(null);
+
+  useEffect(() => {
+    if (isLoading) {
+      setRoom(null);
+      return;
+    }
+
+    let r: PresenceRoom;
+    try {
+      r = playhtml.createPresenceRoom(name);
+    } catch (error) {
+      if (!isPresenceRoomNotReadyError(error)) {
+        throw error;
+      }
+
+      let cancelled = false;
+      const retry = () => {
+        if (!cancelled) {
+          setRetryCount((count) => count + 1);
+        }
+      };
+      const ready = playhtml.ready;
+      const readyRetry = readyRetryRef.current;
+      if (readyRetry?.ready !== ready || readyRetry.name !== name) {
+        readyRetryRef.current = { name, ready };
+        void ready.then(retry, () => {});
+      }
+      document.addEventListener("playhtml:navigated", retry, { once: true });
+      setRoom(null);
+      return () => {
+        cancelled = true;
+        document.removeEventListener("playhtml:navigated", retry);
+      };
+    }
+
+    setRoom(r);
+    return () => {
+      r.destroy();
+      setRoom(null);
+    };
+  }, [isLoading, name, retryCount]);
+
+  return room;
 }
 
 const EMPTY_PLAYER_IDENTITY = {


### PR DESCRIPTION
## Summary

- Keep `usePresenceRoom()` at `null` when React renders while PlayHTML is temporarily unsynced.
- Retry room creation when `playhtml.ready` resolves or navigation finishes.
- Preserve other `createPresenceRoom()` errors instead of swallowing them.
- Add unit and real-core integration coverage for provider remounts and room-name changes during readiness.

## Root cause

`PlayProvider` can retain a synced context value while core PlayHTML is rebuilding its page room during navigation. If the provider remounts in that window, `usePresenceRoom()` calls `createPresenceRoom()` before core sync completes and throws instead of honoring the hook's documented `null` state.

## Validation

- `bun run test` in `packages/react`: 52 unit tests and 2 real-core integration tests passed.
- `bun run build` in `packages/react` passed.
- Tested Spencer's website against local builds of this branch through `/creation -> /about -> /creation -> / -> /creation`.
- The final and directly loaded `/creation` views each rendered 187 rows with no `createPresenceRoom` error.

The public docs already describe the intended behavior: the hook returns `null` until synced. Starter templates do not use this hook, so neither needs an update.

Fixes #267