### PR TITLE
Improve Internet Commute on mobile

### DIFF
--- a/.changeset/quiet-seated-cursors.md
+++ b/.changeset/quiet-seated-cursors.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Reapply cursor visibility filters immediately when their configuration changes so custom presence views can replace an existing cursor without waiting for that person to move again.

--- a/extension/src/__tests__/ExtensionPageNav.test.tsx
+++ b/extension/src/__tests__/ExtensionPageNav.test.tsx
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import browser from "webextension-polyfill";
 import { ExtensionPageNav } from "../components/ExtensionPageNav";
 
+vi.mock("../components/ExtensionPageNav.scss", () => ({}));
+
 async function renderNavigation(currentPage: "portrait" | "time") {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -58,19 +60,15 @@ describe("ExtensionPageNav", () => {
     }
   });
 
-  it("shows scraps when internal development features are enabled", async () => {
+  it("does not release scraps through internal development mode", async () => {
     vi.mocked(browser.storage.local.get).mockResolvedValue({
       internalDevFeaturesEnabled: true,
     });
     const { container, root } = await renderNavigation("portrait");
 
     try {
-      expect(container.textContent).toContain("scraps");
-      expect(
-        container.querySelector(
-          'a[href="chrome-extension://test/scraps.html"]',
-        ),
-      ).not.toBeNull();
+      expect(container.textContent).not.toContain("scraps");
+      expect(browser.storage.local.get).not.toHaveBeenCalled();
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/components/ExtensionPageNav.tsx
+++ b/extension/src/components/ExtensionPageNav.tsx
@@ -1,11 +1,11 @@
 // ABOUTME: Shared navigation for the extension's standalone portrait and history pages.
 // ABOUTME: Keeps page links consistent while hiding unfinished surfaces behind their feature gate.
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import browser from "webextension-polyfill";
 import "@fontsource/martian-mono/latin-400.css";
 import "@fontsource/source-serif-4/latin-200-italic.css";
-import { FLAGS } from "../flags";
+import { isFeatureReleased } from "./ReleasedFeature";
 import "./ExtensionPageNav.scss";
 
 export type ExtensionPageId = "portrait" | "time" | "walking-record" | "scraps";
@@ -21,43 +21,13 @@ const PAGE_LINKS: Array<{
   { id: "scraps", label: "scraps", path: "scraps.html" },
 ];
 
-function useScrapsNavigationEnabled(): boolean {
-  const [internalDevFeaturesEnabled, setInternalDevFeaturesEnabled] =
-    useState(false);
-
-  useEffect(() => {
-    if (FLAGS.SCRAPS) return;
-
-    let active = true;
-    browser.storage.local
-      .get("internalDevFeaturesEnabled")
-      .then((result) => {
-        if (active) {
-          setInternalDevFeaturesEnabled(
-            result.internalDevFeaturesEnabled === true,
-          );
-        }
-      })
-      .catch(() => {
-        if (active) setInternalDevFeaturesEnabled(false);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  return FLAGS.SCRAPS || internalDevFeaturesEnabled;
-}
-
 export function ExtensionPageNav({
   currentPage,
 }: {
   currentPage: ExtensionPageId;
 }) {
-  const scrapsEnabled = useScrapsNavigationEnabled();
   const visibleLinks = PAGE_LINKS.filter(
-    (link) => link.id !== "scraps" || scrapsEnabled,
+    (link) => link.id !== "scraps" || isFeatureReleased("SCRAPS"),
   );
 
   return (

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -13,6 +13,7 @@ import { FLAGS } from "../flags";
 import { PostcardStack } from "../announcements/PostcardStack";
 import { FeedbackForm } from "./FeedbackForm";
 import { SiteVisibilityNotice } from "./SiteVisibilityNotice";
+import { ReleasedFeature } from "./ReleasedFeature";
 
 interface Props {
   playerIdentity: PlayerIdentity | null;
@@ -163,38 +164,40 @@ export function InternetPortraitHome({
             onShowSatchel={onShowSatchel}
           />
         )}
-        {onViewCommute && (
-          <button
-            className="commute-entry"
-            onClick={onViewCommute}
-            aria-label={
-              commuteIsOpen
-                ? "Return to the Internet Commute"
-                : "Board the Internet Commute"
-            }
-          >
-            <span className="commute-entry__route" aria-hidden="true">
-              <span className="commute-entry__stop commute-entry__stop--blue" />
-              <span className="commute-entry__stop commute-entry__stop--gold" />
-              <span className="commute-entry__stop commute-entry__stop--rust" />
-            </span>
-            <span className="commute-entry__copy">
-              <span className="commute-entry__eyebrow">
-                LINE 1 · BOARDING NOW
+        <ReleasedFeature feature="COMMUTE">
+          {onViewCommute && (
+            <button
+              className="commute-entry"
+              onClick={onViewCommute}
+              aria-label={
+                commuteIsOpen
+                  ? "Return to the Internet Commute"
+                  : "Board the Internet Commute"
+              }
+            >
+              <span className="commute-entry__route" aria-hidden="true">
+                <span className="commute-entry__stop commute-entry__stop--blue" />
+                <span className="commute-entry__stop commute-entry__stop--gold" />
+                <span className="commute-entry__stop commute-entry__stop--rust" />
               </span>
-              <strong>
-                {commuteIsOpen
-                  ? "Return to the internet commute"
-                  : "Board the internet commute"}
-              </strong>
-              <span>A slow train through pages people found lately.</span>
-            </span>
-            <span className="commute-entry__door" aria-hidden="true">
-              <span />
-              <span />
-            </span>
-          </button>
-        )}
+              <span className="commute-entry__copy">
+                <span className="commute-entry__eyebrow">
+                  LINE 1 · BOARDING NOW
+                </span>
+                <strong>
+                  {commuteIsOpen
+                    ? "Return to the internet commute"
+                    : "Board the internet commute"}
+                </strong>
+                <span>A slow train through pages people found lately.</span>
+              </span>
+              <span className="commute-entry__door" aria-hidden="true">
+                <span />
+                <span />
+              </span>
+            </button>
+          )}
+        </ReleasedFeature>
         <section className="collection-status">
           <div className="collection-status__header-row">
             <h3>Your Collection Status</h3>
@@ -289,17 +292,19 @@ export function InternetPortraitHome({
             >
               time
             </button>
-            {onViewScraps && (
-              <button
-                className="portrait-home__nav-link"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onViewScraps();
-                }}
-              >
-                scraps
-              </button>
-            )}
+            <ReleasedFeature feature="SCRAPS">
+              {onViewScraps && (
+                <button
+                  className="portrait-home__nav-link"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onViewScraps();
+                  }}
+                >
+                  scraps
+                </button>
+              )}
+            </ReleasedFeature>
             <button
               className="portrait-home__nav-link"
               onClick={(e) => {
@@ -310,14 +315,16 @@ export function InternetPortraitHome({
               changelog
             </button>
           </div>
-          {onViewBagSettings && (
-            <button
-              className="portrait-home__nav-link portrait-home__bag-settings-link"
-              onClick={onViewBagSettings}
-            >
-              bag settings
-            </button>
-          )}
+          <ReleasedFeature feature="BAG_SETTINGS">
+            {onViewBagSettings && (
+              <button
+                className="portrait-home__nav-link portrait-home__bag-settings-link"
+                onClick={onViewBagSettings}
+              >
+                bag settings
+              </button>
+            )}
+          </ReleasedFeature>
         </section>
       </main>
 

--- a/extension/src/components/ReleasedFeature.test.tsx
+++ b/extension/src/components/ReleasedFeature.test.tsx
@@ -1,0 +1,60 @@
+// ABOUTME: Verifies user-facing feature releases follow committed feature flags.
+// ABOUTME: Covers both hidden experiments and features enabled for general use.
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ReleasedFeature } from "./ReleasedFeature";
+
+function renderFeature(feature: "COMMUTE" | "INVENTORY") {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <ReleasedFeature feature={feature}>
+        <span>feature content</span>
+      </ReleasedFeature>,
+    );
+  });
+
+  return { container, root };
+}
+
+function cleanup(root: Root, container: HTMLDivElement) {
+  act(() => root.unmount());
+  container.remove();
+}
+
+describe("ReleasedFeature", () => {
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("hides a feature whose release flag is disabled", () => {
+    const { container, root } = renderFeature("COMMUTE");
+
+    try {
+      expect(container.textContent).toBe("");
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("renders a feature whose release flag is enabled", () => {
+    const { container, root } = renderFeature("INVENTORY");
+
+    try {
+      expect(container.textContent).toBe("feature content");
+    } finally {
+      cleanup(root, container);
+    }
+  });
+});

--- a/extension/src/components/ReleasedFeature.tsx
+++ b/extension/src/components/ReleasedFeature.tsx
@@ -1,0 +1,21 @@
+// ABOUTME: Defines the committed release boundary for user-facing extension features.
+// ABOUTME: Prevents internal development settings from exposing unfinished navigation.
+
+import type { ReactNode } from "react";
+import { FLAGS } from "../flags";
+
+export type FeatureFlag = keyof typeof FLAGS;
+
+export function isFeatureReleased(feature: FeatureFlag): boolean {
+  return FLAGS[feature];
+}
+
+export function ReleasedFeature({
+  feature,
+  children,
+}: {
+  feature: FeatureFlag;
+  children: ReactNode;
+}) {
+  return isFeatureReleased(feature) ? children : null;
+}

--- a/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
@@ -1,0 +1,124 @@
+// ABOUTME: Verifies mobile commute boarding, joystick, action, and fullscreen controls.
+// ABOUTME: Covers the screen-space input shell independently from train geometry.
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CommuteMobileControls } from "./CommuteMobileControls";
+
+function renderControls(
+  props: React.ComponentProps<typeof CommuteMobileControls>,
+): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<CommuteMobileControls {...props} />));
+  return { container, root };
+}
+
+describe("CommuteMobileControls", () => {
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(document.documentElement, "requestFullscreen", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("boards from a user gesture and requests landscape fullscreen", async () => {
+    const onBoard = vi.fn();
+    const { container, root } = renderControls({
+      action: null,
+      boarded: false,
+      onBoard,
+      onMove: vi.fn(),
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-board button")!
+        .click();
+      await Promise.resolve();
+    });
+
+    expect(onBoard).toHaveBeenCalledOnce();
+    expect(document.documentElement.requestFullscreen).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+
+  it("publishes normalized joystick movement and resets on release", () => {
+    const onMove = vi.fn();
+    const { container, root } = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove,
+    });
+    const joystick = container.querySelector<HTMLDivElement>(
+      ".commute-mobile-joystick",
+    )!;
+    Object.assign(joystick, {
+      setPointerCapture: vi.fn(),
+      getBoundingClientRect: () => ({
+        top: 0,
+        left: 0,
+        right: 112,
+        bottom: 112,
+        width: 112,
+        height: 112,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    act(() => {
+      joystick.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          clientX: 90,
+          clientY: 56,
+          pointerId: 1,
+        }),
+      );
+    });
+    expect(onMove).toHaveBeenLastCalledWith({ x: 1, y: 0 });
+
+    act(() => {
+      joystick.dispatchEvent(
+        new PointerEvent("pointerup", { bubbles: true, pointerId: 1 }),
+      );
+    });
+    expect(onMove).toHaveBeenLastCalledWith({ x: 0, y: 0 });
+    act(() => root.unmount());
+  });
+
+  it("shows and invokes the contextual train action", () => {
+    const onSelect = vi.fn();
+    const { container, root } = renderControls({
+      action: {
+        label: "sit down",
+        tone: "sit",
+        onSelect,
+      },
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-action")!
+        .click();
+    });
+    expect(onSelect).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+});

--- a/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
@@ -4,7 +4,10 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CommuteMobileControls } from "./CommuteMobileControls";
+import {
+  CommuteMobileControls,
+  keepMobileCursorOnAvatar,
+} from "./CommuteMobileControls";
 
 function renderControls(
   props: React.ComponentProps<typeof CommuteMobileControls>,
@@ -143,6 +146,32 @@ describe("CommuteMobileControls", () => {
         .click();
     });
     expect(onSelect).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+
+  it("keeps boarded pointer movement from replacing the avatar cursor", () => {
+    const documentMove = vi.fn();
+    document.addEventListener("mousemove", documentMove);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <main onMouseMove={keepMobileCursorOnAvatar}>
+          <span data-testid="train-floor" />
+        </main>,
+      );
+    });
+
+    act(() => {
+      container
+        .querySelector<HTMLElement>('[data-testid="train-floor"]')!
+        .dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    });
+
+    document.removeEventListener("mousemove", documentMove);
+    expect(documentMove).not.toHaveBeenCalled();
     act(() => root.unmount());
   });
 });

--- a/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
@@ -25,11 +25,13 @@ describe("CommuteMobileControls", () => {
       configurable: true,
       value: vi.fn().mockResolvedValue(undefined),
     });
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: true })));
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("boards from a user gesture and requests landscape fullscreen", async () => {
@@ -50,6 +52,28 @@ describe("CommuteMobileControls", () => {
 
     expect(onBoard).toHaveBeenCalledOnce();
     expect(document.documentElement.requestFullscreen).toHaveBeenCalledOnce();
+    act(() => root.unmount());
+  });
+
+  it("boards without forcing fullscreen in a precise-pointer preview", async () => {
+    vi.stubGlobal("matchMedia", vi.fn(() => ({ matches: false })));
+    const onBoard = vi.fn();
+    const { container, root } = renderControls({
+      action: null,
+      boarded: false,
+      onBoard,
+      onMove: vi.fn(),
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-board button")!
+        .click();
+      await Promise.resolve();
+    });
+
+    expect(onBoard).toHaveBeenCalledOnce();
+    expect(document.documentElement.requestFullscreen).not.toHaveBeenCalled();
     act(() => root.unmount());
   });
 

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -4,6 +4,7 @@
 import {
   type CSSProperties,
   type PointerEvent as ReactPointerEvent,
+  type SyntheticEvent,
   useEffect,
   useRef,
   useState,
@@ -25,6 +26,10 @@ interface CommuteMobileControlsProps {
   boarded: boolean;
   onBoard: () => void;
   onMove: (vector: CommutePoint) => void;
+}
+
+export function keepMobileCursorOnAvatar(event: SyntheticEvent) {
+  event.stopPropagation();
 }
 
 function shouldUseTouchFullscreen(): boolean {

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -1,0 +1,81 @@
+// ABOUTME: Provides the mobile orientation prompt and fullscreen control for Internet Commute.
+// ABOUTME: Treats landscape locking as an optional enhancement when the browser supports it.
+
+import { useEffect, useState } from "react";
+
+interface LandscapeOrientation extends ScreenOrientation {
+  lock?: (orientation: "landscape") => Promise<void>;
+}
+
+async function enterLandscapeFullscreen(): Promise<void> {
+  const root = document.documentElement;
+  if (!document.fullscreenElement && root.requestFullscreen) {
+    await root.requestFullscreen({ navigationUI: "hide" });
+  }
+
+  const orientation = window.screen.orientation as LandscapeOrientation;
+  if (!orientation?.lock) return;
+
+  try {
+    await orientation.lock("landscape");
+  } catch {
+    // Orientation locking is optional and commonly rejected outside mobile browsers.
+  }
+}
+
+export function CommuteMobileControls() {
+  const [canFullscreen, setCanFullscreen] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const updateFullscreenState = () => {
+      setIsFullscreen(document.fullscreenElement !== null);
+    };
+
+    setCanFullscreen(
+      typeof document.documentElement.requestFullscreen === "function",
+    );
+    updateFullscreenState();
+    document.addEventListener("fullscreenchange", updateFullscreenState);
+    return () => {
+      document.removeEventListener("fullscreenchange", updateFullscreenState);
+    };
+  }, []);
+
+  const requestFullscreen = async () => {
+    try {
+      await enterLandscapeFullscreen();
+    } catch {
+      // The landscape prompt remains useful when fullscreen is unavailable or denied.
+    }
+  };
+
+  return (
+    <>
+      <aside className="commute-mobile-orientation">
+        <span className="commute-mobile-orientation__phone" aria-hidden="true">
+          <span />
+        </span>
+        <strong>turn your phone sideways</strong>
+        <p>the whole carriage fits better in landscape</p>
+        {canFullscreen ? (
+          <button type="button" onClick={() => void requestFullscreen()}>
+            enter fullscreen
+          </button>
+        ) : null}
+      </aside>
+
+      {canFullscreen && !isFullscreen ? (
+        <button
+          className="commute-mobile-fullscreen"
+          type="button"
+          onClick={() => void requestFullscreen()}
+          aria-label="Enter fullscreen"
+          title="Enter fullscreen"
+        >
+          <span aria-hidden="true">⛶</span>
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -27,6 +27,13 @@ interface CommuteMobileControlsProps {
   onMove: (vector: CommutePoint) => void;
 }
 
+function shouldUseTouchFullscreen(): boolean {
+  return (
+    typeof window.matchMedia !== "function" ||
+    window.matchMedia("(hover: none) and (pointer: coarse)").matches
+  );
+}
+
 async function enterLandscapeFullscreen(): Promise<void> {
   const root = document.documentElement;
   if (!document.fullscreenElement && root.requestFullscreen) {
@@ -69,7 +76,8 @@ export function CommuteMobileControls({
     };
 
     setCanFullscreen(
-      typeof document.documentElement.requestFullscreen === "function",
+      shouldUseTouchFullscreen() &&
+        typeof document.documentElement.requestFullscreen === "function",
     );
     updateFullscreenState();
     document.addEventListener("fullscreenchange", updateFullscreenState);
@@ -102,6 +110,8 @@ export function CommuteMobileControls({
 
   const board = () => {
     onBoard();
+    if (!shouldUseTouchFullscreen()) return;
+
     void enterLandscapeFullscreen().catch(() => {
       // Boarding remains available when fullscreen is unavailable or denied.
     });

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -1,10 +1,30 @@
-// ABOUTME: Provides the mobile orientation prompt and fullscreen control for Internet Commute.
-// ABOUTME: Treats landscape locking as an optional enhancement when the browser supports it.
+// ABOUTME: Provides boarding, orientation, fullscreen, and joystick controls for mobile Commute.
+// ABOUTME: Keeps screen-space controls outside the scaled train artwork.
 
-import { useEffect, useState } from "react";
+import {
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { CommutePoint } from "./commuteMobile";
 
 interface LandscapeOrientation extends ScreenOrientation {
   lock?: (orientation: "landscape") => Promise<void>;
+}
+
+export type CommuteMobileAction = {
+  label: string;
+  tone: "sit" | "stand" | "exit";
+  onSelect: () => void;
+};
+
+interface CommuteMobileControlsProps {
+  action: CommuteMobileAction | null;
+  boarded: boolean;
+  onBoard: () => void;
+  onMove: (vector: CommutePoint) => void;
 }
 
 async function enterLandscapeFullscreen(): Promise<void> {
@@ -23,9 +43,25 @@ async function enterLandscapeFullscreen(): Promise<void> {
   }
 }
 
-export function CommuteMobileControls() {
+async function toggleFullscreen(): Promise<void> {
+  if (document.fullscreenElement) {
+    await document.exitFullscreen();
+    return;
+  }
+  await enterLandscapeFullscreen();
+}
+
+export function CommuteMobileControls({
+  action,
+  boarded,
+  onBoard,
+  onMove,
+}: CommuteMobileControlsProps) {
   const [canFullscreen, setCanFullscreen] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [knob, setKnob] = useState<CommutePoint>({ x: 0, y: 0 });
+  const joystickCenter = useRef<CommutePoint | null>(null);
+  const joystickActive = useRef(false);
 
   useEffect(() => {
     const updateFullscreenState = () => {
@@ -39,43 +75,125 @@ export function CommuteMobileControls() {
     document.addEventListener("fullscreenchange", updateFullscreenState);
     return () => {
       document.removeEventListener("fullscreenchange", updateFullscreenState);
+      onMove({ x: 0, y: 0 });
     };
-  }, []);
+  }, [onMove]);
 
-  const requestFullscreen = async () => {
-    try {
-      await enterLandscapeFullscreen();
-    } catch {
-      // The landscape prompt remains useful when fullscreen is unavailable or denied.
+  const updateJoystick = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!joystickActive.current || !joystickCenter.current) return;
+    let x = event.clientX - joystickCenter.current.x;
+    let y = event.clientY - joystickCenter.current.y;
+    const magnitude = Math.hypot(x, y);
+    const maximum = 34;
+    if (magnitude > maximum) {
+      x = (x / magnitude) * maximum;
+      y = (y / magnitude) * maximum;
     }
+    setKnob({ x, y });
+    onMove({ x: x / maximum, y: y / maximum });
+  };
+
+  const stopJoystick = () => {
+    joystickActive.current = false;
+    joystickCenter.current = null;
+    setKnob({ x: 0, y: 0 });
+    onMove({ x: 0, y: 0 });
+  };
+
+  const board = () => {
+    onBoard();
+    void enterLandscapeFullscreen().catch(() => {
+      // Boarding remains available when fullscreen is unavailable or denied.
+    });
   };
 
   return (
-    <>
-      <aside className="commute-mobile-orientation">
-        <span className="commute-mobile-orientation__phone" aria-hidden="true">
+    <div className="commute-mobile-controls">
+      <aside className="commute-mobile-rotate" aria-label="Rotate your phone">
+        <span className="commute-mobile-rotate__phone" aria-hidden>
           <span />
         </span>
-        <strong>turn your phone sideways</strong>
-        <p>the whole carriage fits better in landscape</p>
-        {canFullscreen ? (
-          <button type="button" onClick={() => void requestFullscreen()}>
-            enter fullscreen
-          </button>
-        ) : null}
+        <strong>rotate your phone</strong>
+        <p>the train runs sideways — turn to landscape to board</p>
       </aside>
 
-      {canFullscreen && !isFullscreen ? (
-        <button
-          className="commute-mobile-fullscreen"
-          type="button"
-          onClick={() => void requestFullscreen()}
-          aria-label="Enter fullscreen"
-          title="Enter fullscreen"
-        >
-          <span aria-hidden="true">⛶</span>
-        </button>
-      ) : null}
-    </>
+      {!boarded && (
+        <aside className="commute-mobile-board">
+          <span className="commute-mobile-board__wordmark">we were online</span>
+          <strong>internet commute</strong>
+          <p>
+            a slow train through the recent web — ride with the joystick, sit
+            anywhere, step off wherever it stops
+          </p>
+          <button type="button" onClick={board}>
+            tap to board
+          </button>
+          <small>GOES FULLSCREEN · BEST IN LANDSCAPE</small>
+        </aside>
+      )}
+
+      {boarded && (
+        <>
+          <span className="commute-mobile-wordmark">we were online</span>
+          {canFullscreen && (
+            <button
+              className="commute-mobile-fullscreen"
+              type="button"
+              onClick={() => void toggleFullscreen()}
+              aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+              title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 18 18"
+                fill="none"
+                aria-hidden
+              >
+                <path d="M2 6V2h4M12 2h4v4M16 12v4h-4M6 16H2v-4" />
+              </svg>
+            </button>
+          )}
+
+          <div
+            className="commute-mobile-joystick"
+            role="group"
+            aria-label="Move around the train"
+            onPointerDown={(event) => {
+              event.currentTarget.setPointerCapture(event.pointerId);
+              const bounds = event.currentTarget.getBoundingClientRect();
+              joystickCenter.current = {
+                x: bounds.left + bounds.width / 2,
+                y: bounds.top + bounds.height / 2,
+              };
+              joystickActive.current = true;
+              updateJoystick(event);
+            }}
+            onPointerMove={updateJoystick}
+            onPointerUp={stopJoystick}
+            onPointerCancel={stopJoystick}
+          >
+            <span
+              style={
+                {
+                  "--joystick-x": `${knob.x}px`,
+                  "--joystick-y": `${knob.y}px`,
+                } as CSSProperties
+              }
+            />
+          </div>
+
+          {action && (
+            <button
+              className={`commute-mobile-action commute-mobile-action--${action.tone}`}
+              type="button"
+              onClick={action.onSelect}
+            >
+              {action.label}
+            </button>
+          )}
+        </>
+      )}
+    </div>
   );
 }

--- a/extension/src/entrypoints/commute/CommuteStage.tsx
+++ b/extension/src/entrypoints/commute/CommuteStage.tsx
@@ -1,0 +1,51 @@
+// ABOUTME: Fits the authored Internet Commute carriage into the available mobile viewport.
+// ABOUTME: Preserves the desktop-size artwork while keeping surrounding status bars readable.
+
+import { type ReactNode, useEffect, useRef } from "react";
+
+interface CommuteStageProps {
+  children: ReactNode;
+}
+
+export function CommuteStage({ children }: CommuteStageProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    const stage = stageRef.current;
+    if (!viewport || !stage) return;
+
+    const fitStage = () => {
+      const scale = Math.min(
+        viewport.clientWidth / stage.offsetWidth,
+        viewport.clientHeight / stage.offsetHeight,
+        1,
+      );
+      stage.style.setProperty("--commute-stage-scale", String(scale));
+    };
+
+    fitStage();
+    window.addEventListener("resize", fitStage);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(fitStage);
+    resizeObserver?.observe(viewport);
+    resizeObserver?.observe(stage);
+
+    return () => {
+      window.removeEventListener("resize", fitStage);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="commute-stage-viewport" ref={viewportRef}>
+      <div className="commute-stage" ref={stageRef}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/commute/CommuteStage.tsx
+++ b/extension/src/entrypoints/commute/CommuteStage.tsx
@@ -17,10 +17,15 @@ export function CommuteStage({ children }: CommuteStageProps) {
     if (!viewport || !stage) return;
 
     const fitStage = () => {
-      const scale = Math.min(
-        viewport.clientWidth / stage.offsetWidth,
-        viewport.clientHeight / stage.offsetHeight,
-        1,
+      const horizontalBreathingRoom = 20;
+      const verticalBreathingRoom = 20;
+      const scale = Math.max(
+        0,
+        Math.min(
+          (viewport.clientWidth - horizontalBreathingRoom) / stage.offsetWidth,
+          (viewport.clientHeight - verticalBreathingRoom) / stage.offsetHeight,
+          1,
+        ),
       );
       stage.style.setProperty("--commute-stage-scale", String(scale));
     };

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -324,8 +324,13 @@ button {
   width: 1100px;
 }
 
-.commute-mobile-orientation,
-.commute-mobile-fullscreen {
+.commute-mobile-board,
+.commute-mobile-rotate,
+.commute-mobile-wordmark,
+.commute-mobile-fullscreen,
+.commute-mobile-joystick,
+.commute-mobile-action,
+.commute-mobile-avatar {
   display: none;
 }
 
@@ -1029,6 +1034,11 @@ button {
     outline: 2px solid $text;
     outline-offset: 2px;
   }
+
+  &--nearby {
+    outline: 2px dashed $accent-gold;
+    outline-offset: 2px;
+  }
 }
 
 .train-seat__prompt {
@@ -1125,7 +1135,8 @@ button {
   }
 }
 
-@media (max-width: 900px) and (orientation: portrait) {
+@media (max-width: 900px) and (orientation: portrait),
+  (hover: none) and (pointer: coarse) and (orientation: portrait) {
   html,
   body,
   #commute-root {
@@ -1148,7 +1159,7 @@ button {
     visibility: hidden;
   }
 
-  .commute-mobile-orientation {
+  .commute-mobile-rotate {
     position: fixed;
     inset: 0;
     z-index: 100;
@@ -1157,6 +1168,7 @@ button {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 14px;
     color: $text;
     background-color: $bg;
     background-image:
@@ -1173,78 +1185,40 @@ button {
     text-align: center;
 
     strong {
-      margin-top: 26px;
       font-family: $font-heading;
-      font-size: 25px;
+      font-size: 22px;
       font-weight: 600;
     }
 
     p {
       max-width: 250px;
-      margin: 7px 0 22px;
+      margin: 0;
       color: $text-muted;
       font-size: 13px;
       font-style: italic;
       line-height: 1.45;
     }
-
-    button {
-      min-height: 42px;
-      padding: 0 18px;
-      color: $bg;
-      border: 1px solid $text;
-      border-radius: 8px;
-      background: $accent-teal;
-      box-shadow: 0 2px 0 rgba($text, 0.24);
-      font-family: $font-mono;
-      font-size: 11px;
-      letter-spacing: 0.04em;
-      cursor: pointer;
-    }
   }
 
-  .commute-mobile-orientation__phone {
-    width: 50px;
-    height: 84px;
+  .commute-mobile-rotate__phone {
+    width: 40px;
+    height: 68px;
     position: relative;
     display: block;
-    border: 2px solid $text;
-    border-radius: 9px;
-    background: $surface;
-    box-shadow:
-      13px 10px 0 rgba($accent-gold, 0.45),
-      -13px -10px 0 rgba($accent-blue, 0.12);
-    transform: rotate(90deg);
-
-    &::before {
-      content: "";
-      width: 15px;
-      height: 2px;
-      position: absolute;
-      top: 5px;
-      left: 50%;
-      border-radius: 2px;
-      background: $text-muted;
-      transform: translateX(-50%);
-    }
+    padding-bottom: 5px;
+    border: 2.5px solid $text;
+    border-radius: 8px;
+    animation: phone-turn 2.4s ease-in-out infinite;
 
     span {
+      width: 10px;
+      height: 3px;
       position: absolute;
-      inset: 11px 5px 7px;
-      border: 1px solid rgba($text, 0.22);
-      border-radius: 3px;
-      background:
-        linear-gradient(
-          90deg,
-          transparent 46%,
-          rgba($text, 0.3) 46% 54%,
-          transparent 54%
-        ),
-        linear-gradient(
-          $accent-rust 0 25%,
-          $car-shell 25% 75%,
-          $accent-blue 75%
-        );
+      bottom: 5px;
+      left: 50%;
+      border-radius: 2px;
+      background: $text;
+      transform: translateX(-50%);
     }
   }
 }
@@ -1259,52 +1233,64 @@ button {
     min-width: 0;
     min-height: 0;
     overflow: hidden;
+    overscroll-behavior: none;
   }
 
   .commute-page {
+    position: fixed;
+    inset: 0;
     width: 100vw;
     height: 100dvh;
     min-height: 0;
-    padding: max(6px, env(safe-area-inset-top))
-      max(8px, env(safe-area-inset-right)) max(6px, env(safe-area-inset-bottom))
-      max(8px, env(safe-area-inset-left));
+    padding: 0;
     overflow: hidden;
+    background: $landscape-paper;
+    touch-action: none;
+    user-select: none;
   }
 
   .commute-shell {
     width: 100%;
     height: 100%;
-    display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr) auto;
-    align-items: stretch;
+    position: relative;
+    display: block;
   }
 
   .commute-header,
   .commute-subtitle,
+  .commute-instruction,
   .commute-note {
     display: none;
   }
 
   .commute-banner {
-    min-height: 40px;
-    padding: 6px 44px 6px 8px;
-    gap: 8px;
-    border-radius: 7px;
+    width: auto;
+    max-width: min(84vw, calc(100vw - 220px));
+    min-height: 42px;
+    position: fixed;
+    top: calc(10px + env(safe-area-inset-top));
+    left: 50%;
+    z-index: 30;
+    padding: 8px 16px;
+    gap: 10px;
+    border-radius: 10px;
+    transform: translateX(-50%);
 
     strong {
-      max-width: 42vw;
-      font-size: 13px;
+      max-width: 48vw;
+      font-size: 15px;
     }
   }
 
   .commute-line-number {
-    width: 24px;
-    height: 24px;
-    font-size: 11px;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+    font-size: 12px;
   }
 
   .commute-banner__rule {
-    min-width: 8px;
+    min-width: 12px;
   }
 
   .commute-banner__destination-label {
@@ -1312,19 +1298,19 @@ button {
   }
 
   .commute-banner__domain {
-    font-size: 11px;
+    font-size: 12px;
   }
 
-  .commute-instruction {
-    min-height: 22px;
-    padding: 4px 0;
+  .commute-banner__aside {
+    max-width: 30vw;
     font-size: 10px;
   }
 
   .commute-stage-viewport {
-    width: 100%;
-    min-height: 0;
-    position: relative;
+    width: 100vw;
+    height: 100dvh;
+    position: fixed;
+    inset: 0;
     overflow: hidden;
   }
 
@@ -1336,38 +1322,244 @@ button {
     transform-origin: center;
   }
 
+  .landscape-window {
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+  }
+
+  .train-seat {
+    pointer-events: none;
+  }
+
   .commute-counts {
-    margin-top: 0;
-    padding: 7px 10px;
-    border-radius: 7px;
+    width: auto;
+    min-width: 280px;
+    margin: 0;
+    position: fixed;
+    right: calc(20px + env(safe-area-inset-right));
+    bottom: calc(24px + env(safe-area-inset-bottom));
+    z-index: 30;
+    padding: 6px 14px;
+    display: flex;
+    grid-template-columns: none;
+    gap: 10px;
+    border-radius: 999px;
 
     strong {
-      font-size: 11px;
+      font-size: 12px;
+    }
+
+    strong:last-child {
+      margin-left: auto;
     }
 
     span {
-      font-size: 8px;
+      font-size: 9px;
+      white-space: nowrap;
     }
   }
 
-  .commute-mobile-fullscreen {
-    width: 30px;
-    height: 30px;
+  .commute-mobile-board {
     position: fixed;
-    top: max(11px, env(safe-area-inset-top));
-    right: max(13px, env(safe-area-inset-right));
-    z-index: 50;
+    inset: 0;
+    z-index: 100;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    background-color: rgba($bg, 0.96);
+    background-image:
+      repeating-linear-gradient(
+        0deg,
+        rgba(90, 78, 65, 0.025) 0 1px,
+        transparent 1px 3px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        rgba(90, 78, 65, 0.025) 0 1px,
+        transparent 1px 3px
+      );
+    text-align: center;
+
+    > strong {
+      font-family: $font-heading;
+      font-size: 34px;
+      font-weight: 600;
+    }
+
+    p {
+      max-width: 340px;
+      margin: 0;
+      color: $text-muted;
+      font-size: 13px;
+      font-style: italic;
+    }
+
+    button {
+      min-height: 56px;
+      margin-top: 10px;
+      padding: 14px 42px;
+      color: $bg;
+      border: 0;
+      border-radius: 999px;
+      background: $accent-teal;
+      box-shadow: 0 2px 10px rgba($text, 0.3);
+      font-size: 18px;
+      font-weight: 700;
+      cursor: pointer;
+
+      &:active {
+        transform: scale(0.96);
+      }
+    }
+
+    small {
+      color: $text-faint;
+      font-family: $font-mono;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+    }
+  }
+
+  .commute-mobile-board__wordmark,
+  .commute-mobile-wordmark {
+    font-family: $font-wordmark;
+    font-style: italic;
+    font-weight: 200;
+  }
+
+  .commute-mobile-wordmark {
+    position: fixed;
+    top: calc(10px + env(safe-area-inset-top));
+    left: calc(12px + env(safe-area-inset-left));
+    z-index: 30;
+    display: block;
+    color: $text-muted;
+    font-size: 13px;
+  }
+
+  .commute-mobile-fullscreen {
+    width: 44px;
+    height: 44px;
+    position: fixed;
+    top: calc(8px + env(safe-area-inset-top));
+    right: calc(10px + env(safe-area-inset-right));
+    z-index: 30;
     display: grid;
     place-items: center;
     color: $text;
-    border: 1px solid rgba($text, 0.24);
-    border-radius: 6px;
-    background: rgba($surface, 0.94);
-    box-shadow: 0 1px 4px $shadow;
-    font-family: $font-mono;
-    font-size: 17px;
-    line-height: 1;
+    border: 1px solid rgba($text, 0.3);
+    border-radius: 10px;
+    background: rgba($bg, 0.9);
+    box-shadow: 0 1px 4px rgba($text, 0.15);
     cursor: pointer;
+
+    svg {
+      stroke: currentColor;
+      stroke-width: 1.8;
+      stroke-linecap: round;
+    }
+  }
+
+  .commute-mobile-joystick {
+    width: 112px;
+    height: 112px;
+    position: fixed;
+    bottom: calc(18px + env(safe-area-inset-bottom));
+    left: calc(20px + env(safe-area-inset-left));
+    z-index: 30;
+    display: block;
+    border: 1.5px solid rgba($text, 0.35);
+    border-radius: 50%;
+    background: rgba($bg, 0.55);
+    box-shadow: inset 0 2px 8px rgba($text, 0.12);
+    touch-action: none;
+
+    span {
+      width: 48px;
+      height: 48px;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      border: 2px solid #35756a;
+      border-radius: 50%;
+      background: $accent-teal;
+      box-shadow: 0 2px 6px rgba($text, 0.3);
+      transform: translate(
+        calc(-50% + var(--joystick-x)),
+        calc(-50% + var(--joystick-y))
+      );
+      pointer-events: none;
+    }
+  }
+
+  .commute-mobile-action {
+    min-height: 44px;
+    position: fixed;
+    bottom: calc(58px + env(safe-area-inset-bottom));
+    left: calc(148px + env(safe-area-inset-left));
+    z-index: 30;
+    padding: 9px 20px;
+    color: $bg;
+    border: 2px solid rgba($text, 0.25);
+    border-radius: 999px;
+    background: $accent-teal;
+    box-shadow: 0 2px 10px rgba($text, 0.3);
+    font-size: 13px;
+    font-weight: 700;
+    white-space: nowrap;
+    cursor: pointer;
+
+    &:active {
+      transform: scale(0.96);
+    }
+
+    &--stand {
+      background: $accent-plum;
+    }
+
+    &--exit {
+      background: $accent-rust;
+    }
+  }
+
+  .commute-mobile-avatar {
+    position: absolute;
+    z-index: 10;
+    display: flex;
+    transform: translate(-14px, -14px);
+    transition:
+      left 0.4s cubic-bezier(0.2, 0.8, 0.3, 1),
+      top 0.4s cubic-bezier(0.2, 0.8, 0.3, 1);
+    pointer-events: none;
+
+    .cursor-rider {
+      position: relative;
+      top: auto;
+      left: auto;
+    }
+
+    &--walking {
+      transition: none;
+    }
+  }
+
+  .commute-toast {
+    bottom: calc(96px + env(safe-area-inset-bottom));
+    z-index: 40;
+  }
+
+  @media (max-width: 720px) {
+    .commute-counts {
+      min-width: 280px;
+
+      span {
+        display: none;
+      }
+    }
   }
 }
 
@@ -1511,6 +1703,18 @@ button {
 
   50% {
     transform: scale(1.12);
+  }
+}
+
+@keyframes phone-turn {
+  0%,
+  18% {
+    transform: rotate(0deg);
+  }
+
+  55%,
+  100% {
+    transform: rotate(90deg);
   }
 }
 

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -1503,6 +1503,7 @@ button {
     left: calc(148px + env(safe-area-inset-left));
     z-index: 30;
     padding: 9px 20px;
+    display: block;
     color: $bg;
     border: 2px solid rgba($text, 0.25);
     border-radius: 999px;

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -211,14 +211,6 @@ button {
   }
 }
 
-@media (max-width: 600px) {
-  .commute-install-cta {
-    right: auto;
-    bottom: 8px;
-    left: 8px;
-  }
-}
-
 .commute-banner {
   width: 100%;
   min-height: 50px;
@@ -325,6 +317,16 @@ button {
   font-size: 12px;
   font-style: italic;
   text-align: center;
+}
+
+.commute-stage-viewport,
+.commute-stage {
+  width: 1100px;
+}
+
+.commute-mobile-orientation,
+.commute-mobile-fullscreen {
+  display: none;
 }
 
 .landscape-window {
@@ -1113,6 +1115,260 @@ button {
   font-size: 11px;
   font-style: italic;
   text-align: center;
+}
+
+@media (max-width: 900px),
+  (max-width: 950px) and (max-height: 600px),
+  (hover: none) and (pointer: coarse) {
+  .commute-install-cta {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) and (orientation: portrait) {
+  html,
+  body,
+  #commute-root {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .commute-page {
+    width: 100%;
+    height: 100dvh;
+    min-height: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .commute-shell {
+    visibility: hidden;
+  }
+
+  .commute-mobile-orientation {
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    padding: 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: $text;
+    background-color: $bg;
+    background-image:
+      repeating-linear-gradient(
+        0deg,
+        rgba(90, 78, 65, 0.025) 0 1px,
+        transparent 1px 3px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        rgba(90, 78, 65, 0.025) 0 1px,
+        transparent 1px 3px
+      );
+    text-align: center;
+
+    strong {
+      margin-top: 26px;
+      font-family: $font-heading;
+      font-size: 25px;
+      font-weight: 600;
+    }
+
+    p {
+      max-width: 250px;
+      margin: 7px 0 22px;
+      color: $text-muted;
+      font-size: 13px;
+      font-style: italic;
+      line-height: 1.45;
+    }
+
+    button {
+      min-height: 42px;
+      padding: 0 18px;
+      color: $bg;
+      border: 1px solid $text;
+      border-radius: 8px;
+      background: $accent-teal;
+      box-shadow: 0 2px 0 rgba($text, 0.24);
+      font-family: $font-mono;
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+    }
+  }
+
+  .commute-mobile-orientation__phone {
+    width: 50px;
+    height: 84px;
+    position: relative;
+    display: block;
+    border: 2px solid $text;
+    border-radius: 9px;
+    background: $surface;
+    box-shadow:
+      13px 10px 0 rgba($accent-gold, 0.45),
+      -13px -10px 0 rgba($accent-blue, 0.12);
+    transform: rotate(90deg);
+
+    &::before {
+      content: "";
+      width: 15px;
+      height: 2px;
+      position: absolute;
+      top: 5px;
+      left: 50%;
+      border-radius: 2px;
+      background: $text-muted;
+      transform: translateX(-50%);
+    }
+
+    span {
+      position: absolute;
+      inset: 11px 5px 7px;
+      border: 1px solid rgba($text, 0.22);
+      border-radius: 3px;
+      background:
+        linear-gradient(
+          90deg,
+          transparent 46%,
+          rgba($text, 0.3) 46% 54%,
+          transparent 54%
+        ),
+        linear-gradient(
+          $accent-rust 0 25%,
+          $car-shell 25% 75%,
+          $accent-blue 75%
+        );
+    }
+  }
+}
+
+@media (max-width: 950px) and (max-height: 600px) and (orientation: landscape),
+  (hover: none) and (pointer: coarse) and (orientation: landscape) {
+  html,
+  body,
+  #commute-root {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .commute-page {
+    width: 100vw;
+    height: 100dvh;
+    min-height: 0;
+    padding: max(6px, env(safe-area-inset-top))
+      max(8px, env(safe-area-inset-right)) max(6px, env(safe-area-inset-bottom))
+      max(8px, env(safe-area-inset-left));
+    overflow: hidden;
+  }
+
+  .commute-shell {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr) auto;
+    align-items: stretch;
+  }
+
+  .commute-header,
+  .commute-subtitle,
+  .commute-note {
+    display: none;
+  }
+
+  .commute-banner {
+    min-height: 40px;
+    padding: 6px 44px 6px 8px;
+    gap: 8px;
+    border-radius: 7px;
+
+    strong {
+      max-width: 42vw;
+      font-size: 13px;
+    }
+  }
+
+  .commute-line-number {
+    width: 24px;
+    height: 24px;
+    font-size: 11px;
+  }
+
+  .commute-banner__rule {
+    min-width: 8px;
+  }
+
+  .commute-banner__destination-label {
+    font-size: 9px;
+  }
+
+  .commute-banner__domain {
+    font-size: 11px;
+  }
+
+  .commute-instruction {
+    min-height: 22px;
+    padding: 4px 0;
+    font-size: 10px;
+  }
+
+  .commute-stage-viewport {
+    width: 100%;
+    min-height: 0;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .commute-stage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(var(--commute-stage-scale, 1));
+    transform-origin: center;
+  }
+
+  .commute-counts {
+    margin-top: 0;
+    padding: 7px 10px;
+    border-radius: 7px;
+
+    strong {
+      font-size: 11px;
+    }
+
+    span {
+      font-size: 8px;
+    }
+  }
+
+  .commute-mobile-fullscreen {
+    width: 30px;
+    height: 30px;
+    position: fixed;
+    top: max(11px, env(safe-area-inset-top));
+    right: max(13px, env(safe-area-inset-right));
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    color: $text;
+    border: 1px solid rgba($text, 0.24);
+    border-radius: 6px;
+    background: rgba($surface, 0.94);
+    box-shadow: 0 1px 4px $shadow;
+    font-family: $font-mono;
+    font-size: 17px;
+    line-height: 1;
+    cursor: pointer;
+  }
 }
 
 .commute-toast {

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -1127,16 +1127,14 @@ button {
   text-align: center;
 }
 
-@media (max-width: 900px),
-  (max-width: 950px) and (max-height: 600px),
-  (hover: none) and (pointer: coarse) {
+@media (hover: none) and (pointer: coarse) {
   .commute-install-cta {
     display: none;
   }
 }
 
-@media (max-width: 900px) and (orientation: portrait),
-  (hover: none) and (pointer: coarse) and (orientation: portrait) {
+@media (hover: none) and (pointer: coarse) and (max-width: 900px) and
+  (orientation: portrait) {
   html,
   body,
   #commute-root {
@@ -1223,8 +1221,8 @@ button {
   }
 }
 
-@media (max-width: 950px) and (max-height: 600px) and (orientation: landscape),
-  (hover: none) and (pointer: coarse) and (orientation: landscape) {
+@media (hover: none) and (pointer: coarse) and (max-width: 950px) and
+  (max-height: 600px) and (orientation: landscape) {
   html,
   body,
   #commute-root {

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -39,6 +39,8 @@ import {
   type CommutePhase,
 } from "./commuteTiming";
 import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
+import { CommuteMobileControls } from "./CommuteMobileControls";
+import { CommuteStage } from "./CommuteStage";
 import { ProceduralLandscape } from "./landscape";
 import "./commute.scss";
 
@@ -838,6 +840,7 @@ function InternetCommute() {
           : undefined
       }
     >
+      <CommuteMobileControls />
       <div className="commute-shell">
         <header className="commute-header">
           <a
@@ -866,32 +869,34 @@ function InternetCommute() {
           hasSeat={hasSeat}
         />
 
-        <LandscapeWindow
-          currentStop={currentStop}
-          platformStop={platformStop}
-          phase={timing.phase}
-          platformAtOrigin={platformAtOrigin}
-          edge="upper"
-          stops={sceneryStops}
-          stopIndex={timing.stopIndex}
-        />
-        <CommuteCar
-          id="internet-commute-car"
-          currentStop={currentStop}
-          phase={timing.phase}
-          atOrigin={timing.atOrigin}
-          isJoining={serviceConnection.joinedExistingService}
-          onSeatStateChange={setHasSeat}
-        />
-        <LandscapeWindow
-          currentStop={currentStop}
-          platformStop={platformStop}
-          phase={timing.phase}
-          platformAtOrigin={platformAtOrigin}
-          edge="lower"
-          stops={sceneryStops}
-          stopIndex={timing.stopIndex}
-        />
+        <CommuteStage>
+          <LandscapeWindow
+            currentStop={currentStop}
+            platformStop={platformStop}
+            phase={timing.phase}
+            platformAtOrigin={platformAtOrigin}
+            edge="upper"
+            stops={sceneryStops}
+            stopIndex={timing.stopIndex}
+          />
+          <CommuteCar
+            id="internet-commute-car"
+            currentStop={currentStop}
+            phase={timing.phase}
+            atOrigin={timing.atOrigin}
+            isJoining={serviceConnection.joinedExistingService}
+            onSeatStateChange={setHasSeat}
+          />
+          <LandscapeWindow
+            currentStop={currentStop}
+            platformStop={platformStop}
+            phase={timing.phase}
+            platformAtOrigin={platformAtOrigin}
+            edge="lower"
+            stops={sceneryStops}
+            stopIndex={timing.stopIndex}
+          />
+        </CommuteStage>
 
         <div className="commute-counts">
           <strong>

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -1,7 +1,14 @@
 // ABOUTME: Full-tab Internet Commute with shared ephemeral cursor seating.
 // ABOUTME: Cycles through recent WWO destinations in a bird's-eye train carriage.
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
 import {
   PlayProvider,
@@ -39,8 +46,20 @@ import {
   type CommutePhase,
 } from "./commuteTiming";
 import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
-import { CommuteMobileControls } from "./CommuteMobileControls";
+import {
+  CommuteMobileControls,
+  type CommuteMobileAction,
+} from "./CommuteMobileControls";
 import { CommuteStage } from "./CommuteStage";
+import {
+  COMMUTE_AVATAR_START,
+  findNearbyCommuteSeat,
+  getStandingPosition,
+  isNearCommuteDoor,
+  moveCommuteAvatar,
+  type CommutePoint,
+  type CommuteSeatGeometry,
+} from "./commuteMobile";
 import { ProceduralLandscape } from "./landscape";
 import "./commute.scss";
 
@@ -48,15 +67,9 @@ type CarData = Record<string, never>;
 
 interface RiderAwareness {
   seatId: number | null;
-  color: string;
-  label: string;
 }
 
-interface SeatDefinition {
-  id: number;
-  x: number;
-  y: number;
-  row: "top" | "bottom";
+interface SeatDefinition extends CommuteSeatGeometry {
   bank: number;
 }
 
@@ -99,6 +112,7 @@ const SEATS: SeatDefinition[] = ["top", "bottom"].flatMap((row) =>
 );
 
 const DOORS = [276, 696];
+const DOOR_GEOMETRY = DOORS.map((x) => ({ x }));
 const COMMUTE_REFRESH_MS = 30_000;
 const COMMUTE_ROUTE_TIMEOUT_MS = 5_000;
 
@@ -189,8 +203,10 @@ function useCommuteService(
   routeStatus: RecentRoute["status"],
   serverTimeOffsetMs: number | null,
 ): CommuteServiceConnection {
-  const { presences, setMyPresence, myIdentity } =
-    usePresence<CommuteServicePresence>(COMMUTE_SERVICE_CHANNEL);
+  const { presences, setMyPresence, myIdentity } = usePresence<
+    typeof COMMUTE_SERVICE_CHANNEL,
+    CommuteServicePresence
+  >(COMMUTE_SERVICE_CHANNEL);
   const [connection, setConnection] = useState<CommuteServiceConnection>({
     joinedExistingService: false,
     service: null,
@@ -307,16 +323,21 @@ function CursorRider({
   color,
   label,
   isYou,
+  ariaLabel,
 }: {
   color: string;
   label: string;
   isYou: boolean;
+  ariaLabel?: string;
 }) {
   return (
     <span
       className={`cursor-rider ${isYou ? "cursor-rider--you" : ""}`}
       style={{ "--cursor-color": color } as React.CSSProperties}
-      aria-label={isYou ? "Your cursor is sitting here" : `${label}'s cursor`}
+      aria-label={
+        ariaLabel ??
+        (isYou ? "Your cursor is sitting here" : `${label}'s cursor`)
+      }
     >
       <svg width="28" height="28" viewBox="0 0 32 32" aria-hidden>
         <path
@@ -337,11 +358,13 @@ function Seat({
   seat,
   occupant,
   isMine,
+  isNearby,
   onSelect,
 }: {
   seat: SeatDefinition;
   occupant?: { color: string; label: string };
   isMine: boolean;
+  isNearby: boolean;
   onSelect: () => void;
 }) {
   const unavailable = Boolean(occupant && !isMine);
@@ -354,7 +377,7 @@ function Seat({
     <button
       className={`train-seat train-seat--${seat.row} train-seat--${fabric} ${
         isMine ? "train-seat--mine" : ""
-      }`}
+      } ${isNearby ? "train-seat--nearby" : ""}`}
       style={{ left: seat.x, top: seat.y }}
       type="button"
       data-seat-id={seat.id}
@@ -524,12 +547,11 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     defaultData: {},
     myDefaultAwareness: {
       seatId: null,
-      color: "#5b8db8",
-      label: "rider",
     },
   }),
   ({ awarenessByStableId, myAwareness, setMyAwareness, ref }, props) => {
     const { onSeatStateChange } = props;
+    const users = useUsers();
     const {
       configureCursors,
       cursors,
@@ -537,20 +559,35 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
       isLoading,
     } = usePlayContext();
     const [toast, setToast] = useState<string | null>(null);
+    const [mobileBoarded, setMobileBoarded] = useState(false);
+    const [avatarPosition, setAvatarPosition] =
+      useState<CommutePoint>(COMMUTE_AVATAR_START);
+    const [avatarWalking, setAvatarWalking] = useState(false);
     const toastTimer = useRef<number | undefined>(undefined);
+    const movementVector = useRef<CommutePoint>({ x: 0, y: 0 });
+    const pressedKeys = useRef(new Set<string>());
+    const mobileActionRef = useRef<CommuteMobileAction | null>(null);
+    const setMyAwarenessRef = useRef(setMyAwareness);
+    setMyAwarenessRef.current = setMyAwareness;
     useCursorZone(ref);
+
+    const usersById = useMemo(
+      () => new Map(users.map((user) => [user.pid, user])),
+      [users],
+    );
 
     const ridersBySeat = useMemo(() => {
       const riders = new Map<number, { label: string; color: string }>();
-      for (const awareness of awarenessByStableId.values()) {
+      for (const [stableId, awareness] of awarenessByStableId) {
         if (awareness.seatId === null) continue;
+        const user = usersById.get(stableId);
         riders.set(awareness.seatId, {
-          label: awareness.label,
-          color: awareness.color,
+          label: user?.name ?? "rider",
+          color: user?.color ?? "#5b8db8",
         });
       }
       return riders;
-    }, [awarenessByStableId]);
+    }, [awarenessByStableId, usersById]);
 
     const mySeatId = myAwareness?.seatId ?? null;
     const seatedRiderIds = useMemo(() => {
@@ -585,16 +622,22 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
       if (mySeatId !== null) {
         riders.set(mySeatId, {
           label: "you",
-          color: myAwareness?.color || cursors.color || "#5b8db8",
+          color: cursors.color || "#5b8db8",
         });
       }
       return riders;
-    }, [
-      cursors.color,
-      myAwareness?.color,
-      mySeatId,
-      ridersBySeat,
-    ]);
+    }, [cursors.color, mySeatId, ridersBySeat]);
+
+    const occupiedSeatIds = useMemo(
+      () => new Set(displayedRiders.keys()),
+      [displayedRiders],
+    );
+    const nearbySeat =
+      mobileBoarded && mySeatId === null
+        ? findNearbyCommuteSeat(avatarPosition, SEATS, occupiedSeatIds)
+        : null;
+    const nearDoor =
+      mobileBoarded && isNearCommuteDoor(avatarPosition, DOOR_GEOMETRY);
 
     useEffect(() => {
       onSeatStateChange(mySeatId !== null);
@@ -623,8 +666,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
 
       setMyAwareness({
         seatId: mySeatId === seatId ? null : seatId,
-        color: cursors.color || myAwareness?.color || "#5b8db8",
-        label: cursors.name || "rider",
       });
     };
 
@@ -643,6 +684,137 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
         window.open(props.currentStop.url, "_blank", "noopener,noreferrer");
       }, 600);
     };
+
+    const standUp = () => {
+      if (mySeatId === null) return;
+      const seat = SEATS.find((candidate) => candidate.id === mySeatId);
+      setMyAwareness({ seatId: null });
+      if (seat) setAvatarPosition(getStandingPosition(seat));
+    };
+
+    let mobileAction: CommuteMobileAction | null = null;
+    if (mySeatId !== null) {
+      mobileAction = {
+        label: "stand up",
+        tone: "stand",
+        onSelect: standUp,
+      };
+    } else if (nearDoor && props.phase === "stopped" && !props.atOrigin) {
+      mobileAction = {
+        label: `step off at ${props.currentStop.domain}`,
+        tone: "exit",
+        onSelect: exitTrain,
+      };
+    } else if (nearbySeat) {
+      mobileAction = {
+        label: "sit down",
+        tone: "sit",
+        onSelect: () => {
+          setAvatarPosition({
+            x: nearbySeat.x + 25,
+            y: nearbySeat.y + 18,
+          });
+          chooseSeat(nearbySeat.id);
+        },
+      };
+    }
+    mobileActionRef.current = mobileAction;
+
+    const updateMovement = useCallback((vector: CommutePoint) => {
+      movementVector.current = vector;
+    }, []);
+
+    useEffect(() => {
+      if (!mobileBoarded) return;
+
+      const keyMap: Record<string, string> = {
+        ArrowLeft: "left",
+        a: "left",
+        ArrowRight: "right",
+        d: "right",
+        ArrowUp: "up",
+        w: "up",
+        ArrowDown: "down",
+        s: "down",
+      };
+      const handleKey = (event: KeyboardEvent) => {
+        const direction = keyMap[event.key];
+        if (direction) {
+          if (event.type === "keydown") {
+            pressedKeys.current.add(direction);
+          } else {
+            pressedKeys.current.delete(direction);
+          }
+          event.preventDefault();
+          return;
+        }
+        if (
+          event.type === "keydown" &&
+          (event.key === "Enter" || event.key === " ")
+        ) {
+          mobileActionRef.current?.onSelect();
+          event.preventDefault();
+        }
+      };
+
+      window.addEventListener("keydown", handleKey);
+      window.addEventListener("keyup", handleKey);
+      return () => {
+        pressedKeys.current.clear();
+        window.removeEventListener("keydown", handleKey);
+        window.removeEventListener("keyup", handleKey);
+      };
+    }, [mobileBoarded]);
+
+    useEffect(() => {
+      if (!mobileBoarded) return;
+
+      const movementTimer = window.setInterval(() => {
+        const vector = { ...movementVector.current };
+        if (pressedKeys.current.has("left")) vector.x -= 1;
+        if (pressedKeys.current.has("right")) vector.x += 1;
+        if (pressedKeys.current.has("up")) vector.y -= 1;
+        if (pressedKeys.current.has("down")) vector.y += 1;
+
+        if (Math.hypot(vector.x, vector.y) < 0.15) {
+          setAvatarWalking(false);
+          return;
+        }
+
+        if (mySeatId !== null) {
+          const seat = SEATS.find((candidate) => candidate.id === mySeatId);
+          setMyAwarenessRef.current({ seatId: null });
+          if (seat) setAvatarPosition(getStandingPosition(seat));
+          setAvatarWalking(true);
+          return;
+        }
+
+        setAvatarWalking(true);
+        setAvatarPosition((current) => moveCommuteAvatar(current, vector));
+      }, 50);
+
+      return () => window.clearInterval(movementTimer);
+    }, [mobileBoarded, mySeatId]);
+
+    useEffect(() => {
+      const car = ref.current;
+      if (!mobileBoarded || mySeatId !== null || !car) return;
+
+      const bounds = car.getBoundingClientRect();
+      if (car.offsetWidth === 0 || car.offsetHeight === 0) return;
+
+      // Feed joystick movement through the cursor client's paced transport so
+      // remote riders see the train avatar instead of the finger on the joystick.
+      document.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX:
+            bounds.left + avatarPosition.x * (bounds.width / car.offsetWidth),
+          clientY:
+            bounds.top + avatarPosition.y * (bounds.height / car.offsetHeight),
+        }),
+      );
+    }, [avatarPosition, mobileBoarded, mySeatId, ref]);
 
     const doorOpen = props.phase === "stopped";
     const canExit = doorOpen && !props.atOrigin;
@@ -701,14 +873,46 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
               seat={seat}
               occupant={displayedRiders.get(seat.id)}
               isMine={mySeatId === seat.id}
+              isNearby={nearbySeat?.id === seat.id}
               onSelect={() => chooseSeat(seat.id)}
             />
           ))}
+
+          {mobileBoarded && mySeatId === null && (
+            <span
+              className={`commute-mobile-avatar ${
+                avatarWalking ? "commute-mobile-avatar--walking" : ""
+              }`}
+              style={{
+                left: avatarPosition.x,
+                top: avatarPosition.y,
+              }}
+            >
+              <CursorRider
+                color={cursors.color || "#3d3833"}
+                label="you"
+                isYou
+                ariaLabel="Your cursor is walking through the train"
+              />
+            </span>
+          )}
         </section>
         {toast && (
           <div className="commute-toast" role="status">
             {toast}
           </div>
+        )}
+        {createPortal(
+          <CommuteMobileControls
+            action={mobileAction}
+            boarded={mobileBoarded}
+            onBoard={() => {
+              setAvatarPosition(COMMUTE_AVATAR_START);
+              setMobileBoarded(true);
+            }}
+            onMove={updateMovement}
+          />,
+          document.body,
         )}
       </section>
     );
@@ -840,7 +1044,6 @@ function InternetCommute() {
           : undefined
       }
     >
-      <CommuteMobileControls />
       <div className="commute-shell">
         <header className="commute-header">
           <a

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -48,6 +48,7 @@ import {
 import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
 import {
   CommuteMobileControls,
+  keepMobileCursorOnAvatar,
   type CommuteMobileAction,
 } from "./CommuteMobileControls";
 import { CommuteStage } from "./CommuteStage";
@@ -79,6 +80,8 @@ interface CommuteCarProps {
   phase: CommutePhase;
   atOrigin: boolean;
   isJoining: boolean;
+  mobileBoarded: boolean;
+  onMobileBoardStateChange: (boarded: boolean) => void;
   onSeatStateChange: (hasSeat: boolean) => void;
 }
 
@@ -550,7 +553,8 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     },
   }),
   ({ awarenessByStableId, myAwareness, setMyAwareness, ref }, props) => {
-    const { onSeatStateChange } = props;
+    const { mobileBoarded, onMobileBoardStateChange, onSeatStateChange } =
+      props;
     const users = useUsers();
     const {
       configureCursors,
@@ -559,7 +563,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
       isLoading,
     } = usePlayContext();
     const [toast, setToast] = useState<string | null>(null);
-    const [mobileBoarded, setMobileBoarded] = useState(false);
     const [avatarPosition, setAvatarPosition] =
       useState<CommutePoint>(COMMUTE_AVATAR_START);
     const [avatarWalking, setAvatarWalking] = useState(false);
@@ -908,7 +911,7 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
             boarded={mobileBoarded}
             onBoard={() => {
               setAvatarPosition(COMMUTE_AVATAR_START);
-              setMobileBoarded(true);
+              onMobileBoardStateChange(true);
             }}
             onMove={updateMovement}
           />,
@@ -1001,6 +1004,7 @@ function InternetCommute() {
   const browsingCount = recentRoute.activePeople;
   const [clockNow, setClockNow] = useState(() => Date.now());
   const [hasSeat, setHasSeat] = useState(false);
+  const [mobileBoarded, setMobileBoarded] = useState(false);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -1043,6 +1047,8 @@ function InternetCommute() {
           ? serviceConnection.service?.id
           : undefined
       }
+      onMouseMove={mobileBoarded ? keepMobileCursorOnAvatar : undefined}
+      onTouchMove={mobileBoarded ? keepMobileCursorOnAvatar : undefined}
     >
       <div className="commute-shell">
         <header className="commute-header">
@@ -1088,6 +1094,8 @@ function InternetCommute() {
             phase={timing.phase}
             atOrigin={timing.atOrigin}
             isJoining={serviceConnection.joinedExistingService}
+            mobileBoarded={mobileBoarded}
+            onMobileBoardStateChange={setMobileBoarded}
             onSeatStateChange={setHasSeat}
           />
           <LandscapeWindow

--- a/extension/src/entrypoints/commute/commuteMobile.test.ts
+++ b/extension/src/entrypoints/commute/commuteMobile.test.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Verifies mobile commute movement, bounds, and proximity interactions.
+// ABOUTME: Covers the geometry used by joystick walking, seating, and train doors.
+
+import { describe, expect, it } from "vitest";
+import {
+  findNearbyCommuteSeat,
+  getStandingPosition,
+  isNearCommuteDoor,
+  moveCommuteAvatar,
+  type CommuteSeatGeometry,
+} from "./commuteMobile";
+
+const SEATS: CommuteSeatGeometry[] = [
+  { id: 0, x: 44, y: 32, row: "top" },
+  { id: 1, x: 100, y: 284, row: "bottom" },
+];
+
+describe("mobile commute geometry", () => {
+  it("normalizes diagonal movement and clamps it inside the carriage", () => {
+    expect(moveCommuteAvatar({ x: 100, y: 100 }, { x: 1, y: 1 }, 10)).toEqual({
+      x: 100 + 10 / Math.sqrt(2),
+      y: 100 + 10 / Math.sqrt(2),
+    });
+    expect(moveCommuteAvatar({ x: 38, y: 32 }, { x: -1, y: -1 }, 10)).toEqual({
+      x: 38,
+      y: 32,
+    });
+    expect(moveCommuteAvatar({ x: 1062, y: 316 }, { x: 1, y: 1 }, 10)).toEqual({
+      x: 1062,
+      y: 316,
+    });
+  });
+
+  it("ignores joystick drift below the movement threshold", () => {
+    const position = { x: 100, y: 100 };
+    expect(moveCommuteAvatar(position, { x: 0.1, y: 0.1 })).toBe(position);
+  });
+
+  it("selects the closest free seat and ignores occupied seats", () => {
+    expect(findNearbyCommuteSeat({ x: 70, y: 54 }, SEATS, new Set())).toEqual(
+      SEATS[0],
+    );
+    expect(
+      findNearbyCommuteSeat({ x: 70, y: 54 }, SEATS, new Set([0])),
+    ).toBeNull();
+  });
+
+  it("recognizes the door threshold only along the top wall", () => {
+    const doors = [{ x: 276 }, { x: 696 }];
+    expect(isNearCommuteDoor({ x: 330, y: 80 }, doors)).toBe(true);
+    expect(isNearCommuteDoor({ x: 330, y: 140 }, doors)).toBe(false);
+    expect(isNearCommuteDoor({ x: 600, y: 80 }, doors)).toBe(false);
+  });
+
+  it("places a standing rider on the aisle side of either seat row", () => {
+    expect(getStandingPosition(SEATS[0])).toEqual({ x: 69, y: 94 });
+    expect(getStandingPosition(SEATS[1])).toEqual({ x: 125, y: 270 });
+  });
+});

--- a/extension/src/entrypoints/commute/commuteMobile.ts
+++ b/extension/src/entrypoints/commute/commuteMobile.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Calculates local mobile rider movement and nearby train interactions.
+// ABOUTME: Keeps joystick geometry independent from React and realtime presence.
+
+export interface CommutePoint {
+  x: number;
+  y: number;
+}
+
+export interface CommuteSeatGeometry extends CommutePoint {
+  id: number;
+  row: "top" | "bottom";
+}
+
+export interface CommuteDoorGeometry {
+  x: number;
+}
+
+export const COMMUTE_AVATAR_START: CommutePoint = { x: 340, y: 70 };
+export const COMMUTE_WALK_SPEED = 5.5;
+
+const CAR_MIN_X = 38;
+const CAR_MAX_X = 1062;
+const CAR_MIN_Y = 32;
+const CAR_MAX_Y = 316;
+const SEAT_INTERACTION_RADIUS = 55;
+
+export function moveCommuteAvatar(
+  position: CommutePoint,
+  vector: CommutePoint,
+  speed: number = COMMUTE_WALK_SPEED,
+): CommutePoint {
+  const magnitude = Math.hypot(vector.x, vector.y);
+  if (magnitude < 0.15) return position;
+
+  const normalizer = Math.max(1, magnitude);
+  return {
+    x: Math.max(
+      CAR_MIN_X,
+      Math.min(CAR_MAX_X, position.x + (vector.x / normalizer) * speed),
+    ),
+    y: Math.max(
+      CAR_MIN_Y,
+      Math.min(CAR_MAX_Y, position.y + (vector.y / normalizer) * speed),
+    ),
+  };
+}
+
+export function findNearbyCommuteSeat(
+  position: CommutePoint,
+  seats: CommuteSeatGeometry[],
+  occupiedSeatIds: ReadonlySet<number>,
+): CommuteSeatGeometry | null {
+  let nearbySeat: CommuteSeatGeometry | null = null;
+  let nearbyDistance = SEAT_INTERACTION_RADIUS;
+
+  for (const seat of seats) {
+    if (occupiedSeatIds.has(seat.id)) continue;
+    const distance = Math.hypot(
+      position.x - (seat.x + 25),
+      position.y - (seat.y + 22),
+    );
+    if (distance >= nearbyDistance) continue;
+    nearbyDistance = distance;
+    nearbySeat = seat;
+  }
+
+  return nearbySeat;
+}
+
+export function isNearCommuteDoor(
+  position: CommutePoint,
+  doors: CommuteDoorGeometry[],
+): boolean {
+  return doors.some(
+    (door) =>
+      position.x > door.x - 14 && position.x < door.x + 142 && position.y < 118,
+  );
+}
+
+export function getStandingPosition(seat: CommuteSeatGeometry): CommutePoint {
+  return {
+    x: seat.x + 25,
+    y: seat.y + (seat.row === "top" ? 62 : -14),
+  };
+}

--- a/extension/src/entrypoints/popup/popup.test.tsx
+++ b/extension/src/entrypoints/popup/popup.test.tsx
@@ -104,12 +104,14 @@ describe("PlayHTMLPopup", () => {
     document.body.innerHTML = "";
   });
 
-  it("keeps the commute entry hidden when only development mode is enabled", async () => {
+  it("keeps unreleased entries hidden when development mode is enabled", async () => {
     const { container, root } = await renderPopup();
 
     try {
       expect(container.querySelector(".portrait-home")).not.toBeNull();
       expect(container.querySelector(".commute-entry")).toBeNull();
+      expect(container.textContent).not.toContain("scraps");
+      expect(container.textContent).not.toContain("bag settings");
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/entrypoints/popup/popup.test.tsx
+++ b/extension/src/entrypoints/popup/popup.test.tsx
@@ -1,0 +1,117 @@
+// ABOUTME: Verifies beta feature visibility in the extension popup.
+// ABOUTME: Ensures internal development mode cannot bypass the commute flag.
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+import PlayHTMLPopup from "./popup";
+
+vi.mock("../../styles/popup.scss", () => ({}));
+vi.mock("../../components/Inventory", () => ({
+  Inventory: () => null,
+}));
+vi.mock("../../components/PlayerIdentityCard", () => ({
+  PlayerIdentityCard: () => null,
+}));
+vi.mock("../../components/SiteStatus", () => ({
+  SiteStatus: () => null,
+}));
+vi.mock("../../components/QuickActions", () => ({
+  QuickActions: () => null,
+}));
+vi.mock("../../components/Collections", () => ({
+  Collections: () => null,
+}));
+vi.mock("../../components/ProfilePage", () => ({
+  ProfilePage: () => null,
+}));
+vi.mock("../../components/InternetPortraitHome.scss", () => ({}));
+vi.mock("../../components/TinyMovementPreview", () => ({
+  TinyMovementPreview: () => null,
+}));
+vi.mock("../../components/PortraitCard", () => ({
+  PortraitCard: () => null,
+}));
+vi.mock("../../announcements/PostcardStack", () => ({
+  PostcardStack: () => null,
+}));
+vi.mock("../../components/FeedbackForm", () => ({
+  FeedbackForm: () => null,
+}));
+
+vi.mock("../../features/inventory/siteVisibility", () => ({
+  pageObjectsAreHiddenOnSite: vi.fn().mockResolvedValue(false),
+  showPageObjectsOnSite: vi.fn().mockResolvedValue(undefined),
+  siteOriginFromUrl: vi.fn().mockReturnValue("https://example.com"),
+}));
+
+async function renderPopup() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<PlayHTMLPopup />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+
+  return { container, root };
+}
+
+function cleanup(root: Root, container: HTMLDivElement) {
+  act(() => root.unmount());
+  container.remove();
+}
+
+describe("PlayHTMLPopup", () => {
+  beforeEach(() => {
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.mocked(browser.storage.local.get).mockImplementation(async (keys) => {
+      const requestedKeys = Array.isArray(keys) ? keys : [keys];
+      if (requestedKeys.includes("internalDevFeaturesEnabled")) {
+        return {
+          internalDevFeaturesEnabled: true,
+          onboarding_complete: true,
+        };
+      }
+      if (requestedKeys.includes("gameInventory")) {
+        return {
+          gameInventory: {
+            items: [],
+            totalItems: 0,
+            lastUpdated: 0,
+          },
+        };
+      }
+      return {};
+    });
+    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
+      identity: null,
+      discoveredSites: [],
+    });
+    vi.mocked(browser.tabs.sendMessage).mockResolvedValue({
+      elementCount: 0,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("keeps the commute entry hidden when only development mode is enabled", async () => {
+    const { container, root } = await renderPopup();
+
+    try {
+      expect(container.querySelector(".portrait-home")).not.toBeNull();
+      expect(container.querySelector(".commute-entry")).toBeNull();
+    } finally {
+      cleanup(root, container);
+    }
+  });
+});

--- a/extension/src/entrypoints/popup/popup.tsx
+++ b/extension/src/entrypoints/popup/popup.tsx
@@ -106,11 +106,11 @@ function PlayHTMLPopup() {
   }, []);
 
   useEffect(() => {
-    if (!FLAGS.COMMUTE && !internalDevFeaturesEnabled) return;
+    if (!FLAGS.COMMUTE) return;
     findOpenCommuteTab()
       .then((tab) => setCommuteIsOpen(tab !== null))
       .catch(() => setCommuteIsOpen(false));
-  }, [internalDevFeaturesEnabled]);
+  }, []);
 
   const loadPlayerData = async () => {
     try {
@@ -469,7 +469,7 @@ function PlayHTMLPopup() {
         bagEnabled ? () => setCurrentView("bag-settings") : undefined
       }
       onViewCommute={
-        FLAGS.COMMUTE || internalDevFeaturesEnabled
+        FLAGS.COMMUTE
           ? async () => {
               await openOrFocusCommute();
               window.close();

--- a/extension/src/entrypoints/popup/popup.tsx
+++ b/extension/src/entrypoints/popup/popup.tsx
@@ -55,7 +55,7 @@ function PlayHTMLPopup() {
   const [currentView, setCurrentView] = useState<
     "main" | "inventory" | "collections" | "profile" | "bag-settings"
   >("main");
-  const [internalDevFeaturesEnabled, setInternalDevFeaturesEnabled] = useState(false);
+  const [, setInternalDevFeaturesEnabled] = useState(false);
   const [commuteIsOpen, setCommuteIsOpen] = useState(false);
   const [hiddenSite, setHiddenSite] = useState<{
     origin: string;
@@ -284,12 +284,6 @@ function PlayHTMLPopup() {
     }
   };
 
-  // PlayHTML Bag is dev-only until public release.
-  // To enable: open the extension popup, then toggle via Cmd/Ctrl+Shift+. (or > on US keyboards).
-  // Alternative: from any extension page devtools, run
-  //   `browser.storage.local.set({ internalDevFeaturesEnabled: true })` and reopen the popup.
-  const bagEnabled = internalDevFeaturesEnabled;
-
   const pingContentScript = async () => {
     try {
       if (currentTab?.id) {
@@ -465,27 +459,17 @@ function PlayHTMLPopup() {
       onViewCollections={() => setCurrentView("collections")}
       onViewHistory={toggleHistoricalOverlay}
       onViewProfile={() => setCurrentView("profile")}
-      onViewBagSettings={
-        bagEnabled ? () => setCurrentView("bag-settings") : undefined
-      }
-      onViewCommute={
-        FLAGS.COMMUTE
-          ? async () => {
-              await openOrFocusCommute();
-              window.close();
-            }
-          : undefined
-      }
+      onViewBagSettings={() => setCurrentView("bag-settings")}
+      onViewCommute={async () => {
+        await openOrFocusCommute();
+        window.close();
+      }}
       commuteIsOpen={commuteIsOpen}
-      onViewScraps={
-        FLAGS.SCRAPS || internalDevFeaturesEnabled
-          ? async () => {
-              const url = browser.runtime.getURL("scraps.html");
-              await browser.tabs.create({ url });
-              window.close();
-            }
-          : undefined
-      }
+      onViewScraps={async () => {
+        const url = browser.runtime.getURL("scraps.html");
+        await browser.tabs.create({ url });
+        window.close();
+      }}
       onViewChangelog={async () => {
         await browser.tabs.create({ url: PUBLIC_CHANGELOG_URL });
         window.close();

--- a/extension/src/flags.ts
+++ b/extension/src/flags.ts
@@ -1,9 +1,8 @@
 // ABOUTME: Feature flags for the browser extension.
-// ABOUTME: Controls visibility of in-development features like copresence.
+// ABOUTME: Controls released and experimental extension capabilities.
 
 export const FLAGS = {
-  // When false, hide PlayHTML Bag features by default in popup
-  // Devs can override via Cmd+Shift+. in the popup
+  // Shared cursor presence and the popup's presence count.
   COPRESENCE: true,
 
   // Social experiments — each runs on every page via the social registry
@@ -20,6 +19,9 @@ export const FLAGS = {
   // Internet scraps: passive collection of distinctive images seen while
   // browsing, rendered as a scatter-collage (scraps.html). Local-only data.
   SCRAPS: false,
+
+  // Settings for PlayHTML Bag features that are not ready for general use.
+  BAG_SETTINGS: false,
 
   // Internet Commute: full-tab slow browsing train populated from recent
   // extension navigation events.

--- a/extension/src/flags.ts
+++ b/extension/src/flags.ts
@@ -23,5 +23,5 @@ export const FLAGS = {
 
   // Internet Commute: full-tab slow browsing train populated from recent
   // extension navigation events.
-  COMMUTE: true,
+  COMMUTE: false,
 } as const;

--- a/packages/playhtml/src/__tests__/cursor-render-filter.test.ts
+++ b/packages/playhtml/src/__tests__/cursor-render-filter.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Verifies runtime cursor filters immediately replace already-rendered cursors.
+// ABOUTME: Covers custom presence views that take over rendering without another pointer move.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { playhtml, resetPlayHTML } from "../index";
+import { getPresenceSocketForRoom } from "./presence-test-utils";
+
+describe("runtime cursor rendering filters", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    await resetPlayHTML();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+    localStorage.clear();
+    await resetPlayHTML();
+  });
+
+  it("removes an existing cursor as soon as shouldRenderCursor changes", async () => {
+    await playhtml.init({
+      room: "/cursor-render-filter",
+      cursors: { enabled: true },
+    });
+    const socket = getPresenceSocketForRoom(playhtml.roomId);
+    socket.receive({
+      type: "presence-sync",
+      peers: {
+        "remote-connection": {
+          identity: {
+            publicKey: "remote-rider",
+            playerStyle: { colorPalette: ["#4a9a8a"] },
+          },
+          cursor: {
+            cursor: { x: 40, y: 40, pointer: "mouse" },
+            page: "/",
+            zone: null,
+            at: Date.now(),
+          },
+        },
+      },
+    });
+
+    expect(document.querySelector(".playhtml-cursor-other")).not.toBeNull();
+
+    playhtml.cursorClient!.configure({
+      shouldRenderCursor: (presence) =>
+        presence.playerIdentity?.publicKey !== "remote-rider",
+    });
+    expect(
+      document
+        .querySelector(".playhtml-cursor-other")
+        ?.classList.contains("playhtml-cursor-fade-out"),
+    ).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(document.querySelector(".playhtml-cursor-other")).toBeNull();
+
+    playhtml.cursorClient!.configure({
+      shouldRenderCursor: () => true,
+    });
+    expect(document.querySelector(".playhtml-cursor-other")).not.toBeNull();
+  });
+});

--- a/packages/playhtml/src/cursors/cursor-client.ts
+++ b/packages/playhtml/src/cursors/cursor-client.ts
@@ -2119,6 +2119,12 @@ export class CursorClientAwareness {
     // Update options object
     Object.assign(this.options, options);
 
+    if (options.shouldRenderCursor !== undefined) {
+      for (const [stableId, presence] of this.activeCursorPresenceEntries()) {
+        this.updateCursor(stableId, presence);
+      }
+    }
+
     // Update visibility threshold if changed
     if (options.visibilityThreshold !== undefined) {
       this.visibilityThreshold = options.visibilityThreshold;


### PR DESCRIPTION
## Summary

- Add landscape mobile controls for boarding, movement, contextual actions, and fullscreen.
- Keep mobile rider presence visible without duplicating the local cursor.
- Reserve the mobile layout for touch devices so narrow desktop windows keep the desktop experience.
- Gate Commute, Scraps, and Bag Settings discovery behind committed release flags.

## Validation

- `bun run --cwd packages/playhtml test` (51 files, 502 tests)
- `bun run --cwd extension test` (95 files, 580 tests)
- `bun run --cwd extension build`

## Documentation

No public documentation or starter-template changes are needed. The package change adjusts internal cursor rendering and does not change the public API. Internet Commute remains an unreleased, flag-disabled beta, so this PR does not add an extension release-note entry.