### PR TITLE
Extension: refine walking record hierarchy and heuristics

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -3,7 +3,7 @@
 - Keep newly collected activity queued when local storage temporarily fails.
 - Get reload guidance instead of an endless loading screen when an older extension process blocks a local-history update.
 - See a visible patina on Wikipedia links after their first click.
-- See time by site, active explorations, regularly visited places, and daily cursor portraits in your weekly, monthly, or yearly walking record.
+- See time by site, active explorations, regularly visited places, and daily cursor portraits in a walking record that shows its progress as it opens.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -3,7 +3,7 @@
 - Keep newly collected activity queued when local storage temporarily fails.
 - Get reload guidance instead of an endless loading screen when an older extension process blocks a local-history update.
 - See a visible patina on Wikipedia links after their first click.
-- See time by site, active explorations, regularly visited places, and daily cursor portraits in a walking record that shows its progress as it opens.
+- See time by site, active explorations, regularly visited places, and combined daily cursor portraits that open the matching full-day portrait.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,7 +2,7 @@
 
 - Keep newly collected activity queued when local storage temporarily fails.
 - See a visible patina on Wikipedia links after their first click.
-- See a walking record of the places you explored across the past week, month, or year whenever you open a new tab.
+- See a walking record of the places you explored across the past week, month, or year, with progress shown while each period opens.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,7 +2,7 @@
 
 - Keep newly collected activity queued when local storage temporarily fails.
 - See a visible patina on Wikipedia links after their first click.
-- See a walking record of the places you explored across the past week, month, or year, with progress shown while each period opens.
+- See a walking record of the places you explored across the past week, month, or year, with recognizable site icons and progress while each period opens.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,7 +2,7 @@
 
 - Keep newly collected activity queued when local storage temporarily fails.
 - See a visible patina on Wikipedia links after their first click.
-- See a walking record of the places you explored across the past week, month, or year, with recognizable site icons and progress while each period opens.
+- See time by site, active explorations, regularly visited places, and daily cursor portraits in your weekly, monthly, or yearly walking record.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -3,7 +3,7 @@
 - Keep newly collected activity queued when local storage temporarily fails.
 - Get reload guidance instead of an endless loading screen when an older extension process blocks a local-history update.
 - See a visible patina on Wikipedia links after their first click.
-- See time by site, active explorations, regularly visited places, and combined daily cursor portraits that open the matching full-day portrait.
+- See time by site, active explorations, regularly visited places, daily cursor portraits, and a moving landscape of real browsing traces.
 
 <!--
 Add a bullet here for each meaningful user-facing change that ships in the

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Keep newly collected activity queued when local storage temporarily fails.
+- Get reload guidance instead of an endless loading screen when an older extension process blocks a local-history update.
 - See a visible patina on Wikipedia links after their first click.
 - See time by site, active explorations, regularly visited places, and daily cursor portraits in your weekly, monthly, or yearly walking record.
 

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -598,7 +598,7 @@ describe("LocalEventStore walking record events", () => {
       cursor("after", 12_000, 1, 1),
     ]);
 
-    const traces = await store.getWalkingRecordTraces([
+    const movement = await store.getWalkingRecordMovement([
       {
         id: "day:2026-07-20",
         url: "https://example.com/page",
@@ -607,7 +607,7 @@ describe("LocalEventStore walking record events", () => {
       },
     ]);
 
-    expect(traces).toEqual([
+    expect(movement.traces).toEqual([
       {
         targetId: "day:2026-07-20",
         paths: [
@@ -616,6 +616,46 @@ describe("LocalEventStore walking record events", () => {
         ],
       },
     ]);
+    expect(movement.landscapePaths).toHaveLength(2);
+    expect(movement.landscapePaths[0].map((event) => event.id)).toEqual([
+      "first",
+      "middle",
+    ]);
+    expect(movement.landscapePaths[1].map((event) => event.id)).toEqual([
+      "after-gap",
+      "last",
+    ]);
+  });
+
+  it("turns long movement into a bounded queue of consecutive landscape trails", async () => {
+    const store = createStore();
+    const cursorEvents = Array.from({ length: 300 }, (_, index) => ({
+      ...event(`cursor-${index}`, "cursor"),
+      ts: 1_000 + index * 100,
+      data: {
+        event: "move" as const,
+        x: index / 300,
+        y: index % 2 === 0 ? 0.25 : 0.75,
+      },
+    }));
+    await store.addEvents(cursorEvents);
+
+    const movement = await store.getWalkingRecordMovement([
+      {
+        id: "day:2026-07-20",
+        url: "https://example.com/page",
+        startTs: 1_000,
+        endTs: 31_000,
+      },
+    ]);
+
+    expect(movement.landscapePaths).toHaveLength(4);
+    expect(
+      movement.landscapePaths.every((path) => path.length <= 96),
+    ).toBe(true);
+    expect(movement.landscapePaths[0][0].id).toBe("cursor-0");
+    expect(movement.landscapePaths.at(-1)?.at(-1)?.id).toBe("cursor-299");
+    expect(movement.landscapePaths.at(-1)?.at(-1)?.ts).toBe(30_900);
   });
 });
 

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -6,7 +6,10 @@ import {
   IDBKeyRange as fakeIDBKeyRange,
   indexedDB as fakeIndexedDB,
 } from "fake-indexeddb";
-import { LocalEventStore, type DomainStatsAggregate } from "../storage/LocalEventStore";
+import {
+  LocalEventStore,
+  type DomainStatsAggregate,
+} from "../storage/LocalEventStore";
 import type { CollectionEvent } from "../collectors/types";
 
 const DB_NAME = "collection_events_db";
@@ -155,6 +158,7 @@ function aggregate(): DomainStatsAggregate {
     firstVisit: 0,
     lastVisit: 0,
     uniqueUrlCount: 1,
+    activeDayCount: 0,
   };
 }
 
@@ -298,6 +302,82 @@ describe("LocalEventStore aggregates", () => {
       });
     }
   });
+
+  it("restores active-day counts after a bulk import rebuilds domain stats", async () => {
+    const store = createStore();
+    const firstDay = Date.parse("2026-07-20T12:00:00-04:00");
+    const secondDay = Date.parse("2026-07-21T12:00:00-04:00");
+
+    await store.getAllDomains();
+    await store.addRestoredEvents([
+      {
+        ...event("focus-first", "navigation"),
+        ts: firstDay,
+        data: { event: "focus" },
+      },
+      {
+        ...event("focus-second", "navigation"),
+        ts: secondDay,
+        data: { event: "focus" },
+      },
+    ]);
+
+    const [stats, days] = await Promise.all([
+      store.getSessionStats("example.com"),
+      store.getDomainDayHistory(["example.com"]),
+    ]);
+
+    expect(stats?.activeDayCount).toBe(2);
+    expect(days.map((day) => day.localDayKey)).toEqual([
+      "2026-07-20",
+      "2026-07-21",
+    ]);
+  });
+
+  it("tracks one active day per domain regardless of focus churn", async () => {
+    const store = createStore();
+    const firstDay = Date.parse("2026-07-20T12:00:00-04:00");
+    const secondDay = Date.parse("2026-07-21T12:00:00-04:00");
+
+    await store.addEvents([
+      {
+        ...event("focus-first", "navigation"),
+        ts: firstDay,
+        data: { event: "focus" },
+      },
+      {
+        ...event("focus-again", "navigation"),
+        ts: firstDay + 60_000,
+        data: { event: "focus" },
+      },
+      {
+        ...event("focus-next-day", "navigation"),
+        ts: secondDay,
+        data: { event: "focus" },
+      },
+    ]);
+
+    const [stats, days] = await Promise.all([
+      store.getSessionStats("example.com"),
+      store.getDomainDayHistory(["example.com"]),
+    ]);
+
+    expect(stats?.activeDayCount).toBe(2);
+    expect(days).toEqual([
+      {
+        domain: "example.com",
+        localDayKey: "2026-07-20",
+        firstVisitTs: firstDay,
+        lastVisitTs: firstDay + 60_000,
+      },
+      {
+        domain: "example.com",
+        localDayKey: "2026-07-21",
+        firstVisitTs: secondDay,
+        lastVisitTs: secondDay,
+      },
+    ]);
+  });
 });
 
 describe("LocalEventStore walking record events", () => {
@@ -338,6 +418,44 @@ describe("LocalEventStore walking record events", () => {
         },
       ],
     });
