### PR TITLE
Fix initialization, recent pagination, and package builds

### DIFF
--- a/.changeset/quiet-functions-configure.md
+++ b/.changeset/quiet-functions-configure.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Preserve function-valued initialization options when they are the only configuration so dynamic rooms and error handlers run as declared.

--- a/extension/worker/src/__tests__/recent.test.ts
+++ b/extension/worker/src/__tests__/recent.test.ts
@@ -1,43 +1,11 @@
 // ABOUTME: Tests stable pagination for recent extension events.
 // ABOUTME: Verifies live inserts cannot shift later pages onto duplicate rows.
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Env } from '../lib/supabase';
-
-const collectionEvents = {
-  select: vi.fn(),
-  eq: vi.fn(),
-  gte: vi.fn(),
-  lte: vi.fn(),
-  or: vi.fn(),
-  order: vi.fn(),
-  limit: vi.fn(),
-  range: vi.fn(),
-};
-
-const participants = {
-  select: vi.fn(),
-  in: vi.fn(),
-};
-
-const from = vi.fn();
-let offsetPages: Array<{ data: Array<Record<string, unknown>>; error: null }>;
-let keysetPages: Array<{ data: Array<Record<string, unknown>>; error: null }>;
-
-vi.mock('../lib/supabase', () => ({
-  createSupabaseClient: vi.fn(() => ({ from })),
-}));
-
-import { handleRecent } from '../routes/recent';
-
-const ENV: Env = {
-  SUPABASE_URL: 'https://example.supabase.co',
-  SUPABASE_SECRET_KEY: 'k',
-  ADMIN_KEY: 'a',
-  RESEND_API_KEY: 'r',
-  CODA_API_TOKEN: 'c',
-  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
-};
+import { describe, expect, it } from 'vitest';
+import {
+  getEarlierEventFilter,
+  loadRecentEventRows,
+} from '../routes/recent';
 
 function makeRow(index: number): Record<string, unknown> {
   return {
@@ -54,62 +22,47 @@ function makeRow(index: number): Record<string, unknown> {
   };
 }
 
-describe('handleRecent', () => {
-  beforeEach(() => {
-    Object.values(collectionEvents).forEach((mock) => mock.mockReset());
-    Object.values(participants).forEach((mock) => mock.mockReset());
-    from.mockReset();
+describe('recent event pagination', () => {
+  it('continues after the last row instead of using a shifted offset', async () => {
+    const storedRows = Array.from({ length: 1001 }, (_, index) => makeRow(index));
+    let pageCount = 0;
 
-    const firstPage = Array.from({ length: 1000 }, (_, index) => makeRow(index));
-    offsetPages = [
-      { data: firstPage, error: null },
-      { data: [makeRow(999)], error: null },
-    ];
-    keysetPages = [
-      { data: firstPage, error: null },
-      { data: [makeRow(1000)], error: null },
-    ];
+    const result = await loadRecentEventRows(1001, async (cursor, pageSize) => {
+      pageCount += 1;
+      if (pageCount === 2) storedRows.unshift(makeRow(-1));
 
-    from.mockImplementation((table: string) => {
-      if (table === 'collection_events') return collectionEvents;
-      if (table === 'participants') return participants;
-      throw new Error(`Unexpected table: ${table}`);
+      const rows = storedRows
+        .filter((row) => {
+          if (!cursor) return true;
+          const ts = row.ts as string;
+          const id = row.id as string;
+          return ts < cursor.ts || (ts === cursor.ts && id < cursor.id);
+        })
+        .sort((a, b) => {
+          const tsOrder = (b.ts as string).localeCompare(a.ts as string);
+          return tsOrder || (b.id as string).localeCompare(a.id as string);
+        })
+        .slice(0, pageSize);
+
+      return { data: rows, error: null };
     });
 
-    collectionEvents.select.mockReturnValue(collectionEvents);
-    collectionEvents.eq.mockReturnValue(collectionEvents);
-    collectionEvents.gte.mockReturnValue(collectionEvents);
-    collectionEvents.lte.mockReturnValue(collectionEvents);
-    collectionEvents.or.mockReturnValue(collectionEvents);
-    collectionEvents.order.mockReturnValue(collectionEvents);
-    collectionEvents.range.mockImplementation(() =>
-      Promise.resolve(offsetPages.shift()),
-    );
-    collectionEvents.limit.mockImplementation(() =>
-      Promise.resolve(keysetPages.shift()),
-    );
-
-    participants.select.mockReturnValue(participants);
-    participants.in.mockResolvedValue({ data: [], error: null });
-  });
-
-  it('continues after the last row instead of using a shifted offset', async () => {
-    const response = await handleRecent(
-      new Request('https://worker.example/events/recent?limit=1001'),
-      ENV,
-    );
-
-    expect(response.status).toBe(200);
-    const events = await response.json() as Array<{ id: string }>;
+    if (result.error) throw new Error(result.error.message);
+    const events = result.rows;
 
     expect(events).toHaveLength(1001);
     expect(new Set(events.map((event) => event.id)).size).toBe(1001);
     expect(events.at(-1)?.id).toBe('event-1000');
-    expect(collectionEvents.range).not.toHaveBeenCalled();
-    expect(collectionEvents.order).toHaveBeenCalledWith('ts', { ascending: false });
-    expect(collectionEvents.order).toHaveBeenCalledWith('id', { ascending: false });
-    expect(collectionEvents.or).toHaveBeenCalledWith(
-      'ts.lt."2026-01-01T23:43:21.000Z",and(ts.eq."2026-01-01T23:43:21.000Z",id.lt."event-0999")',
+  });
+
+  it('builds a stable filter for equal timestamps and quoted ids', () => {
+    expect(
+      getEarlierEventFilter(
+        '2026-01-01T23:43:21.000Z',
+        'event-"0999"',
+      ),
+    ).toBe(
+      'ts.lt."2026-01-01T23:43:21.000Z",and(ts.eq."2026-01-01T23:43:21.000Z",id.lt."event-\\"0999\\"")',
     );
   });
 });

--- a/extension/worker/src/__tests__/recent.test.ts
+++ b/extension/worker/src/__tests__/recent.test.ts
@@ -1,0 +1,115 @@
+// ABOUTME: Tests stable pagination for recent extension events.
+// ABOUTME: Verifies live inserts cannot shift later pages onto duplicate rows.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../lib/supabase';
+
+const collectionEvents = {
+  select: vi.fn(),
+  eq: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  or: vi.fn(),
+  order: vi.fn(),
+  limit: vi.fn(),
+  range: vi.fn(),
+};
+
+const participants = {
+  select: vi.fn(),
+  in: vi.fn(),
+};
+
+const from = vi.fn();
+let offsetPages: Array<{ data: Array<Record<string, unknown>>; error: null }>;
+let keysetPages: Array<{ data: Array<Record<string, unknown>>; error: null }>;
+
+vi.mock('../lib/supabase', () => ({
+  createSupabaseClient: vi.fn(() => ({ from })),
+}));
+
+import { handleRecent } from '../routes/recent';
+
+const ENV: Env = {
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_SECRET_KEY: 'k',
+  ADMIN_KEY: 'a',
+  RESEND_API_KEY: 'r',
+  CODA_API_TOKEN: 'c',
+  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
+};
+
+function makeRow(index: number): Record<string, unknown> {
+  return {
+    id: `event-${index.toString().padStart(4, '0')}`,
+    type: 'cursor',
+    ts: new Date(Date.UTC(2026, 0, 2) - index * 1000).toISOString(),
+    participant_id: 'participant',
+    session_id: 'session',
+    url: 'https://example.com/',
+    viewport_width: 1024,
+    viewport_height: 768,
+    timezone: 'America/Los_Angeles',
+    data: { event: 'move' },
+  };
+}
+
+describe('handleRecent', () => {
+  beforeEach(() => {
+    Object.values(collectionEvents).forEach((mock) => mock.mockReset());
+    Object.values(participants).forEach((mock) => mock.mockReset());
+    from.mockReset();
+
+    const firstPage = Array.from({ length: 1000 }, (_, index) => makeRow(index));
+    offsetPages = [
+      { data: firstPage, error: null },
+      { data: [makeRow(999)], error: null },
+    ];
+    keysetPages = [
+      { data: firstPage, error: null },
+      { data: [makeRow(1000)], error: null },
+    ];
+
+    from.mockImplementation((table: string) => {
+      if (table === 'collection_events') return collectionEvents;
+      if (table === 'participants') return participants;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    collectionEvents.select.mockReturnValue(collectionEvents);
+    collectionEvents.eq.mockReturnValue(collectionEvents);
+    collectionEvents.gte.mockReturnValue(collectionEvents);
+    collectionEvents.lte.mockReturnValue(collectionEvents);
+    collectionEvents.or.mockReturnValue(collectionEvents);
+    collectionEvents.order.mockReturnValue(collectionEvents);
+    collectionEvents.range.mockImplementation(() =>
+      Promise.resolve(offsetPages.shift()),
+    );
+    collectionEvents.limit.mockImplementation(() =>
+      Promise.resolve(keysetPages.shift()),
+    );
+
+    participants.select.mockReturnValue(participants);
+    participants.in.mockResolvedValue({ data: [], error: null });
+  });
+
+  it('continues after the last row instead of using a shifted offset', async () => {
+    const response = await handleRecent(
+      new Request('https://worker.example/events/recent?limit=1001'),
+      ENV,
+    );
+
+    expect(response.status).toBe(200);
+    const events = await response.json() as Array<{ id: string }>;
+
+    expect(events).toHaveLength(1001);
+    expect(new Set(events.map((event) => event.id)).size).toBe(1001);
+    expect(events.at(-1)?.id).toBe('event-1000');
+    expect(collectionEvents.range).not.toHaveBeenCalled();
+    expect(collectionEvents.order).toHaveBeenCalledWith('ts', { ascending: false });
+    expect(collectionEvents.order).toHaveBeenCalledWith('id', { ascending: false });
+    expect(collectionEvents.or).toHaveBeenCalledWith(
+      'ts.lt."2026-01-01T23:43:21.000Z",and(ts.eq."2026-01-01T23:43:21.000Z",id.lt."event-0999")',
+    );
+  });
+});

--- a/extension/worker/src/routes/recent.ts
+++ b/extension/worker/src/routes/recent.ts
@@ -24,6 +24,16 @@ function extractDomain(url: string | null): string {
 /** Supabase/PostgREST returns at most 1000 rows per request; we paginate to satisfy larger limits. */
 const SUPABASE_PAGE_SIZE = 1000;
 
+function quoteEventCursorValue(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function getEarlierEventFilter(ts: string, id: string): string {
+  const quotedTs = quoteEventCursorValue(ts);
+  const quotedId = quoteEventCursorValue(id);
+  return `ts.lt.${quotedTs},and(ts.eq.${quotedTs},id.lt.${quotedId})`;
+}
+
 type PageMeta = { title?: string; favicon_url?: string };
 
 /**
@@ -89,11 +99,9 @@ export async function handleRecent(
 
     const supabase = createSupabaseClient(env);
     const allRows: Record<string, unknown>[] = [];
+    let cursor: { ts: string; id: string } | null = null;
 
-    for (let offset = 0; offset < limit; offset += SUPABASE_PAGE_SIZE) {
-      const from = offset;
-      const to = offset + SUPABASE_PAGE_SIZE - 1;
-
+    while (allRows.length < limit) {
       let query = supabase
         .from('collection_events')
         .select('*')
@@ -110,10 +118,14 @@ export async function handleRecent(
       const toDate = url.searchParams.get('to');
       if (fromDate) query = query.gte('ts', fromDate);
       if (toDate) query = query.lte('ts', toDate);
+      if (cursor) query = query.or(getEarlierEventFilter(cursor.ts, cursor.id));
+
+      const pageSize = Math.min(SUPABASE_PAGE_SIZE, limit - allRows.length);
 
       const { data, error } = await query
         .order('ts', { ascending: false })
-        .range(from, to);
+        .order('id', { ascending: false })
+        .limit(pageSize);
 
       if (error) {
         console.error('Supabase query error:', error);
@@ -125,7 +137,13 @@ export async function handleRecent(
 
       const page = data ?? [];
       allRows.push(...page);
-      if (page.length < SUPABASE_PAGE_SIZE) break;
+      if (page.length < pageSize) break;
+
+      const lastRow = page.at(-1);
+      if (typeof lastRow?.ts !== 'string' || typeof lastRow.id !== 'string') {
+        throw new Error('Recent event row is missing pagination fields');
+      }
+      cursor = { ts: lastRow.ts, id: lastRow.id };
     }
 
     // Cap at requested limit

--- a/extension/worker/src/routes/recent.ts
+++ b/extension/worker/src/routes/recent.ts
@@ -28,10 +28,53 @@ function quoteEventCursorValue(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
-function getEarlierEventFilter(ts: string, id: string): string {
+export function getEarlierEventFilter(ts: string, id: string): string {
   const quotedTs = quoteEventCursorValue(ts);
   const quotedId = quoteEventCursorValue(id);
   return `ts.lt.${quotedTs},and(ts.eq.${quotedTs},id.lt.${quotedId})`;
+}
+
+interface RecentEventCursor {
+  ts: string;
+  id: string;
+}
+
+interface RecentEventPage {
+  data: Record<string, unknown>[] | null;
+  error: { message: string } | null;
+}
+
+type RecentEventRows =
+  | { rows: Record<string, unknown>[]; error: null }
+  | { rows: null; error: { message: string } };
+
+export async function loadRecentEventRows(
+  limit: number,
+  loadPage: (
+    cursor: RecentEventCursor | null,
+    pageSize: number,
+  ) => Promise<RecentEventPage>,
+): Promise<RecentEventRows> {
+  const rows: Record<string, unknown>[] = [];
+  let cursor: RecentEventCursor | null = null;
+
+  while (rows.length < limit) {
+    const pageSize = Math.min(SUPABASE_PAGE_SIZE, limit - rows.length);
+    const result = await loadPage(cursor, pageSize);
+    if (result.error) return { rows: null, error: result.error };
+
+    const page = result.data ?? [];
+    rows.push(...page);
+    if (page.length < pageSize) break;
+
+    const lastRow = page.at(-1);
+    if (typeof lastRow?.ts !== 'string' || typeof lastRow.id !== 'string') {
+      throw new Error('Recent event row is missing pagination fields');
+    }
+    cursor = { ts: lastRow.ts, id: lastRow.id };
+  }
+
+  return { rows, error: null };
 }
 
 type PageMeta = { title?: string; favicon_url?: string };
@@ -98,10 +141,7 @@ export async function handleRecent(
     const requireTitle = url.searchParams.get('require_title') === 'true';
 
     const supabase = createSupabaseClient(env);
-    const allRows: Record<string, unknown>[] = [];
-    let cursor: { ts: string; id: string } | null = null;
-
-    while (allRows.length < limit) {
+    const { rows, error } = await loadRecentEventRows(limit, async (cursor, pageSize) => {
       let query = supabase
         .from('collection_events')
         .select('*')
@@ -120,34 +160,19 @@ export async function handleRecent(
       if (toDate) query = query.lte('ts', toDate);
       if (cursor) query = query.or(getEarlierEventFilter(cursor.ts, cursor.id));
 
-      const pageSize = Math.min(SUPABASE_PAGE_SIZE, limit - allRows.length);
-
-      const { data, error } = await query
+      return query
         .order('ts', { ascending: false })
         .order('id', { ascending: false })
         .limit(pageSize);
+    });
 
-      if (error) {
-        console.error('Supabase query error:', error);
-        return new Response(
-          JSON.stringify({ error: 'Failed to fetch events', details: error.message }),
-          { status: 500, headers: { 'Content-Type': 'application/json' } }
-        );
-      }
-
-      const page = data ?? [];
-      allRows.push(...page);
-      if (page.length < pageSize) break;
-
-      const lastRow = page.at(-1);
-      if (typeof lastRow?.ts !== 'string' || typeof lastRow.id !== 'string') {
-        throw new Error('Recent event row is missing pagination fields');
-      }
-      cursor = { ts: lastRow.ts, id: lastRow.id };
+    if (error) {
+      console.error('Supabase query error:', error);
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch events', details: error.message }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
     }
-
-    // Cap at requested limit
-    const rows = allRows.slice(0, limit);
 
     // ── Join page titles from page_metadata_history ───────────────────────────
     // Titles are stripped from navigation event rows at ingest time and stored

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "deploy-server": "bunx wrangler deploy --config partykit/wrangler.jsonc",
     "deploy-server:staging": "bunx wrangler deploy --config partykit/wrangler.jsonc --env staging",
     "build-site": "vite build website --config vite.config.site.mts && cd apps/docs && bun run build",
-    "build-packages": "for dir in packages/*; do (cd \"$dir\" && bun run build); done",
+    "build-packages": "for dir in packages/*; do (cd \"$dir\" && bun run build) || exit $?; done",
     "build-extension": "cd extension && bun run build",
     "build-extension:website": "cd extension/website && bun run build",
     "changeset": "changeset",

--- a/packages/playhtml/src/__tests__/init-configure.test.ts
+++ b/packages/playhtml/src/__tests__/init-configure.test.ts
@@ -24,6 +24,25 @@ describe("playhtml configure() + init()", () => {
     expect(playhtml.cursorClient).not.toBeNull();
   });
 
+  it("uses a function-only room declaration", async () => {
+    await playhtml.init({ room: () => "/function-room" });
+
+    const host = window.location.host.replace(/^www\./, "");
+    expect(playhtml.roomId).toBe(
+      encodeURIComponent(`${host}-/function-room`),
+    );
+  });
+
+  it("uses a function-only error handler declaration", async () => {
+    const onError = vi.fn();
+    await playhtml.init({ onError });
+
+    const [provider] = (globalThis as any).PLAYHTML_TEST_PROVIDERS;
+    provider.emit("error", new Error("connection failed"));
+
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
   it("a repeated empty configure() before init() does not lock config", async () => {
     // configure() with no options is a true no-op: it must not freeze config, so
     // a later real configure() still wins. (configure() is connection-free, so

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -751,6 +751,15 @@ function normalizeConfig(value: unknown): unknown {
   return value;
 }
 
+function containsConfiguredFunction(value: unknown): boolean {
+  if (typeof value === "function") return true;
+  if (Array.isArray(value)) return value.some(containsConfiguredFunction);
+  if (value && typeof value === "object") {
+    return Object.values(value).some(containsConfiguredFunction);
+  }
+  return false;
+}
+
 /**
  * Returns true if `incoming` conflicts with the already-locked config.
  *
@@ -799,10 +808,13 @@ function configsConflict(locked: InitOptions, incoming: InitOptions): boolean {
 
 /** True if these options declare no config worth locking (an "ensure running"
  * call). Such a call must NOT lock config, so a real configure() can still win
- * before connection. Uses the same normalization as configsConflict, so
- * `{}`, `{ cursors: {} }`, and `{ room: undefined }` all count as empty. */
+ * before connection. `{}`, `{ cursors: {} }`, and `{ room: undefined }` all
+ * count as empty, while function-valued options still declare config. */
 function isEmptyConfig(options: InitOptions): boolean {
-  return normalizeConfig(options) === undefined;
+  return (
+    normalizeConfig(options) === undefined &&
+    !containsConfiguredFunction(options)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- preserve function-valued initialization options when they are the only configuration
- paginate recent extension events with a stable descending `(ts, id)` cursor
- stop package builds after the first workspace failure
- add a PlayHTML patch changeset

## Root causes

`isEmptyConfig` reused comparison normalization that intentionally removes functions, so function-only `room` and `onError` options looked empty.

`/events/recent` used offsets against a table receiving live inserts. Rows shifting between requests could duplicate one event and omit another. The route now continues after the last `(ts, id)` pair and quotes cursor values before building the PostgREST filter.

The package build loop returned the final workspace's status. An earlier failure could therefore be hidden when a later package built successfully.

## Reproduction

- function-only room and error-handler tests failed before the config fix
- the pagination regression inserts a newer in-memory row between page reads and verifies all original rows are returned once
- an injected failure in `packages/extension-types` previously produced exit code `0`; the updated loop propagates exit code `23`

## Validation

- `bun run build-packages`
- `bun run --cwd packages/playhtml test` (51 files, 505 tests)
- `bun run --cwd extension/worker test` (13 files, 76 tests)
- `bunx tsc -p extension/worker/tsconfig.json --noEmit`
- `bunx changeset status`
- `git diff --check origin/main...HEAD`

The existing init reference already documents function-valued rooms and error handlers. Public usage did not change, so the docs and starter templates need no edits.