### PR TITLE
Fix React package readiness follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ playhtml is in beta and actively developed. Join the [Discord](https://discord.c
 **React:**
 
 ```bash
-npm install @playhtml/react @playhtml/common
+npm install playhtml @playhtml/react
 ```
 
 ```tsx

--- a/templates/react-starter/package.json
+++ b/templates/react-starter/package.json
@@ -19,6 +19,6 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
## Summary

- Install `playhtml` instead of the internal `@playhtml/common` package in the README React setup command.
- Update the React starter from Vite 5 to the patched Vite 6.4.3 release line.

## Why

The README bypassed the public runtime boundary and told React users to install an internal package. The starter's Vite 5 range also resolved to Vite 5.4.21, which `npm audit` reports with high and moderate development-server vulnerabilities.

## Validation

- `npm install`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npx vite build`
- Loaded the starter locally in a browser
- Verified the reaction button updates from 0 to 1
- Confirmed no browser console warnings or errors
- `git diff --check`

## Release notes

No changeset is needed because this PR does not modify a published package. The public package API is unchanged, so `apps/docs` and the HTML starter do not need updates.