+  });
+
+  it("compresses interaction events into active browsing windows", async () => {
+    const store = createStore();
+    await store.addEvents([
+      {
+        ...event("cursor-first", "cursor"),
+        ts: 1_000,
+        data: { event: "move", x: 0.1, y: 0.1 },
+      },
+      {
+        ...event("scroll-same-window", "viewport"),
+        ts: 20_000,
+        data: { event: "scroll", scrollDistancePx: 300 },
+      },
+      {
+        ...event("keyboard-next-window", "keyboard"),
+        ts: 35_000,
+        data: { event: "typing", x: 0.5, y: 0.5 },
+      },
+      {
+        ...event("resize-ignored", "viewport"),
+        ts: 65_000,
+        data: { event: "resize", width: 1_000, height: 800 },
+      },
+    ]);
+
+    const result = await store.getWalkingRecordEvents({
+      startTs: 0,
+      endTs: 90_000,
+    });
+
+    expect(result.activity).toEqual([
+      {
+        url: "https://example.com/page",
+        windowStarts: [0, 30_000],
+      },
+    ]);
   });
 
   it("keeps navigation events and samples cursors without losing measured distance", async () => {
@@ -407,6 +525,16 @@ describe("LocalEventStore walking record events", () => {
       "navigation-2",
     ]);
     expect(result.cursorDistancePx).toBeCloseTo(102.4);
+    expect(result.activity).toEqual([
+      {
+        url: "https://example.com/page",
+        windowStarts: [0, 300_000],
+      },
+      {
+        url: "https://example.com/other",
+        windowStarts: [0],
+      },
+    ]);
   });
 
   it("requires an explicit walking-record range", async () => {

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests local event database storage, query, and aggregate behavior.
 // ABOUTME: Guards hot paths, storage stats, and upload metadata handling in IndexedDB.
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   IDBKeyRange as fakeIDBKeyRange,
   indexedDB as fakeIndexedDB,
@@ -199,6 +199,33 @@ afterEach(async () => {
 });
 
 describe("LocalEventStore aggregates", () => {
+  it("fails with reload guidance instead of hanging when an upgrade is blocked", async () => {
+    const existingConnection = await openVersion8Database();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createStore();
+
+    await expect(store.getAllDomains()).rejects.toThrow(
+      "Reload the extension and open a new tab.",
+    );
+
+    existingConnection.close();
+    consoleError.mockRestore();
+  });
+
+  it("closes its connection when a newer database version is requested", async () => {
+    const store = createStore();
+    await store.getAllDomains();
+
+    const upgradedDatabase = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = fakeIndexedDB.open(DB_NAME, 12);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+
+    expect((store as unknown as { db: IDBDatabase | null }).db).toBeNull();
+    upgradedDatabase.close();
+  });
+
   it("updates bounded aggregate fields for non-navigation events", () => {
     const agg = aggregate();
 

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -5,6 +5,11 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import browser from "webextension-polyfill";
+import type { TrailState } from "@movement/types";
+import {
+  cycleLandscapeTrails,
+  scheduleLandscapeTrails,
+} from "../components/MovementLandscape";
 import { WalkingRecordPage } from "../components/WalkingRecord";
 import {
   getWalkingRecordPeriodRange,
@@ -27,6 +32,7 @@ const record: WalkingRecord = {
   movementCount: 0,
   departures: [],
   revisits: [],
+  landscapePaths: [],
   dayPlates: [
     {
       date: "day:2026-07-27",
@@ -87,6 +93,34 @@ const periodSummaries: WalkingRecordPeriodSummary[] = Array.from(
   },
 );
 
+function trailState(
+  id: string,
+  startOffsetMs: number,
+  durationMs: number,
+): TrailState {
+  return {
+    trail: {
+      id,
+      points: [
+        { x: 10, y: 10, ts: 1_000 },
+        { x: 20, y: 20, ts: 2_000 },
+      ],
+      color: "#4a9a8a",
+      opacity: 1,
+      startTime: 1_000,
+      endTime: 2_000,
+      clicks: [],
+    },
+    startOffsetMs,
+    durationMs,
+    variedPoints: [
+      { x: 10, y: 10 },
+      { x: 20, y: 20 },
+    ],
+    clicksWithProgress: [],
+  };
+}
+
 async function renderWalkingRecord(
   periodOffset: number,
   callbacks: {
@@ -94,6 +128,7 @@ async function renderWalkingRecord(
     onPeriodOffsetChange: ReturnType<typeof vi.fn>;
   },
   loading = false,
+  visibleRecord = record,
 ) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -102,7 +137,7 @@ async function renderWalkingRecord(
   await act(async () => {
     root.render(
       <WalkingRecordPage
-        record={record}
+        record={visibleRecord}
         period="week"
         periodOffset={periodOffset}
         periodSummaries={periodSummaries}
@@ -284,5 +319,135 @@ describe("WalkingRecordPage calendar navigation", () => {
     } finally {
       cleanup(root, container);
     }
+  });
+
+  it("shows a real movement landscape when the period has cursor paths", async () => {
+    const cursorEvent = (id: string, ts: number, x: number) => ({
+      id,
+      type: "cursor" as const,
+      ts,
+      data: { event: "move" as const, x, y: 0.5 },
+      meta: {
+        pid: "pk_test",
+        sid: "sid_test",
+        url: "https://example.com/page",
+        vw: 1_000,
+        vh: 800,
+        tz: "America/Los_Angeles",
+        cursor_color: "#4a9a8a",
+      },
+    });
+    const callbacks = {
+      onPeriodChange: vi.fn(),
+      onPeriodOffsetChange: vi.fn(),
+    };
+    const { container, root } = await renderWalkingRecord(
+      0,
+      callbacks,
+      false,
+      {
+        ...record,
+        landscapePaths: [
+          [
+            cursorEvent("cursor-1", 1_000, 0.2),
+            cursorEvent("cursor-2", 1_250, 0.8),
+          ],
+        ],
+      },
+    );
+
+    try {
+      expect(container.textContent).toContain("movement from this week");
+      expect(
+        container
+          .querySelector(".walking-record__movement-landscape")
+          ?.getAttribute("aria-label"),
+      ).toBe("Real cursor movements from this week");
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("reveals every ranked exploration in place", async () => {
+    const departures = Array.from({ length: 5 }, (_, index) => ({
+      day: "mon",
+      from: "google.com",
+      to: `small-${index + 1}.example`,
+      toUrl: `https://small-${index + 1}.example`,
+      time: `${index + 1} min active`,
+      note: "your first visit",
+      score: 1 - index * 0.1,
+    }));
+    const callbacks = {
+      onPeriodChange: vi.fn(),
+      onPeriodOffsetChange: vi.fn(),
+    };
+    const { container, root } = await renderWalkingRecord(
+      0,
+      callbacks,
+      false,
+      {
+        ...record,
+        departures,
+        movementCount: departures.length,
+      },
+    );
+
+    try {
+      const showMore = container.querySelector(
+        ".walking-record__departures-more",
+      ) as HTMLButtonElement;
+
+      expect(container.querySelectorAll(".walking-record__departure")).toHaveLength(
+        3,
+      );
+      expect(container.textContent).toContain("3 shown from 5");
+      expect(showMore.textContent).toBe("show more");
+
+      await act(async () => {
+        showMore.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      expect(container.querySelectorAll(".walking-record__departure")).toHaveLength(
+        5,
+      );
+      expect(container.textContent).toContain("5 shown from 5");
+      expect(showMore.textContent).toBe("show less");
+      expect(showMore.getAttribute("aria-expanded")).toBe("true");
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("keeps landscape trails entering on a dense repeating schedule", () => {
+    const scheduled = scheduleLandscapeTrails([
+      trailState("long", 1_000, 60_000),
+      trailState("short", 0, 500),
+      trailState("medium", 500, 6_000),
+    ]);
+
+    expect(scheduled.map((trail) => trail.durationMs)).toEqual([
+      9_000,
+      3_000,
+      6_000,
+    ]);
+    expect(scheduled.map((trail) => trail.startOffsetMs)).toEqual([
+      600,
+      0,
+      300,
+    ]);
+
+    const playback = cycleLandscapeTrails(scheduled);
+    expect(playback.duration).toBe(6_000);
+    expect(
+      playback.trailStates.filter((trail) => trail.startOffsetMs < 0),
+    ).toHaveLength(2);
+    expect(
+      playback.trailStates
+        .filter((trail) => trail.startOffsetMs < 0)
+        .every(
+          (trail) => trail.startOffsetMs + trail.durationMs > 0,
+        ),
+    ).toBe(true);
   });
 });

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -54,10 +54,18 @@ const record: WalkingRecord = {
       site: "example.com",
       faviconUrl: "https://example.com/icon.png",
       time: "12 min",
-      percentage: 100,
+      percentage: 80,
       hue: "#4a9a8a",
       note: "mostly around 9 AM–10 AM",
       href: "https://example.com",
+    },
+    {
+      rank: 2,
+      site: "3 others",
+      time: "4m",
+      percentage: 20,
+      hue: "#c8c3bb",
+      note: "",
     },
   ],
   timeSpentIntro: "there is no screen-time record for this period.",
@@ -188,6 +196,9 @@ describe("WalkingRecordPage calendar navigation", () => {
           ) as HTMLElement | null
         )?.style.borderBottomColor,
       ).toBe("rgb(74, 154, 138)");
+      expect(
+        container.querySelector(".walking-record__site-favicon-globe"),
+      ).not.toBeNull();
       expect(
         container
           .querySelector(".walking-record__site-favicon")

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -28,7 +28,18 @@ const record: WalkingRecord = {
   departures: [],
   revisits: [],
   dayPlates: [],
-  timeSpent: [],
+  timeSpent: [
+    {
+      rank: 1,
+      site: "example.com",
+      faviconUrl: "https://example.com/icon.png",
+      time: "12 min",
+      percentage: 100,
+      hue: "#4a9a8a",
+      note: "mostly around 9 AM–10 AM",
+      href: "https://example.com",
+    },
+  ],
   timeSpentIntro: "there is no screen-time record for this period.",
 };
 
@@ -141,6 +152,20 @@ describe("WalkingRecordPage calendar navigation", () => {
       expect(earlier?.textContent).toBe("↤ earlier");
       expect(later?.textContent).toBe("browsing to come ↦");
       expect(later?.disabled).toBe(true);
+      expect(
+        Array.from(container.querySelectorAll("section h1, section h2")).map(
+          (heading) => heading.textContent,
+        ),
+      ).toEqual([
+        "where the hours went",
+        "how you traveled",
+        "revisiting history",
+      ]);
+      expect(
+        container
+          .querySelector(".walking-record__site-favicon")
+          ?.getAttribute("src"),
+      ).toBe("https://example.com/icon.png");
 
       await act(async () => {
         earlier?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -184,9 +184,9 @@ describe("WalkingRecordPage calendar navigation", () => {
       expect(
         (
           container.querySelector(
-            ".walking-record__time-legend-ink",
+            ".walking-record__time-legend-site",
           ) as HTMLElement | null
-        )?.style.backgroundColor,
+        )?.style.borderBottomColor,
       ).toBe("rgb(74, 154, 138)");
       expect(
         container

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -27,7 +27,16 @@ const record: WalkingRecord = {
   movementCount: 0,
   departures: [],
   revisits: [],
-  dayPlates: [],
+  dayPlates: [
+    {
+      date: "2026-08-02",
+      day: "sun",
+      vignette: "still to come",
+      hue: "#b5aea5",
+      future: true,
+      tracePaths: [],
+    },
+  ],
   timeSpent: [
     {
       rank: 1,
@@ -166,6 +175,12 @@ describe("WalkingRecordPage calendar navigation", () => {
           .querySelector(".walking-record__site-favicon")
           ?.getAttribute("src"),
       ).toBe("https://example.com/icon.png");
+      expect(
+        container.querySelector(".walking-record__day-plate--future"),
+      ).not.toBeNull();
+      expect(
+        container.querySelector(".walking-record__future-trace"),
+      ).not.toBeNull();
 
       await act(async () => {
         earlier?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -29,11 +29,22 @@ const record: WalkingRecord = {
   revisits: [],
   dayPlates: [
     {
+      date: "day:2026-07-27",
+      day: "mon",
+      vignette: "12 quiet minutes on example.com",
+      hue: "#4a9a8a",
+      future: false,
+      portraitDay: "2026-07-27",
+      traceTargets: [],
+      tracePaths: [],
+    },
+    {
       date: "2026-08-02",
       day: "sun",
       vignette: "still to come",
       hue: "#b5aea5",
       future: true,
+      traceTargets: [],
       tracePaths: [],
     },
   ],
@@ -185,6 +196,11 @@ describe("WalkingRecordPage calendar navigation", () => {
       expect(
         container.querySelector(".walking-record__day-plate--future"),
       ).not.toBeNull();
+      expect(
+        container
+          .querySelector('a[title="Open mon portrait"]')
+          ?.getAttribute("href"),
+      ).toBe("chrome-extension://test/portrait.html?day=2026-07-27");
       expect(
         container.querySelector(".walking-record__future-trace"),
       ).not.toBeNull();

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -93,7 +93,7 @@ async function renderWalkingRecord(
         loadingProgress={{
           completed: 3,
           total: 5,
-          message: "familiar places found…",
+          message: "finding familiar places…",
         }}
         error={null}
       />,
@@ -166,9 +166,10 @@ describe("WalkingRecordPage calendar navigation", () => {
           (heading) => heading.textContent,
         ),
       ).toEqual([
-        "where the hours went",
-        "how you traveled",
-        "revisiting history",
+        "how you browsed",
+        "notable new exploration",
+        "where you used to visit",
+        "browsing portraits",
       ]);
       expect(
         container
@@ -210,7 +211,7 @@ describe("WalkingRecordPage calendar navigation", () => {
         '[role="progressbar"]',
       ) as HTMLElement | null;
 
-      expect(container.textContent).toContain("familiar places found…");
+      expect(container.textContent).toContain("finding familiar places…");
       expect(container.textContent).toContain("60%");
       expect(progress?.getAttribute("aria-valuenow")).toBe("60");
       expect(progress?.querySelector("span")?.style.width).toBe("60%");

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -54,6 +54,7 @@ async function renderWalkingRecord(
     onPeriodChange: ReturnType<typeof vi.fn>;
     onPeriodOffsetChange: ReturnType<typeof vi.fn>;
   },
+  loading = false,
 ) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -68,7 +69,12 @@ async function renderWalkingRecord(
         periodSummaries={periodSummaries}
         onPeriodChange={callbacks.onPeriodChange}
         onPeriodOffsetChange={callbacks.onPeriodOffsetChange}
-        loading={false}
+        loading={loading}
+        loadingProgress={{
+          completed: 3,
+          total: 5,
+          message: "familiar places found…",
+        }}
         error={null}
       />,
     );
@@ -143,6 +149,31 @@ describe("WalkingRecordPage calendar navigation", () => {
 
       expect(callbacks.onPeriodOffsetChange).toHaveBeenNthCalledWith(1, -1);
       expect(callbacks.onPeriodOffsetChange).toHaveBeenNthCalledWith(2, 0);
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("shows the current loading step and measured progress", async () => {
+    const callbacks = {
+      onPeriodChange: vi.fn(),
+      onPeriodOffsetChange: vi.fn(),
+    };
+    const { container, root } = await renderWalkingRecord(
+      0,
+      callbacks,
+      true,
+    );
+
+    try {
+      const progress = container.querySelector(
+        '[role="progressbar"]',
+      ) as HTMLElement | null;
+
+      expect(container.textContent).toContain("familiar places found…");
+      expect(container.textContent).toContain("60%");
+      expect(progress?.getAttribute("aria-valuenow")).toBe("60");
+      expect(progress?.querySelector("span")?.style.width).toBe("60%");
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -167,10 +167,16 @@ describe("WalkingRecordPage calendar navigation", () => {
         ),
       ).toEqual([
         "how you browsed",
-        "notable new exploration",
         "where you used to visit",
         "browsing portraits",
       ]);
+      expect(
+        (
+          container.querySelector(
+            ".walking-record__time-legend-ink",
+          ) as HTMLElement | null
+        )?.style.backgroundColor,
+      ).toBe("rgb(74, 154, 138)");
       expect(
         container
           .querySelector(".walking-record__site-favicon")
@@ -210,9 +216,16 @@ describe("WalkingRecordPage calendar navigation", () => {
       const progress = container.querySelector(
         '[role="progressbar"]',
       ) as HTMLElement | null;
+      const cursorWalk = container.querySelector(
+        ".walking-record__loading-cursors",
+      );
 
       expect(container.textContent).toContain("finding familiar places…");
       expect(container.textContent).toContain("60%");
+      expect(cursorWalk?.getAttribute("aria-hidden")).toBe("true");
+      expect(
+        cursorWalk?.querySelectorAll(".walking-record__loading-cursor"),
+      ).toHaveLength(3);
       expect(progress?.getAttribute("aria-valuenow")).toBe("60");
       expect(progress?.querySelector("span")?.style.width).toBe("60%");
     } finally {

--- a/extension/src/__tests__/loadWalkingRecord.test.ts
+++ b/extension/src/__tests__/loadWalkingRecord.test.ts
@@ -80,8 +80,12 @@ describe("loadWalkingRecord", () => {
 
     expect(progress).toHaveBeenCalledTimes(5);
     expect(
-      progress.mock.calls.slice(0, 3).map(([update]) => update.completed),
-    ).toEqual([1, 2, 3]);
+      progress.mock.calls.slice(0, 3).map(([update]) => update.message),
+    ).toEqual([
+      "gathering movement traces…",
+      "counting browsing time…",
+      "finding familiar places…",
+    ]);
     expect(progress).toHaveBeenNthCalledWith(4, {
       completed: 4,
       total: 5,
@@ -90,7 +94,7 @@ describe("loadWalkingRecord", () => {
     expect(progress).toHaveBeenLastCalledWith({
       completed: 5,
       total: 5,
-      message: "cursor trails restored…",
+      message: "restoring cursor trails…",
     });
   });
 });

--- a/extension/src/__tests__/loadWalkingRecord.test.ts
+++ b/extension/src/__tests__/loadWalkingRecord.test.ts
@@ -108,4 +108,21 @@ describe("loadWalkingRecord", () => {
       message: "restoring cursor trails…",
     });
   });
+
+  it("surfaces background reload guidance", async () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      0,
+      new Date(2026, 6, 30, 14),
+    );
+    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
+      success: false,
+      error:
+        "Local history is waiting for an older extension process to close. Reload the extension and open a new tab.",
+    });
+
+    await expect(
+      loadWalkingRecord("week", range, "#4a9a8a", vi.fn()),
+    ).rejects.toThrow("Reload the extension and open a new tab.");
+  });
 });

--- a/extension/src/__tests__/loadWalkingRecord.test.ts
+++ b/extension/src/__tests__/loadWalkingRecord.test.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Verifies walking-record loading progress follows completed local-data work.
+// ABOUTME: Covers parallel data steps, record arrangement, and cursor trace completion.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import { loadWalkingRecord } from "../history/loadWalkingRecord";
+import { getWalkingRecordPeriodRange } from "../history/walkingRecord";
+
+describe("loadWalkingRecord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports completed data work and finishes after restoring traces", async () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      -1,
+      new Date(2026, 6, 30, 14),
+    );
+    const focusTs = range.startTs + 60_000;
+    const responses = {
+      GET_WALKING_RECORD_EVENTS: {
+        success: true,
+        events: [
+          {
+            id: "focus",
+            type: "navigation",
+            ts: focusTs,
+            data: { event: "focus" },
+            meta: {
+              pid: "pk_test",
+              sid: "sid_test",
+              url: "https://example.com/page",
+              vw: 1_000,
+              vh: 800,
+              tz: "America/Los_Angeles",
+            },
+          },
+        ],
+        cursorDistancePx: 0,
+      },
+      GET_SCREEN_TIME: {
+        success: true,
+        sessions: [
+          {
+            url: "https://example.com/page",
+            focusTs,
+            blurTs: focusTs + 60_000,
+            durationMs: 60_000,
+          },
+        ],
+      },
+      GET_ALL_DOMAINS: {
+        success: true,
+        domains: [
+          {
+            domain: "example.com",
+            eventCount: 1,
+            firstVisit: focusTs,
+            lastVisit: focusTs,
+            totalTimeMs: 60_000,
+            uniquePageCount: 1,
+            sessionCount: 1,
+            eventCounts: { navigation: 1 },
+          },
+        ],
+      },
+      GET_WALKING_RECORD_TRACES: {
+        success: true,
+        traces: [],
+      },
+    };
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(
+      async (message: { type: keyof typeof responses }) =>
+        responses[message.type],
+    );
+    const progress = vi.fn();
+
+    await loadWalkingRecord("week", range, "#4a9a8a", progress);
+
+    expect(progress).toHaveBeenCalledTimes(5);
+    expect(
+      progress.mock.calls.slice(0, 3).map(([update]) => update.completed),
+    ).toEqual([1, 2, 3]);
+    expect(progress).toHaveBeenNthCalledWith(4, {
+      completed: 4,
+      total: 5,
+      message: "arranging this week’s record…",
+    });
+    expect(progress).toHaveBeenLastCalledWith({
+      completed: 5,
+      total: 5,
+      message: "cursor trails restored…",
+    });
+  });
+});

--- a/extension/src/__tests__/loadWalkingRecord.test.ts
+++ b/extension/src/__tests__/loadWalkingRecord.test.ts
@@ -71,9 +71,10 @@ describe("loadWalkingRecord", () => {
         success: true,
         days: [],
       },
-      GET_WALKING_RECORD_TRACES: {
+      GET_WALKING_RECORD_MOVEMENT: {
         success: true,
         traces: [],
+        landscapePaths: [],
       },
     };
     vi.mocked(browser.runtime.sendMessage).mockImplementation(

--- a/extension/src/__tests__/loadWalkingRecord.test.ts
+++ b/extension/src/__tests__/loadWalkingRecord.test.ts
@@ -38,6 +38,7 @@ describe("loadWalkingRecord", () => {
           },
         ],
         cursorDistancePx: 0,
+        activity: [],
       },
       GET_SCREEN_TIME: {
         success: true,
@@ -61,9 +62,14 @@ describe("loadWalkingRecord", () => {
             totalTimeMs: 60_000,
             uniquePageCount: 1,
             sessionCount: 1,
+            activeDayCount: 1,
             eventCounts: { navigation: 1 },
           },
         ],
+      },
+      GET_WALKING_RECORD_DOMAIN_DAYS: {
+        success: true,
+        days: [],
       },
       GET_WALKING_RECORD_TRACES: {
         success: true,
@@ -78,7 +84,7 @@ describe("loadWalkingRecord", () => {
 
     await loadWalkingRecord("week", range, "#4a9a8a", progress);
 
-    expect(progress).toHaveBeenCalledTimes(5);
+    expect(progress).toHaveBeenCalledTimes(6);
     expect(
       progress.mock.calls.slice(0, 3).map(([update]) => update.message),
     ).toEqual([
@@ -88,12 +94,17 @@ describe("loadWalkingRecord", () => {
     ]);
     expect(progress).toHaveBeenNthCalledWith(4, {
       completed: 4,
-      total: 5,
+      total: 6,
+      message: "tracing familiar routines…",
+    });
+    expect(progress).toHaveBeenNthCalledWith(5, {
+      completed: 5,
+      total: 6,
       message: "arranging this week’s record…",
     });
     expect(progress).toHaveBeenLastCalledWith({
-      completed: 5,
-      total: 5,
+      completed: 6,
+      total: 6,
       message: "restoring cursor trails…",
     });
   });

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -4,7 +4,10 @@
 import { describe, expect, it } from "vitest";
 import { parseColorToHsl } from "@movement/utils/eventUtils";
 import type { CollectionEvent } from "../collectors/types";
-import type { ScreenTimeSession } from "../storage/LocalEventStore";
+import type {
+  AggregateDay,
+  ScreenTimeSession,
+} from "../storage/LocalEventStore";
 import {
   attachWalkingRecordTraces,
   colorForDomain,
@@ -52,8 +55,24 @@ function domain(
     totalTimeMs: 0,
     uniquePageCount: 1,
     sessionCount: 1,
+    activeDayCount: 0,
     eventCounts: { navigation: 2 },
     ...overrides,
+  };
+}
+
+function aggregateDay(domain: string, timestamp: number): AggregateDay {
+  const date = new Date(timestamp);
+  const localDayKey = [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+  return {
+    domain,
+    localDayKey,
+    firstVisitTs: timestamp,
+    lastVisitTs: timestamp,
   };
 }
 
@@ -327,21 +346,11 @@ describe("deriveWalkingRecord", () => {
       expect.objectContaining({
         from: "github.com",
         to: "foldedpaper.garden",
-        note: "stayed 11 minutes · your first visit",
-        familiarity: "new to you",
-        hue: colorForDomain("#4a9a8a", "foldedpaper.garden"),
-        accentHue: paletteColorForIndex(0),
-        traceTarget: {
-          id: `departure:${departureTs}:foldedpaper.garden`,
-          url: quietSession.url,
-          startTs: quietSession.focusTs,
-          endTs: quietSession.blurTs,
-        },
+        note: "your first visit · stayed 11 minutes",
+        fromFaviconUrl:
+          "https://github.githubassets.com/favicons/favicon.svg",
       }),
     ]);
-    expect(record.timeSpent.map((entry) => entry.site)).toContain(
-      "the quiet streets, together",
-    );
     expect(
       record.timeSpent.find((entry) => entry.site === "github.com")?.faviconUrl,
     ).toBe("https://github.githubassets.com/favicons/favicon.svg");
@@ -362,24 +371,18 @@ describe("deriveWalkingRecord", () => {
     );
 
     const targets = getWalkingRecordTraceTargets(record);
-    expect(targets).toHaveLength(2);
+    expect(targets).toHaveLength(1);
 
     const tracedRecord = attachWalkingRecordTraces(record, [
       {
         targetId: "day:2026-07-20",
         paths: [[{ x: 0.1, y: 0.2 }, { x: 0.4, y: 0.6 }]],
       },
-      {
-        targetId: `departure:${departureTs}:foldedpaper.garden`,
-        paths: [[{ x: 0.3, y: 0.4 }, { x: 0.7, y: 0.8 }]],
-      },
     ]);
     expect(tracedRecord.dayPlates[0].tracePaths).toEqual([
       [{ x: 0.1, y: 0.2 }, { x: 0.4, y: 0.6 }],
     ]);
-    expect(tracedRecord.departures[0].tracePaths).toEqual([
-      [{ x: 0.3, y: 0.4 }, { x: 0.7, y: 0.8 }],
-    ]);
+    expect(tracedRecord.departures[0]).not.toHaveProperty("tracePaths");
   });
 
   it("surfaces familiar small sites that went quiet before the report week", () => {
@@ -401,12 +404,19 @@ describe("deriveWalkingRecord", () => {
           sessionCount: 31,
           lastVisit: oldVisit,
           totalTimeMs: 90 * 60_000,
+          activeDayCount: 5,
         }),
         domain("youtube.com", {
           sessionCount: 80,
           lastVisit: oldVisit,
         }),
       ],
+      domainDays: [120, 90, 60, 30, 0].map((daysBeforeLast) =>
+        aggregateDay(
+          "diagram.website",
+          oldVisit - daysBeforeLast * 24 * 60 * 60_000,
+        ),
+      ),
       range,
     });
 
@@ -414,7 +424,7 @@ describe("deriveWalkingRecord", () => {
       expect.objectContaining({
         span: "7 months",
         site: "diagram.website",
-        memory: "part of your browsing for 4 months before the gap",
+        memory: "visited on 5 days across 4 months",
         hue: paletteColorForIndex(0),
       }),
     ]);
@@ -441,12 +451,28 @@ describe("deriveWalkingRecord", () => {
           firstVisit: lastVisit - 180 * 24 * 60 * 60_000,
           lastVisit,
           sessionCount: 24,
+          activeDayCount: 5,
         }),
         domain("application.example", {
           firstVisit: lastVisit - 2 * 24 * 60 * 60_000,
           lastVisit,
           sessionCount: 96,
+          activeDayCount: 5,
         }),
+      ],
+      domainDays: [
+        ...[180, 135, 90, 45, 0].map((daysBeforeLast) =>
+          aggregateDay(
+            "regular.example",
+            lastVisit - daysBeforeLast * 24 * 60 * 60_000,
+          ),
+        ),
+        ...[2, 1, 1, 0, 0].map((daysBeforeLast, index) =>
+          aggregateDay(
+            "application.example",
+            lastVisit - daysBeforeLast * 24 * 60 * 60_000 + index,
+          ),
+        ),
       ],
       range,
     });
@@ -456,7 +482,7 @@ describe("deriveWalkingRecord", () => {
     ]);
   });
 
-  it("keeps a real departure trace interval when no screen-time session completed", () => {
+  it("keeps a departure when no screen-time session completed", () => {
     const range = getWalkingRecordPeriodRange(
       "week",
       -1,
@@ -507,16 +533,10 @@ describe("deriveWalkingRecord", () => {
     expect(record.departures).toEqual([
       expect.objectContaining({
         to: "tiny.garden",
-        familiarity: "new to you",
-        tracePaths: [expect.arrayContaining([expect.any(Object)])],
-        traceTarget: {
-          id: `departure:${departureTs}:tiny.garden`,
-          url: "https://tiny.garden/path",
-          startTs: departureTs,
-          endTs: nextFocusTs - 1,
-        },
+        time: "0 min",
       }),
     ]);
+    expect(record.departures[0]).not.toHaveProperty("traceTarget");
   });
 
   it("uses a traceable session for a portrait and preserves a derived mark when cursor data is absent", () => {
@@ -579,7 +599,7 @@ describe("deriveWalkingRecord", () => {
     );
   });
 
-  it("shows six real sites before the quiet-streets summary", () => {
+  it("shows five real sites before the remaining-time summary", () => {
     const range = getWalkingRecordPeriodRange(
       "week",
       -1,
@@ -616,13 +636,12 @@ describe("deriveWalkingRecord", () => {
       "site-3.example",
       "site-4.example",
       "site-5.example",
-      "site-6.example",
-      "the quiet streets, together",
+      "3 other places",
     ]);
-    expect(record.timeSpent.at(-1)?.time).toBe("30 min");
+    expect(record.timeSpent.at(-1)?.time).toBe("1 hr");
   });
 
-  it("ranks traceable departures above equally rare visits without movement", () => {
+  it("ranks active browsing above a longer passive visit", () => {
     const range = getWalkingRecordPeriodRange(
       "week",
       -1,
@@ -675,7 +694,29 @@ describe("deriveWalkingRecord", () => {
           { event: "focus" },
         ),
       ],
-      sessions: [],
+      activity: [
+        {
+          url: "https://moving.example/path",
+          windowStarts: Array.from(
+            { length: 30 },
+            (_, index) => secondDepartureTs + index * 30_000,
+          ),
+        },
+      ],
+      sessions: [
+        {
+          url: "https://still.example/path",
+          focusTs: firstDepartureTs,
+          blurTs: firstDepartureTs + 50 * 60_000,
+          durationMs: 50 * 60_000,
+        },
+        {
+          url: "https://moving.example/path",
+          focusTs: secondDepartureTs,
+          blurTs: secondDepartureTs + 15 * 60_000,
+          durationMs: 15 * 60_000,
+        },
+      ],
       domains: [
         domain("google.com", { sessionCount: 100 }),
         domain("still.example", {

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -723,9 +723,10 @@ describe("deriveWalkingRecord", () => {
       "site-3.example",
       "site-4.example",
       "site-5.example",
-      "3 other places",
+      "3 others",
     ]);
-    expect(record.timeSpent.at(-1)?.time).toBe("1 hr");
+    expect(record.timeSpent[0].time).toBe("1h 20m");
+    expect(record.timeSpent.at(-1)?.time).toBe("1h");
   });
 
   it("ranks active browsing above a longer passive visit", () => {

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -361,17 +361,20 @@ describe("deriveWalkingRecord", () => {
       expect.objectContaining({
         day: "mon",
         vignette: "11 quiet minutes on foldedpaper.garden",
-        traceTarget: {
-          id: "day:2026-07-20",
-          url: quietSession.url,
-          startTs: quietSession.focusTs,
-          endTs: quietSession.blurTs,
-        },
+        portraitDay: "2026-07-20",
+        traceTargets: expect.arrayContaining([
+          {
+            id: "day:2026-07-20",
+            url: quietSession.url,
+            startTs: quietSession.focusTs,
+            endTs: quietSession.blurTs,
+          },
+        ]),
       }),
     );
 
     const targets = getWalkingRecordTraceTargets(record);
-    expect(targets).toHaveLength(1);
+    expect(targets).toHaveLength(2);
 
     const tracedRecord = attachWalkingRecordTraces(record, [
       {
@@ -379,9 +382,10 @@ describe("deriveWalkingRecord", () => {
         paths: [[{ x: 0.1, y: 0.2 }, { x: 0.4, y: 0.6 }]],
       },
     ]);
-    expect(tracedRecord.dayPlates[0].tracePaths).toEqual([
+    expect(tracedRecord.dayPlates[0].tracePaths[0]).toEqual(
       [{ x: 0.1, y: 0.2 }, { x: 0.4, y: 0.6 }],
-    ]);
+    );
+    expect(tracedRecord.dayPlates[0].tracePaths).toHaveLength(2);
     expect(tracedRecord.departures[0]).not.toHaveProperty("tracePaths");
   });
 
@@ -666,8 +670,13 @@ describe("deriveWalkingRecord", () => {
 
     expect(record.dayPlates[0]).toEqual(
       expect.objectContaining({
-        traceTarget: expect.objectContaining({ url: tracedSession.url }),
-        tracePaths: [expect.arrayContaining([expect.any(Object)])],
+        traceTargets: expect.arrayContaining([
+          expect.objectContaining({ url: tracedSession.url }),
+          expect.objectContaining({ url: lightlyTracedSession.url }),
+        ]),
+        tracePaths: expect.arrayContaining([
+          expect.arrayContaining([expect.any(Object)]),
+        ]),
       }),
     );
 

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -269,7 +269,10 @@ describe("deriveWalkingRecord", () => {
         "navigation",
         mondayMorning,
         "https://github.com/spencerc99/playhtml",
-        { event: "focus" },
+        {
+          event: "focus",
+          favicon_url: "https://github.githubassets.com/favicons/favicon.svg",
+        },
       ),
       event(
         "garden-focus",
@@ -330,6 +333,9 @@ describe("deriveWalkingRecord", () => {
     expect(record.timeSpent.map((entry) => entry.site)).toContain(
       "the quiet streets, together",
     );
+    expect(
+      record.timeSpent.find((entry) => entry.site === "github.com")?.faviconUrl,
+    ).toBe("https://github.githubassets.com/favicons/favicon.svg");
     expect(record.pageCount).toBe(2);
     expect(record.cursorDistancePx).toBeCloseTo(100);
     expect(record.dayPlates).toHaveLength(7);

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -539,15 +539,15 @@ describe("deriveWalkingRecord", () => {
     expect(record.departures[0]).not.toHaveProperty("traceTarget");
   });
 
-  it("uses a traceable session for a portrait and preserves a derived mark when cursor data is absent", () => {
+  it("uses the most actively browsed session for a portrait and preserves a derived mark", () => {
     const range = getWalkingRecordPeriodRange(
       "week",
       -1,
       new Date(2026, 6, 30, 14),
     );
     const monday = range.startTs + 9 * 60 * 60_000;
-    const untracedSession: ScreenTimeSession = {
-      url: "https://untraced.example/long",
+    const lightlyTracedSession: ScreenTimeSession = {
+      url: "https://lightly-traced.example/long",
       focusTs: monday,
       blurTs: monday + 2 * 60 * 60_000,
       durationMs: 2 * 60 * 60_000,
@@ -563,6 +563,20 @@ describe("deriveWalkingRecord", () => {
       baseColor: "#4a9a8a",
       events: [
         event(
+          "light-trace-1",
+          "cursor",
+          lightlyTracedSession.focusTs + 1_000,
+          lightlyTracedSession.url,
+          { event: "move", x: 0.2, y: 0.3 },
+        ),
+        event(
+          "light-trace-2",
+          "cursor",
+          lightlyTracedSession.focusTs + 2_000,
+          lightlyTracedSession.url,
+          { event: "move", x: 0.5, y: 0.6 },
+        ),
+        event(
           "trace-1",
           "cursor",
           tracedSession.focusTs + 1_000,
@@ -576,10 +590,17 @@ describe("deriveWalkingRecord", () => {
           tracedSession.url,
           { event: "move", x: 0.5, y: 0.6 },
         ),
+        event(
+          "trace-3",
+          "cursor",
+          tracedSession.focusTs + 3_000,
+          tracedSession.url,
+          { event: "move", x: 0.7, y: 0.4 },
+        ),
       ],
-      sessions: [untracedSession, tracedSession],
+      sessions: [lightlyTracedSession, tracedSession],
       domains: [
-        domain("untraced.example", { sessionCount: 20 }),
+        domain("lightly-traced.example", { sessionCount: 20 }),
         domain("traced.example", { sessionCount: 20 }),
       ],
       range,

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -239,6 +239,15 @@ describe("walking record color and trace cadence", () => {
       "still to come",
       "still to come",
     ]);
+    expect(record.dayPlates.map((plate) => plate.future)).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+    ]);
   });
 });
 

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -216,6 +216,30 @@ describe("walking record color and trace cadence", () => {
     expect(year.dayPlates[0].day).toBe("jan");
     expect(year.dayPlates[11].day).toBe("dec");
   });
+
+  it("distinguishes future intervals from past days without activity", () => {
+    const now = new Date(2026, 6, 29, 12);
+    const range = getWalkingRecordPeriodRange("week", 0, now);
+    const record = deriveWalkingRecord({
+      period: "week",
+      baseColor: "#4a9a8a",
+      events: [],
+      sessions: [],
+      domains: [],
+      range,
+      nowTs: now.getTime(),
+    });
+
+    expect(record.dayPlates.map((plate) => plate.vignette)).toEqual([
+      "no trace kept",
+      "no trace kept",
+      "no trace kept",
+      "still to come",
+      "still to come",
+      "still to come",
+      "still to come",
+    ]);
+  });
 });
 
 describe("deriveWalkingRecord", () => {
@@ -358,6 +382,7 @@ describe("deriveWalkingRecord", () => {
       sessions: [],
       domains: [
         domain("diagram.website", {
+          firstVisit: oldVisit - 120 * 24 * 60 * 60 * 1_000,
           sessionCount: 31,
           lastVisit: oldVisit,
           totalTimeMs: 90 * 60_000,
@@ -374,13 +399,46 @@ describe("deriveWalkingRecord", () => {
       expect.objectContaining({
         span: "7 months",
         site: "diagram.website",
-        memory: "you visited 31 times before the gap",
+        memory: "part of your browsing for 4 months before the gap",
         hue: paletteColorForIndex(0),
       }),
     ]);
     expect(record.totalTimeMs).toBe(0);
     expect(record.totalTimeLabel).toBe("0 min");
     expect(record.timeSpent).toEqual([]);
+  });
+
+  it("prefers sustained familiarity over a compressed visit burst", () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      -1,
+      new Date(2026, 6, 30, 14),
+    );
+    const lastVisit = range.startTs - 45 * 24 * 60 * 60_000;
+
+    const record = deriveWalkingRecord({
+      period: "week",
+      baseColor: "#4a9a8a",
+      events: [],
+      sessions: [],
+      domains: [
+        domain("regular.example", {
+          firstVisit: lastVisit - 180 * 24 * 60 * 60_000,
+          lastVisit,
+          sessionCount: 24,
+        }),
+        domain("application.example", {
+          firstVisit: lastVisit - 2 * 24 * 60 * 60_000,
+          lastVisit,
+          sessionCount: 96,
+        }),
+      ],
+      range,
+    });
+
+    expect(record.revisits.map((revisit) => revisit.site)).toEqual([
+      "regular.example",
+    ]);
   });
 
   it("keeps a real departure trace interval when no screen-time session completed", () => {
@@ -435,6 +493,7 @@ describe("deriveWalkingRecord", () => {
       expect.objectContaining({
         to: "tiny.garden",
         familiarity: "new to you",
+        tracePaths: [expect.arrayContaining([expect.any(Object)])],
         traceTarget: {
           id: `departure:${departureTs}:tiny.garden`,
           url: "https://tiny.garden/path",
@@ -443,6 +502,109 @@ describe("deriveWalkingRecord", () => {
         },
       }),
     ]);
+  });
+
+  it("uses a traceable session for a portrait and preserves a derived mark when cursor data is absent", () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      -1,
+      new Date(2026, 6, 30, 14),
+    );
+    const monday = range.startTs + 9 * 60 * 60_000;
+    const untracedSession: ScreenTimeSession = {
+      url: "https://untraced.example/long",
+      focusTs: monday,
+      blurTs: monday + 2 * 60 * 60_000,
+      durationMs: 2 * 60 * 60_000,
+    };
+    const tracedSession: ScreenTimeSession = {
+      url: "https://traced.example/short",
+      focusTs: monday + 3 * 60 * 60_000,
+      blurTs: monday + 3 * 60 * 60_000 + 12 * 60_000,
+      durationMs: 12 * 60_000,
+    };
+    const record = deriveWalkingRecord({
+      period: "week",
+      baseColor: "#4a9a8a",
+      events: [
+        event(
+          "trace-1",
+          "cursor",
+          tracedSession.focusTs + 1_000,
+          tracedSession.url,
+          { event: "move", x: 0.2, y: 0.3 },
+        ),
+        event(
+          "trace-2",
+          "cursor",
+          tracedSession.focusTs + 2_000,
+          tracedSession.url,
+          { event: "move", x: 0.5, y: 0.6 },
+        ),
+      ],
+      sessions: [untracedSession, tracedSession],
+      domains: [
+        domain("untraced.example", { sessionCount: 20 }),
+        domain("traced.example", { sessionCount: 20 }),
+      ],
+      range,
+      nowTs: range.endTs + 1,
+    });
+
+    expect(record.dayPlates[0]).toEqual(
+      expect.objectContaining({
+        traceTarget: expect.objectContaining({ url: tracedSession.url }),
+        tracePaths: [expect.arrayContaining([expect.any(Object)])],
+      }),
+    );
+
+    const withoutStoredCursorPath = attachWalkingRecordTraces(record, []);
+    expect(withoutStoredCursorPath.dayPlates[0].tracePaths[0].length).toBeGreaterThan(
+      1,
+    );
+  });
+
+  it("shows six real sites before the quiet-streets summary", () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      -1,
+      new Date(2026, 6, 30, 14),
+    );
+    const domains = Array.from({ length: 8 }, (_, index) =>
+      domain(`site-${index + 1}.example`, {
+        sessionCount: index < 6 ? 20 : 2,
+      }),
+    );
+    const sessions = domains.map((entry, index) => {
+      const durationMs = (8 - index) * 10 * 60_000;
+      return {
+        url: `https://${entry.domain}/page`,
+        focusTs: range.startTs + index * 60 * 60_000,
+        blurTs: range.startTs + index * 60 * 60_000 + durationMs,
+        durationMs,
+      };
+    });
+
+    const record = deriveWalkingRecord({
+      period: "week",
+      baseColor: "#4a9a8a",
+      events: [],
+      sessions,
+      domains,
+      range,
+      nowTs: range.endTs + 1,
+    });
+
+    expect(record.timeSpent.map((entry) => entry.site)).toEqual([
+      "site-1.example",
+      "site-2.example",
+      "site-3.example",
+      "site-4.example",
+      "site-5.example",
+      "site-6.example",
+      "the quiet streets, together",
+    ]);
+    expect(record.timeSpent.at(-1)?.time).toBe("30 min");
   });
 
   it("ranks traceable departures above equally rare visits without movement", () => {

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -482,7 +482,7 @@ describe("deriveWalkingRecord", () => {
     ]);
   });
 
-  it("keeps a departure when no screen-time session completed", () => {
+  it("omits a departure when no browsing evidence was recorded", () => {
     const range = getWalkingRecordPeriodRange(
       "week",
       -1,
@@ -530,13 +530,70 @@ describe("deriveWalkingRecord", () => {
       range,
     });
 
+    expect(record.departures).toEqual([]);
+    expect(record.movementCount).toBe(0);
+  });
+
+  it("describes a sub-minute active departure without rounding it to zero", () => {
+    const range = getWalkingRecordPeriodRange(
+      "week",
+      -1,
+      new Date(2026, 6, 30, 14),
+    );
+    const mondayMorning = new Date(2026, 6, 20, 9).getTime();
+    const departureTs = mondayMorning + 5 * 60_000;
+
+    const record = deriveWalkingRecord({
+      period: "week",
+      baseColor: "#4a9a8a",
+      events: [
+        event(
+          "main-focus",
+          "navigation",
+          mondayMorning,
+          "https://google.com/search",
+          { event: "focus" },
+        ),
+        event(
+          "departure-focus",
+          "navigation",
+          departureTs,
+          "https://tiny.garden/path",
+          { event: "focus" },
+        ),
+      ],
+      activity: [
+        {
+          url: "https://tiny.garden/path",
+          windowStarts: [departureTs],
+        },
+      ],
+      sessions: [
+        {
+          url: "https://tiny.garden/path",
+          focusTs: departureTs,
+          blurTs: departureTs + 45_000,
+          durationMs: 45_000,
+        },
+      ],
+      domains: [
+        domain("google.com", { sessionCount: 100 }),
+        domain("tiny.garden", {
+          firstVisit: departureTs - 2 * 60_000,
+          lastVisit: departureTs,
+          sessionCount: 1,
+        }),
+      ],
+      range,
+    });
+
     expect(record.departures).toEqual([
       expect.objectContaining({
         to: "tiny.garden",
-        time: "0 min",
+        time: "< 1 min active",
+        note: "actively browsed",
       }),
     ]);
-    expect(record.departures[0]).not.toHaveProperty("traceTarget");
   });
 
   it("uses the most actively browsed session for a portrait and preserves a derived mark", () => {

--- a/extension/src/components/MovementLandscape.tsx
+++ b/extension/src/components/MovementLandscape.tsx
@@ -1,0 +1,275 @@
+// ABOUTME: Renders a compact, period-specific replay of real cursor movement.
+// ABOUTME: Reuses the portrait trail renderer and its default visual settings.
+
+import React, { useEffect, useId, useMemo, useRef, useState } from "react";
+import { AnimatedTrails } from "@movement/components/AnimatedTrails";
+import { DEFAULT_SETTINGS } from "@movement/components/settingsDefaults";
+import { useCursorTrails } from "@movement/hooks/useCursorTrails";
+import type {
+  CollectionEvent as MovementEvent,
+  TrailState,
+} from "@movement/types";
+import type { CollectionEvent } from "../collectors/types";
+
+const MIN_TRAIL_PLAYBACK_MS = 3_000;
+const MAX_TRAIL_PLAYBACK_MS = 9_000;
+const MIN_LANDSCAPE_CYCLE_MS = 6_000;
+
+interface MovementLandscapeProps {
+  paths: CollectionEvent[][];
+  label: string;
+}
+
+function movementEvents(paths: CollectionEvent[][]): MovementEvent[] {
+  return paths.flatMap((path, pathIndex) =>
+    path.flatMap((event) => {
+      const data = event.data as {
+        x?: unknown;
+        y?: unknown;
+        event?: unknown;
+      };
+      if (
+        event.type !== "cursor" ||
+        typeof data.x !== "number" ||
+        typeof data.y !== "number"
+      ) {
+        return [];
+      }
+
+      return [
+        {
+          ...event,
+          meta: {
+            ...event.meta,
+            url: `${event.meta.url}#walking-record-path-${pathIndex}`,
+          },
+          data: {
+            ...event.data,
+            x: data.x,
+            y: data.y,
+          },
+        } as MovementEvent,
+      ];
+    }),
+  );
+}
+
+export function scheduleLandscapeTrails(
+  trailStates: TrailState[],
+): TrailState[] {
+  if (trailStates.length === 0) return [];
+
+  const durations = trailStates.map((trail) =>
+    Math.max(
+      MIN_TRAIL_PLAYBACK_MS,
+      Math.min(MAX_TRAIL_PLAYBACK_MS, trail.durationMs),
+    ),
+  );
+  const averageDuration =
+    durations.reduce((total, duration) => total + duration, 0) /
+    durations.length;
+  const overlapMultiplier = 1 - DEFAULT_SETTINGS.overlapFactor * 0.8;
+  const spacing = Math.max(
+    DEFAULT_SETTINGS.minGapBetweenTrails * 1_000,
+    (averageDuration / DEFAULT_SETTINGS.maxConcurrentTrails) *
+      overlapMultiplier,
+  );
+  const orderedIndices = trailStates
+    .map((trail, index) => ({ index, startOffsetMs: trail.startOffsetMs }))
+    .sort((first, second) => first.startOffsetMs - second.startOffsetMs);
+  const positionByIndex = new Int32Array(trailStates.length);
+  orderedIndices.forEach(({ index }, position) => {
+    positionByIndex[index] = position;
+  });
+
+  return trailStates.map((trail, index) => ({
+    ...trail,
+    startOffsetMs: positionByIndex[index] * spacing,
+    durationMs: durations[index],
+  }));
+}
+
+export function cycleLandscapeTrails(trailStates: TrailState[]): {
+  trailStates: TrailState[];
+  duration: number;
+} {
+  if (trailStates.length === 0) {
+    return { trailStates: [], duration: 1 };
+  }
+
+  const orderedStarts = trailStates
+    .map((trail) => trail.startOffsetMs)
+    .sort((first, second) => first - second);
+  const spacing =
+    orderedStarts.length > 1
+      ? orderedStarts[1] - orderedStarts[0]
+      : DEFAULT_SETTINGS.minGapBetweenTrails * 1_000;
+  const duration = Math.max(
+    MIN_LANDSCAPE_CYCLE_MS,
+    orderedStarts.at(-1)! + spacing,
+  );
+  const wrappedTrails = trailStates.flatMap((trail) =>
+    trail.startOffsetMs + trail.durationMs > duration
+      ? [
+          {
+            ...trail,
+            startOffsetMs: trail.startOffsetMs - duration,
+          },
+          trail,
+        ]
+      : [trail],
+  );
+
+  return { trailStates: wrappedTrails, duration };
+}
+
+export function MovementLandscape({
+  paths,
+  label,
+}: MovementLandscapeProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [viewportSize, setViewportSize] = useState({ width: 0, height: 0 });
+  const [hasEnteredViewport, setHasEnteredViewport] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const filterId = useId().replaceAll(":", "");
+  const events = useMemo(() => movementEvents(paths), [paths]);
+  const { trailStates } = useCursorTrails(
+    events,
+    viewportSize,
+    DEFAULT_SETTINGS,
+  );
+  const scheduledTrailStates = useMemo(
+    () => scheduleLandscapeTrails(trailStates),
+    [trailStates],
+  );
+  const playback = useMemo(
+    () => cycleLandscapeTrails(scheduledTrailStates),
+    [scheduledTrailStates],
+  );
+  const timeRange = useMemo(
+    () => ({ min: 0, max: playback.duration, duration: playback.duration }),
+    [playback.duration],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateSize = () => {
+      const bounds = container.getBoundingClientRect();
+      setViewportSize({
+        width: Math.max(1, bounds.width),
+        height: Math.max(1, bounds.height),
+      });
+    };
+    updateSize();
+
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", updateSize);
+      return () => window.removeEventListener("resize", updateSize);
+    }
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      setHasEnteredViewport(true);
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsVisible(entry.isIntersecting);
+        if (entry.isIntersecting) setHasEnteredViewport(true);
+      },
+      { rootMargin: "180px 0px" },
+    );
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const query = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+    if (!query) return;
+
+    const updatePreference = () => setReducedMotion(query.matches);
+    updatePreference();
+    query.addEventListener("change", updatePreference);
+    return () => query.removeEventListener("change", updatePreference);
+  }, []);
+
+  if (paths.length === 0) return null;
+
+  return (
+    <div
+      className="walking-record__movement-landscape"
+      ref={containerRef}
+      role="img"
+      aria-label={label}
+    >
+      <svg
+        className="walking-record__movement-paper"
+        width="100%"
+        height="100%"
+        aria-hidden="true"
+      >
+        <defs>
+          <filter id={`${filterId}-noise`}>
+            <feTurbulence
+              type="fractalNoise"
+              baseFrequency="0.9"
+              numOctaves="3"
+              stitchTiles="stitch"
+            />
+            <feColorMatrix
+              type="matrix"
+              values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 2 -1"
+            />
+          </filter>
+          <filter id={`${filterId}-grain`}>
+            <feTurbulence
+              type="turbulence"
+              baseFrequency="0.5"
+              numOctaves="2"
+              stitchTiles="stitch"
+            />
+            <feColorMatrix type="saturate" values="0" />
+            <feComponentTransfer>
+              <feFuncA type="discrete" tableValues="0 0.2 0.3 0.4" />
+            </feComponentTransfer>
+          </filter>
+        </defs>
+        <rect
+          width="100%"
+          height="100%"
+          filter={`url(#${filterId}-noise)`}
+        />
+        <rect
+          width="100%"
+          height="100%"
+          filter={`url(#${filterId}-grain)`}
+          opacity="0.3"
+        />
+      </svg>
+
+      {hasEnteredViewport && playback.trailStates.length > 0 && (
+        <AnimatedTrails
+          trailStates={playback.trailStates}
+          timeRange={timeRange}
+          showClickRipples
+          windowSize={DEFAULT_SETTINGS.maxConcurrentTrails * 2}
+          settings={DEFAULT_SETTINGS}
+          frozen={reducedMotion || !isVisible}
+        />
+      )}
+    </div>
+  );
+}

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -472,6 +472,24 @@ button:focus-visible {
   white-space: nowrap;
 }
 
+.walking-record__departures-more {
+  display: block;
+  margin: 10px 4px 0 auto;
+  padding: 2px 0;
+  border: 0;
+  border-bottom: 1px solid rgba($accent-teal, 0.35);
+  background: transparent;
+  color: $accent-teal;
+  cursor: pointer;
+  font-family: $font-mono;
+  font-size: 10px;
+
+  &:hover {
+    border-bottom-color: $accent-teal;
+    color: $text;
+  }
+}
+
 .walking-record__empty {
   padding: 20px;
   border: 1px dashed $border-strong;
@@ -734,6 +752,34 @@ button:focus-visible {
   stroke-width: 1;
 }
 
+.walking-record__movement-section {
+  margin-bottom: 0;
+}
+
+.walking-record__movement-landscape {
+  position: relative;
+  height: 210px;
+  margin-top: 14px;
+  overflow: hidden;
+  border: 1px solid $border;
+  border-radius: 10px;
+  background: $surface;
+  box-shadow: 0 1px 4px $shadow;
+
+  .trails-svg {
+    z-index: 2;
+  }
+}
+
+.walking-record__movement-paper {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  opacity: 0.42;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+
 @media (max-width: 650px) {
   .walking-record {
     padding: 30px 18px 56px;
@@ -814,6 +860,10 @@ button:focus-visible {
     small {
       grid-column: 2;
     }
+  }
+
+  .walking-record__movement-landscape {
+    height: 160px;
   }
 }
 

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -503,6 +503,14 @@ button:focus-visible {
   mix-blend-mode: multiply;
 }
 
+.walking-record__future-trace {
+  fill: none;
+  stroke: rgba(90, 78, 65, 0.12);
+  stroke-dasharray: 2 4;
+  stroke-linecap: round;
+  stroke-width: 1;
+}
+
 .walking-record__day-plate {
   display: flex;
   min-width: 0;
@@ -533,6 +541,18 @@ button:focus-visible {
     font-style: italic;
     line-height: 1.35;
     text-align: center;
+  }
+}
+
+.walking-record__day-plate--future {
+  border-color: rgba(90, 78, 65, 0.18);
+  border-style: dashed;
+  background: rgba($surface, 0.2);
+  box-shadow: none;
+
+  strong,
+  > span {
+    color: rgba(90, 78, 65, 0.45);
   }
 }
 

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -87,6 +87,75 @@ button:focus-visible {
   margin: 0 auto;
 }
 
+.walking-record__loading-cursors {
+  position: relative;
+  width: 100%;
+  height: 64px;
+  overflow: hidden;
+
+  > svg:first-child {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.walking-record__loading-route {
+  fill: none;
+  stroke: rgba(90, 78, 65, 0.16);
+  stroke-dasharray: 2 5;
+  stroke-linecap: round;
+  stroke-width: 1;
+  animation: walking-record-route 3s linear infinite;
+}
+
+.walking-record__loading-cursor {
+  position: absolute;
+  top: -9px;
+  left: -9px;
+  width: 18px;
+  height: 18px;
+  offset-path: path(
+    "M 8 42 C 54 10, 93 53, 137 27 S 218 14, 260 36 S 296 43, 312 17"
+  );
+  offset-rotate: 0deg;
+  opacity: 0;
+  filter: drop-shadow(0 1px 1px rgba(90, 78, 65, 0.12));
+  animation: walking-record-cursor-walk 5.4s linear infinite;
+}
+
+.walking-record__loading-cursor--two {
+  animation-delay: -1.8s;
+}
+
+.walking-record__loading-cursor--three {
+  animation-delay: -3.6s;
+}
+
+@keyframes walking-record-route {
+  to {
+    stroke-dashoffset: -14;
+  }
+}
+
+@keyframes walking-record-cursor-walk {
+  0% {
+    offset-distance: 0%;
+    opacity: 0;
+  }
+
+  10%,
+  88% {
+    opacity: 0.78;
+  }
+
+  100% {
+    offset-distance: 100%;
+    opacity: 0;
+  }
+}
+
 .walking-record__loading-copy {
   display: flex;
   width: 100%;
@@ -344,10 +413,12 @@ button:focus-visible {
 
 .walking-record__departure {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) 72px;
+  width: 100%;
+  box-sizing: border-box;
+  grid-template-columns: 34px minmax(0, 1fr) max-content;
   gap: 10px;
   align-items: start;
-  padding: 10px 4px;
+  padding: 10px 8px 10px 4px;
   border-bottom: 1px solid rgba(90, 78, 65, 0.1);
   transition: background 0.12s;
 
@@ -372,6 +443,7 @@ button:focus-visible {
       color: $accent-blue;
       font-size: 13px;
       font-weight: 500;
+      overflow-wrap: anywhere;
     }
   }
 
@@ -604,6 +676,14 @@ button:focus-visible {
   }
 }
 
+.walking-record__time-legend-ink {
+  width: 10px;
+  height: 3px;
+  flex: 0 0 10px;
+  border-radius: 99px;
+  opacity: 0.82;
+}
+
 .walking-record__site-favicon,
 .walking-record__site-favicon-fallback {
   width: 14px;
@@ -711,6 +791,27 @@ button:focus-visible {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .walking-record__loading-route,
+  .walking-record__loading-cursor {
+    animation: none;
+  }
+
+  .walking-record__loading-cursor {
+    opacity: 0.5;
+  }
+
+  .walking-record__loading-cursor--one {
+    offset-distance: 22%;
+  }
+
+  .walking-record__loading-cursor--two {
+    offset-distance: 50%;
+  }
+
+  .walking-record__loading-cursor--three {
+    offset-distance: 78%;
+  }
+
   *,
   *::before,
   *::after {

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -80,6 +80,36 @@ button:focus-visible {
   font-size: 11px;
 }
 
+.walking-record__loading {
+  width: min(100%, 320px);
+  flex-direction: column;
+  gap: 10px;
+  margin: 0 auto;
+}
+
+.walking-record__loading-copy {
+  display: flex;
+  width: 100%;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.walking-record__loading-track {
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(90, 78, 65, 0.12);
+
+  > span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: $accent-teal;
+    transition: width 0.22s ease-out;
+  }
+}
+
 .walking-record__error {
   flex-direction: column;
   gap: 8px;

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -339,32 +339,20 @@ button:focus-visible {
 .walking-record__departures {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  margin-top: 2px;
 }
 
 .walking-record__departure {
-  display: flex;
-  gap: 14px;
-  align-items: flex-start;
-  padding: 14px 16px;
-  border: 1px solid $border;
-  border-radius: 8px;
-  background: $surface;
-  box-shadow: 0 1px 4px $shadow;
-  transition:
-    border-color 0.12s,
-    background 0.12s;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 72px;
+  gap: 10px;
+  align-items: start;
+  padding: 10px 4px;
+  border-bottom: 1px solid rgba(90, 78, 65, 0.1);
+  transition: background 0.12s;
 
   &:hover {
-    border-color: $border-strong;
-    background: $surface-hover;
-  }
-
-  > svg {
-    width: 44px;
-    height: 44px;
-    flex: 0 0 44px;
-    margin-top: 2px;
+    background: rgba($surface, 0.55);
   }
 }
 
@@ -374,42 +362,41 @@ button:focus-visible {
 
   > div {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: 7px;
     color: $text-muted;
-    font-size: 13px;
-
-    span:nth-child(-n + 2) {
-      font-family: $font-mono;
-      font-size: 10px;
-    }
+    font-size: 12.5px;
 
     strong {
-      color: $text;
-      font-family: $font-heading;
-      font-size: 15px;
-      font-weight: 600;
+      color: $accent-blue;
+      font-size: 13px;
+      font-weight: 500;
     }
   }
 
   p {
     margin: 4px 0 0;
-    color: $text-muted;
-    font-size: 12.5px;
+    color: $text-faint;
+    font-family: $font-mono;
+    font-size: 10.5px;
   }
 }
 
 .walking-record__day {
+  padding-top: 3px;
   color: $text-faint;
-}
-
-.walking-record__familiarity {
-  margin-top: 3px;
-  color: $accent-teal;
-  flex-shrink: 0;
   font-family: $font-mono;
   font-size: 10px;
+}
+
+.walking-record__departure-time {
+  padding-top: 2px;
+  color: $accent-teal;
+  font-family: $font-mono;
+  font-size: 11px;
+  font-weight: 600;
+  text-align: right;
   white-space: nowrap;
 }
 
@@ -423,18 +410,24 @@ button:focus-visible {
   line-height: 1.5;
 }
 
-.walking-record__subheading {
-  margin: 24px 0 4px !important;
-  color: $text-muted;
-  font-size: 14px !important;
-  font-style: italic;
-}
+.walking-record__subsection-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 24px 0 8px;
 
-.walking-record__revisit-intro {
-  margin: 0 0 12px;
-  color: $text-faint;
-  font-size: 11.5px;
-  font-style: italic;
+  h2 {
+    color: $text-muted;
+    font-size: 14px !important;
+    font-style: italic;
+  }
+
+  span {
+    color: $text-faint;
+    font-family: $font-mono;
+    font-size: 9.5px;
+  }
 }
 
 .walking-record__revisit-ledger {
@@ -488,7 +481,7 @@ button:focus-visible {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 8px;
-  margin-bottom: 12px;
+  margin-top: 18px;
 
   &[data-period="month"] {
     grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -556,43 +549,66 @@ button:focus-visible {
   }
 }
 
-.walking-record__hours {
+.walking-record__time-spent {
+  padding: 14px 16px 12px;
+  border: 1px solid $border;
+  border-radius: 8px;
+  background: $surface;
+  box-shadow: 0 1px 4px $shadow;
+}
+
+.walking-record__time-stack {
   display: flex;
-  flex-direction: column;
+  width: 100%;
+  height: 20px;
+  overflow: hidden;
+  border-radius: 5px;
+  background: $border;
 
-  > a,
-  > div {
-    display: grid;
-    grid-template-columns: 18px 16px minmax(0, 1fr);
-    gap: 10px;
-    align-items: flex-start;
-    padding: 9px 4px;
-    border-bottom: 1px solid $border;
-  }
+  span {
+    display: block;
+    min-width: 1px;
+    height: 100%;
+    opacity: 0.82;
 
-  > a:hover {
-    background: rgba($surface, 0.55);
-  }
-
-  small {
-    color: $text-faint;
-    font-size: 11px;
+    &:not(:last-child) {
+      border-right: 1px solid rgba($bg, 0.7);
+    }
   }
 }
 
-.walking-record__rank {
-  padding-top: 2px;
-  color: $text-faint;
-  font-family: $font-mono;
-  font-size: 11px;
-  text-align: right;
+.walking-record__time-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin-top: 10px;
+
+  > a,
+  > div {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: $text-muted;
+    font-size: 10.5px;
+  }
+
+  > a:hover span {
+    text-decoration: underline;
+  }
+
+  strong {
+    color: $text-faint;
+    font-family: $font-mono;
+    font-size: 10px;
+    font-weight: 400;
+  }
 }
 
 .walking-record__site-favicon,
 .walking-record__site-favicon-fallback {
-  width: 16px;
-  height: 16px;
-  margin-top: 2px;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
 }
 
 .walking-record__site-favicon {
@@ -609,44 +625,6 @@ button:focus-visible {
   font-family: $font-mono;
   font-size: 8px;
   line-height: 1;
-}
-
-.walking-record__hour-title {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 8px;
-
-  strong {
-    overflow: hidden;
-    font-size: 13px;
-    font-weight: 500;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  span {
-    color: $accent-teal;
-    flex-shrink: 0;
-    font-family: $font-mono;
-    font-size: 12px;
-    font-weight: 600;
-  }
-}
-
-.walking-record__time-track {
-  height: 3px;
-  margin: 4px 0;
-  overflow: hidden;
-  border-radius: 2px;
-  background: $border;
-
-  span {
-    display: block;
-    height: 100%;
-    border-radius: 2px;
-    opacity: 0.7;
-  }
 }
 
 @media (max-width: 650px) {
@@ -696,19 +674,12 @@ button:focus-visible {
   }
 
   .walking-record__departure {
-    display: grid;
-    grid-template-columns: 36px minmax(0, 1fr);
-
-    > svg {
-      width: 36px;
-      height: 36px;
-      flex-basis: 36px;
-    }
+    grid-template-columns: 28px minmax(0, 1fr);
   }
 
-  .walking-record__familiarity {
+  .walking-record__departure-time {
     grid-column: 2;
-    margin-top: -8px;
+    text-align: left;
   }
 
   .walking-record__day-plates {

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -543,7 +543,7 @@ button:focus-visible {
   > a,
   > div {
     display: grid;
-    grid-template-columns: 18px 14px minmax(0, 1fr);
+    grid-template-columns: 18px 16px minmax(0, 1fr);
     gap: 10px;
     align-items: flex-start;
     padding: 9px 4px;
@@ -568,11 +568,27 @@ button:focus-visible {
   text-align: right;
 }
 
-.walking-record__site-color {
-  width: 14px;
-  height: 14px;
-  margin-top: 3px;
-  border-radius: 3px;
+.walking-record__site-favicon,
+.walking-record__site-favicon-fallback {
+  width: 16px;
+  height: 16px;
+  margin-top: 2px;
+}
+
+.walking-record__site-favicon {
+  object-fit: contain;
+}
+
+.walking-record__site-favicon-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(90, 78, 65, 0.2);
+  border-radius: 50%;
+  color: $text-faint;
+  font-family: $font-mono;
+  font-size: 8px;
+  line-height: 1;
 }
 
 .walking-record__hour-title {

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -643,7 +643,7 @@ button:focus-visible {
 .walking-record__time-stack {
   display: flex;
   width: 100%;
-  height: 20px;
+  height: 22px;
   overflow: hidden;
   border-radius: 5px;
   background: $border;
@@ -663,16 +663,17 @@ button:focus-visible {
 .walking-record__time-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 16px;
-  margin-top: 10px;
+  gap: 9px 18px;
+  margin-top: 12px;
 
   > a,
   > div {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
+    gap: 6px;
     color: $text-muted;
-    font-size: 10.5px;
+    font-size: 12.5px;
+    line-height: 1.3;
   }
 
   > a:hover .walking-record__time-legend-site {
@@ -682,14 +683,23 @@ button:focus-visible {
   strong {
     color: $text-faint;
     font-family: $font-mono;
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 400;
+    letter-spacing: -0.02em;
+  }
+
+  .walking-record__site-favicon,
+  .walking-record__site-favicon-fallback {
+    width: 15px;
+    height: 15px;
+    flex-basis: 15px;
   }
 }
 
 .walking-record__time-legend-site {
   border-bottom: 2px solid;
-  line-height: 1.35;
+  padding-bottom: 2px;
+  line-height: 1.15;
 }
 
 .walking-record__site-favicon,
@@ -713,6 +723,15 @@ button:focus-visible {
   font-family: $font-mono;
   font-size: 8px;
   line-height: 1;
+}
+
+.walking-record__site-favicon-globe {
+  border: 0;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1;
 }
 
 @media (max-width: 650px) {

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -586,6 +586,17 @@ button:focus-visible {
   border-radius: 8px;
   background: $surface;
   box-shadow: 0 1px 4px $shadow;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s,
+    transform 0.12s;
+
+  &[href]:hover,
+  &[href]:focus-visible {
+    border-color: rgba($accent-teal, 0.45);
+    box-shadow: 0 3px 10px rgba(90, 78, 65, 0.12);
+    transform: translateY(-1px);
+  }
 
   svg {
     width: 100%;

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -675,8 +675,8 @@ button:focus-visible {
     font-size: 10.5px;
   }
 
-  > a:hover span {
-    text-decoration: underline;
+  > a:hover .walking-record__time-legend-site {
+    color: $text;
   }
 
   strong {
@@ -687,12 +687,9 @@ button:focus-visible {
   }
 }
 
-.walking-record__time-legend-ink {
-  width: 10px;
-  height: 3px;
-  flex: 0 0 10px;
-  border-radius: 99px;
-  opacity: 0.82;
+.walking-record__time-legend-site {
+  border-bottom: 2px solid;
+  line-height: 1.35;
 }
 
 .walking-record__site-favicon,

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -377,17 +377,17 @@ function PeriodNavigationRail({
 function TimeSpentLegendEntry({ entry }: { entry: TimeSpentEntry }) {
   const content = (
     <>
-      <span
-        className="walking-record__time-legend-ink"
-        style={{ backgroundColor: entry.hue }}
-        aria-hidden="true"
-      />
       <SiteFavicon
         faviconUrl={entry.faviconUrl}
         site={entry.site}
         muted={!entry.href}
       />
-      <span>{entry.site}</span>
+      <span
+        className="walking-record__time-legend-site"
+        style={{ borderBottomColor: entry.hue }}
+      >
+        {entry.site}
+      </span>
       <strong>{entry.time}</strong>
     </>
   );

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -27,6 +27,11 @@ interface WalkingRecordPageProps {
   onPeriodChange: (period: WalkingRecordPeriod) => void;
   onPeriodOffsetChange: (offset: number) => void;
   loading: boolean;
+  loadingProgress: {
+    completed: number;
+    total: number;
+    message: string;
+  };
   error: string | null;
 }
 
@@ -279,8 +284,13 @@ export function WalkingRecordPage({
   onPeriodChange,
   onPeriodOffsetChange,
   loading,
+  loadingProgress,
   error,
 }: WalkingRecordPageProps) {
+  const loadingPercentage = Math.round(
+    (loadingProgress.completed / loadingProgress.total) * 100,
+  );
+
   return (
     <main className="walking-record">
       <header className="walking-record__header">
@@ -289,7 +299,20 @@ export function WalkingRecordPage({
 
       {loading && (
         <div className="walking-record__loading" role="status">
-          gathering this {period}’s record…
+          <div className="walking-record__loading-copy">
+            <span>{loadingProgress.message}</span>
+            <span>{loadingPercentage}%</span>
+          </div>
+          <div
+            className="walking-record__loading-track"
+            role="progressbar"
+            aria-label={`Loading ${period} record`}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={loadingPercentage}
+          >
+            <span style={{ width: `${loadingPercentage}%` }} />
+          </div>
         </div>
       )}
 

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -13,6 +13,7 @@ import {
   type WalkingRecord,
   type WalkingRecordPeriod,
   type WalkingRecordPeriodSummary,
+  type TimeSpentEntry,
 } from "../history/walkingRecord";
 import type { WalkingRecordTracePoint } from "../storage/LocalEventStore";
 import { ExtensionPageNav } from "./ExtensionPageNav";
@@ -175,6 +176,27 @@ function EmptySection({ children }: { children: React.ReactNode }) {
   return <div className="walking-record__empty">{children}</div>;
 }
 
+function SiteFavicon({ entry }: { entry: TimeSpentEntry }) {
+  const [failed, setFailed] = React.useState(false);
+
+  if (!entry.faviconUrl || failed) {
+    return (
+      <span className="walking-record__site-favicon-fallback" aria-hidden="true">
+        {entry.href ? entry.site.charAt(0).toLowerCase() : "···"}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      className="walking-record__site-favicon"
+      src={entry.faviconUrl}
+      alt=""
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
 function periodTitle(
   period: WalkingRecordPeriod,
   timestamp: number,
@@ -276,6 +298,71 @@ function PeriodNavigationRail({
   );
 }
 
+function HoursSection({ record }: { record: WalkingRecord }) {
+  return (
+    <section className="walking-record__section">
+      <div className="walking-record__section-heading">
+        <h1>where the hours went</h1>
+        <span>{record.totalTimeLabel} browsing</span>
+      </div>
+      <p className="walking-record__section-intro">{record.timeSpentIntro}</p>
+
+      <div
+        className="walking-record__day-plates"
+        data-period={record.period}
+      >
+        {record.dayPlates.map((plate) => (
+          <div className="walking-record__day-plate" key={plate.date}>
+            <DayPlateGraphic plate={plate} />
+            <strong>{plate.day}</strong>
+            <span>{plate.vignette}</span>
+          </div>
+        ))}
+      </div>
+
+      {record.timeSpent.length > 0 ? (
+        <div className="walking-record__hours">
+          {record.timeSpent.map((entry) => {
+            const content = (
+              <>
+                <span className="walking-record__rank">{entry.rank}</span>
+                <SiteFavicon entry={entry} />
+                <div>
+                  <div className="walking-record__hour-title">
+                    <strong>{entry.site}</strong>
+                    <span>{entry.time}</span>
+                  </div>
+                  <div className="walking-record__time-track">
+                    <span
+                      style={{
+                        background: entry.hue,
+                        width: `${entry.percentage}%`,
+                      }}
+                    />
+                  </div>
+                  <small>{entry.note}</small>
+                </div>
+              </>
+            );
+
+            return entry.href ? (
+              <a href={entry.href} key={entry.site}>
+                {content}
+              </a>
+            ) : (
+              <div key={entry.site}>{content}</div>
+            );
+          })}
+        </div>
+      ) : (
+        <EmptySection>
+          time appears after a page has been in focus and then left.
+        </EmptySection>
+      )}
+    </section>
+  );
+}
+
 export function WalkingRecordPage({
   record,
   period,
@@ -370,9 +457,11 @@ export function WalkingRecordPage({
             />
           </div>
 
+          <HoursSection record={record} />
+
           <section className="walking-record__section">
             <div className="walking-record__section-heading">
-              <h1>how you traveled</h1>
+              <h2>how you traveled</h2>
               <span>
                 top {record.departures.length} of {record.movementCount}{" "}
                 movement
@@ -455,74 +544,6 @@ export function WalkingRecordPage({
               <EmptySection>
                 no familiar place has been quiet long enough to call you back
                 yet.
-              </EmptySection>
-            )}
-          </section>
-
-          <section className="walking-record__section">
-            <div className="walking-record__section-heading">
-              <h2>where the hours went</h2>
-              <span>
-                {record.totalTimeLabel} browsing
-              </span>
-            </div>
-            <p className="walking-record__section-intro">
-              {record.timeSpentIntro}
-            </p>
-
-            <div
-              className="walking-record__day-plates"
-              data-period={record.period}
-            >
-              {record.dayPlates.map((plate) => (
-                <div className="walking-record__day-plate" key={plate.date}>
-                  <DayPlateGraphic plate={plate} />
-                  <strong>{plate.day}</strong>
-                  <span>{plate.vignette}</span>
-                </div>
-              ))}
-            </div>
-
-            {record.timeSpent.length > 0 ? (
-              <div className="walking-record__hours">
-                {record.timeSpent.map((entry) => {
-                  const content = (
-                    <>
-                      <span className="walking-record__rank">{entry.rank}</span>
-                      <span
-                        className="walking-record__site-color"
-                        style={{ background: entry.hue }}
-                      />
-                      <div>
-                        <div className="walking-record__hour-title">
-                          <strong>{entry.site}</strong>
-                          <span>{entry.time}</span>
-                        </div>
-                        <div className="walking-record__time-track">
-                          <span
-                            style={{
-                              background: entry.hue,
-                              width: `${entry.percentage}%`,
-                            }}
-                          />
-                        </div>
-                        <small>{entry.note}</small>
-                      </div>
-                    </>
-                  );
-
-                  return entry.href ? (
-                    <a href={entry.href} key={entry.site}>
-                      {content}
-                    </a>
-                  ) : (
-                    <div key={entry.site}>{content}</div>
-                  );
-                })}
-              </div>
-            ) : (
-              <EmptySection>
-                time appears after a page has been in focus and then left.
               </EmptySection>
             )}
           </section>

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -256,9 +256,22 @@ function SiteFavicon({
   const [failed, setFailed] = React.useState(false);
 
   if (!faviconUrl || failed) {
+    if (muted) {
+      return (
+        <svg
+          className="walking-record__site-favicon-fallback walking-record__site-favicon-globe"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="6.25" />
+          <path d="M1.75 8h12.5M8 1.75c2 1.7 3 3.8 3 6.25s-1 4.55-3 6.25C6 12.55 5 10.45 5 8s1-4.55 3-6.25Z" />
+        </svg>
+      );
+    }
+
     return (
       <span className="walking-record__site-favicon-fallback" aria-hidden="true">
-        {muted ? "···" : site.charAt(0).toLowerCase()}
+        {site.charAt(0).toLowerCase()}
       </span>
     );
   }

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -191,13 +191,21 @@ function EmptySection({ children }: { children: React.ReactNode }) {
   return <div className="walking-record__empty">{children}</div>;
 }
 
-function SiteFavicon({ entry }: { entry: TimeSpentEntry }) {
+function SiteFavicon({
+  faviconUrl,
+  site,
+  muted = false,
+}: {
+  faviconUrl?: string;
+  site: string;
+  muted?: boolean;
+}) {
   const [failed, setFailed] = React.useState(false);
 
-  if (!entry.faviconUrl || failed) {
+  if (!faviconUrl || failed) {
     return (
       <span className="walking-record__site-favicon-fallback" aria-hidden="true">
-        {entry.href ? entry.site.charAt(0).toLowerCase() : "···"}
+        {muted ? "···" : site.charAt(0).toLowerCase()}
       </span>
     );
   }
@@ -205,7 +213,7 @@ function SiteFavicon({ entry }: { entry: TimeSpentEntry }) {
   return (
     <img
       className="walking-record__site-favicon"
-      src={entry.faviconUrl}
+      src={faviconUrl}
       alt=""
       onError={() => setFailed(true)}
     />
@@ -313,15 +321,153 @@ function PeriodNavigationRail({
   );
 }
 
-function HoursSection({ record }: { record: WalkingRecord }) {
+function TimeSpentLegendEntry({ entry }: { entry: TimeSpentEntry }) {
+  const content = (
+    <>
+      <SiteFavicon
+        faviconUrl={entry.faviconUrl}
+        site={entry.site}
+        muted={!entry.href}
+      />
+      <span>{entry.site}</span>
+      <strong>{entry.time}</strong>
+    </>
+  );
+
+  return entry.href ? (
+    <a href={entry.href}>{content}</a>
+  ) : (
+    <div>{content}</div>
+  );
+}
+
+function HowBrowsedSection({ record }: { record: WalkingRecord }) {
   return (
     <section className="walking-record__section">
       <div className="walking-record__section-heading">
-        <h1>where the hours went</h1>
-        <span>{record.totalTimeLabel} browsing</span>
+        <h1>how you browsed</h1>
+        <span>{record.totalTimeLabel} online this {record.period}</span>
       </div>
       <p className="walking-record__section-intro">{record.timeSpentIntro}</p>
 
+      {record.timeSpent.length > 0 ? (
+        <div className="walking-record__time-spent">
+          <div
+            className="walking-record__time-stack"
+            aria-label="Browsing time by site"
+          >
+            {record.timeSpent.map((entry) => (
+              <span
+                key={entry.site}
+                title={`${entry.site}: ${entry.time}`}
+                style={{
+                  background: entry.hue,
+                  width: `${entry.percentage}%`,
+                }}
+              />
+            ))}
+          </div>
+          <div className="walking-record__time-legend">
+            {record.timeSpent.map((entry) => (
+              <TimeSpentLegendEntry entry={entry} key={entry.site} />
+            ))}
+          </div>
+        </div>
+      ) : (
+        <EmptySection>
+          time appears after a page has been in focus and then left.
+        </EmptySection>
+      )}
+
+      <div className="walking-record__subsection-heading">
+        <h2>notable new exploration</h2>
+        <span>
+          {record.departures.length} shown from {record.movementCount}
+        </span>
+      </div>
+
+      {record.departures.length > 0 ? (
+        <div className="walking-record__departures">
+          {record.departures.map((departure) => (
+            <a
+              className="walking-record__departure"
+              href={departure.toUrl}
+              key={`${departure.day}:${departure.to}`}
+            >
+              <span className="walking-record__day">{departure.day}</span>
+              <div className="walking-record__departure-copy">
+                <div>
+                  <SiteFavicon
+                    faviconUrl={departure.fromFaviconUrl}
+                    site={departure.from}
+                  />
+                  <span>{departure.from}</span>
+                  <span aria-hidden="true">→</span>
+                  <SiteFavicon
+                    faviconUrl={departure.toFaviconUrl}
+                    site={departure.to}
+                  />
+                  <strong>{departure.to}</strong>
+                </div>
+                {departure.note && <p>{departure.note}</p>}
+              </div>
+              <span className="walking-record__departure-time">
+                {departure.time}
+              </span>
+            </a>
+          ))}
+        </div>
+      ) : (
+        <EmptySection>
+          new explorations appear after you leave one of your usual places for
+          a quieter corner of the web.
+        </EmptySection>
+      )}
+    </section>
+  );
+}
+
+function RevisitSection({ record }: { record: WalkingRecord }) {
+  return (
+    <section className="walking-record__section">
+      <div className="walking-record__section-heading">
+        <h2>where you used to visit</h2>
+      </div>
+      <p className="walking-record__section-intro">
+        places you returned to across many days that you haven’t walked lately.
+        the doors are still open.
+      </p>
+      {record.revisits.length > 0 ? (
+        <div className="walking-record__revisit-ledger">
+          {record.revisits.map((revisit) => (
+            <a href={revisit.href} key={revisit.site}>
+              <span style={{ color: readablePaletteColor(revisit.hue) }}>
+                {revisit.span}
+              </span>
+              <strong>{revisit.site}</strong>
+              <small>{revisit.memory}</small>
+            </a>
+          ))}
+        </div>
+      ) : (
+        <EmptySection>
+          no regularly visited place has been quiet long enough to call you
+          back yet.
+        </EmptySection>
+      )}
+    </section>
+  );
+}
+
+function BrowsingPortraitsSection({ record }: { record: WalkingRecord }) {
+  return (
+    <section className="walking-record__section">
+      <div className="walking-record__section-heading">
+        <h2>browsing portraits</h2>
+      </div>
+      <p className="walking-record__section-intro">
+        one small portrait from each {record.period === "week" ? "day" : "part"}.
+      </p>
       <div
         className="walking-record__day-plates"
         data-period={record.period}
@@ -339,46 +485,6 @@ function HoursSection({ record }: { record: WalkingRecord }) {
           </div>
         ))}
       </div>
-
-      {record.timeSpent.length > 0 ? (
-        <div className="walking-record__hours">
-          {record.timeSpent.map((entry) => {
-            const content = (
-              <>
-                <span className="walking-record__rank">{entry.rank}</span>
-                <SiteFavicon entry={entry} />
-                <div>
-                  <div className="walking-record__hour-title">
-                    <strong>{entry.site}</strong>
-                    <span>{entry.time}</span>
-                  </div>
-                  <div className="walking-record__time-track">
-                    <span
-                      style={{
-                        background: entry.hue,
-                        width: `${entry.percentage}%`,
-                      }}
-                    />
-                  </div>
-                  <small>{entry.note}</small>
-                </div>
-              </>
-            );
-
-            return entry.href ? (
-              <a href={entry.href} key={entry.site}>
-                {content}
-              </a>
-            ) : (
-              <div key={entry.site}>{content}</div>
-            );
-          })}
-        </div>
-      ) : (
-        <EmptySection>
-          time appears after a page has been in focus and then left.
-        </EmptySection>
-      )}
     </section>
   );
 }
@@ -477,96 +583,9 @@ export function WalkingRecordPage({
             />
           </div>
 
-          <HoursSection record={record} />
-
-          <section className="walking-record__section">
-            <div className="walking-record__section-heading">
-              <h2>how you traveled</h2>
-              <span>
-                top {record.departures.length} of {record.movementCount}{" "}
-                movement
-                {record.movementCount === 1 ? "" : "s"}
-              </span>
-            </div>
-            <p className="walking-record__section-intro">
-              some of the off-beaten paths and places you haven’t visited in a
-              while
-            </p>
-
-            {record.departures.length > 0 ? (
-              <div className="walking-record__departures">
-                {record.departures.map((departure) => (
-                  <a
-                    className="walking-record__departure"
-                    href={departure.toUrl}
-                    key={`${departure.day}:${departure.to}`}
-                  >
-                    <TraceGraphic
-                      paths={departure.tracePaths}
-                      hue={departure.hue}
-                      width={44}
-                      height={44}
-                      padding={4}
-                      minimumSize={1.5}
-                      maximumSize={3.2}
-                    />
-                    <div className="walking-record__departure-copy">
-                      <div>
-                        <span className="walking-record__day">
-                          {departure.day}
-                        </span>
-                        <span
-                          style={{
-                            color: readablePaletteColor(departure.accentHue),
-                          }}
-                        >
-                          {departure.verb}
-                        </span>
-                        <span>{departure.from}</span>
-                        <span aria-hidden="true">→</span>
-                        <strong>{departure.to}</strong>
-                      </div>
-                      {departure.note && <p>{departure.note}</p>}
-                    </div>
-                    <span className="walking-record__familiarity">
-                      {departure.familiarity}
-                    </span>
-                  </a>
-                ))}
-              </div>
-            ) : (
-              <EmptySection>
-                no departures were recorded. the quiet roads will appear here
-                when you leave one of your usual places for somewhere
-                unfamiliar.
-              </EmptySection>
-            )}
-
-            <h2 className="walking-record__subheading">revisiting history</h2>
-            <p className="walking-record__revisit-intro">
-              places you knew well, ordered by familiarity and time away
-            </p>
-            {record.revisits.length > 0 ? (
-              <div className="walking-record__revisit-ledger">
-                {record.revisits.map((revisit) => (
-                  <a href={revisit.href} key={revisit.site}>
-                    <span
-                      style={{ color: readablePaletteColor(revisit.hue) }}
-                    >
-                      {revisit.span}
-                    </span>
-                    <strong>{revisit.site}</strong>
-                    <small>{revisit.memory}</small>
-                  </a>
-                ))}
-              </div>
-            ) : (
-              <EmptySection>
-                no familiar place has been quiet long enough to call you back
-                yet.
-              </EmptySection>
-            )}
-          </section>
+          <HowBrowsedSection record={record} />
+          <RevisitSection record={record} />
+          <BrowsingPortraitsSection record={record} />
         </>
       )}
     </main>

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -2,6 +2,7 @@
 // ABOUTME: Presents period-specific departures, familiar sites, and time spent from local data.
 
 import React from "react";
+import browser from "webextension-polyfill";
 import {
   colorShade,
   readableTextLightness,
@@ -16,6 +17,7 @@ import {
   type TimeSpentEntry,
 } from "../history/walkingRecord";
 import type { WalkingRecordTracePoint } from "../storage/LocalEventStore";
+import { portraitDayPath } from "../utils/portraitDay";
 import { ExtensionPageNav } from "./ExtensionPageNav";
 import { PortraitCard } from "./PortraitCard";
 import "./WalkingRecord.scss";
@@ -524,18 +526,33 @@ function BrowsingPortraitsSection({ record }: { record: WalkingRecord }) {
         className="walking-record__day-plates"
         data-period={record.period}
       >
-        {record.dayPlates.map((plate) => (
-          <div
-            className={`walking-record__day-plate${
-              plate.future ? " walking-record__day-plate--future" : ""
-            }`}
-            key={plate.date}
-          >
-            <DayPlateGraphic plate={plate} />
-            <strong>{plate.day}</strong>
-            <span>{plate.vignette}</span>
-          </div>
-        ))}
+        {record.dayPlates.map((plate) => {
+          const className = `walking-record__day-plate${
+            plate.future ? " walking-record__day-plate--future" : ""
+          }`;
+          const content = (
+            <>
+              <DayPlateGraphic plate={plate} />
+              <strong>{plate.day}</strong>
+              <span>{plate.vignette}</span>
+            </>
+          );
+
+          return plate.portraitDay ? (
+            <a
+              className={className}
+              href={browser.runtime.getURL(portraitDayPath(plate.portraitDay))}
+              title={`Open ${plate.day} portrait`}
+              key={plate.date}
+            >
+              {content}
+            </a>
+          ) : (
+            <div className={className} key={plate.date}>
+              {content}
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -158,6 +158,21 @@ function TraceGraphic({
 }
 
 function DayPlateGraphic({ plate }: { plate: DayPlate }) {
+  if (plate.future) {
+    return (
+      <svg
+        viewBox="0 0 80 58"
+        role="img"
+        aria-label={`${plate.day} portrait still to come`}
+      >
+        <path
+          className="walking-record__future-trace"
+          d="M 8 45 C 20 30, 31 33, 43 29 S 60 31, 72 14"
+        />
+      </svg>
+    );
+  }
+
   return (
     <TraceGraphic
       paths={plate.tracePaths}
@@ -312,7 +327,12 @@ function HoursSection({ record }: { record: WalkingRecord }) {
         data-period={record.period}
       >
         {record.dayPlates.map((plate) => (
-          <div className="walking-record__day-plate" key={plate.date}>
+          <div
+            className={`walking-record__day-plate${
+              plate.future ? " walking-record__day-plate--future" : ""
+            }`}
+            key={plate.date}
+          >
             <DayPlateGraphic plate={plate} />
             <strong>{plate.day}</strong>
             <span>{plate.vignette}</span>

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -191,6 +191,57 @@ function EmptySection({ children }: { children: React.ReactNode }) {
   return <div className="walking-record__empty">{children}</div>;
 }
 
+const LOADING_CURSOR_BODY =
+  "M12 4 L12 16.5 L14.7 14 L16.7 18.5 L18.3 17.8 L16.3 13.4 L20 13.4 Z";
+
+function LoadingCursor({
+  className,
+  color,
+}: {
+  className: string;
+  color: string;
+}) {
+  return (
+    <svg
+      className={`walking-record__loading-cursor ${className}`}
+      viewBox="0 0 24 24"
+    >
+      <path
+        d={LOADING_CURSOR_BODY}
+        fill={color}
+        stroke="#f7f3ed"
+        strokeLinejoin="round"
+        strokeWidth="0.8"
+      />
+    </svg>
+  );
+}
+
+function LoadingCursorWalk() {
+  return (
+    <div className="walking-record__loading-cursors" aria-hidden="true">
+      <svg viewBox="0 0 320 64" preserveAspectRatio="none">
+        <path
+          className="walking-record__loading-route"
+          d="M8 42 C54 10, 93 53, 137 27 S218 14, 260 36 S296 43, 312 17"
+        />
+      </svg>
+      <LoadingCursor
+        className="walking-record__loading-cursor--one"
+        color="#4a9a8a"
+      />
+      <LoadingCursor
+        className="walking-record__loading-cursor--two"
+        color="#c87959"
+      />
+      <LoadingCursor
+        className="walking-record__loading-cursor--three"
+        color="#6f91b2"
+      />
+    </div>
+  );
+}
+
 function SiteFavicon({
   faviconUrl,
   site,
@@ -324,6 +375,11 @@ function PeriodNavigationRail({
 function TimeSpentLegendEntry({ entry }: { entry: TimeSpentEntry }) {
   const content = (
     <>
+      <span
+        className="walking-record__time-legend-ink"
+        style={{ backgroundColor: entry.hue }}
+        aria-hidden="true"
+      />
       <SiteFavicon
         faviconUrl={entry.faviconUrl}
         site={entry.site}
@@ -379,49 +435,45 @@ function HowBrowsedSection({ record }: { record: WalkingRecord }) {
         </EmptySection>
       )}
 
-      <div className="walking-record__subsection-heading">
-        <h2>notable new exploration</h2>
-        <span>
-          {record.departures.length} shown from {record.movementCount}
-        </span>
-      </div>
-
-      {record.departures.length > 0 ? (
-        <div className="walking-record__departures">
-          {record.departures.map((departure) => (
-            <a
-              className="walking-record__departure"
-              href={departure.toUrl}
-              key={`${departure.day}:${departure.to}`}
-            >
-              <span className="walking-record__day">{departure.day}</span>
-              <div className="walking-record__departure-copy">
-                <div>
-                  <SiteFavicon
-                    faviconUrl={departure.fromFaviconUrl}
-                    site={departure.from}
-                  />
-                  <span>{departure.from}</span>
-                  <span aria-hidden="true">→</span>
-                  <SiteFavicon
-                    faviconUrl={departure.toFaviconUrl}
-                    site={departure.to}
-                  />
-                  <strong>{departure.to}</strong>
+      {record.departures.length > 0 && (
+        <>
+          <div className="walking-record__subsection-heading">
+            <h2>notable new exploration</h2>
+            <span>
+              {record.departures.length} shown from {record.movementCount}
+            </span>
+          </div>
+          <div className="walking-record__departures">
+            {record.departures.map((departure) => (
+              <a
+                className="walking-record__departure"
+                href={departure.toUrl}
+                key={`${departure.day}:${departure.to}`}
+              >
+                <span className="walking-record__day">{departure.day}</span>
+                <div className="walking-record__departure-copy">
+                  <div>
+                    <SiteFavicon
+                      faviconUrl={departure.fromFaviconUrl}
+                      site={departure.from}
+                    />
+                    <span>{departure.from}</span>
+                    <span aria-hidden="true">→</span>
+                    <SiteFavicon
+                      faviconUrl={departure.toFaviconUrl}
+                      site={departure.to}
+                    />
+                    <strong>{departure.to}</strong>
+                  </div>
+                  {departure.note && <p>{departure.note}</p>}
                 </div>
-                {departure.note && <p>{departure.note}</p>}
-              </div>
-              <span className="walking-record__departure-time">
-                {departure.time}
-              </span>
-            </a>
-          ))}
-        </div>
-      ) : (
-        <EmptySection>
-          new explorations appear after you leave one of your usual places for
-          a quieter corner of the web.
-        </EmptySection>
+                <span className="walking-record__departure-time">
+                  {departure.time}
+                </span>
+              </a>
+            ))}
+          </div>
+        </>
       )}
     </section>
   );
@@ -512,6 +564,7 @@ export function WalkingRecordPage({
 
       {loading && (
         <div className="walking-record__loading" role="status">
+          <LoadingCursorWalk />
           <div className="walking-record__loading-copy">
             <span>{loadingProgress.message}</span>
             <span>{loadingPercentage}%</span>

--- a/extension/src/components/WalkingRecord.tsx
+++ b/extension/src/components/WalkingRecord.tsx
@@ -19,6 +19,7 @@ import {
 import type { WalkingRecordTracePoint } from "../storage/LocalEventStore";
 import { portraitDayPath } from "../utils/portraitDay";
 import { ExtensionPageNav } from "./ExtensionPageNav";
+import { MovementLandscape } from "./MovementLandscape";
 import { PortraitCard } from "./PortraitCard";
 import "./WalkingRecord.scss";
 
@@ -37,6 +38,8 @@ interface WalkingRecordPageProps {
   };
   error: string | null;
 }
+
+const INITIAL_DEPARTURE_COUNT = 3;
 
 function readablePaletteColor(color: string): string {
   return colorShade(color, readableTextLightness(color));
@@ -413,6 +416,11 @@ function TimeSpentLegendEntry({ entry }: { entry: TimeSpentEntry }) {
 }
 
 function HowBrowsedSection({ record }: { record: WalkingRecord }) {
+  const [showAllDepartures, setShowAllDepartures] = React.useState(false);
+  const visibleDepartures = showAllDepartures
+    ? record.departures
+    : record.departures.slice(0, INITIAL_DEPARTURE_COUNT);
+
   return (
     <section className="walking-record__section">
       <div className="walking-record__section-heading">
@@ -455,11 +463,11 @@ function HowBrowsedSection({ record }: { record: WalkingRecord }) {
           <div className="walking-record__subsection-heading">
             <h2>notable new exploration</h2>
             <span>
-              {record.departures.length} shown from {record.movementCount}
+              {visibleDepartures.length} shown from {record.movementCount}
             </span>
           </div>
           <div className="walking-record__departures">
-            {record.departures.map((departure) => (
+            {visibleDepartures.map((departure) => (
               <a
                 className="walking-record__departure"
                 href={departure.toUrl}
@@ -488,6 +496,16 @@ function HowBrowsedSection({ record }: { record: WalkingRecord }) {
               </a>
             ))}
           </div>
+          {record.departures.length > INITIAL_DEPARTURE_COUNT && (
+            <button
+              className="walking-record__departures-more"
+              type="button"
+              aria-expanded={showAllDepartures}
+              onClick={() => setShowAllDepartures((visible) => !visible)}
+            >
+              {showAllDepartures ? "show less" : "show more"}
+            </button>
+          )}
         </>
       )}
     </section>
@@ -567,6 +585,22 @@ function BrowsingPortraitsSection({ record }: { record: WalkingRecord }) {
           );
         })}
       </div>
+    </section>
+  );
+}
+
+function MovementLandscapeSection({ record }: { record: WalkingRecord }) {
+  if (record.landscapePaths.length === 0) return null;
+
+  return (
+    <section className="walking-record__section walking-record__movement-section">
+      <div className="walking-record__section-heading">
+        <h2>movement from this {record.period}</h2>
+      </div>
+      <MovementLandscape
+        paths={record.landscapePaths}
+        label={`Real cursor movements from this ${record.period}`}
+      />
     </section>
   );
 }
@@ -666,9 +700,13 @@ export function WalkingRecordPage({
             />
           </div>
 
-          <HowBrowsedSection record={record} />
+          <HowBrowsedSection
+            key={`${record.period}:${record.range.startTs}`}
+            record={record}
+          />
           <RevisitSection record={record} />
           <BrowsingPortraitsSection record={record} />
+          <MovementLandscapeSection record={record} />
         </>
       )}
     </main>

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -751,7 +751,12 @@ export default defineBackground(() => {
         .then((result) => reply({ success: true, ...result }))
         .catch((e) => {
           console.error('[Background] GET_SCREEN_TIME error:', e)
-          reply({ success: false, totalMs: 0, sessions: [] })
+          reply({
+            success: false,
+            error: e instanceof Error ? e.message : 'Local screen time is unavailable.',
+            totalMs: 0,
+            sessions: [],
+          })
         })
       return true
     }
@@ -774,7 +779,13 @@ export default defineBackground(() => {
         .then((result) => reply({ success: true, ...result }))
         .catch((e) => {
           console.error('[Background] GET_WALKING_RECORD_EVENTS error:', e)
-          reply({ success: false, events: [], cursorDistancePx: 0, activity: [] })
+          reply({
+            success: false,
+            error: e instanceof Error ? e.message : 'Local activity is unavailable.',
+            events: [],
+            cursorDistancePx: 0,
+            activity: [],
+          })
         })
       return true
     }
@@ -821,7 +832,11 @@ export default defineBackground(() => {
         .then((domains) => reply({ success: true, domains }))
         .catch((e) => {
           console.error('[Background] GET_ALL_DOMAINS error:', e)
-          reply({ success: false, domains: [] })
+          reply({
+            success: false,
+            error: e instanceof Error ? e.message : 'Local places are unavailable.',
+            domains: [],
+          })
         })
       return true
     }
@@ -836,7 +851,11 @@ export default defineBackground(() => {
         .then((days) => reply({ success: true, days }))
         .catch((e) => {
           console.error('[Background] GET_WALKING_RECORD_DOMAIN_DAYS error:', e)
-          reply({ success: false, days: [] })
+          reply({
+            success: false,
+            error: e instanceof Error ? e.message : 'Local routines are unavailable.',
+            days: [],
+          })
         })
       return true
     }

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -790,13 +790,19 @@ export default defineBackground(() => {
       return true
     }
 
-    if (message.type === 'GET_WALKING_RECORD_TRACES') {
+    if (message.type === 'GET_WALKING_RECORD_MOVEMENT') {
       const targets = (message.targets || []) as WalkingRecordTraceTarget[]
-      store.getWalkingRecordTraces(targets)
-        .then((traces) => reply({ success: true, traces }))
+      store.getWalkingRecordMovement(targets)
+        .then(async (movement) => ({
+          ...movement,
+          landscapePaths: await Promise.all(
+            movement.landscapePaths.map(hydrateCursorColor),
+          ),
+        }))
+        .then((movement) => reply({ success: true, ...movement }))
         .catch((e) => {
-          console.error('[Background] GET_WALKING_RECORD_TRACES error:', e)
-          reply({ success: false, traces: [] })
+          console.error('[Background] GET_WALKING_RECORD_MOVEMENT error:', e)
+          reply({ success: false, traces: [], landscapePaths: [] })
         })
       return true
     }

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -774,7 +774,7 @@ export default defineBackground(() => {
         .then((result) => reply({ success: true, ...result }))
         .catch((e) => {
           console.error('[Background] GET_WALKING_RECORD_EVENTS error:', e)
-          reply({ success: false, events: [], cursorDistancePx: 0 })
+          reply({ success: false, events: [], cursorDistancePx: 0, activity: [] })
         })
       return true
     }
@@ -822,6 +822,21 @@ export default defineBackground(() => {
         .catch((e) => {
           console.error('[Background] GET_ALL_DOMAINS error:', e)
           reply({ success: false, domains: [] })
+        })
+      return true
+    }
+
+    if (message.type === 'GET_WALKING_RECORD_DOMAIN_DAYS') {
+      const domains = Array.isArray(message.domains)
+        ? message.domains.filter(
+            (domain: unknown): domain is string => typeof domain === 'string',
+          )
+        : []
+      store.getDomainDayHistory(domains)
+        .then((days) => reply({ success: true, days }))
+        .catch((e) => {
+          console.error('[Background] GET_WALKING_RECORD_DOMAIN_DAYS error:', e)
+          reply({ success: false, days: [] })
         })
       return true
     }

--- a/extension/src/entrypoints/newtab/newtab.tsx
+++ b/extension/src/entrypoints/newtab/newtab.tsx
@@ -178,8 +178,16 @@ function NewTabPage() {
   const selectPeriod = (nextPeriod: WalkingRecordPeriod) => {
     const nextRange = getWalkingRecordPeriodRange(nextPeriod);
     const nextRecordKey = `${nextPeriod}:${nextRange.startTs}`;
+    const nextRecord = records[nextRecordKey];
     setError(null);
-    setLoading(!records[nextRecordKey]);
+    if (!nextRecord) {
+      setLoadingProgress({
+        completed: 0,
+        total: WALKING_RECORD_LOAD_STEP_COUNT,
+        message: `opening this ${nextPeriod}’s record…`,
+      });
+    }
+    setLoading(!nextRecord);
     setPeriodOffset(0);
     setPeriod(nextPeriod);
   };
@@ -188,8 +196,16 @@ function NewTabPage() {
     if (nextOffset < EARLIEST_PERIOD_OFFSET || nextOffset > 0) return;
 
     const nextRange = getWalkingRecordPeriodRange(period, nextOffset);
+    const nextRecord = records[`${period}:${nextRange.startTs}`];
     setError(null);
-    setLoading(!records[`${period}:${nextRange.startTs}`]);
+    if (!nextRecord) {
+      setLoadingProgress({
+        completed: 0,
+        total: WALKING_RECORD_LOAD_STEP_COUNT,
+        message: `opening this ${period}’s record…`,
+      });
+    }
+    setLoading(!nextRecord);
     setPeriodOffset(nextOffset);
   };
 

--- a/extension/src/entrypoints/newtab/newtab.tsx
+++ b/extension/src/entrypoints/newtab/newtab.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../history/walkingRecord";
 import {
   loadWalkingRecord,
+  WALKING_RECORD_LOAD_STEP_COUNT,
   type WalkingRecordLoadProgress,
 } from "../../history/loadWalkingRecord";
 import type { ScreenTimeSession } from "../../storage/LocalEventStore";
@@ -52,7 +53,7 @@ function NewTabPage() {
   const [loadingProgress, setLoadingProgress] =
     useState<WalkingRecordLoadProgress>({
       completed: 0,
-      total: 5,
+      total: WALKING_RECORD_LOAD_STEP_COUNT,
       message: "opening your local record…",
     });
   const [error, setError] = useState<string | null>(null);
@@ -90,7 +91,7 @@ function NewTabPage() {
     setLoading(true);
     setLoadingProgress({
       completed: 0,
-      total: 5,
+      total: WALKING_RECORD_LOAD_STEP_COUNT,
       message: `opening this ${period}’s record…`,
     });
     setError(null);
@@ -152,11 +153,12 @@ function NewTabPage() {
       })
       .then((response: ScreenTimeResponse) => {
         if (cancelled || !response.success || !response.sessions) return;
+        const sessions = response.sessions;
         setPeriodSummaries((current) => ({
           ...current,
           [period]: summarizeWalkingRecordPeriods(
             period,
-            response.sessions,
+            sessions,
             PERIOD_RAIL_COUNT,
           ),
         }));

--- a/extension/src/entrypoints/newtab/newtab.tsx
+++ b/extension/src/entrypoints/newtab/newtab.tsx
@@ -18,102 +18,26 @@ import { createRoot } from "react-dom/client";
 import browser from "webextension-polyfill";
 import { WalkingRecordPage } from "../../components/WalkingRecord";
 import {
-  attachWalkingRecordTraces,
-  deriveWalkingRecord,
   getWalkingRecordPeriodRange,
-  getWalkingRecordTraceTargets,
   summarizeWalkingRecordPeriods,
   type WalkingRecord,
-  type WalkingRecordRange,
-  type WalkingRecordDomain,
   type WalkingRecordPeriod,
   type WalkingRecordPeriodSummary,
 } from "../../history/walkingRecord";
-import type { CollectionEvent } from "../../collectors/types";
-import type {
-  ScreenTimeSession,
-  WalkingRecordTrace,
-} from "../../storage/LocalEventStore";
+import {
+  loadWalkingRecord,
+  type WalkingRecordLoadProgress,
+} from "../../history/loadWalkingRecord";
+import type { ScreenTimeSession } from "../../storage/LocalEventStore";
 import { getPublicPlayerIdentity } from "../../storage/playerIdentity";
 
 const DEFAULT_CURSOR_COLOR = "#4a9a8a";
 const PERIOD_RAIL_COUNT = 12;
 const EARLIEST_PERIOD_OFFSET = 1 - PERIOD_RAIL_COUNT;
 
-interface EventsResponse {
-  success?: boolean;
-  events?: CollectionEvent[];
-  cursorDistancePx?: number;
-}
-
 interface ScreenTimeResponse {
   success?: boolean;
   sessions?: ScreenTimeSession[];
-}
-
-interface DomainsResponse {
-  success?: boolean;
-  domains?: WalkingRecordDomain[];
-}
-
-interface TracesResponse {
-  success?: boolean;
-  traces?: WalkingRecordTrace[];
-}
-
-async function loadWalkingRecord(
-  period: WalkingRecordPeriod,
-  range: WalkingRecordRange,
-  baseColor: string,
-): Promise<WalkingRecord> {
-  const [eventsResponse, screenTimeResponse, domainsResponse] =
-    (await Promise.all([
-      browser.runtime.sendMessage({
-        type: "GET_WALKING_RECORD_EVENTS",
-        options: {
-          startTs: range.startTs,
-          endTs: range.endTs,
-        },
-      }),
-      browser.runtime.sendMessage({
-        type: "GET_SCREEN_TIME",
-        options: {
-          startTs: range.startTs,
-          endTs: range.endTs,
-        },
-      }),
-      browser.runtime.sendMessage({ type: "GET_ALL_DOMAINS" }),
-    ])) as [EventsResponse, ScreenTimeResponse, DomainsResponse];
-
-  if (!eventsResponse.success || !eventsResponse.events) {
-    throw new Error("The local activity record is unavailable.");
-  }
-  if (!screenTimeResponse.success || !screenTimeResponse.sessions) {
-    throw new Error("The local screen-time record is unavailable.");
-  }
-  if (!domainsResponse.success || !domainsResponse.domains) {
-    throw new Error("The local place record is unavailable.");
-  }
-
-  const record = deriveWalkingRecord({
-    period,
-    baseColor,
-    events: eventsResponse.events,
-    sessions: screenTimeResponse.sessions,
-    domains: domainsResponse.domains,
-    range,
-    cursorDistancePx: eventsResponse.cursorDistancePx,
-  });
-  const targets = getWalkingRecordTraceTargets(record);
-  if (targets.length === 0) return record;
-
-  const tracesResponse = (await browser.runtime.sendMessage({
-    type: "GET_WALKING_RECORD_TRACES",
-    targets,
-  })) as TracesResponse;
-  if (!tracesResponse.success || !tracesResponse.traces) return record;
-
-  return attachWalkingRecordTraces(record, tracesResponse.traces);
 }
 
 function NewTabPage() {
@@ -125,6 +49,12 @@ function NewTabPage() {
   >({});
   const [baseColor, setBaseColor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadingProgress, setLoadingProgress] =
+    useState<WalkingRecordLoadProgress>({
+      completed: 0,
+      total: 5,
+      message: "opening your local record…",
+    });
   const [error, setError] = useState<string | null>(null);
   const range = getWalkingRecordPeriodRange(period, periodOffset);
   const recordKey = `${period}:${range.startTs}`;
@@ -158,8 +88,15 @@ function NewTabPage() {
 
     let cancelled = false;
     setLoading(true);
+    setLoadingProgress({
+      completed: 0,
+      total: 5,
+      message: `opening this ${period}’s record…`,
+    });
     setError(null);
-    loadWalkingRecord(period, range, baseColor)
+    loadWalkingRecord(period, range, baseColor, (progress) => {
+      if (!cancelled) setLoadingProgress(progress);
+    })
       .then((walkingRecord) => {
         if (cancelled) return;
         setRecords((current) => ({
@@ -263,6 +200,7 @@ function NewTabPage() {
       onPeriodChange={selectPeriod}
       onPeriodOffsetChange={selectPeriodOffset}
       loading={loading}
+      loadingProgress={loadingProgress}
       error={error}
     />
   );

--- a/extension/src/entrypoints/portrait/portrait.tsx
+++ b/extension/src/entrypoints/portrait/portrait.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../utils/portraitExport";
 import type { PortraitCardProps } from "../../components/PortraitCard";
 import type { ScreenTimeSession } from "../../storage/LocalEventStore";
+import { portraitDayFromSearch } from "../../utils/portraitDay";
 
 /** Convert sessions to hour buckets (total ms per hour-of-day) for PortraitCard */
 function sessionsToHourBuckets(sessions: ScreenTimeSession[]): number[] {
@@ -45,7 +46,9 @@ const PortraitPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const [hovering, setHovering] = useState(false);
-  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  const [selectedDay, setSelectedDay] = useState<string | null>(() =>
+    portraitDayFromSearch(window.location.search),
+  );
   const [dayCounts, setDayCounts] = useState<DayCounts>(new Map());
   const [activeVisualizations, setActiveVisualizations] = useState<string[]>(
     DEFAULT_ACTIVE_VISUALIZATIONS,

--- a/extension/src/history/loadWalkingRecord.ts
+++ b/extension/src/history/loadWalkingRecord.ts
@@ -1,0 +1,151 @@
+// ABOUTME: Loads the local data used to build one walking-record period.
+// ABOUTME: Reports progress as each real data and trace step completes.
+
+import browser from "webextension-polyfill";
+import type { CollectionEvent } from "../collectors/types";
+import type {
+  ScreenTimeSession,
+  WalkingRecordTrace,
+} from "../storage/LocalEventStore";
+import {
+  attachWalkingRecordTraces,
+  deriveWalkingRecord,
+  getWalkingRecordTraceTargets,
+  type WalkingRecord,
+  type WalkingRecordDomain,
+  type WalkingRecordPeriod,
+  type WalkingRecordRange,
+} from "./walkingRecord";
+
+export interface WalkingRecordLoadProgress {
+  completed: number;
+  total: number;
+  message: string;
+}
+
+interface EventsResponse {
+  success?: boolean;
+  events?: CollectionEvent[];
+  cursorDistancePx?: number;
+}
+
+interface ScreenTimeResponse {
+  success?: boolean;
+  sessions?: ScreenTimeSession[];
+}
+
+interface DomainsResponse {
+  success?: boolean;
+  domains?: WalkingRecordDomain[];
+}
+
+interface TracesResponse {
+  success?: boolean;
+  traces?: WalkingRecordTrace[];
+}
+
+const LOAD_STEP_COUNT = 5;
+
+export async function loadWalkingRecord(
+  period: WalkingRecordPeriod,
+  range: WalkingRecordRange,
+  baseColor: string,
+  onProgress: (progress: WalkingRecordLoadProgress) => void,
+): Promise<WalkingRecord> {
+  let completedDataSteps = 0;
+  const trackDataRequest = async <Response>(
+    request: Promise<Response>,
+    message: string,
+  ): Promise<Response> => {
+    const response = await request;
+    completedDataSteps += 1;
+    onProgress({
+      completed: completedDataSteps,
+      total: LOAD_STEP_COUNT,
+      message,
+    });
+    return response;
+  };
+
+  const [eventsResponse, screenTimeResponse, domainsResponse] =
+    (await Promise.all([
+      trackDataRequest(
+        browser.runtime.sendMessage({
+          type: "GET_WALKING_RECORD_EVENTS",
+          options: {
+            startTs: range.startTs,
+            endTs: range.endTs,
+          },
+        }),
+        "movement traces gathered…",
+      ),
+      trackDataRequest(
+        browser.runtime.sendMessage({
+          type: "GET_SCREEN_TIME",
+          options: {
+            startTs: range.startTs,
+            endTs: range.endTs,
+          },
+        }),
+        "browsing time counted…",
+      ),
+      trackDataRequest(
+        browser.runtime.sendMessage({ type: "GET_ALL_DOMAINS" }),
+        "familiar places found…",
+      ),
+    ])) as [EventsResponse, ScreenTimeResponse, DomainsResponse];
+
+  if (!eventsResponse.success || !eventsResponse.events) {
+    throw new Error("The local activity record is unavailable.");
+  }
+  if (!screenTimeResponse.success || !screenTimeResponse.sessions) {
+    throw new Error("The local screen-time record is unavailable.");
+  }
+  if (!domainsResponse.success || !domainsResponse.domains) {
+    throw new Error("The local place record is unavailable.");
+  }
+
+  onProgress({
+    completed: 4,
+    total: LOAD_STEP_COUNT,
+    message: `arranging this ${period}’s record…`,
+  });
+  const record = deriveWalkingRecord({
+    period,
+    baseColor,
+    events: eventsResponse.events,
+    sessions: screenTimeResponse.sessions,
+    domains: domainsResponse.domains,
+    range,
+    cursorDistancePx: eventsResponse.cursorDistancePx,
+  });
+  const targets = getWalkingRecordTraceTargets(record);
+  if (targets.length === 0) {
+    onProgress({
+      completed: LOAD_STEP_COUNT,
+      total: LOAD_STEP_COUNT,
+      message: "record ready…",
+    });
+    return record;
+  }
+
+  const tracesResponse = (await browser.runtime.sendMessage({
+    type: "GET_WALKING_RECORD_TRACES",
+    targets,
+  })) as TracesResponse;
+  if (!tracesResponse.success || !tracesResponse.traces) {
+    onProgress({
+      completed: LOAD_STEP_COUNT,
+      total: LOAD_STEP_COUNT,
+      message: "record ready…",
+    });
+    return record;
+  }
+
+  onProgress({
+    completed: LOAD_STEP_COUNT,
+    total: LOAD_STEP_COUNT,
+    message: "cursor trails restored…",
+  });
+  return attachWalkingRecordTraces(record, tracesResponse.traces);
+}

--- a/extension/src/history/loadWalkingRecord.ts
+++ b/extension/src/history/loadWalkingRecord.ts
@@ -27,6 +27,7 @@ export interface WalkingRecordLoadProgress {
 
 interface EventsResponse {
   success?: boolean;
+  error?: string;
   events?: CollectionEvent[];
   cursorDistancePx?: number;
   activity?: WalkingRecordActivity[];
@@ -34,11 +35,13 @@ interface EventsResponse {
 
 interface ScreenTimeResponse {
   success?: boolean;
+  error?: string;
   sessions?: ScreenTimeSession[];
 }
 
 interface DomainsResponse {
   success?: boolean;
+  error?: string;
   domains?: WalkingRecordDomain[];
 }
 
@@ -49,6 +52,7 @@ interface TracesResponse {
 
 interface DomainDaysResponse {
   success?: boolean;
+  error?: string;
   days?: AggregateDay[];
 }
 
@@ -104,13 +108,19 @@ export async function loadWalkingRecord(
     ])) as [EventsResponse, ScreenTimeResponse, DomainsResponse];
 
   if (!eventsResponse.success || !eventsResponse.events) {
-    throw new Error("The local activity record is unavailable.");
+    throw new Error(
+      eventsResponse.error ?? "The local activity record is unavailable.",
+    );
   }
   if (!screenTimeResponse.success || !screenTimeResponse.sessions) {
-    throw new Error("The local screen-time record is unavailable.");
+    throw new Error(
+      screenTimeResponse.error ?? "The local screen-time record is unavailable.",
+    );
   }
   if (!domainsResponse.success || !domainsResponse.domains) {
-    throw new Error("The local place record is unavailable.");
+    throw new Error(
+      domainsResponse.error ?? "The local place record is unavailable.",
+    );
   }
 
   const familiarDomains = domainsResponse.domains
@@ -121,7 +131,10 @@ export async function loadWalkingRecord(
     domains: familiarDomains,
   })) as DomainDaysResponse;
   if (!domainDaysResponse.success || !domainDaysResponse.days) {
-    throw new Error("The local relationship record is unavailable.");
+    throw new Error(
+      domainDaysResponse.error ??
+        "The local relationship record is unavailable.",
+    );
   }
   onProgress({
     completed: 4,

--- a/extension/src/history/loadWalkingRecord.ts
+++ b/extension/src/history/loadWalkingRecord.ts
@@ -4,7 +4,9 @@
 import browser from "webextension-polyfill";
 import type { CollectionEvent } from "../collectors/types";
 import type {
+  AggregateDay,
   ScreenTimeSession,
+  WalkingRecordActivity,
   WalkingRecordTrace,
 } from "../storage/LocalEventStore";
 import {
@@ -27,6 +29,7 @@ interface EventsResponse {
   success?: boolean;
   events?: CollectionEvent[];
   cursorDistancePx?: number;
+  activity?: WalkingRecordActivity[];
 }
 
 interface ScreenTimeResponse {
@@ -44,7 +47,12 @@ interface TracesResponse {
   traces?: WalkingRecordTrace[];
 }
 
-const LOAD_STEP_COUNT = 5;
+interface DomainDaysResponse {
+  success?: boolean;
+  days?: AggregateDay[];
+}
+
+export const WALKING_RECORD_LOAD_STEP_COUNT = 6;
 
 export async function loadWalkingRecord(
   period: WalkingRecordPeriod,
@@ -61,7 +69,7 @@ export async function loadWalkingRecord(
     completedDataSteps += 1;
     onProgress({
       completed: completedDataSteps,
-      total: LOAD_STEP_COUNT,
+      total: WALKING_RECORD_LOAD_STEP_COUNT,
       message,
     });
     return response;
@@ -105,25 +113,43 @@ export async function loadWalkingRecord(
     throw new Error("The local place record is unavailable.");
   }
 
+  const familiarDomains = domainsResponse.domains
+    .filter((domain) => domain.activeDayCount >= 5)
+    .map((domain) => domain.domain);
+  const domainDaysResponse = (await browser.runtime.sendMessage({
+    type: "GET_WALKING_RECORD_DOMAIN_DAYS",
+    domains: familiarDomains,
+  })) as DomainDaysResponse;
+  if (!domainDaysResponse.success || !domainDaysResponse.days) {
+    throw new Error("The local relationship record is unavailable.");
+  }
   onProgress({
     completed: 4,
-    total: LOAD_STEP_COUNT,
+    total: WALKING_RECORD_LOAD_STEP_COUNT,
+    message: "tracing familiar routines…",
+  });
+
+  onProgress({
+    completed: 5,
+    total: WALKING_RECORD_LOAD_STEP_COUNT,
     message: `arranging this ${period}’s record…`,
   });
   const record = deriveWalkingRecord({
     period,
     baseColor,
     events: eventsResponse.events,
+    activity: eventsResponse.activity ?? [],
     sessions: screenTimeResponse.sessions,
     domains: domainsResponse.domains,
+    domainDays: domainDaysResponse.days,
     range,
     cursorDistancePx: eventsResponse.cursorDistancePx,
   });
   const targets = getWalkingRecordTraceTargets(record);
   if (targets.length === 0) {
     onProgress({
-      completed: LOAD_STEP_COUNT,
-      total: LOAD_STEP_COUNT,
+      completed: WALKING_RECORD_LOAD_STEP_COUNT,
+      total: WALKING_RECORD_LOAD_STEP_COUNT,
       message: `finishing this ${period}’s record…`,
     });
     return record;
@@ -135,16 +161,16 @@ export async function loadWalkingRecord(
   })) as TracesResponse;
   if (!tracesResponse.success || !tracesResponse.traces) {
     onProgress({
-      completed: LOAD_STEP_COUNT,
-      total: LOAD_STEP_COUNT,
+      completed: WALKING_RECORD_LOAD_STEP_COUNT,
+      total: WALKING_RECORD_LOAD_STEP_COUNT,
       message: `finishing this ${period}’s record…`,
     });
     return record;
   }
 
   onProgress({
-    completed: LOAD_STEP_COUNT,
-    total: LOAD_STEP_COUNT,
+    completed: WALKING_RECORD_LOAD_STEP_COUNT,
+    total: WALKING_RECORD_LOAD_STEP_COUNT,
     message: "restoring cursor trails…",
   });
   return attachWalkingRecordTraces(record, tracesResponse.traces);

--- a/extension/src/history/loadWalkingRecord.ts
+++ b/extension/src/history/loadWalkingRecord.ts
@@ -10,6 +10,7 @@ import type {
   WalkingRecordTrace,
 } from "../storage/LocalEventStore";
 import {
+  attachWalkingRecordLandscape,
   attachWalkingRecordTraces,
   deriveWalkingRecord,
   getWalkingRecordTraceTargets,
@@ -45,9 +46,10 @@ interface DomainsResponse {
   domains?: WalkingRecordDomain[];
 }
 
-interface TracesResponse {
+interface MovementResponse {
   success?: boolean;
   traces?: WalkingRecordTrace[];
+  landscapePaths?: CollectionEvent[][];
 }
 
 interface DomainDaysResponse {
@@ -168,11 +170,11 @@ export async function loadWalkingRecord(
     return record;
   }
 
-  const tracesResponse = (await browser.runtime.sendMessage({
-    type: "GET_WALKING_RECORD_TRACES",
+  const movementResponse = (await browser.runtime.sendMessage({
+    type: "GET_WALKING_RECORD_MOVEMENT",
     targets,
-  })) as TracesResponse;
-  if (!tracesResponse.success || !tracesResponse.traces) {
+  })) as MovementResponse;
+  if (!movementResponse.success || !movementResponse.traces) {
     onProgress({
       completed: WALKING_RECORD_LOAD_STEP_COUNT,
       total: WALKING_RECORD_LOAD_STEP_COUNT,
@@ -186,5 +188,8 @@ export async function loadWalkingRecord(
     total: WALKING_RECORD_LOAD_STEP_COUNT,
     message: "restoring cursor trails…",
   });
-  return attachWalkingRecordTraces(record, tracesResponse.traces);
+  return attachWalkingRecordLandscape(
+    attachWalkingRecordTraces(record, movementResponse.traces),
+    movementResponse.landscapePaths ?? [],
+  );
 }

--- a/extension/src/history/loadWalkingRecord.ts
+++ b/extension/src/history/loadWalkingRecord.ts
@@ -77,7 +77,7 @@ export async function loadWalkingRecord(
             endTs: range.endTs,
           },
         }),
-        "movement traces gathered…",
+        "gathering movement traces…",
       ),
       trackDataRequest(
         browser.runtime.sendMessage({
@@ -87,11 +87,11 @@ export async function loadWalkingRecord(
             endTs: range.endTs,
           },
         }),
-        "browsing time counted…",
+        "counting browsing time…",
       ),
       trackDataRequest(
         browser.runtime.sendMessage({ type: "GET_ALL_DOMAINS" }),
-        "familiar places found…",
+        "finding familiar places…",
       ),
     ])) as [EventsResponse, ScreenTimeResponse, DomainsResponse];
 
@@ -124,7 +124,7 @@ export async function loadWalkingRecord(
     onProgress({
       completed: LOAD_STEP_COUNT,
       total: LOAD_STEP_COUNT,
-      message: "record ready…",
+      message: `finishing this ${period}’s record…`,
     });
     return record;
   }
@@ -137,7 +137,7 @@ export async function loadWalkingRecord(
     onProgress({
       completed: LOAD_STEP_COUNT,
       total: LOAD_STEP_COUNT,
-      message: "record ready…",
+      message: `finishing this ${period}’s record…`,
     });
     return record;
   }
@@ -145,7 +145,7 @@ export async function loadWalkingRecord(
   onProgress({
     completed: LOAD_STEP_COUNT,
     total: LOAD_STEP_COUNT,
-    message: "cursor trails restored…",
+    message: "restoring cursor trails…",
   });
   return attachWalkingRecordTraces(record, tracesResponse.traces);
 }

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -129,6 +129,7 @@ export interface DayPlate {
 export interface TimeSpentEntry {
   rank: number;
   site: string;
+  faviconUrl?: string;
   time: string;
   percentage: number;
   hue: string;
@@ -829,6 +830,7 @@ function topHourNote(sessions: ScreenTimeSession[]): string {
 }
 
 function buildTimeSpent(
+  events: CollectionEvent[],
   sessions: ScreenTimeSession[],
   domains: WalkingRecordDomain[],
   mainRoads: Set<string>,
@@ -837,6 +839,26 @@ function buildTimeSpent(
     (a, b) => b.totalMs - a.totalMs,
   );
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
+  const faviconByDomain = new Map<string, string>();
+  for (const event of events) {
+    if (event.type !== "navigation") continue;
+
+    const faviconUrl = (event.data as NavigationEventData).favicon_url;
+    if (typeof faviconUrl !== "string" || faviconUrl.length === 0) continue;
+
+    try {
+      const parsed = new URL(faviconUrl);
+      if (
+        parsed.protocol === "https:" ||
+        parsed.protocol === "http:" ||
+        parsed.protocol === "data:"
+      ) {
+        faviconByDomain.set(extractDomain(event.meta.url), faviconUrl);
+      }
+    } catch {
+      // Ignore malformed favicon metadata from the visited page.
+    }
+  }
   const quiet = grouped.filter((entry) => {
     const domain = domainByName.get(entry.domain);
     return (
@@ -880,6 +902,7 @@ function buildTimeSpent(
     return {
       rank: index + 1,
       site: row.domain,
+      faviconUrl: faviconByDomain.get(row.domain),
       time: formatDuration(row.totalMs),
       percentage: (row.totalMs / maxMs) * 100,
       hue: paletteColorForIndex(index),
@@ -930,6 +953,7 @@ export function deriveWalkingRecord({
     baseColor,
   );
   const { entries: timeSpent, intro: timeSpentIntro } = buildTimeSpent(
+    events,
     sessions,
     domains,
     mainRoads,

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -155,6 +155,7 @@ export interface WalkingRecord {
   departures: Departure[];
   revisits: Revisit[];
   dayPlates: DayPlate[];
+  landscapePaths: CollectionEvent[][];
   timeSpent: TimeSpentEntry[];
   timeSpentIntro: string;
 }
@@ -611,7 +612,7 @@ function buildDepartures(
   const ranked = [...deduped.values()].sort((a, b) => b.score - a.score);
   return {
     movementCount: ranked.length,
-    departures: ranked.slice(0, 3).map((candidate) => {
+    departures: ranked.map((candidate) => {
       const { dayKey: _, ...departure } = candidate;
       return departure;
     }),
@@ -1054,6 +1055,7 @@ export function deriveWalkingRecord({
       baseColor,
       nowTs,
     ),
+    landscapePaths: [],
     timeSpent,
     timeSpentIntro,
   };
@@ -1091,5 +1093,15 @@ export function attachWalkingRecordTraces(
         pathsForTarget(target, pathsByTarget),
       ),
     })),
+  };
+}
+
+export function attachWalkingRecordLandscape(
+  record: WalkingRecord,
+  landscapePaths: CollectionEvent[][],
+): WalkingRecord {
+  return {
+    ...record,
+    landscapePaths,
   };
 }

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -19,8 +19,10 @@ import { parseColorToHsl } from "@movement/utils/eventUtils";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SMALL_SITE_MAX_VISITS = 5;
 const FAMILIAR_SITE_MIN_VISITS = 10;
+const FAMILIAR_SITE_MIN_SPAN_DAYS = 14;
 const MAIN_ROAD_LIMIT = 20;
 const DEPARTURE_TRACE_MAX_MS = 30 * 60_000;
+const TIME_SPENT_SITE_LIMIT = 6;
 const PAGE_HUE_SHIFTS = [-28, -18, -10, 10, 18, 28];
 
 const POPULAR_DOMAIN_ROOTS = [
@@ -159,6 +161,7 @@ interface WalkingRecordInput {
   domains: WalkingRecordDomain[];
   range: WalkingRecordRange;
   cursorDistancePx?: number;
+  nowTs?: number;
 }
 
 interface DomainTime {
@@ -289,6 +292,46 @@ function hashDomain(domain: string): number {
     hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
   }
   return hash;
+}
+
+function seededValue(seed: number, offset: number): number {
+  const value = Math.sin(seed + offset * 12.9898) * 43_758.5453;
+  return value - Math.floor(value);
+}
+
+function derivedSessionPath(
+  target: WalkingRecordTraceTarget,
+): WalkingRecordTracePoint[][] {
+  const seed = hashDomain(`${target.url}:${target.startTs}:${target.endTs}`);
+  const durationMinutes = Math.max(
+    1,
+    (target.endTs - target.startTs) / 60_000,
+  );
+  const pointCount = Math.min(
+    11,
+    4 + Math.floor(Math.log2(durationMinutes + 1)),
+  );
+  const points: WalkingRecordTracePoint[] = [];
+  let x = 0.18 + seededValue(seed, 0) * 0.64;
+  let y = 0.18 + seededValue(seed, 1) * 0.64;
+
+  points.push({ x, y });
+  for (let index = 1; index < pointCount; index++) {
+    x = Math.max(
+      0.08,
+      Math.min(0.92, x + (seededValue(seed, index * 2) - 0.5) * 0.42),
+    );
+    y = Math.max(
+      0.08,
+      Math.min(
+        0.92,
+        y + (seededValue(seed, index * 2 + 1) - 0.5) * 0.42,
+      ),
+    );
+    points.push({ x, y });
+  }
+
+  return [points];
 }
 
 export function colorForDomain(baseColor: string, domain: string): string {
@@ -462,6 +505,13 @@ function buildDepartures(
     ).filter((timestamp) => timestamp >= visit.ts && timestamp <= traceEndTs).length;
     const movementScore = Math.min(movementSamples, 3) * 2;
 
+    const traceTarget = {
+      id: `departure:${visit.ts}:${visit.domain}`,
+      url: visit.url,
+      startTs: visit.ts,
+      endTs: traceEndTs,
+    };
+
     candidates.push({
       dayKey,
       day: date.toLocaleDateString("en", { weekday: "short" }).toLowerCase(),
@@ -483,13 +533,8 @@ function buildDepartures(
             : "seen before",
       hue: colorForDomain(baseColor, visit.domain),
       score: rarityScore + dwellScore + movementScore,
-      traceTarget: {
-        id: `departure:${visit.ts}:${visit.domain}`,
-        url: visit.url,
-        startTs: visit.ts,
-        endTs: traceEndTs,
-      },
-      tracePaths: [],
+      traceTarget,
+      tracePaths: derivedSessionPath(traceTarget),
     });
   }
 
@@ -537,18 +582,36 @@ function buildRevisits(
     .filter(
       (domain) =>
         domain.sessionCount >= FAMILIAR_SITE_MIN_VISITS &&
+        domain.firstVisit > 0 &&
+        domain.lastVisit > domain.firstVisit &&
+        Math.floor((domain.lastVisit - domain.firstVisit) / DAY_MS) + 1 >=
+          FAMILIAR_SITE_MIN_SPAN_DAYS &&
         domain.lastVisit > 0 &&
         domain.lastVisit < range.startTs &&
         !isPopularDomain(domain.domain),
     )
     .map((domain) => {
       const gapMs = range.endTs - domain.lastVisit;
+      const visitSpanMs = domain.lastVisit - domain.firstVisit;
+      const visitSpanDays = Math.max(
+        1,
+        Math.floor(visitSpanMs / DAY_MS) + 1,
+      );
+      const cappedVisitCount = Math.min(domain.sessionCount, visitSpanDays);
+      const visitsPerSpanDay = domain.sessionCount / visitSpanDays;
+      const concentrationPenalty = Math.sqrt(
+        Math.max(1, visitsPerSpanDay),
+      );
       return {
         span: formatGap(gapMs),
         site: domain.domain,
         href: `https://${domain.domain}`,
-        memory: `you visited ${domain.sessionCount} times before the gap`,
-        score: Math.log2(domain.sessionCount + 1) * Math.log2(gapMs / DAY_MS + 1),
+        memory: `part of your browsing for ${formatGap(visitSpanMs)} before the gap`,
+        score:
+          (Math.log2(visitSpanDays + 1) ** 2 *
+            Math.log2(cappedVisitCount + 1) *
+            Math.log2(gapMs / DAY_MS + 1)) /
+          concentrationPenalty,
       };
     })
     .sort((a, b) => b.score - a.score)
@@ -690,13 +753,16 @@ function traceIntervals(
 }
 
 function buildDayPlates(
+  events: CollectionEvent[],
   sessions: ScreenTimeSession[],
   range: WalkingRecordRange,
   domains: WalkingRecordDomain[],
   period: WalkingRecordPeriod,
   baseColor: string,
+  nowTs: number,
 ): DayPlate[] {
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
+  const movementByUrl = cursorSamplesByUrl(events);
 
   return traceIntervals(period, range).map((interval) => {
     const sessionsForInterval = sessions
@@ -706,6 +772,13 @@ function buildDayPlates(
           session.focusTs <= interval.endTs,
       )
       .sort((a, b) => {
+        const aMovement = (
+          movementByUrl.get(normalizeUrl(a.url)) ?? []
+        ).some((timestamp) => timestamp >= a.focusTs && timestamp <= a.blurTs);
+        const bMovement = (
+          movementByUrl.get(normalizeUrl(b.url)) ?? []
+        ).some((timestamp) => timestamp >= b.focusTs && timestamp <= b.blurTs);
+        if (aMovement !== bMovement) return aMovement ? -1 : 1;
         if (a.durationMs !== b.durationMs) return b.durationMs - a.durationMs;
         const aVisits = domainByName.get(extractDomain(a.url))?.sessionCount ?? Infinity;
         const bVisits = domainByName.get(extractDomain(b.url))?.sessionCount ?? Infinity;
@@ -717,7 +790,8 @@ function buildDayPlates(
       return {
         date: interval.key,
         day: interval.label,
-        vignette: "no trace kept",
+        vignette:
+          interval.startTs > nowTs ? "still to come" : "no trace kept",
         hue: "#b5aea5",
         tracePaths: [],
       };
@@ -725,19 +799,20 @@ function buildDayPlates(
 
     const domain = extractDomain(session.url);
     const minutes = Math.max(1, Math.round(session.durationMs / 60_000));
+    const traceTarget = {
+      id: interval.key,
+      url: session.url,
+      startTs: session.focusTs,
+      endTs: session.blurTs,
+    };
 
     return {
       date: interval.key,
       day: interval.label,
       vignette: `${minutes} quiet minute${minutes === 1 ? "" : "s"} on ${domain}`,
       hue: colorForDomain(baseColor, domain),
-      traceTarget: {
-        id: interval.key,
-        url: session.url,
-        startTs: session.focusTs,
-        endTs: session.blurTs,
-      },
-      tracePaths: [],
+      traceTarget,
+      tracePaths: derivedSessionPath(traceTarget),
     };
   });
 }
@@ -762,7 +837,6 @@ function buildTimeSpent(
     (a, b) => b.totalMs - a.totalMs,
   );
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
-  const top = grouped.slice(0, 3);
   const quiet = grouped.filter((entry) => {
     const domain = domainByName.get(entry.domain);
     return (
@@ -771,6 +845,10 @@ function buildTimeSpent(
       !isMainRoad(entry.domain, mainRoads)
     );
   });
+  const quietDomains = new Set(quiet.map((entry) => entry.domain));
+  const top = grouped
+    .filter((entry) => !quietDomains.has(entry.domain))
+    .slice(0, TIME_SPENT_SITE_LIMIT);
   const quietMs = quiet.reduce((sum, entry) => sum + entry.totalMs, 0);
   const quietLongReads = quiet.flatMap((entry) => entry.sessions).filter(
     (session) => session.durationMs >= 10 * 60_000,
@@ -835,6 +913,7 @@ export function deriveWalkingRecord({
   domains,
   range,
   cursorDistancePx: measuredCursorDistance,
+  nowTs = Date.now(),
 }: WalkingRecordInput): WalkingRecord {
   const portrait = deriveBrowsingPortrait({
     events,
@@ -869,11 +948,13 @@ export function deriveWalkingRecord({
     departures,
     revisits: buildRevisits(domains, range),
     dayPlates: buildDayPlates(
+      events,
       sessions,
       range,
       domains,
       period,
       baseColor,
+      nowTs,
     ),
     timeSpent,
     timeSpentIntro,
@@ -889,6 +970,19 @@ export function getWalkingRecordTraceTargets(
   ].filter((target): target is WalkingRecordTraceTarget => target !== undefined);
 }
 
+function pathsForTarget(
+  target: WalkingRecordTraceTarget | undefined,
+  fallbackPaths: WalkingRecordTracePoint[][],
+  pathsByTarget: Map<string, WalkingRecordTracePoint[][]>,
+): WalkingRecordTracePoint[][] {
+  if (!target) return [];
+
+  const storedPaths = pathsByTarget.get(target.id);
+  return storedPaths?.some((path) => path.length >= 2)
+    ? storedPaths
+    : fallbackPaths;
+}
+
 export function attachWalkingRecordTraces(
   record: WalkingRecord,
   traces: WalkingRecordTrace[],
@@ -901,15 +995,19 @@ export function attachWalkingRecordTraces(
     ...record,
     dayPlates: record.dayPlates.map((plate) => ({
       ...plate,
-      tracePaths: plate.traceTarget
-        ? pathsByTarget.get(plate.traceTarget.id) ?? []
-        : [],
+      tracePaths: pathsForTarget(
+        plate.traceTarget,
+        plate.tracePaths,
+        pathsByTarget,
+      ),
     })),
     departures: record.departures.map((departure) => ({
       ...departure,
-      tracePaths: departure.traceTarget
-        ? pathsByTarget.get(departure.traceTarget.id) ?? []
-        : [],
+      tracePaths: pathsForTarget(
+        departure.traceTarget,
+        departure.tracePaths,
+        pathsByTarget,
+      ),
     })),
   };
 }

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -122,6 +122,7 @@ export interface DayPlate {
   day: string;
   vignette: string;
   hue: string;
+  future: boolean;
   traceTarget?: WalkingRecordTraceTarget;
   tracePaths: WalkingRecordTracePoint[][];
 }
@@ -788,12 +789,13 @@ function buildDayPlates(
     const session = sessionsForInterval[0];
 
     if (!session) {
+      const future = interval.startTs > nowTs;
       return {
         date: interval.key,
         day: interval.label,
-        vignette:
-          interval.startTs > nowTs ? "still to come" : "no trace kept",
+        vignette: future ? "still to come" : "no trace kept",
         hue: "#b5aea5",
+        future,
         tracePaths: [],
       };
     }
@@ -812,6 +814,7 @@ function buildDayPlates(
       day: interval.label,
       vignette: `${minutes} quiet minute${minutes === 1 ? "" : "s"} on ${domain}`,
       hue: colorForDomain(baseColor, domain),
+      future: false,
       traceTarget,
       tracePaths: derivedSessionPath(traceTarget),
     };

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -126,7 +126,8 @@ export interface DayPlate {
   vignette: string;
   hue: string;
   future: boolean;
-  traceTarget?: WalkingRecordTraceTarget;
+  portraitDay?: string;
+  traceTargets: WalkingRecordTraceTarget[];
   tracePaths: WalkingRecordTracePoint[][];
 }
 
@@ -859,8 +860,10 @@ function buildDayPlates(
 ): DayPlate[] {
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
   const movementByUrl = cursorMovementByUrl(events);
+  const intervals = traceIntervals(period, range);
+  const targetLimit = Math.max(1, Math.floor(16 / intervals.length));
 
-  return traceIntervals(period, range).map((interval) => {
+  return intervals.map((interval) => {
     const sessionsForInterval = sessions
       .filter(
         (session) =>
@@ -891,7 +894,10 @@ function buildDayPlates(
           Infinity;
         return aVisits - bVisits;
       });
-    const session = sessionsForInterval[0]?.session;
+    const selectedSessions = sessionsForInterval
+      .slice(0, targetLimit)
+      .map((candidate) => candidate.session);
+    const session = selectedSessions[0];
 
     if (!session) {
       const future = interval.startTs > nowTs;
@@ -901,18 +907,19 @@ function buildDayPlates(
         vignette: future ? "still to come" : "no trace kept",
         hue: "#b5aea5",
         future,
+        traceTargets: [],
         tracePaths: [],
       };
     }
 
     const domain = extractDomain(session.url);
     const minutes = Math.max(1, Math.round(session.durationMs / 60_000));
-    const traceTarget = {
-      id: interval.key,
-      url: session.url,
-      startTs: session.focusTs,
-      endTs: session.blurTs,
-    };
+    const traceTargets = selectedSessions.map((selectedSession, index) => ({
+      id: index === 0 ? interval.key : `${interval.key}:${index + 1}`,
+      url: selectedSession.url,
+      startTs: selectedSession.focusTs,
+      endTs: selectedSession.blurTs,
+    }));
 
     return {
       date: interval.key,
@@ -920,8 +927,9 @@ function buildDayPlates(
       vignette: `${minutes} quiet minute${minutes === 1 ? "" : "s"} on ${domain}`,
       hue: colorForDomain(baseColor, domain),
       future: false,
-      traceTarget,
-      tracePaths: derivedSessionPath(traceTarget),
+      portraitDay: period === "week" ? interval.key.slice(4) : undefined,
+      traceTargets,
+      tracePaths: traceTargets.flatMap(derivedSessionPath),
     };
   });
 }
@@ -1043,22 +1051,17 @@ export function deriveWalkingRecord({
 export function getWalkingRecordTraceTargets(
   record: WalkingRecord,
 ): WalkingRecordTraceTarget[] {
-  return record.dayPlates
-    .map((plate) => plate.traceTarget)
-    .filter((target): target is WalkingRecordTraceTarget => target !== undefined);
+  return record.dayPlates.flatMap((plate) => plate.traceTargets);
 }
 
 function pathsForTarget(
-  target: WalkingRecordTraceTarget | undefined,
-  fallbackPaths: WalkingRecordTracePoint[][],
+  target: WalkingRecordTraceTarget,
   pathsByTarget: Map<string, WalkingRecordTracePoint[][]>,
 ): WalkingRecordTracePoint[][] {
-  if (!target) return [];
-
   const storedPaths = pathsByTarget.get(target.id);
   return storedPaths?.some((path) => path.length >= 2)
     ? storedPaths
-    : fallbackPaths;
+    : derivedSessionPath(target);
 }
 
 export function attachWalkingRecordTraces(
@@ -1073,10 +1076,8 @@ export function attachWalkingRecordTraces(
     ...record,
     dayPlates: record.dayPlates.map((plate) => ({
       ...plate,
-      tracePaths: pathsForTarget(
-        plate.traceTarget,
-        plate.tracePaths,
-        pathsByTarget,
+      tracePaths: plate.traceTargets.flatMap((target) =>
+        pathsForTarget(target, pathsByTarget),
       ),
     })),
   };

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -854,20 +854,31 @@ function buildDayPlates(
           session.focusTs >= interval.startTs &&
           session.focusTs <= interval.endTs,
       )
+      .map((session) => ({
+        session,
+        movementCount: (
+          movementByUrl.get(normalizeUrl(session.url)) ?? []
+        ).filter(
+          (timestamp) =>
+            timestamp >= session.focusTs && timestamp <= session.blurTs,
+        ).length,
+      }))
       .sort((a, b) => {
-        const aMovement = (
-          movementByUrl.get(normalizeUrl(a.url)) ?? []
-        ).some((timestamp) => timestamp >= a.focusTs && timestamp <= a.blurTs);
-        const bMovement = (
-          movementByUrl.get(normalizeUrl(b.url)) ?? []
-        ).some((timestamp) => timestamp >= b.focusTs && timestamp <= b.blurTs);
-        if (aMovement !== bMovement) return aMovement ? -1 : 1;
-        if (a.durationMs !== b.durationMs) return b.durationMs - a.durationMs;
-        const aVisits = domainByName.get(extractDomain(a.url))?.sessionCount ?? Infinity;
-        const bVisits = domainByName.get(extractDomain(b.url))?.sessionCount ?? Infinity;
+        if (a.movementCount !== b.movementCount) {
+          return b.movementCount - a.movementCount;
+        }
+        if (a.session.durationMs !== b.session.durationMs) {
+          return b.session.durationMs - a.session.durationMs;
+        }
+        const aVisits =
+          domainByName.get(extractDomain(a.session.url))?.sessionCount ??
+          Infinity;
+        const bVisits =
+          domainByName.get(extractDomain(b.session.url))?.sessionCount ??
+          Infinity;
         return aVisits - bVisits;
       });
-    const session = sessionsForInterval[0];
+    const session = sessionsForInterval[0]?.session;
 
     if (!session) {
       const future = interval.startTs > nowTs;

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -27,6 +27,7 @@ const FAMILIAR_SITE_MIN_GAP_DAYS = 14;
 const MAIN_ROAD_LIMIT = 20;
 const TIME_SPENT_SITE_LIMIT = 5;
 const ACTIVE_WINDOW_MS = 30_000;
+const MIN_DEPARTURE_DWELL_MS = 60_000;
 const PAGE_HUE_SHIFTS = [-28, -18, -10, 10, 18, 28];
 
 const POPULAR_DOMAIN_ROOTS = [
@@ -437,6 +438,10 @@ function logarithmicScore(valueMinutes: number, capMinutes: number): number {
   );
 }
 
+function formatDepartureDuration(ms: number): string {
+  return ms < 60_000 ? "< 1 min" : formatDuration(ms);
+}
+
 function activeTimeForSession(
   session: ScreenTimeSession | undefined,
   activityByUrl: Map<string, number[]>,
@@ -479,6 +484,8 @@ function buildDepartureNote(
   }
   if (activeTimeMs >= 60_000) {
     notes.push(`${Math.round(activeTimeMs / 60_000)} active minutes`);
+  } else if (activeTimeMs > 0) {
+    notes.push("actively browsed");
   } else if (session && session.durationMs >= 10 * 60_000) {
     notes.push(`stayed ${Math.round(session.durationMs / 60_000)} minutes`);
   }
@@ -530,6 +537,12 @@ function buildDepartures(
 
     const session = getVisitSession(visit, timeByDomain.get(visit.domain));
     const activeTimeMs = activeTimeForSession(session, activityByUrl);
+    if (
+      activeTimeMs < ACTIVE_WINDOW_MS &&
+      (session?.durationMs ?? 0) < MIN_DEPARTURE_DWELL_MS
+    ) {
+      continue;
+    }
     const dwellMinutes = (session?.durationMs ?? 0) / 60_000;
     const activeMinutes = activeTimeMs / 60_000;
     const activeScore = logarithmicScore(activeMinutes, 30);
@@ -556,9 +569,9 @@ function buildDepartures(
       fromFaviconUrl: faviconByDomain.get(previous.domain),
       toFaviconUrl: faviconByDomain.get(visit.domain),
       time:
-        activeTimeMs >= 60_000
-          ? `${formatDuration(activeTimeMs)} active`
-          : formatDuration(session?.durationMs ?? 0),
+        activeTimeMs > 0
+          ? `${formatDepartureDuration(activeTimeMs)} active`
+          : formatDepartureDuration(session!.durationMs),
       note: buildDepartureNote(
         visit,
         session,

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -269,6 +269,17 @@ export function formatDuration(ms: number): string {
   return minutes === 0 ? hourLabel : `${hourLabel} ${minutes} min`;
 }
 
+function formatCompactDuration(ms: number): string {
+  if (ms <= 0) return "0m";
+  const totalMinutes = Math.floor(ms / 60_000);
+  if (totalMinutes < 1) return "<1m";
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
 export function formatRange(range: WalkingRecordRange): string {
   const start = new Date(range.startTs);
   const end = new Date(range.endTs);
@@ -952,7 +963,7 @@ function buildTimeSpent(
       rank: index + 1,
       site: row.domain,
       faviconUrl: faviconByDomain.get(row.domain),
-      time: formatDuration(row.totalMs),
+      time: formatCompactDuration(row.totalMs),
       percentage: (row.totalMs / Math.max(totalMs, 1)) * 100,
       hue: paletteColorForIndex(index),
       note: "",
@@ -962,8 +973,8 @@ function buildTimeSpent(
   if (remainingMs > 0) {
     entries.push({
       rank: entries.length + 1,
-      site: `${remaining.length} other place${remaining.length === 1 ? "" : "s"}`,
-      time: formatDuration(remainingMs),
+      site: `${remaining.length} other${remaining.length === 1 ? "" : "s"}`,
+      time: formatCompactDuration(remainingMs),
       percentage: (remainingMs / Math.max(totalMs, 1)) * 100,
       hue: "#c8c3bb",
       note: "",

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -7,7 +7,9 @@ import type {
   NavigationEventData,
 } from "../collectors/types";
 import type {
+  AggregateDay,
   ScreenTimeSession,
+  WalkingRecordActivity,
   WalkingRecordTrace,
   WalkingRecordTracePoint,
   WalkingRecordTraceTarget,
@@ -18,11 +20,13 @@ import { parseColorToHsl } from "@movement/utils/eventUtils";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SMALL_SITE_MAX_VISITS = 5;
-const FAMILIAR_SITE_MIN_VISITS = 10;
-const FAMILIAR_SITE_MIN_SPAN_DAYS = 14;
+const FAMILIAR_SITE_MIN_ACTIVE_DAYS = 5;
+const FAMILIAR_SITE_MIN_ACTIVE_WEEKS = 3;
+const FAMILIAR_SITE_MIN_SPAN_DAYS = 21;
+const FAMILIAR_SITE_MIN_GAP_DAYS = 14;
 const MAIN_ROAD_LIMIT = 20;
-const DEPARTURE_TRACE_MAX_MS = 30 * 60_000;
-const TIME_SPENT_SITE_LIMIT = 6;
+const TIME_SPENT_SITE_LIMIT = 5;
+const ACTIVE_WINDOW_MS = 30_000;
 const PAGE_HUE_SHIFTS = [-28, -18, -10, 10, 18, 28];
 
 const POPULAR_DOMAIN_ROOTS = [
@@ -90,22 +94,20 @@ export interface WalkingRecordDomain {
   totalTimeMs: number;
   uniquePageCount: number;
   sessionCount: number;
+  activeDayCount: number;
   eventCounts: Record<string, number>;
 }
 
 export interface Departure {
   day: string;
-  verb: "departed";
   from: string;
   to: string;
   toUrl: string;
+  fromFaviconUrl?: string;
+  toFaviconUrl?: string;
+  time: string;
   note: string;
-  familiarity: string;
-  hue: string;
-  accentHue: string;
   score: number;
-  traceTarget?: WalkingRecordTraceTarget;
-  tracePaths: WalkingRecordTracePoint[][];
 }
 
 export interface Revisit {
@@ -159,8 +161,10 @@ interface WalkingRecordInput {
   period: WalkingRecordPeriod;
   baseColor: string;
   events: CollectionEvent[];
+  activity?: WalkingRecordActivity[];
   sessions: ScreenTimeSession[];
   domains: WalkingRecordDomain[];
+  domainDays?: AggregateDay[];
   range: WalkingRecordRange;
   cursorDistancePx?: number;
   nowTs?: number;
@@ -401,21 +405,50 @@ function sessionsByDomain(sessions: ScreenTimeSession[]): Map<string, DomainTime
   return grouped;
 }
 
-function cursorSamplesByUrl(events: CollectionEvent[]): Map<string, number[]> {
-  const samples = new Map<string, number[]>();
+function faviconsByDomain(events: CollectionEvent[]): Map<string, string> {
+  const favicons = new Map<string, string>();
 
   for (const event of events) {
-    if (event.type !== "cursor") continue;
-    const data = event.data as CursorEventData;
-    if (data.event !== "move" && data.event !== undefined) continue;
+    if (event.type !== "navigation") continue;
+    const faviconUrl = (event.data as NavigationEventData).favicon_url;
+    if (typeof faviconUrl !== "string" || faviconUrl.length === 0) continue;
 
-    const url = normalizeUrl(event.meta.url);
-    const timestamps = samples.get(url) ?? [];
-    timestamps.push(event.ts);
-    samples.set(url, timestamps);
+    try {
+      const parsed = new URL(faviconUrl);
+      if (
+        parsed.protocol === "https:" ||
+        parsed.protocol === "http:" ||
+        parsed.protocol === "data:"
+      ) {
+        favicons.set(extractDomain(event.meta.url), faviconUrl);
+      }
+    } catch {
+      // Ignore malformed favicon metadata from the visited page.
+    }
   }
 
-  return samples;
+  return favicons;
+}
+
+function logarithmicScore(valueMinutes: number, capMinutes: number): number {
+  return (
+    Math.log1p(Math.min(Math.max(0, valueMinutes), capMinutes)) /
+    Math.log1p(capMinutes)
+  );
+}
+
+function activeTimeForSession(
+  session: ScreenTimeSession | undefined,
+  activityByUrl: Map<string, number[]>,
+): number {
+  if (!session) return 0;
+  const windows = activityByUrl.get(normalizeUrl(session.url)) ?? [];
+  const activeWindows = windows.filter(
+    (timestamp) =>
+      timestamp < session.blurTs &&
+      timestamp + ACTIVE_WINDOW_MS > session.focusTs,
+  ).length;
+  return Math.min(session.durationMs, activeWindows * ACTIVE_WINDOW_MS);
 }
 
 function getVisitSession(
@@ -435,19 +468,24 @@ function getVisitSession(
 function buildDepartureNote(
   visit: FocusVisit,
   session: ScreenTimeSession | undefined,
+  activeTimeMs: number,
   domain: WalkingRecordDomain,
   visitsThisPeriod: number,
 ): string {
   const notes: string[] = [];
 
-  if (session && session.durationMs >= 10 * 60_000) {
-    notes.push(`stayed ${Math.round(session.durationMs / 60_000)} minutes`);
-  }
   if (domain.firstVisit >= visit.ts - 60_000) {
     notes.push("your first visit");
   }
+  if (activeTimeMs >= 60_000) {
+    notes.push(`${Math.round(activeTimeMs / 60_000)} active minutes`);
+  } else if (session && session.durationMs >= 10 * 60_000) {
+    notes.push(`stayed ${Math.round(session.durationMs / 60_000)} minutes`);
+  }
   if (visitsThisPeriod > 1) {
-    notes.push(`went back ${visitsThisPeriod - 1 === 1 ? "once" : `${visitsThisPeriod - 1} times`}`);
+    notes.push(
+      `returned ${visitsThisPeriod - 1 === 1 ? "once" : `${visitsThisPeriod - 1} times`}`,
+    );
   }
   if (new Date(visit.ts).getHours() < 5) {
     notes.push("found after midnight");
@@ -458,28 +496,31 @@ function buildDepartureNote(
 
 function buildDepartures(
   events: CollectionEvent[],
+  activity: WalkingRecordActivity[],
   sessions: ScreenTimeSession[],
   domains: WalkingRecordDomain[],
   mainRoads: Set<string>,
-  range: WalkingRecordRange,
-  baseColor: string,
 ): { departures: Departure[]; movementCount: number } {
   const visits = focusVisits(events);
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
   const timeByDomain = sessionsByDomain(sessions);
-  const movementByUrl = cursorSamplesByUrl(events);
+  const activityByUrl = new Map(
+    activity.map((entry) => [entry.url, entry.windowStarts]),
+  );
+  const hasActivityCoverage = activity.some(
+    (entry) => entry.windowStarts.length > 0,
+  );
+  const faviconByDomain = faviconsByDomain(events);
   const visitsByDomain = new Map<string, number>();
 
   for (const visit of visits) {
     visitsByDomain.set(visit.domain, (visitsByDomain.get(visit.domain) ?? 0) + 1);
   }
 
-  const candidates: Array<Omit<Departure, "accentHue"> & { dayKey: string }> =
-    [];
+  const candidates: Array<Departure & { dayKey: string }> = [];
   for (let index = 1; index < visits.length; index++) {
     const previous = visits[index - 1];
     const visit = visits[index];
-    const nextVisit = visits[index + 1];
     const domain = domainByName.get(visit.domain);
 
     if (!domain) continue;
@@ -488,61 +529,51 @@ function buildDepartures(
     if (domain.sessionCount > SMALL_SITE_MAX_VISITS) continue;
 
     const session = getVisitSession(visit, timeByDomain.get(visit.domain));
-    const rarityScore = SMALL_SITE_MAX_VISITS - domain.sessionCount + 1;
-    const dwellScore = session ? Math.min(session.durationMs / 60_000, 30) / 10 : 0;
+    const activeTimeMs = activeTimeForSession(session, activityByUrl);
+    const dwellMinutes = (session?.durationMs ?? 0) / 60_000;
+    const activeMinutes = activeTimeMs / 60_000;
+    const activeScore = logarithmicScore(activeMinutes, 30);
+    const dwellScore = logarithmicScore(dwellMinutes, 30);
+    const browsingScore = hasActivityCoverage
+      ? activeScore * 0.8 + dwellScore * 0.2
+      : dwellScore;
+    const rarityScore =
+      (SMALL_SITE_MAX_VISITS - domain.sessionCount + 1) /
+      (SMALL_SITE_MAX_VISITS + 1);
     const date = new Date(visit.ts);
     const dayKey = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
-    const traceEndTs = Math.max(
-      visit.ts,
-      Math.min(
-        range.endTs,
-        visit.ts + DEPARTURE_TRACE_MAX_MS,
-        session?.blurTs ?? Infinity,
-        nextVisit ? nextVisit.ts - 1 : Infinity,
-      ),
-    );
     const isFirstVisit = domain.firstVisit >= visit.ts - 60_000;
-    const movementSamples = (
-      movementByUrl.get(normalizeUrl(visit.url)) ?? []
-    ).filter((timestamp) => timestamp >= visit.ts && timestamp <= traceEndTs).length;
-    const movementScore = Math.min(movementSamples, 3) * 2;
-
-    const traceTarget = {
-      id: `departure:${visit.ts}:${visit.domain}`,
-      url: visit.url,
-      startTs: visit.ts,
-      endTs: traceEndTs,
-    };
+    const visitsThisPeriod = visitsByDomain.get(visit.domain) ?? 1;
+    const discoveryScore =
+      (isFirstVisit ? 0.6 : 0) + (visitsThisPeriod > 1 ? 0.4 : 0);
 
     candidates.push({
       dayKey,
       day: date.toLocaleDateString("en", { weekday: "short" }).toLowerCase(),
-      verb: "departed",
       from: previous.domain,
       to: visit.domain,
       toUrl: visit.url,
+      fromFaviconUrl: faviconByDomain.get(previous.domain),
+      toFaviconUrl: faviconByDomain.get(visit.domain),
+      time:
+        activeTimeMs >= 60_000
+          ? `${formatDuration(activeTimeMs)} active`
+          : formatDuration(session?.durationMs ?? 0),
       note: buildDepartureNote(
         visit,
         session,
+        activeTimeMs,
         domain,
-        visitsByDomain.get(visit.domain) ?? 1,
+        visitsThisPeriod,
       ),
-      familiarity:
-        isFirstVisit
-          ? "new to you"
-          : domain.sessionCount > 0
-            ? `${domain.sessionCount} visits by you`
-            : "seen before",
-      hue: colorForDomain(baseColor, visit.domain),
-      score: rarityScore + dwellScore + movementScore,
-      traceTarget,
-      tracePaths: derivedSessionPath(traceTarget),
+      score:
+        browsingScore * 0.6 + rarityScore * 0.25 + discoveryScore * 0.15,
     });
   }
 
   const deduped = new Map<
     string,
-    Omit<Departure, "accentHue"> & { dayKey: string }
+    Departure & { dayKey: string }
   >();
   for (const candidate of candidates) {
     const key = `${candidate.dayKey}:${candidate.to}`;
@@ -555,12 +586,9 @@ function buildDepartures(
   const ranked = [...deduped.values()].sort((a, b) => b.score - a.score);
   return {
     movementCount: ranked.length,
-    departures: ranked.slice(0, 4).map((candidate, index) => {
+    departures: ranked.slice(0, 3).map((candidate) => {
       const { dayKey: _, ...departure } = candidate;
-      return {
-        ...departure,
-        accentHue: paletteColorForIndex(index),
-      };
+      return departure;
     }),
   };
 }
@@ -576,48 +604,84 @@ function formatGap(ms: number): string {
   return `${years} year${years === 1 ? "" : "s"}`;
 }
 
+function weekKey(dayKey: string): string {
+  const date = new Date(`${dayKey}T12:00:00`);
+  const day = (date.getDay() + 6) % 7;
+  date.setDate(date.getDate() - day);
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function revisitEvidence(days: AggregateDay[], relationshipMs: number): string {
+  const weekdayCounts = new Map<number, number>();
+  for (const day of days) {
+    const weekday = new Date(`${day.localDayKey}T12:00:00`).getDay();
+    weekdayCounts.set(weekday, (weekdayCounts.get(weekday) ?? 0) + 1);
+  }
+  const [topWeekday, topCount] = [...weekdayCounts].sort(
+    (a, b) => b[1] - a[1],
+  )[0] ?? [0, 0];
+  if (topCount >= 4 && topCount / days.length >= 0.6) {
+    const weekday = new Intl.DateTimeFormat("en", {
+      weekday: "long",
+    }).format(new Date(2026, 7, 2 + topWeekday));
+    return `usually returned on ${weekday.toLowerCase()}s`;
+  }
+
+  return `visited on ${days.length} days across ${formatGap(relationshipMs)}`;
+}
+
 function buildRevisits(
   domains: WalkingRecordDomain[],
+  domainDays: AggregateDay[],
   range: WalkingRecordRange,
 ): Revisit[] {
+  const daysByDomain = new Map<string, AggregateDay[]>();
+  for (const day of domainDays) {
+    if (day.lastVisitTs >= range.startTs) continue;
+    const days = daysByDomain.get(day.domain) ?? [];
+    days.push(day);
+    daysByDomain.set(day.domain, days);
+  }
+
   return domains
-    .filter(
-      (domain) =>
-        domain.sessionCount >= FAMILIAR_SITE_MIN_VISITS &&
-        domain.firstVisit > 0 &&
-        domain.lastVisit > domain.firstVisit &&
-        Math.floor((domain.lastVisit - domain.firstVisit) / DAY_MS) + 1 >=
-          FAMILIAR_SITE_MIN_SPAN_DAYS &&
-        domain.lastVisit > 0 &&
-        domain.lastVisit < range.startTs &&
-        !isPopularDomain(domain.domain),
-    )
-    .map((domain) => {
-      const gapMs = range.endTs - domain.lastVisit;
-      const visitSpanMs = domain.lastVisit - domain.firstVisit;
-      const visitSpanDays = Math.max(
-        1,
-        Math.floor(visitSpanMs / DAY_MS) + 1,
+    .flatMap((domain) => {
+      if (isPopularDomain(domain.domain)) return [];
+      const days = (daysByDomain.get(domain.domain) ?? []).sort(
+        (a, b) => a.firstVisitTs - b.firstVisitTs,
       );
-      const cappedVisitCount = Math.min(domain.sessionCount, visitSpanDays);
-      const visitsPerSpanDay = domain.sessionCount / visitSpanDays;
-      const concentrationPenalty = Math.sqrt(
-        Math.max(1, visitsPerSpanDay),
-      );
+      if (days.length < FAMILIAR_SITE_MIN_ACTIVE_DAYS) return [];
+
+      const activeWeeks = new Set(days.map((day) => weekKey(day.localDayKey)));
+      if (activeWeeks.size < FAMILIAR_SITE_MIN_ACTIVE_WEEKS) return [];
+
+      const firstVisitTs = days[0].firstVisitTs;
+      const lastVisitTs = days.at(-1)!.lastVisitTs;
+      const relationshipMs = lastVisitTs - firstVisitTs;
+      const relationshipDays =
+        Math.floor(relationshipMs / DAY_MS) + 1;
+      if (relationshipDays < FAMILIAR_SITE_MIN_SPAN_DAYS) return [];
+
+      const gapMs = range.endTs - lastVisitTs;
+      if (gapMs < FAMILIAR_SITE_MIN_GAP_DAYS * DAY_MS) return [];
+
       return {
         span: formatGap(gapMs),
         site: domain.domain,
         href: `https://${domain.domain}`,
-        memory: `part of your browsing for ${formatGap(visitSpanMs)} before the gap`,
+        memory: revisitEvidence(days, relationshipMs),
         score:
-          (Math.log2(visitSpanDays + 1) ** 2 *
-            Math.log2(cappedVisitCount + 1) *
-            Math.log2(gapMs / DAY_MS + 1)) /
-          concentrationPenalty,
+          Math.log2(days.length + 1) ** 2 *
+          Math.log2(activeWeeks.size + 1) *
+          Math.log2(relationshipDays + 1) *
+          Math.log2(gapMs / DAY_MS + 1),
       };
     })
     .sort((a, b) => b.score - a.score)
-    .slice(0, 8)
+    .slice(0, 5)
     .map((revisit, index) => ({
       ...revisit,
       hue: paletteColorForIndex(index),
@@ -650,6 +714,23 @@ function cursorDistance(events: CollectionEvent[]): number {
   }
 
   return distance;
+}
+
+function cursorMovementByUrl(
+  events: CollectionEvent[],
+): Map<string, number[]> {
+  const movementByUrl = new Map<string, number[]>();
+  for (const event of events) {
+    if (event.type !== "cursor") continue;
+    const data = event.data as CursorEventData;
+    if (data.event !== "move" && data.event !== undefined) continue;
+
+    const url = normalizeUrl(event.meta.url);
+    const timestamps = movementByUrl.get(url) ?? [];
+    timestamps.push(event.ts);
+    movementByUrl.set(url, timestamps);
+  }
+  return movementByUrl;
 }
 
 function hourBuckets(sessions: ScreenTimeSession[]): number[] {
@@ -764,7 +845,7 @@ function buildDayPlates(
   nowTs: number,
 ): DayPlate[] {
   const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
-  const movementByUrl = cursorSamplesByUrl(events);
+  const movementByUrl = cursorMovementByUrl(events);
 
   return traceIntervals(period, range).map((interval) => {
     const sessionsForInterval = sessions
@@ -821,98 +902,41 @@ function buildDayPlates(
   });
 }
 
-function topHourNote(sessions: ScreenTimeSession[]): string {
-  const buckets = hourBuckets(sessions);
-  const topHour = buckets.indexOf(Math.max(...buckets));
-  if (topHour < 0 || buckets[topHour] === 0) return "";
-
-  const formatter = new Intl.DateTimeFormat("en", { hour: "numeric" });
-  const start = new Date(2020, 0, 1, topHour);
-  const end = new Date(2020, 0, 1, (topHour + 1) % 24);
-  return `mostly around ${formatter.format(start)}–${formatter.format(end)}`;
-}
-
 function buildTimeSpent(
   events: CollectionEvent[],
   sessions: ScreenTimeSession[],
-  domains: WalkingRecordDomain[],
-  mainRoads: Set<string>,
 ): { entries: TimeSpentEntry[]; intro: string } {
   const grouped = [...sessionsByDomain(sessions).values()].sort(
     (a, b) => b.totalMs - a.totalMs,
   );
-  const domainByName = new Map(domains.map((domain) => [domain.domain, domain]));
-  const faviconByDomain = new Map<string, string>();
-  for (const event of events) {
-    if (event.type !== "navigation") continue;
-
-    const faviconUrl = (event.data as NavigationEventData).favicon_url;
-    if (typeof faviconUrl !== "string" || faviconUrl.length === 0) continue;
-
-    try {
-      const parsed = new URL(faviconUrl);
-      if (
-        parsed.protocol === "https:" ||
-        parsed.protocol === "http:" ||
-        parsed.protocol === "data:"
-      ) {
-        faviconByDomain.set(extractDomain(event.meta.url), faviconUrl);
-      }
-    } catch {
-      // Ignore malformed favicon metadata from the visited page.
-    }
-  }
-  const quiet = grouped.filter((entry) => {
-    const domain = domainByName.get(entry.domain);
-    return (
-      domain &&
-      domain.sessionCount <= SMALL_SITE_MAX_VISITS &&
-      !isMainRoad(entry.domain, mainRoads)
-    );
-  });
-  const quietDomains = new Set(quiet.map((entry) => entry.domain));
-  const top = grouped
-    .filter((entry) => !quietDomains.has(entry.domain))
-    .slice(0, TIME_SPENT_SITE_LIMIT);
-  const quietMs = quiet.reduce((sum, entry) => sum + entry.totalMs, 0);
-  const quietLongReads = quiet.flatMap((entry) => entry.sessions).filter(
-    (session) => session.durationMs >= 10 * 60_000,
-  ).length;
-  const rows: Array<DomainTime & { quiet?: boolean }> = [...top];
-
-  if (quietMs > 0) {
-    rows.push({
-      domain: "the quiet streets, together",
-      totalMs: quietMs,
-      sessions: quiet.flatMap((entry) => entry.sessions),
-      quiet: true,
-    });
-  }
-
-  const maxMs = Math.max(...rows.map((row) => row.totalMs), 1);
-  const entries = rows.map((row, index): TimeSpentEntry => {
-    if (row.quiet) {
-      return {
-        rank: index + 1,
-        site: row.domain,
-        time: formatDuration(row.totalMs),
-        percentage: (row.totalMs / maxMs) * 100,
-        hue: paletteColorForIndex(index),
-        note: `${quiet.length} small site${quiet.length === 1 ? "" : "s"} · ${quietLongReads} long read${quietLongReads === 1 ? "" : "s"}`,
-      };
-    }
-
-    return {
+  const faviconByDomain = faviconsByDomain(events);
+  const totalMs = grouped.reduce((sum, entry) => sum + entry.totalMs, 0);
+  const top = grouped.slice(0, TIME_SPENT_SITE_LIMIT);
+  const topMs = top.reduce((sum, entry) => sum + entry.totalMs, 0);
+  const remaining = grouped.slice(TIME_SPENT_SITE_LIMIT);
+  const remainingMs = totalMs - topMs;
+  const entries = top.map(
+    (row, index): TimeSpentEntry => ({
       rank: index + 1,
       site: row.domain,
       faviconUrl: faviconByDomain.get(row.domain),
       time: formatDuration(row.totalMs),
-      percentage: (row.totalMs / maxMs) * 100,
+      percentage: (row.totalMs / Math.max(totalMs, 1)) * 100,
       hue: paletteColorForIndex(index),
-      note: topHourNote(row.sessions),
+      note: "",
       href: `https://${row.domain}`,
-    };
-  });
+    }),
+  );
+  if (remainingMs > 0) {
+    entries.push({
+      rank: entries.length + 1,
+      site: `${remaining.length} other place${remaining.length === 1 ? "" : "s"}`,
+      time: formatDuration(remainingMs),
+      percentage: (remainingMs / Math.max(totalMs, 1)) * 100,
+      hue: "#c8c3bb",
+      note: "",
+    });
+  }
 
   if (grouped.length === 0) {
     return {
@@ -921,13 +945,18 @@ function buildTimeSpent(
     };
   }
 
-  const quietSentence =
-    quiet.length > 0
-      ? ` ${quiet.length} quiet street${quiet.length === 1 ? "" : "s"} held ${formatDuration(quietMs)}.`
+  const leading = top[0];
+  const topSentence =
+    top.length === 1
+      ? `most of this period gathered on ${leading.domain}.`
+      : `${leading.domain} held the most time, followed by ${top[1].domain}.`;
+  const remainingSentence =
+    remaining.length > 0
+      ? ` another ${formatDuration(remainingMs)} was spread across ${remaining.length} other place${remaining.length === 1 ? "" : "s"}.`
       : "";
   return {
     entries,
-    intro: `you spent the most time on ${grouped[0].domain}.${quietSentence}`,
+    intro: `${topSentence}${remainingSentence}`,
   };
 }
 
@@ -935,8 +964,10 @@ export function deriveWalkingRecord({
   period,
   baseColor,
   events,
+  activity = [],
   sessions,
   domains,
+  domainDays = [],
   range,
   cursorDistancePx: measuredCursorDistance,
   nowTs = Date.now(),
@@ -949,17 +980,14 @@ export function deriveWalkingRecord({
   const mainRoads = getMainRoads(domains);
   const { departures, movementCount } = buildDepartures(
     events,
+    activity,
     sessions,
     domains,
     mainRoads,
-    range,
-    baseColor,
   );
   const { entries: timeSpent, intro: timeSpentIntro } = buildTimeSpent(
     events,
     sessions,
-    domains,
-    mainRoads,
   );
 
   return {
@@ -973,7 +1001,7 @@ export function deriveWalkingRecord({
     hourBuckets: portrait.hourBuckets,
     movementCount,
     departures,
-    revisits: buildRevisits(domains, range),
+    revisits: buildRevisits(domains, domainDays, range),
     dayPlates: buildDayPlates(
       events,
       sessions,
@@ -991,10 +1019,9 @@ export function deriveWalkingRecord({
 export function getWalkingRecordTraceTargets(
   record: WalkingRecord,
 ): WalkingRecordTraceTarget[] {
-  return [
-    ...record.dayPlates.map((plate) => plate.traceTarget),
-    ...record.departures.map((departure) => departure.traceTarget),
-  ].filter((target): target is WalkingRecordTraceTarget => target !== undefined);
+  return record.dayPlates
+    .map((plate) => plate.traceTarget)
+    .filter((target): target is WalkingRecordTraceTarget => target !== undefined);
 }
 
 function pathsForTarget(
@@ -1025,14 +1052,6 @@ export function attachWalkingRecordTraces(
       tracePaths: pathsForTarget(
         plate.traceTarget,
         plate.tracePaths,
-        pathsByTarget,
-      ),
-    })),
-    departures: record.departures.map((departure) => ({
-      ...departure,
-      tracePaths: pathsForTarget(
-        departure.traceTarget,
-        departure.tracePaths,
         pathsByTarget,
       ),
     })),

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -23,6 +23,10 @@ const STATS_BACKFILL_STATE_KEY = "__stats_backfill_state__";
 const DAYS_BACKFILL_STATE_KEY = "__days_backfill_state__";
 const UPLOAD_STATE_PENDING = "pending";
 const UPLOAD_STATE_UPLOADED = "uploaded";
+const LANDSCAPE_SEGMENT_POINT_LIMIT = 96;
+const LANDSCAPE_SEGMENT_DURATION_MS = 12_000;
+const LANDSCAPE_SEGMENTS_PER_TARGET = 8;
+const LANDSCAPE_SOURCE_PATH_LIMIT = 8;
 const COLLECTION_EVENT_TYPES: CollectionEventType[] = [
   "cursor",
   "navigation",
@@ -195,8 +199,14 @@ export interface WalkingRecordTrace {
   paths: WalkingRecordTracePoint[][];
 }
 
+export interface WalkingRecordMovement {
+  traces: WalkingRecordTrace[];
+  landscapePaths: CollectionEvent[][];
+}
+
 interface TimedTracePoint extends WalkingRecordTracePoint {
   ts: number;
+  event: CollectionEvent;
 }
 
 function squaredDistance(
@@ -282,6 +292,42 @@ function tracePathDistance(points: TimedTracePoint[]): number {
     distance += Math.sqrt(squaredDistance(points[index - 1], points[index]));
   }
   return distance;
+}
+
+function splitLandscapePath(
+  points: TimedTracePoint[],
+): TimedTracePoint[][] {
+  const segments: TimedTracePoint[][] = [];
+  let current: TimedTracePoint[] = [];
+
+  for (const point of points) {
+    const first = current[0];
+    if (
+      current.length >= 2 &&
+      (current.length >= LANDSCAPE_SEGMENT_POINT_LIMIT ||
+        point.ts - first.ts > LANDSCAPE_SEGMENT_DURATION_MS)
+    ) {
+      segments.push(current);
+      current = [current.at(-1)!, point];
+    } else {
+      current.push(point);
+    }
+  }
+
+  if (current.length >= 2) segments.push(current);
+  return segments;
+}
+
+function evenlySpacedPaths(
+  paths: TimedTracePoint[][],
+  limit: number,
+): TimedTracePoint[][] {
+  if (paths.length <= limit) return paths;
+
+  return Array.from({ length: limit }, (_, index) => {
+    const sourceIndex = Math.round((index / (limit - 1)) * (paths.length - 1));
+    return paths[sourceIndex];
+  });
 }
 
 /**
@@ -1813,18 +1859,20 @@ export class LocalEventStore {
   }
 
   /**
-   * Extract a few representative, continuous cursor paths for selected sessions.
-   * Paths remain normalized to the source viewport and are simplified before transfer.
+   * Extract representative cursor paths for cards and animated playback.
+   * Card paths are simplified more heavily; playback keeps original timestamps.
    */
-  async getWalkingRecordTraces(
+  async getWalkingRecordMovement(
     targets: WalkingRecordTraceTarget[],
-  ): Promise<WalkingRecordTrace[]> {
+  ): Promise<WalkingRecordMovement> {
     await this.ensureInitialized();
 
     if (targets.length > 16) {
-      throw new Error("Walking record trace target limit exceeded");
+      throw new Error("Walking record movement target limit exceeded");
     }
-    if (targets.length === 0) return [];
+    if (targets.length === 0) {
+      return { traces: [], landscapePaths: [] };
+    }
 
     for (const target of targets) {
       if (
@@ -1834,7 +1882,7 @@ export class LocalEventStore {
         !Number.isFinite(target.endTs) ||
         target.endTs < target.startTs
       ) {
-        throw new Error("Walking record trace target is invalid");
+        throw new Error("Walking record movement target is invalid");
       }
     }
 
@@ -1866,26 +1914,44 @@ export class LocalEventStore {
       request.onsuccess = () => {
         const cursor = request.result;
         if (!cursor) {
-          const traces = [...collectors.values()].map((collector) => {
+          const completed = [...collectors.values()].map((collector) => {
             if (collector.currentPath.length >= 2) {
               collector.paths.push(collector.currentPath);
             }
 
-            const paths = collector.paths
+            const rankedPaths = collector.paths
               .map((points, index) => ({
                 points,
                 index,
                 distance: tracePathDistance(points),
               }))
               .filter(({ points }) => points.length >= 2)
-              .sort((a, b) => b.distance - a.distance)
-              .slice(0, 3)
-              .sort((a, b) => a.index - b.index)
-              .map(({ points }) => simplifyTracePath(points));
+              .sort((a, b) => b.distance - a.distance);
 
-            return { targetId: collector.target.id, paths };
+            const selectedPaths = rankedPaths
+              .slice(0, 3)
+              .sort((a, b) => a.index - b.index);
+            const paths = selectedPaths
+              .map(({ points }) => simplifyTracePath(points));
+            const landscapePaths = evenlySpacedPaths(
+              rankedPaths
+                .slice(0, LANDSCAPE_SOURCE_PATH_LIMIT)
+                .sort((a, b) => a.index - b.index)
+                .flatMap(({ points }) => splitLandscapePath(points)),
+              LANDSCAPE_SEGMENTS_PER_TARGET,
+            ).map((points) => points.map(({ event }) => event));
+
+            return {
+              trace: { targetId: collector.target.id, paths },
+              landscapePaths,
+            };
           });
-          resolve(traces);
+          resolve({
+            traces: completed.map(({ trace }) => trace),
+            landscapePaths: completed
+              .flatMap(({ landscapePaths }) => landscapePaths)
+              .filter((path) => path.length >= 2),
+          });
           return;
         }
 
@@ -1912,6 +1978,7 @@ export class LocalEventStore {
                 x: Math.max(0, Math.min(1, data.x)),
                 y: Math.max(0, Math.min(1, data.y)),
                 ts: event.ts,
+                event: toCollectionEvent(event),
               };
               const previous = collector.currentPath.at(-1);
 

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -321,17 +321,38 @@ export class LocalEventStore {
 
     this.initPromise = new Promise((resolve, reject) => {
       const request = indexedDB.open(DB_NAME, DB_VERSION);
+      let upgradeBlocked = false;
 
       request.onerror = () => {
         this.initPromise = null;
         reject(request.error);
       };
       request.onblocked = () => {
-        console.warn("[LocalEventStore] DB upgrade blocked by another connection");
+        upgradeBlocked = true;
+        this.initPromise = null;
+        reject(
+          new Error(
+            "Local history is waiting for an older extension process to close. Reload the extension and open a new tab.",
+          ),
+        );
       };
 
       request.onsuccess = () => {
-        this.db = request.result;
+        const db = request.result;
+        if (upgradeBlocked) {
+          db.close();
+          return;
+        }
+
+        db.onversionchange = () => {
+          db.close();
+          if (this.db === db) {
+            this.db = null;
+            this.isInitialized = false;
+            this.initPromise = null;
+          }
+        };
+        this.db = db;
         this.isInitialized = true;
         if (VERBOSE) {
           console.log("[LocalEventStore] Initialized successfully");

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -14,11 +14,13 @@ import {
 } from "../utils/urlNormalization";
 
 const DB_NAME = "collection_events_db";
-const DB_VERSION = 10;
+const DB_VERSION = 11;
 const STORE_NAME = "events";
 const STATS_STORE_NAME = "domain_stats";
 const AGGREGATE_URLS_STORE_NAME = "aggregate_urls";
+const AGGREGATE_DAYS_STORE_NAME = "aggregate_days";
 const STATS_BACKFILL_STATE_KEY = "__stats_backfill_state__";
+const DAYS_BACKFILL_STATE_KEY = "__days_backfill_state__";
 const UPLOAD_STATE_PENDING = "pending";
 const UPLOAD_STATE_UPLOADED = "uploaded";
 const COLLECTION_EVENT_TYPES: CollectionEventType[] = [
@@ -41,6 +43,13 @@ interface StoredCollectionEvent extends CollectionEvent {
 interface AggregateUrl {
   aggregateKey: string;
   url: string;
+}
+
+export interface AggregateDay {
+  domain: string;
+  localDayKey: string;
+  firstVisitTs: number;
+  lastVisitTs: number;
 }
 
 // Aggregate key for cross-domain totals (all browsing activity combined)
@@ -103,6 +112,8 @@ export interface DomainStatsAggregate {
   lastVisit: number;
   /** Number of unique URLs represented by this aggregate */
   uniqueUrlCount: number;
+  /** Number of local calendar days with at least one focused visit */
+  activeDayCount: number;
 }
 
 function domainStatsKey(domain: string): string {
@@ -111,6 +122,26 @@ function domainStatsKey(domain: string): string {
 
 function pageStatsKey(domain: string, normalizedUrl: string): string {
   return `${domain}::${normalizedUrl}`;
+}
+
+function localDayKey(timestamp: number, timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(timestamp);
+    const values = new Map(parts.map((part) => [part.type, part.value]));
+    return `${values.get("year")}-${values.get("month")}-${values.get("day")}`;
+  } catch {
+    const date = new Date(timestamp);
+    return [
+      date.getFullYear(),
+      String(date.getMonth() + 1).padStart(2, "0"),
+      String(date.getDate()).padStart(2, "0"),
+    ].join("-");
+  }
 }
 
 function getUploadState(event: StoredCollectionEvent): UploadState {
@@ -139,6 +170,12 @@ export interface ScreenTimeResult {
 export interface WalkingRecordEventResult {
   events: CollectionEvent[];
   cursorDistancePx: number;
+  activity: WalkingRecordActivity[];
+}
+
+export interface WalkingRecordActivity {
+  url: string;
+  windowStarts: number[];
 }
 
 export interface WalkingRecordTracePoint {
@@ -266,6 +303,8 @@ export class LocalEventStore {
   private initPromise: Promise<void> | null = null;
   private statsBackfillPromise: Promise<void> | null = null;
   private statsBackfillComplete = false;
+  private daysBackfillPromise: Promise<void> | null = null;
+  private daysBackfillComplete = false;
   private eventsPendingStatsAfterBackfill: CollectionEvent[] = [];
   private eventIdsPendingStatsAfterBackfill = new Set<string>();
 
@@ -450,6 +489,20 @@ export class LocalEventStore {
           };
         }
 
+        if (oldVersion < 11) {
+          if (!db.objectStoreNames.contains(AGGREGATE_DAYS_STORE_NAME)) {
+            db.createObjectStore(AGGREGATE_DAYS_STORE_NAME, {
+              keyPath: ["domain", "localDayKey"],
+            });
+          }
+
+          const tx = (event.target as IDBOpenDBRequest).transaction!;
+          tx.objectStore(STATS_STORE_NAME).put({
+            key: DAYS_BACKFILL_STATE_KEY,
+            state: oldVersion === 0 ? "complete" : "running",
+          });
+        }
+
         if (oldVersion < 9) {
           if (store.indexNames.contains("uploaded")) {
             store.deleteIndex("uploaded");
@@ -511,6 +564,237 @@ export class LocalEventStore {
     return this.statsBackfillPromise;
   }
 
+  private async ensureAggregateDaysBackfilled(): Promise<void> {
+    if (this.daysBackfillComplete) return;
+
+    if (!this.daysBackfillPromise) {
+      this.daysBackfillPromise = this.readDaysBackfillState()
+        .then(async (state) => {
+          if (state !== "complete") {
+            await this.rebuildAggregateDays();
+          }
+        })
+        .then(() => this.writeDaysBackfillState("complete"))
+        .then(() => {
+          this.daysBackfillComplete = true;
+        })
+        .finally(() => {
+          this.daysBackfillPromise = null;
+        });
+    }
+
+    return this.daysBackfillPromise;
+  }
+
+  private async readDaysBackfillState(): Promise<StatsBackfillState | null> {
+    if (!this.db) return null;
+
+    return new Promise((resolve, reject) => {
+      const transaction = this.db!.transaction([STATS_STORE_NAME], "readonly");
+      const request = transaction
+        .objectStore(STATS_STORE_NAME)
+        .get(DAYS_BACKFILL_STATE_KEY);
+      request.onsuccess = () => {
+        const state = (request.result as { state?: unknown } | undefined)?.state;
+        resolve(
+          state === "running" || state === "complete" ? state : null,
+        );
+      };
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async writeDaysBackfillState(
+    state: StatsBackfillState,
+  ): Promise<void> {
+    if (!this.db) return;
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        [STATS_STORE_NAME],
+        "readwrite",
+      );
+      transaction.objectStore(STATS_STORE_NAME).put({
+        key: DAYS_BACKFILL_STATE_KEY,
+        state,
+      });
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  private static aggregateDaysForEvents(
+    events: CollectionEvent[],
+  ): AggregateDay[] {
+    const days = new Map<string, AggregateDay>();
+
+    for (const event of events) {
+      if (event.type !== "navigation") continue;
+      const data = event.data as NavigationEventData;
+      if (data.event !== "focus") continue;
+
+      const domain = event.domain || extractDomain(event.meta?.url);
+      if (!domain) continue;
+      const dayKey = localDayKey(event.ts, event.meta.tz);
+      const key = `${domain}\n${dayKey}`;
+      const existing = days.get(key);
+      if (existing) {
+        existing.firstVisitTs = Math.min(existing.firstVisitTs, event.ts);
+        existing.lastVisitTs = Math.max(existing.lastVisitTs, event.ts);
+      } else {
+        days.set(key, {
+          domain,
+          localDayKey: dayKey,
+          firstVisitTs: event.ts,
+          lastVisitTs: event.ts,
+        });
+      }
+    }
+
+    return [...days.values()];
+  }
+
+  private async upsertAggregateDays(
+    events: CollectionEvent[],
+  ): Promise<void> {
+    const days = LocalEventStore.aggregateDaysForEvents(events);
+    if (days.length === 0 || !this.db) return;
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        [AGGREGATE_DAYS_STORE_NAME, STATS_STORE_NAME],
+        "readwrite",
+      );
+      const daysStore = transaction.objectStore(AGGREGATE_DAYS_STORE_NAME);
+      const statsStore = transaction.objectStore(STATS_STORE_NAME);
+      const newDaysByDomain = new Map<string, number>();
+      let pendingDayReads = days.length;
+
+      const updateActiveDayCounts = () => {
+        for (const [domain, count] of newDaysByDomain) {
+          const request = statsStore.get(domainStatsKey(domain));
+          request.onsuccess = () => {
+            const aggregate = request.result as
+              | DomainStatsAggregate
+              | undefined;
+            if (!aggregate) return;
+            aggregate.activeDayCount =
+              (aggregate.activeDayCount ?? 0) + count;
+            statsStore.put(aggregate);
+          };
+        }
+      };
+
+      for (const day of days) {
+        const request = daysStore.get([day.domain, day.localDayKey]);
+        request.onsuccess = () => {
+          const existing = request.result as AggregateDay | undefined;
+          if (existing) {
+            daysStore.put({
+              ...existing,
+              firstVisitTs: Math.min(existing.firstVisitTs, day.firstVisitTs),
+              lastVisitTs: Math.max(existing.lastVisitTs, day.lastVisitTs),
+            } satisfies AggregateDay);
+          } else {
+            daysStore.put(day);
+            newDaysByDomain.set(
+              day.domain,
+              (newDaysByDomain.get(day.domain) ?? 0) + 1,
+            );
+          }
+
+          pendingDayReads--;
+          if (pendingDayReads === 0) updateActiveDayCounts();
+        };
+      }
+
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+  }
+
+  private async rebuildAggregateDays(): Promise<void> {
+    if (!this.db) return;
+    await this.writeDaysBackfillState("running");
+
+    const days = await new Promise<AggregateDay[]>((resolve, reject) => {
+      const transaction = this.db!.transaction([STORE_NAME], "readonly");
+      const index = transaction.objectStore(STORE_NAME).index("type");
+      const request = index.openCursor(IDBKeyRange.only("navigation"));
+      const aggregated = new Map<string, AggregateDay>();
+
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          resolve([...aggregated.values()]);
+          return;
+        }
+
+        const event = toCollectionEvent(
+          cursor.value as StoredCollectionEvent,
+        );
+        for (const day of LocalEventStore.aggregateDaysForEvents([event])) {
+          const key = `${day.domain}\n${day.localDayKey}`;
+          const existing = aggregated.get(key);
+          if (existing) {
+            existing.firstVisitTs = Math.min(
+              existing.firstVisitTs,
+              day.firstVisitTs,
+            );
+            existing.lastVisitTs = Math.max(
+              existing.lastVisitTs,
+              day.lastVisitTs,
+            );
+          } else {
+            aggregated.set(key, day);
+          }
+        }
+        cursor.continue();
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    const counts = new Map<string, number>();
+    for (const day of days) {
+      counts.set(day.domain, (counts.get(day.domain) ?? 0) + 1);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = this.db!.transaction(
+        [AGGREGATE_DAYS_STORE_NAME, STATS_STORE_NAME],
+        "readwrite",
+      );
+      transaction.objectStore(AGGREGATE_DAYS_STORE_NAME).clear();
+      const request = transaction.objectStore(STATS_STORE_NAME).openCursor();
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) return;
+        const aggregate = cursor.value as DomainStatsAggregate;
+        if (aggregate.domain && !aggregate.key.includes("::")) {
+          aggregate.activeDayCount = counts.get(aggregate.domain) ?? 0;
+          cursor.update(aggregate);
+        }
+        cursor.continue();
+      };
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+    });
+
+    for (let index = 0; index < days.length; index += 1_000) {
+      const batch = days.slice(index, index + 1_000);
+      await new Promise<void>((resolve, reject) => {
+        const transaction = this.db!.transaction(
+          [AGGREGATE_DAYS_STORE_NAME],
+          "readwrite",
+        );
+        const store = transaction.objectStore(AGGREGATE_DAYS_STORE_NAME);
+        for (const day of batch) store.put(day);
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      });
+    }
+  }
+
   private async canUpdateStatsIncrementally(): Promise<boolean> {
     if (this.statsBackfillComplete) return true;
     if (this.statsBackfillPromise) return false;
@@ -527,7 +811,7 @@ export class LocalEventStore {
       const eventStore = transaction.objectStore(STORE_NAME);
       const statsStore = transaction.objectStore(STATS_STORE_NAME);
       const eventCountRequest = eventStore.count();
-      const statsCountRequest = statsStore.count();
+      const statsCursorRequest = statsStore.openCursor();
       const stateRequest = statsStore.get(STATS_BACKFILL_STATE_KEY);
       let eventCount = 0;
       let statsCount = 0;
@@ -551,8 +835,14 @@ export class LocalEventStore {
         eventCount = eventCountRequest.result;
         complete();
       };
-      statsCountRequest.onsuccess = () => {
-        statsCount = statsCountRequest.result;
+      statsCursorRequest.onsuccess = () => {
+        const cursor = statsCursorRequest.result;
+        if (cursor) {
+          const value = cursor.value as Partial<DomainStatsAggregate>;
+          if (typeof value.domain === "string") statsCount++;
+          cursor.continue();
+          return;
+        }
         complete();
       };
       stateRequest.onsuccess = () => {
@@ -566,7 +856,7 @@ export class LocalEventStore {
         complete();
       };
       eventCountRequest.onerror = () => reject(eventCountRequest.error);
-      statsCountRequest.onerror = () => reject(statsCountRequest.error);
+      statsCursorRequest.onerror = () => reject(statsCursorRequest.error);
       stateRequest.onerror = () => reject(stateRequest.error);
       transaction.onerror = () => reject(transaction.error);
     });
@@ -636,7 +926,7 @@ export class LocalEventStore {
     }>((resolve, reject) => {
       const tx = this.db!.transaction([STATS_STORE_NAME], "readonly");
       const store = tx.objectStore(STATS_STORE_NAME);
-      const countReq = store.count();
+      const countReq = store.openCursor();
       const stateReq = store.get(STATS_BACKFILL_STATE_KEY);
       let statsCount = 0;
       let state: StatsBackfillState | null = null;
@@ -649,7 +939,13 @@ export class LocalEventStore {
       };
 
       countReq.onsuccess = () => {
-        statsCount = countReq.result;
+        const cursor = countReq.result;
+        if (cursor) {
+          const value = cursor.value as Partial<DomainStatsAggregate>;
+          if (typeof value.domain === "string") statsCount++;
+          cursor.continue();
+          return;
+        }
         complete();
       };
       stateReq.onsuccess = () => {
@@ -1089,11 +1385,13 @@ export class LocalEventStore {
       totalTimeMs: number;
       uniquePageCount: number;
       sessionCount: number;
+      activeDayCount: number;
       eventCounts: Record<string, number>;
     }>
   > {
     await this.ensureInitialized();
     await this.ensureSessionStatsBackfilled();
+    await this.ensureAggregateDaysBackfilled();
 
     return new Promise((resolve, reject) => {
       if (!this.db) {
@@ -1112,6 +1410,7 @@ export class LocalEventStore {
         totalTimeMs: number;
         uniquePageCount: number;
         sessionCount: number;
+        activeDayCount: number;
         eventCounts: Record<string, number>;
       }> = [];
 
@@ -1138,6 +1437,7 @@ export class LocalEventStore {
               totalTimeMs: aggregate.totalTimeMs,
               uniquePageCount: aggregate.uniqueUrlCount,
               sessionCount: aggregate.sessionCount,
+              activeDayCount: aggregate.activeDayCount ?? 0,
               eventCounts,
             });
           }
@@ -1150,6 +1450,48 @@ export class LocalEventStore {
       };
 
       request.onerror = () => reject(request.error);
+    });
+  }
+
+  async getDomainDayHistory(domains: string[]): Promise<AggregateDay[]> {
+    await this.ensureInitialized();
+    await this.ensureAggregateDaysBackfilled();
+
+    const uniqueDomains = [...new Set(domains)].filter(Boolean);
+    if (uniqueDomains.length === 0) return [];
+
+    return new Promise((resolve, reject) => {
+      if (!this.db) {
+        reject(new Error("Database not initialized"));
+        return;
+      }
+
+      const transaction = this.db.transaction(
+        [AGGREGATE_DAYS_STORE_NAME],
+        "readonly",
+      );
+      const store = transaction.objectStore(AGGREGATE_DAYS_STORE_NAME);
+      const days: AggregateDay[] = [];
+      let pending = uniqueDomains.length;
+
+      for (const domain of uniqueDomains) {
+        const request = store.getAll(
+          IDBKeyRange.bound([domain, ""], [domain, "\uffff"]),
+        );
+        request.onsuccess = () => {
+          days.push(...(request.result as AggregateDay[]));
+          pending--;
+          if (pending === 0) {
+            days.sort(
+              (a, b) =>
+                a.domain.localeCompare(b.domain) ||
+                a.localDayKey.localeCompare(b.localDayKey),
+            );
+            resolve(days);
+          }
+        };
+        request.onerror = () => reject(request.error);
+      }
     });
   }
 
@@ -1333,6 +1675,7 @@ export class LocalEventStore {
     }
 
     const sampleIntervalMs = 5 * 60_000;
+    const activityWindowMs = 30_000;
     return new Promise((resolve, reject) => {
       if (!this.db) {
         reject(new Error("Database not initialized"));
@@ -1346,13 +1689,35 @@ export class LocalEventStore {
       const request = tsIndex.openCursor(range);
       const events: CollectionEvent[] = [];
       const sampledCursorWindows = new Set<string>();
+      const activityWindowsByUrl = new Map<string, Set<number>>();
       let previousCursorEvent: CollectionEvent | null = null;
       let cursorDistancePx = 0;
+
+      const recordActivity = (event: CollectionEvent) => {
+        const url = event.normalizedUrl ?? normalizeUrl(event.meta.url);
+        if (!url) return;
+        const windowStart =
+          startTs +
+          Math.floor((event.ts - startTs) / activityWindowMs) *
+            activityWindowMs;
+        const windows = activityWindowsByUrl.get(url) ?? new Set<number>();
+        windows.add(windowStart);
+        activityWindowsByUrl.set(url, windows);
+      };
 
       request.onsuccess = () => {
         const cursor = request.result;
         if (!cursor) {
-          resolve({ events, cursorDistancePx });
+          resolve({
+            events,
+            cursorDistancePx,
+            activity: [...activityWindowsByUrl].map(
+              ([url, windowStarts]) => ({
+                url,
+                windowStarts: [...windowStarts].sort((a, b) => a - b),
+              }),
+            ),
+          });
           return;
         }
 
@@ -1361,8 +1726,18 @@ export class LocalEventStore {
 
         if (event.type === "navigation") {
           events.push(event);
+          const data = event.data as NavigationEventData;
+          if (data.event === "popstate") recordActivity(event);
         } else if (event.type === "cursor") {
           const data = event.data as CursorEventData;
+          if (
+            data.event === "move" ||
+            data.event === "click" ||
+            data.event === "hold" ||
+            data.event === undefined
+          ) {
+            recordActivity(event);
+          }
           if (data.event === "move" || data.event === undefined) {
             if (previousCursorEvent) {
               const previous = previousCursorEvent.data as CursorEventData;
@@ -1396,6 +1771,17 @@ export class LocalEventStore {
             sampledCursorWindows.add(sampleKey);
             events.push(event);
           }
+        } else if (event.type === "viewport") {
+          const data = event.data as { event?: unknown; scrollDistancePx?: unknown };
+          if (
+            data.event === "scroll" &&
+            typeof data.scrollDistancePx === "number" &&
+            data.scrollDistancePx > 0
+          ) {
+            recordActivity(event);
+          }
+        } else if (event.type === "keyboard") {
+          recordActivity(event);
         }
 
         cursor.continue();
@@ -1711,6 +2097,12 @@ export class LocalEventStore {
       } catch (e) {
         console.error("[LocalEventStore] Failed to update domain stats:", e);
       }
+
+      try {
+        await this.upsertAggregateDays(eventsForStats);
+      } catch (e) {
+        console.error("[LocalEventStore] Failed to update active days:", e);
+      }
     }
   }
 
@@ -1719,6 +2111,9 @@ export class LocalEventStore {
     await this.ensureSessionStatsBackfilled();
     await this.addEvents(events);
     await this.rebuildSessionStats();
+    await this.rebuildAggregateDays();
+    await this.writeDaysBackfillState("complete");
+    this.daysBackfillComplete = true;
     await this.writeStatsBackfillState("complete");
     this.statsBackfillComplete = true;
   }
@@ -1744,6 +2139,7 @@ export class LocalEventStore {
       firstVisit: 0,
       lastVisit: 0,
       uniqueUrlCount: 0,
+      activeDayCount: 0,
     };
   }
 
@@ -1998,16 +2394,27 @@ export class LocalEventStore {
       }
 
       const transaction = this.db.transaction(
-        [STORE_NAME, STATS_STORE_NAME, AGGREGATE_URLS_STORE_NAME],
+        [
+          STORE_NAME,
+          STATS_STORE_NAME,
+          AGGREGATE_URLS_STORE_NAME,
+          AGGREGATE_DAYS_STORE_NAME,
+        ],
         "readwrite",
       );
       const evtStore = transaction.objectStore(STORE_NAME);
       const statsStore = transaction.objectStore(STATS_STORE_NAME);
       const aggregateUrlsStore = transaction.objectStore(AGGREGATE_URLS_STORE_NAME);
+      const aggregateDaysStore = transaction.objectStore(AGGREGATE_DAYS_STORE_NAME);
       evtStore.clear();
       statsStore.clear();
       aggregateUrlsStore.clear();
-      transaction.oncomplete = () => resolve();
+      aggregateDaysStore.clear();
+      transaction.oncomplete = () => {
+        this.statsBackfillComplete = false;
+        this.daysBackfillComplete = false;
+        resolve();
+      };
       transaction.onerror = () => reject(transaction.error);
     });
   }

--- a/extension/src/utils/portraitDay.test.ts
+++ b/extension/src/utils/portraitDay.test.ts
@@ -1,0 +1,22 @@
+// ABOUTME: Verifies walking-record portrait links preserve valid local calendar days.
+// ABOUTME: Rejects malformed or impossible day filters before portrait data loads.
+
+import { describe, expect, it } from "vitest";
+import { portraitDayFromSearch, portraitDayPath } from "./portraitDay";
+
+describe("portrait day links", () => {
+  it("round-trips a valid local day", () => {
+    const path = portraitDayPath("2026-08-05");
+
+    expect(path).toBe("portrait.html?day=2026-08-05");
+    expect(portraitDayFromSearch(path.slice(path.indexOf("?")))).toBe(
+      "2026-08-05",
+    );
+  });
+
+  it("rejects malformed and impossible days", () => {
+    expect(portraitDayFromSearch("?day=2026-02-30")).toBeNull();
+    expect(portraitDayFromSearch("?day=august-5")).toBeNull();
+    expect(portraitDayFromSearch("")).toBeNull();
+  });
+});

--- a/extension/src/utils/portraitDay.ts
+++ b/extension/src/utils/portraitDay.ts
@@ -1,0 +1,19 @@
+// ABOUTME: Builds and reads the day filter shared by walking-record and portrait pages.
+// ABOUTME: Accepts only real local calendar dates in YYYY-MM-DD form.
+
+export function portraitDayPath(day: string): string {
+  return `portrait.html?${new URLSearchParams({ day }).toString()}`;
+}
+
+export function portraitDayFromSearch(search: string): string | null {
+  const day = new URLSearchParams(search).get("day");
+  if (!day || !/^\d{4}-\d{2}-\d{2}$/.test(day)) return null;
+
+  const date = new Date(`${day}T00:00:00`);
+  const validDay = [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+  return validDay === day ? day : null;
+}


### PR DESCRIPTION
## Summary

- Replace the walking-record page with a period-aware view for week, month, and year.
- Show a stacked breakdown of the five sites that held the most browsing time, plus the remaining time.
- Rank notable explorations by active cursor, scroll, and keyboard use, time spent, site rarity, and whether the visit was new or repeated.
- Let people expand the exploration list when more than three entries qualify.
- Identify regularly visited places from distinct active days across multiple weeks instead of raw visit counts.
- Show combined daily cursor portraits that open the matching day in the full portrait page.
- Replay real cursor movement for the selected period in a compact animated landscape.
- Show measured loading progress and moving cursors while the extension gathers each period.
- Close local database connections during extension upgrades and show reload guidance instead of waiting indefinitely when an older process blocks an upgrade.

## Heuristics

Exploration ranking gives 60% of its weight to browsing activity, 25% to site rarity, and 15% to discovery or return visits. Within the activity component, active 30-second windows provide 80% of the score and elapsed focus time provides 20%. If the installed data predates activity-window collection, elapsed focus time is used by itself.

A departure must include at least one active 30-second window or one minute of completed browsing time. Navigation-only departures are omitted.

A regularly visited place must appear on at least five distinct days, across at least three weeks and a 21-day span. It must also have been absent for at least 14 days before the selected period. The page shows at most five places and states the evidence directly.

## Storage and privacy

The extension stores one small record per domain and local calendar day. Repeated focus events on the same day update that record instead of adding rows. Existing local history is backfilled once after the database upgrade.

Favicons come from navigation metadata already stored locally. The extension does not send browsing-history domains to a third-party favicon service.

## Validation

- `bun run build-packages`
- `bun run --cwd extension test --run` (91 files, 562 tests)
- `bun run --cwd extension build`
- `git diff --check`
- Live review in the loaded unpacked extension with real local browsing data throughout development

## Visual verification

The walking record was reviewed in the loaded unpacked extension against real local data throughout development. Those screenshots contain private browsing-history domains, so they are not attached to the public PR. Automated browser control cannot open `chrome-extension://` pages in the current environment.