### PR TITLE
Fix Firefox presence message handling

### DIFF
--- a/.changeset/firefox-presence-messages.md
+++ b/.changeset/firefox-presence-messages.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Receive realtime presence messages reliably in Firefox so remote cursors and presence controls appear.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -2,6 +2,7 @@
 
 - Open History from every new tab or the popup to see time by site, active explorations, smaller places you returned to, daily cursor portraits, and a moving landscape of real browsing traces.
 - Browse a full year of History without repeated page metadata overwhelming the extension.
+- Presence controls and remote cursors now appear reliably in Firefox.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/packages/playhtml/src/__tests__/presence-transport.test.ts
+++ b/packages/playhtml/src/__tests__/presence-transport.test.ts
@@ -61,11 +61,28 @@ class FakeSocket {
   }
 }
 
-class PropertyMessageSocket extends FakeSocket {
+class PropertyHandlerSocket extends FakeSocket {
   onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
 
   override receive(data: unknown): void {
     this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+
+  override open(): void {
+    this.readyState = WebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  override disconnect(): void {
+    this.readyState = WebSocket.CLOSED;
+    this.onclose?.(new Event("close"));
+  }
+
+  fail(): void {
+    this.onerror?.(new Event("error"));
   }
 }
 
@@ -328,8 +345,9 @@ describe("RealtimePresenceTransport", () => {
     ]);
   });
 
-  it("uses the socket message handler property when available", () => {
-    const socket = new PropertyMessageSocket();
+  it("uses socket handler properties when available", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const socket = new PropertyHandlerSocket();
     const transport = new RealtimePresenceTransport({
       host: "example.com",
       room: "room-1",
@@ -338,13 +356,30 @@ describe("RealtimePresenceTransport", () => {
     const received: unknown[] = [];
     transport.subscribe((message) => received.push(message));
 
-    expect(socket.listeners.has("message")).toBe(false);
-    socket.receive({ type: "presence-sync", peers: {} });
+    expect(
+      ["message", "open", "close", "error"].every(
+        (event) => !socket.listeners.has(event),
+      ),
+    ).toBe(true);
 
+    socket.open();
+    expect(transport.connectionState).toBe("open");
+    socket.receive({ type: "presence-sync", peers: {} });
     expect(received).toEqual([{ type: "presence-sync", peers: {} }]);
+
+    socket.disconnect();
+    expect(transport.connectionState).toBe("connecting");
+    socket.fail();
+    socket.fail();
+    socket.fail();
+    expect(transport.connectionState).toBe("unreachable");
 
     transport.destroy();
     expect(socket.onmessage).toBeNull();
+    expect(socket.onopen).toBeNull();
+    expect(socket.onclose).toBeNull();
+    expect(socket.onerror).toBeNull();
+    errorSpy.mockRestore();
   });
 
   it("ignores malformed nested server change messages", () => {

--- a/packages/playhtml/src/__tests__/presence-transport.test.ts
+++ b/packages/playhtml/src/__tests__/presence-transport.test.ts
@@ -61,6 +61,14 @@ class FakeSocket {
   }
 }
 
+class PropertyMessageSocket extends FakeSocket {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  override receive(data: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
 describe("RealtimePresenceTransport", () => {
   it("connects to the generic presence party", () => {
     let createdOptions: Parameters<PresenceSocketFactory>[0] | null = null;
@@ -318,6 +326,25 @@ describe("RealtimePresenceTransport", () => {
       { type: "presence-sync", peers: {} },
       { type: "presence-changes", updates: {}, removes: {} },
     ]);
+  });
+
+  it("uses the socket message handler property when available", () => {
+    const socket = new PropertyMessageSocket();
+    const transport = new RealtimePresenceTransport({
+      host: "example.com",
+      room: "room-1",
+      socketFactory: () => socket,
+    });
+    const received: unknown[] = [];
+    transport.subscribe((message) => received.push(message));
+
+    expect(socket.listeners.has("message")).toBe(false);
+    socket.receive({ type: "presence-sync", peers: {} });
+
+    expect(received).toEqual([{ type: "presence-sync", peers: {} }]);
+
+    transport.destroy();
+    expect(socket.onmessage).toBeNull();
   });
 
   it("ignores malformed nested server change messages", () => {

--- a/packages/playhtml/src/presence-transport.ts
+++ b/packages/playhtml/src/presence-transport.ts
@@ -120,6 +120,9 @@ export class RealtimePresenceTransport {
       party: "presence",
       maxEnqueuedMessages: 0,
     });
+    // PartySocket 1.2.0 redispatches cloned events through a custom EventTarget,
+    // which Firefox WebExtension content scripts can skip (playhtml#358). Its
+    // direct handler properties run before that redispatch path.
     if (supportsHandlerProperties(this.socket)) {
       this.socket.onmessage = this.onMessage;
       this.socket.onopen = this.onOpen;
@@ -242,6 +245,8 @@ export class RealtimePresenceTransport {
       this.usesHandlerProperties &&
       supportsHandlerProperties(this.socket)
     ) {
+      // Only clear handlers still owned by this transport; another consumer may
+      // have replaced a property after the playhtml#358 handlers were installed.
       if (this.socket.onmessage === this.onMessage) {
         this.socket.onmessage = null;
       }

--- a/packages/playhtml/src/presence-transport.ts
+++ b/packages/playhtml/src/presence-transport.ts
@@ -19,6 +19,10 @@ import { PeerStore } from "./peer-store";
 export type PresenceSocket = Pick<PartySocket, "readyState" | "send" | "close"> &
   Pick<EventTarget, "addEventListener" | "removeEventListener">;
 
+type MessageHandlerSocket = PresenceSocket & {
+  onmessage: ((event: MessageEvent) => void) | null;
+};
+
 export type PresenceSocketFactory = (
   options: PartySocketOptions,
 ) => PresenceSocket;
@@ -68,6 +72,7 @@ export class RealtimePresenceTransport {
   private unreachableLogged = false;
   private unreachableTimer: ReturnType<typeof setTimeout> | null = null;
   private lastControlLogAt = new Map<string, number>();
+  private usesMessageHandlerProperty = false;
   private onMessage = (event: MessageEvent) => {
     const message = parsePresenceServerMessage(event.data);
     if (!message) return;
@@ -112,7 +117,12 @@ export class RealtimePresenceTransport {
       party: "presence",
       maxEnqueuedMessages: 0,
     });
-    this.socket.addEventListener("message", this.onMessage as EventListener);
+    if (supportsMessageHandlerProperty(this.socket)) {
+      this.socket.onmessage = this.onMessage;
+      this.usesMessageHandlerProperty = true;
+    } else {
+      this.socket.addEventListener("message", this.onMessage as EventListener);
+    }
     this.socket.addEventListener("open", this.onOpen);
     this.socket.addEventListener("close", this.onCloseOrError);
     this.socket.addEventListener("error", this.onCloseOrError);
@@ -222,7 +232,19 @@ export class RealtimePresenceTransport {
       this.unreachableTimer = null;
     }
     this.peers.destroy();
-    this.socket.removeEventListener("message", this.onMessage as EventListener);
+    if (
+      this.usesMessageHandlerProperty &&
+      supportsMessageHandlerProperty(this.socket)
+    ) {
+      if (this.socket.onmessage === this.onMessage) {
+        this.socket.onmessage = null;
+      }
+    } else {
+      this.socket.removeEventListener(
+        "message",
+        this.onMessage as EventListener,
+      );
+    }
     this.socket.removeEventListener("open", this.onOpen);
     this.socket.removeEventListener("close", this.onCloseOrError);
     this.socket.removeEventListener("error", this.onCloseOrError);
@@ -265,6 +287,12 @@ export class RealtimePresenceTransport {
 
 export function canUseRealtimePresenceTransport(): boolean {
   return typeof WebSocket !== "undefined";
+}
+
+function supportsMessageHandlerProperty(
+  socket: PresenceSocket,
+): socket is MessageHandlerSocket {
+  return "onmessage" in socket;
 }
 
 function parsePresenceServerMessage(value: unknown): PresenceServerMessage | null {

--- a/packages/playhtml/src/presence-transport.ts
+++ b/packages/playhtml/src/presence-transport.ts
@@ -19,8 +19,11 @@ import { PeerStore } from "./peer-store";
 export type PresenceSocket = Pick<PartySocket, "readyState" | "send" | "close"> &
   Pick<EventTarget, "addEventListener" | "removeEventListener">;
 
-type MessageHandlerSocket = PresenceSocket & {
+type HandlerPropertySocket = PresenceSocket & {
   onmessage: ((event: MessageEvent) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  onclose: ((event: Event) => void) | null;
+  onerror: ((event: Event) => void) | null;
 };
 
 export type PresenceSocketFactory = (
@@ -72,7 +75,7 @@ export class RealtimePresenceTransport {
   private unreachableLogged = false;
   private unreachableTimer: ReturnType<typeof setTimeout> | null = null;
   private lastControlLogAt = new Map<string, number>();
-  private usesMessageHandlerProperty = false;
+  private usesHandlerProperties = false;
   private onMessage = (event: MessageEvent) => {
     const message = parsePresenceServerMessage(event.data);
     if (!message) return;
@@ -117,15 +120,18 @@ export class RealtimePresenceTransport {
       party: "presence",
       maxEnqueuedMessages: 0,
     });
-    if (supportsMessageHandlerProperty(this.socket)) {
+    if (supportsHandlerProperties(this.socket)) {
       this.socket.onmessage = this.onMessage;
-      this.usesMessageHandlerProperty = true;
+      this.socket.onopen = this.onOpen;
+      this.socket.onclose = this.onCloseOrError;
+      this.socket.onerror = this.onCloseOrError;
+      this.usesHandlerProperties = true;
     } else {
       this.socket.addEventListener("message", this.onMessage as EventListener);
+      this.socket.addEventListener("open", this.onOpen);
+      this.socket.addEventListener("close", this.onCloseOrError);
+      this.socket.addEventListener("error", this.onCloseOrError);
     }
-    this.socket.addEventListener("open", this.onOpen);
-    this.socket.addEventListener("close", this.onCloseOrError);
-    this.socket.addEventListener("error", this.onCloseOrError);
     // Grace window: if the socket never opens at all, flag it once.
     this.unreachableTimer = setTimeout(() => {
       this.unreachableTimer = null;
@@ -233,21 +239,30 @@ export class RealtimePresenceTransport {
     }
     this.peers.destroy();
     if (
-      this.usesMessageHandlerProperty &&
-      supportsMessageHandlerProperty(this.socket)
+      this.usesHandlerProperties &&
+      supportsHandlerProperties(this.socket)
     ) {
       if (this.socket.onmessage === this.onMessage) {
         this.socket.onmessage = null;
+      }
+      if (this.socket.onopen === this.onOpen) {
+        this.socket.onopen = null;
+      }
+      if (this.socket.onclose === this.onCloseOrError) {
+        this.socket.onclose = null;
+      }
+      if (this.socket.onerror === this.onCloseOrError) {
+        this.socket.onerror = null;
       }
     } else {
       this.socket.removeEventListener(
         "message",
         this.onMessage as EventListener,
       );
+      this.socket.removeEventListener("open", this.onOpen);
+      this.socket.removeEventListener("close", this.onCloseOrError);
+      this.socket.removeEventListener("error", this.onCloseOrError);
     }
-    this.socket.removeEventListener("open", this.onOpen);
-    this.socket.removeEventListener("close", this.onCloseOrError);
-    this.socket.removeEventListener("error", this.onCloseOrError);
     this.socket.close();
     this.listeners.clear();
   }
@@ -289,10 +304,15 @@ export function canUseRealtimePresenceTransport(): boolean {
   return typeof WebSocket !== "undefined";
 }
 
-function supportsMessageHandlerProperty(
+function supportsHandlerProperties(
   socket: PresenceSocket,
-): socket is MessageHandlerSocket {
-  return "onmessage" in socket;
+): socket is HandlerPropertySocket {
+  return (
+    "onmessage" in socket &&
+    "onopen" in socket &&
+    "onclose" in socket &&
+    "onerror" in socket
+  );
 }
 
 function parsePresenceServerMessage(value: unknown): PresenceServerMessage | null {


### PR DESCRIPTION
## Summary

- Receive PartySocket messages and lifecycle events through direct handler properties when that interface is available.
- Keep the event-listener path for injected sockets that do not expose the complete handler interface.
- Add regression coverage and a Firefox extension release note.

## Root cause

Firefox WebExtension content scripts can silently skip listeners on custom `EventTarget` subclasses. The native WebSocket received presence events and PartySocket handled them, but PartySocket's redispatched events never reached PlayHTML's listeners. Remote peers therefore never entered the shared presence store, leaving the presence control hidden. The skipped `open` event also left the connection grace timer active, which could mark a working connection unreachable.

PartySocket calls its `onmessage`, `onopen`, `onclose`, and `onerror` properties directly before calling `dispatchEvent()`. Using those handlers bypasses Firefox's broken redispatch path.

## User impact

Firefox users can see remote cursors and the bottom-right presence and chat control when other people are on the page. Working connections no longer emit a false presence-degraded error after the grace period.

## Validation

- Verified the production-style Firefox build on Wikipedia after the 15-second connection grace period; the presence control remained visible.
- Confirmed the Firefox page console contained no `presence transport unreachable` or `realtime presence degraded` errors.
- `packages/playhtml`: 503 tests passed.
- PlayHTML package build passed.
- Firefox extension build passed.
- Focused transport suite: 15 tests passed, including direct `message`, `open`, `close`, and `error` handlers and guarded cleanup.

## Documentation

No public documentation or starter-template changes are needed. This fixes internal transport compatibility without changing the public API or usage.