### PR TITLE
extension: reduce background performance overhead

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -6,6 +6,7 @@
 - Use the extension in Safari 18 or later on Mac.
 - Turn on Safari website access once during setup, then close the setup tab when you’re done.
 - Get clear recovery steps if Safari cannot save your setup choices.
+- Reduced WWO's impact on browser performance during long browsing sessions.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -7,6 +7,7 @@
 - Turn on Safari website access once during setup, then close the setup tab when you’re done.
 - Get clear recovery steps if Safari cannot save your setup choices.
 - Reduced WWO's impact on browser performance during long browsing sessions.
+- Shortened browsing portrait captions and kept long site names inside their cards.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/src/__tests__/CursorCollector.test.ts
+++ b/extension/src/__tests__/CursorCollector.test.ts
@@ -59,6 +59,7 @@ describe("CursorCollector", () => {
         "mousemove",
         expect.any(Function)
       );
+      expect(removeSpy).toHaveBeenCalledWith("mouseover", expect.any(Function));
       expect(removeSpy).toHaveBeenCalledWith(
         "mousedown",
         expect.any(Function)
@@ -170,7 +171,7 @@ describe("CursorCollector", () => {
       expect(realTimeCallback).toHaveBeenCalled();
     });
 
-    it("reuses cursor style while the pointer stays on the same target", () => {
+    it("reads cursor style only when the pointer enters a target", () => {
       const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
       const element = createTestElement("button", {
         id: "steady-target",
@@ -179,11 +180,26 @@ describe("CursorCollector", () => {
 
       collector.enable();
 
+      element.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       simulateMouseMove(100, 100, element);
       simulateMouseMove(120, 120, element);
       simulateMouseMove(140, 140, element);
 
       expect(getComputedStyleSpy).toHaveBeenCalledTimes(1);
+      getComputedStyleSpy.mockRestore();
+    });
+
+    it("does not read computed style from the raw mousemove handler", () => {
+      const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
+      const element = createTestElement("button", {
+        id: "move-target",
+        cursor: "pointer",
+      });
+
+      collector.enable();
+      simulateMouseMove(100, 100, element);
+
+      expect(getComputedStyleSpy).not.toHaveBeenCalled();
       getComputedStyleSpy.mockRestore();
     });
   });
@@ -218,20 +234,20 @@ describe("CursorCollector", () => {
       expect(call.duration).toBeGreaterThanOrEqual(250);
       expect(call.quantity).toBeUndefined(); // Hold events don't have quantity
     });
-    
+
     it("emits rapid clicks as separate events", async () => {
       collector.enable();
 
       const element = createTestElement("button", { id: "rapid-click" });
-      
+
       // First click
       await simulateClick(100, 100, 50, 0, element);
       await advanceTime(300);
-      
+
       // Second click (within 2s window)
       await simulateClick(150, 150, 50, 0, element);
       await advanceTime(500);
-      
+
       // Third click (within 2s window)
       await simulateClick(200, 200, 50, 0, element);
 
@@ -246,12 +262,12 @@ describe("CursorCollector", () => {
       expect((clickCalls[2][0] as CursorEventData).x).toBeCloseTo(200 / 1024, 4);
       expect((clickCalls[2][0] as CursorEventData).y).toBeCloseTo(200 / 768, 4);
     });
-    
+
     it("emits separate click events if clicks are spaced out", async () => {
       collector.enable();
 
       const element = createTestElement("button", { id: "spaced-clicks" });
-      
+
       // First click
       await simulateClick(100, 100, 50, 0, element);
       await advanceTime(2500); // Past 2s debounce
@@ -264,7 +280,7 @@ describe("CursorCollector", () => {
         (call) => (call[0] as CursorEventData).event === "click"
       );
       expect(clickCalls.length).toBe(2);
-      
+
       // Each should have quantity of 1
       expect((clickCalls[0][0] as CursorEventData).quantity).toBe(1);
       expect((clickCalls[1][0] as CursorEventData).quantity).toBe(1);
@@ -296,7 +312,6 @@ describe("CursorCollector", () => {
     });
   });
 
-
   describe("cursor style detection", () => {
     it("detects cursor style changes", async () => {
       collector.enable();
@@ -311,10 +326,12 @@ describe("CursorCollector", () => {
       });
 
       // Move to pointer element
+      pointerElement.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       simulateMouseMove(100, 100, pointerElement);
       await advanceTime(20);
 
       // Move to text element (cursor changes)
+      textElement.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       simulateMouseMove(200, 200, textElement);
       await advanceTime(600); // Wait for 500ms cursor change debounce
 
@@ -340,6 +357,7 @@ describe("CursorCollector", () => {
         id: "button",
         cursor: "pointer",
       });
+      element.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
       simulateMouseMove(100, 100, element);
 
       await advanceTime(250);

--- a/extension/src/__tests__/CursorCollector.test.ts
+++ b/extension/src/__tests__/CursorCollector.test.ts
@@ -189,7 +189,7 @@ describe("CursorCollector", () => {
       getComputedStyleSpy.mockRestore();
     });
 
-    it("does not read computed style from the raw mousemove handler", () => {
+    it("initializes cursor style from the first mousemove only", async () => {
       const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle");
       const element = createTestElement("button", {
         id: "move-target",
@@ -198,8 +198,13 @@ describe("CursorCollector", () => {
 
       collector.enable();
       simulateMouseMove(100, 100, element);
+      simulateMouseMove(120, 120, element);
+      await advanceTime(250);
 
-      expect(getComputedStyleSpy).not.toHaveBeenCalled();
+      expect(getComputedStyleSpy).toHaveBeenCalledTimes(1);
+      expect((emitCallback.mock.calls[0][0] as CursorEventData).cursor).toBe(
+        "pointer",
+      );
       getComputedStyleSpy.mockRestore();
     });
   });

--- a/extension/src/__tests__/EventBuffer.test.ts
+++ b/extension/src/__tests__/EventBuffer.test.ts
@@ -66,7 +66,11 @@ describe("EventBuffer", () => {
 
     expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(250);
+    await vi.advanceTimersByTimeAsync(999);
+
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
 
     expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
     expect(browser.runtime.sendMessage).toHaveBeenCalledWith({

--- a/extension/src/__tests__/LocalEventStore.test.ts
+++ b/extension/src/__tests__/LocalEventStore.test.ts
@@ -214,6 +214,121 @@ afterEach(async () => {
 });
 
 describe("LocalEventStore aggregates", () => {
+  it("maintains compact milestone activity and recent domain metadata", async () => {
+    const store = createStore();
+    const focusTs = Date.UTC(2026, 7, 10, 10);
+    const blurTs = focusTs + 5_000;
+
+    await store.addEvents([
+      {
+        ...event("focus", "navigation"),
+        ts: focusTs,
+        data: {
+          event: "focus",
+          favicon_url: "https://example.com/favicon.png",
+        },
+        meta: { ...event("focus", "navigation").meta, tz: "UTC" },
+      },
+      {
+        ...event("cursor-first", "cursor"),
+        ts: focusTs + 1_000,
+        data: { event: "move", x: 0.1, y: 0.2 },
+        meta: { ...event("cursor-first", "cursor").meta, tz: "UTC" },
+      },
+      {
+        ...event("cursor-second", "cursor"),
+        ts: focusTs + 2_000,
+        data: { event: "move", x: 0.2, y: 0.2 },
+        meta: { ...event("cursor-second", "cursor").meta, tz: "UTC" },
+      },
+      {
+        ...event("blur", "navigation"),
+        ts: blurTs,
+        data: { event: "blur" },
+        meta: { ...event("blur", "navigation").meta, tz: "UTC" },
+      },
+    ]);
+
+    const globalStats = await store.getGlobalStats();
+    const domains = await store.getAllDomains();
+
+    expect(globalStats?.milestoneActivity).toEqual({
+      localDayKey: "2026-08-10",
+      cursorDistancePx: 192,
+      lastCursorPosition: { x: 0.2, y: 0.2 },
+      screenTimeMs: 5_000,
+      pendingFocusTs: null,
+    });
+    expect(domains[0]).toEqual(
+      expect.objectContaining({
+        latestFaviconUrl: "https://example.com/favicon.png",
+        recentFocusVisits: [focusTs],
+      }),
+    );
+  });
+
+  it("seeds recent visits from retained aggregate history", async () => {
+    const store = createStore();
+    const previousVisitTs = Date.UTC(2026, 0, 1, 10);
+    const returnTs = Date.UTC(2026, 7, 10, 10);
+
+    await store.addEvents([
+      {
+        ...event("previous-event", "cursor"),
+        ts: previousVisitTs,
+        data: { event: "move", x: 0.1, y: 0.1 },
+        meta: { ...event("previous-event", "cursor").meta, tz: "UTC" },
+      },
+    ]);
+    await store.addEvents([
+      {
+        ...event("return-focus", "navigation"),
+        ts: returnTs,
+        data: { event: "focus" },
+        meta: { ...event("return-focus", "navigation").meta, tz: "UTC" },
+      },
+    ]);
+
+    const domains = await store.getAllDomains();
+
+    expect(domains[0].recentFocusVisits).toEqual([returnTs, previousVisitTs]);
+  });
+
+  it("resets compact daily activity when the local day changes", async () => {
+    const store = createStore();
+
+    await store.addEvents([
+      {
+        ...event("day-one-first", "cursor"),
+        ts: Date.UTC(2026, 7, 10, 10),
+        data: { event: "move", x: 0.1, y: 0.1 },
+        meta: { ...event("day-one-first", "cursor").meta, tz: "UTC" },
+      },
+      {
+        ...event("day-one-second", "cursor"),
+        ts: Date.UTC(2026, 7, 10, 10, 1),
+        data: { event: "move", x: 0.2, y: 0.1 },
+        meta: { ...event("day-one-second", "cursor").meta, tz: "UTC" },
+      },
+      {
+        ...event("day-two-first", "cursor"),
+        ts: Date.UTC(2026, 7, 11, 10),
+        data: { event: "move", x: 0.3, y: 0.1 },
+        meta: { ...event("day-two-first", "cursor").meta, tz: "UTC" },
+      },
+    ]);
+
+    const globalStats = await store.getGlobalStats();
+
+    expect(globalStats?.milestoneActivity).toEqual({
+      localDayKey: "2026-08-11",
+      cursorDistancePx: 0,
+      lastCursorPosition: { x: 0.3, y: 0.1 },
+      screenTimeMs: 0,
+      pendingFocusTs: null,
+    });
+  });
+
   it("fails with reload guidance instead of hanging when an upgrade is blocked", async () => {
     const existingConnection = await openVersion8Database();
     const consoleError = vi

--- a/extension/src/__tests__/WalkingRecord.test.tsx
+++ b/extension/src/__tests__/WalkingRecord.test.tsx
@@ -47,7 +47,7 @@ const record: WalkingRecord = {
     {
       date: "day:2026-07-27",
       day: "mon",
-      vignette: "12 quiet minutes on example.com",
+      vignette: "12m on example.com",
       hue: "#4a9a8a",
       future: false,
       portraitDay: "2026-07-27",
@@ -260,7 +260,6 @@ describe("WalkingRecordPage calendar navigation", () => {
       expect(
         container.querySelector(".walking-record__future-trace"),
       ).not.toBeNull();
-
       await act(async () => {
         earlier?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         selected?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/extension/src/__tests__/background-retention.test.ts
+++ b/extension/src/__tests__/background-retention.test.ts
@@ -5,13 +5,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const browserMock = vi.hoisted(() => ({
   storage: {
-      local: {
-        get: vi.fn().mockResolvedValue({}),
-        set: vi.fn().mockResolvedValue(undefined),
-        getBytesInUse: vi.fn().mockResolvedValue(1024),
-      },
+    local: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+      getBytesInUse: vi.fn().mockResolvedValue(1024),
+    },
     session: {
-      get: vi.fn().mockResolvedValue({ collection_session_id: "sid_background" }),
+      get: vi
+        .fn()
+        .mockResolvedValue({ collection_session_id: "sid_background" }),
       set: vi.fn().mockResolvedValue(undefined),
     },
   },
@@ -26,6 +28,11 @@ const browserMock = vi.hoisted(() => ({
   },
   tabs: {
     create: vi.fn().mockResolvedValue({}),
+    query: vi.fn().mockResolvedValue([]),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  },
+  idle: {
+    queryState: vi.fn().mockResolvedValue("active"),
   },
   alarms: {
     create: vi.fn(),
@@ -47,6 +54,17 @@ const storeMock = vi.hoisted(() => ({
     newestEvent: 2_000,
     countsByType: { cursor: 1, keyboard: 1 },
   }),
+  getGlobalStats: vi.fn().mockResolvedValue({
+    hourBuckets: new Array(24).fill(0),
+    milestoneActivity: {
+      localDayKey: "2026-08-10",
+      cursorDistancePx: 0,
+      lastCursorPosition: null,
+      screenTimeMs: 0,
+      pendingFocusTs: null,
+    },
+  }),
+  getAllDomains: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("webextension-polyfill", () => ({
@@ -106,6 +124,20 @@ describe("background local retention", () => {
     expect(storeMock.pruneUploadedEventsOlderThan).not.toHaveBeenCalled();
   });
 
+  it("checks milestones without reading raw event history", async () => {
+    const background = await import("../entrypoints/background");
+
+    const startBackground = background.default as unknown as () => void;
+    startBackground();
+
+    const alarmListener =
+      browserMock.alarms.onAlarm.addListener.mock.calls[0]?.[0];
+    await alarmListener?.({ name: "checkMilestones" });
+
+    expect(storeMock.getGlobalStats).toHaveBeenCalledOnce();
+    expect(storeMock.getAllDomains).toHaveBeenCalledOnce();
+  });
+
   it("reports extension local storage usage with collection event stats", async () => {
     const background = await import("../entrypoints/background");
 
@@ -116,7 +148,11 @@ describe("background local retention", () => {
       browserMock.runtime.onMessage.addListener.mock.calls[0]?.[0];
     const reply = vi.fn();
 
-    const keepAlive = messageListener?.({ type: "GET_STORAGE_STATS" }, {}, reply);
+    const keepAlive = messageListener?.(
+      { type: "GET_STORAGE_STATS" },
+      {},
+      reply,
+    );
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(keepAlive).toBe(true);

--- a/extension/src/__tests__/walkingRecord.test.ts
+++ b/extension/src/__tests__/walkingRecord.test.ts
@@ -336,7 +336,7 @@ describe("deriveWalkingRecord", () => {
     expect(record.dayPlates[0]).toEqual(
       expect.objectContaining({
         day: "mon",
-        vignette: "11 quiet minutes on foldedpaper.garden",
+        vignette: "11m on foldedpaper.garden",
         portraitDay: "2026-07-20",
         traceTargets: expect.arrayContaining([
           {

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -8,15 +8,16 @@ import { VERBOSE } from '../config';
 
 /**
  * CursorCollector captures cursor movement with dual-layer approach:
- * 
+ *
  * 1. Real-time streaming (60fps) to PartyKit for live visualization
- * 2. Sparse sampling (100ms) to EventBuffer for archival
+ * 2. Sparse sampling (250ms) to EventBuffer for archival
  */
 export class CursorCollector extends BaseCollector<CursorEventData> {
   readonly type = 'cursor' as const;
   readonly description = 'Captures cursor movement, clicks, holds, and cursor style changes';
-  
+
   private mouseMoveHandler?: (e: MouseEvent) => void;
+  private mouseOverHandler?: (e: MouseEvent) => void;
   private animationFrameId?: number;
   private sampleTimer: number | null = null;
   protected sampleRate = 250; // ms between samples for archival
@@ -27,7 +28,9 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
   // Current cursor state
   private currentX = 0;
   private currentY = 0;
+  private currentTargetElement: HTMLElement | null = null;
   private currentTarget: string | undefined;
+  private targetSelectorDirty = false;
   private currentCursorStyle: string | undefined;
   private lastCursorStyle: string | undefined;
   private cursorChangeTimer: number | null = null;
@@ -38,11 +41,11 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
   // Last sampled position (for movement threshold)
   private lastSampledX = 0;
   private lastSampledY = 0;
-  
+
   // Mouse event handlers
   private mouseDownHandler?: (e: MouseEvent) => void;
   private mouseUpHandler?: (e: MouseEvent) => void;
-  
+
   // Click vs hold tracking
   private mouseDownTime: number = 0;
   private mouseDownButton: number = -1;
@@ -51,7 +54,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
   private mouseDownScrollX: number = 0;
   private mouseDownScrollY: number = 0;
   private holdThreshold = 250; // ms to distinguish click vs hold
-  
+
   start(): void {
     // Note: enable() already checks if enabled, so we don't need to check here
     if (VERBOSE) {
@@ -61,63 +64,72 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
 
     this.lastSampledX = this.currentX;
     this.lastSampledY = this.currentY;
-    
+
     // Set up mouse move handler
     this.mouseMoveHandler = (e: MouseEvent) => {
       this.currentX = e.clientX;
       this.currentY = e.clientY;
-      
-      // Try to capture target element
+
       const target = e.target as HTMLElement;
-      if (target instanceof HTMLElement) {
-        // Create a simple selector (tag + id/class if available)
-        this.currentTarget = getElementSelector(target);
-
-        if (target !== this.lastCursorStyleTarget) {
-          this.lastCursorStyleTarget = target;
-
-          // Detect cursor style changes (debounced)
-          const computedStyle = window.getComputedStyle(target);
-          const cursorStyle = computedStyle.cursor || 'auto';
-          this.currentCursorStyle = cursorStyle;
-
-          if (this.lastCursorStyle === undefined) {
-            this.lastCursorStyle = cursorStyle;
-          } else if (this.lastCursorStyle !== cursorStyle) {
-            this.pendingCursorStyle = cursorStyle;
-            if (this.cursorChangeTimer === null) {
-              this.cursorChangeTimer = window.setTimeout(() => {
-                this.cursorChangeTimer = null;
-                // Only emit if cursor actually settled on a different style
-                if (this.pendingCursorStyle !== undefined && this.pendingCursorStyle !== this.lastCursorStyle) {
-                  this.lastCursorStyle = this.pendingCursorStyle;
-                  this.emitCursorChangeEvent();
-                }
-              }, this.cursorChangeDebounce);
-            }
-          }
-        }
+      if (target instanceof HTMLElement && target !== this.currentTargetElement) {
+        this.currentTargetElement = target;
+        this.targetSelectorDirty = true;
       }
-      
+
       if (this.hasRealTimeCallback()) {
         this.scheduleRealTimeUpdate();
       }
 
       // Schedule archival sample if movement is significant enough
-      const dx = Math.abs(this.currentX - this.lastSampledX);
-      const dy = Math.abs(this.currentY - this.lastSampledY);
-      const distance = Math.sqrt(dx * dx + dy * dy);
+      const dx = this.currentX - this.lastSampledX;
+      const dy = this.currentY - this.lastSampledY;
 
-      if (distance >= this.minMovementThreshold) {
+      if (dx * dx + dy * dy >= this.minMovementThreshold ** 2) {
         this.scheduleArchivalSample();
       }
     };
-    
+
+    this.mouseOverHandler = (e: MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (!(target instanceof HTMLElement)) return;
+
+      if (target !== this.currentTargetElement) {
+        this.currentTargetElement = target;
+        this.targetSelectorDirty = true;
+      }
+      if (target === this.lastCursorStyleTarget) return;
+
+      this.lastCursorStyleTarget = target;
+      const cursorStyle = window.getComputedStyle(target).cursor || 'auto';
+      this.currentCursorStyle = cursorStyle;
+
+      if (this.lastCursorStyle === undefined) {
+        this.lastCursorStyle = cursorStyle;
+        return;
+      }
+      if (this.lastCursorStyle === cursorStyle) {
+        this.pendingCursorStyle = undefined;
+        return;
+      }
+
+      this.pendingCursorStyle = cursorStyle;
+      if (this.cursorChangeTimer !== null) return;
+
+      this.cursorChangeTimer = window.setTimeout(() => {
+        this.cursorChangeTimer = null;
+        if (this.pendingCursorStyle !== undefined && this.pendingCursorStyle !== this.lastCursorStyle) {
+          this.lastCursorStyle = this.pendingCursorStyle;
+          this.emitCursorChangeEvent();
+        }
+      }, this.cursorChangeDebounce);
+    };
+
     document.addEventListener('mousemove', this.mouseMoveHandler, { passive: true });
+    document.addEventListener('mouseover', this.mouseOverHandler, { passive: true });
     if (VERBOSE) {
       console.log('[CursorCollector] Mouse move listener attached');
     }
-    
+
     // Set up mouse down handler (for click/hold detection)
     this.mouseDownHandler = (e: MouseEvent) => {
       this.mouseDownTime = Date.now();
@@ -127,7 +139,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       this.mouseDownScrollX = window.scrollX;
       this.mouseDownScrollY = window.scrollY;
     };
-    
+
     // Set up mouse up handler (for click/hold detection)
     this.mouseUpHandler = (e: MouseEvent) => {
       // Skip if no mousedown was captured (e.g., mouse was already held when collector started)
@@ -142,7 +154,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
 
       const target = e.target as HTMLElement;
       const targetSelector = target ? getElementSelector(target) : undefined;
-      
+
       if (duration >= this.holdThreshold) {
         // Hold events are emitted immediately (not debounced)
         this.emitDiscreteEvent({
@@ -164,15 +176,15 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
           button: this.mouseDownButton,
         });
       }
-      
+
       this.mouseDownTime = 0;
       this.mouseDownButton = -1;
     };
-    
+
     // Attach event listeners
     document.addEventListener('mousedown', this.mouseDownHandler, { passive: true });
     document.addEventListener('mouseup', this.mouseUpHandler, { passive: true });
-    
+
     if (this.hasRealTimeCallback()) {
       this.startRealTimeLoop();
     }
@@ -180,11 +192,16 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       console.log('[CursorCollector] Started successfully');
     }
   }
-  
+
   stop(): void {
     if (this.mouseMoveHandler) {
       document.removeEventListener('mousemove', this.mouseMoveHandler);
       this.mouseMoveHandler = undefined;
+    }
+
+    if (this.mouseOverHandler) {
+      document.removeEventListener('mouseover', this.mouseOverHandler);
+      this.mouseOverHandler = undefined;
     }
 
     if (this.mouseDownHandler) {
@@ -213,7 +230,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       this.cursorChangeTimer = null;
     }
   }
-  
+
   /**
    * Schedule a real-time update (throttled to ~60fps)
    */
@@ -242,27 +259,27 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       }
     }, this.sampleRate);
   }
-  
+
   /**
    * Start animation frame loop for real-time streaming
    */
   private startRealTimeLoop(): void {
     const loop = () => {
       if (!this.enabled) return;
-      
+
       // Emit real-time data if enough time has passed
       const now = Date.now();
       if (now - this.lastRealTimeTime >= this.realTimeRate) {
         this.emitRealTimeData();
         this.lastRealTimeTime = now;
       }
-      
+
       this.animationFrameId = requestAnimationFrame(loop);
     };
-    
+
     this.animationFrameId = requestAnimationFrame(loop);
   }
-  
+
   /**
    * Emit real-time cursor data (for PartyKit streaming)
    */
@@ -273,45 +290,45 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       window.innerWidth,
       window.innerHeight
     );
-    
+
     const data: CursorEventData = {
       x: normalized.x,
       y: normalized.y,
-      t: this.currentTarget,
+      t: this.getCurrentTarget(),
       cursor: this.currentCursorStyle,
       event: 'move',
     };
-    
+
     // Emit to real-time stream (PartyKit)
     if (!this.hasRealTimeCallback()) return;
     this.emitRealTime(data);
   }
-  
+
   /**
    * Emit a discrete event (click, hold, cursor_change)
    * These are emitted immediately to the buffer (not throttled)
    */
   private emitDiscreteEvent(data: CursorEventData): void {
     if (!this.enabled) return;
-    
+
     if (VERBOSE) {
       console.log('[CursorCollector] Emitting discrete event:', data);
     }
-    
+
     // Emit to buffer for archival
     this.emit(data);
-    
+
     // Also emit to real-time stream for live visualization
     this.emitRealTime(data);
   }
-  
+
   private handleClick(clickData: CursorEventData): void {
     this.emitDiscreteEvent({
       ...clickData,
       quantity: 1,
     });
   }
-  
+
   /**
    * Emit cursor style change event
    */
@@ -322,15 +339,15 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       window.innerWidth,
       window.innerHeight
     );
-    
+
     this.emitDiscreteEvent({
       ...normalized,
-      t: this.currentTarget,
+      t: this.getCurrentTarget(),
       cursor: this.currentCursorStyle,
       event: 'cursor_change',
     });
   }
-  
+
   /**
    * Sample current cursor state for archival
    */
@@ -352,7 +369,7 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
       y: normalized.y,
       scrollX: window.scrollX,
       scrollY: window.scrollY,
-      t: this.currentTarget,
+      t: this.getCurrentTarget(),
       cursor: this.currentCursorStyle,
       event: 'move',
     };
@@ -364,5 +381,13 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
     this.emit(data);
 
     return data;
+  }
+
+  private getCurrentTarget(): string | undefined {
+    if (this.targetSelectorDirty && this.currentTargetElement) {
+      this.currentTarget = getElementSelector(this.currentTargetElement);
+      this.targetSelectorDirty = false;
+    }
+    return this.currentTarget;
   }
 }

--- a/extension/src/collectors/CursorCollector.ts
+++ b/extension/src/collectors/CursorCollector.ts
@@ -75,6 +75,9 @@ export class CursorCollector extends BaseCollector<CursorEventData> {
         this.currentTargetElement = target;
         this.targetSelectorDirty = true;
       }
+      if (target instanceof HTMLElement && this.lastCursorStyleTarget === null) {
+        this.mouseOverHandler?.(e);
+      }
 
       if (this.hasRealTimeCallback()) {
         this.scheduleRealTimeUpdate();

--- a/extension/src/components/WalkingRecord.scss
+++ b/extension/src/components/WalkingRecord.scss
@@ -633,11 +633,16 @@ button:focus-visible {
   }
 
   > span {
+    display: -webkit-box;
+    overflow: hidden;
     color: $text-faint;
     font-size: 9.5px;
     font-style: italic;
     line-height: 1.35;
+    overflow-wrap: anywhere;
     text-align: center;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
   }
 }
 

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -1037,45 +1037,16 @@ export default defineBackground(() => {
       hourBuckets: globalAgg.hourBuckets,
     }
 
-    // Query cursor distance for today
-    const midnightTs = new Date()
-    midnightTs.setHours(0, 0, 0, 0)
-    const cursorEvents = await store.getAllEvents({
-      type: 'cursor',
-      startTs: midnightTs.getTime(),
-      limit: 5000,
-    })
-    const moveEvents = cursorEvents
-      .filter((e) => (e.data as any).event === 'move')
-      .sort((a, b) => a.ts - b.ts)
-    let cursorDistancePx = 0
-    for (let i = 1; i < moveEvents.length; i++) {
-      const prev = moveEvents[i - 1].data as any
-      const curr = moveEvents[i].data as any
-      const dx = (curr.x - prev.x) * 1920
-      const dy = (curr.y - prev.y) * 1080
-      cursorDistancePx += Math.sqrt(dx * dx + dy * dy)
-    }
-
-    // Compute today's screen time from focus/blur navigation events since midnight
-    const navEvents = await store.getAllEvents({
-      type: 'navigation',
-      startTs: midnightTs.getTime(),
-      limit: 10000,
-    })
-    let dailyScreenTimeMs = 0
-    let focusTs: number | null = null
-    for (const e of navEvents.sort((a, b) => a.ts - b.ts)) {
-      const event = (e.data as any).event
-      if (event === 'focus') {
-        focusTs = e.ts
-      } else if (event === 'blur' && focusTs !== null) {
-        dailyScreenTimeMs += e.ts - focusTs
-        focusTs = null
-      }
-    }
-    // If still focused, count up to now
-    if (focusTs !== null) dailyScreenTimeMs += Date.now() - focusTs
+    const activity =
+      globalAgg.milestoneActivity?.localDayKey === today
+        ? globalAgg.milestoneActivity
+        : null
+    const cursorDistancePx = activity?.cursorDistancePx ?? 0
+    const dailyScreenTimeMs =
+      (activity?.screenTimeMs ?? 0) +
+      (activity?.pendingFocusTs
+        ? Math.max(0, Date.now() - activity.pendingFocusTs)
+        : 0)
     state = { ...state, dailyScreenTimeMs }
 
     // Build top domains by visit count
@@ -1084,30 +1055,16 @@ export default defineBackground(() => {
       visitCount: number
       faviconUrl?: string
     }> = []
-    for (const { domain } of allDomainEntries.slice(0, 20)) {
-      const agg = await store.getSessionStats(domain).catch(() => null)
-      if (!agg) continue
-      // Pull recent navigation events and pick the most recent one with a
-      // non-empty favicon_url. The first stored event is often a blur/beforeunload
-      // captured before <link rel="icon"> was parsed, which leaves favicon_url
-      // pointing at a /favicon.ico fallback that many sites don't actually serve.
-      const domainNavEvents = await store.queryByDomain(domain, {
-        type: 'navigation',
-        limit: 50,
+    for (const domainEntry of allDomainEntries.slice(0, 20)) {
+      topDomains.push({
+        domain: domainEntry.domain,
+        visitCount: domainEntry.sessionCount,
+        ...(domainEntry.latestFaviconUrl
+          ? { faviconUrl: domainEntry.latestFaviconUrl }
+          : {}),
       })
-      let faviconUrl: string | undefined
-      for (let i = domainNavEvents.length - 1; i >= 0; i--) {
-        const candidate = (domainNavEvents[i].data as any).favicon_url
-        if (typeof candidate === 'string' && candidate.length > 0) {
-          faviconUrl = candidate
-          break
-        }
-      }
-      topDomains.push({ domain, visitCount: agg.sessionCount, faviconUrl })
     }
 
-    // Long-gap return: for the active tab's domain, look at raw
-    // navigation timestamps and see if the user just came back after >90 days.
     const [gapTab] = await browser.tabs.query({
       active: true,
       lastFocusedWindow: true,
@@ -1115,15 +1072,11 @@ export default defineBackground(() => {
     const activeDomain = extractDomain(gapTab?.url ?? null)
     let longGap: Parameters<typeof checkAllMilestones>[4] = null
     if (activeDomain) {
-      // No limit: queryByDomain resolves early when a limit is hit, before its
-      // ascending-by-time sort, so a limit would return the OLDEST events and
-      // miss the recent return. Navigation events are sparse (2s dedup), so an
-      // unbounded per-domain scan stays cheap.
-      const gapNavEvents = await store.queryByDomain(activeDomain, {
-        type: 'navigation',
-      })
+      const domainEntry = allDomainEntries.find(
+        (entry) => entry.domain === activeDomain,
+      )
       const gap = detectLongGapReturn(
-        gapNavEvents.map((e) => e.ts),
+        domainEntry?.recentFocusVisits ?? [],
         Date.now(),
       )
       if (gap) {

--- a/extension/src/history/walkingRecord.ts
+++ b/extension/src/history/walkingRecord.ts
@@ -995,7 +995,7 @@ function buildDayPlates(
     return {
       date: interval.key,
       day: interval.label,
-      vignette: `${minutes} quiet minute${minutes === 1 ? "" : "s"} on ${domain}`,
+      vignette: `${minutes}m on ${domain}`,
       hue: colorForDomain(baseColor, domain),
       future: false,
       portraitDay: period === "week" ? interval.key.slice(4) : undefined,

--- a/extension/src/storage/EventBuffer.ts
+++ b/extension/src/storage/EventBuffer.ts
@@ -8,7 +8,7 @@ import { requestSessionId, getTimezone } from './participant';
 import { VERBOSE } from '../config';
 
 const BATCH_INTERVAL_MS = 3000; // 3 seconds
-const STORE_BATCH_INTERVAL_MS = 250;
+const STORE_BATCH_INTERVAL_MS = 1000;
 const STORE_BATCH_MAX_EVENTS = 25;
 const STORE_RETRY_INITIAL_MS = 1000;
 const STORE_RETRY_MAX_MS = 30_000;

--- a/extension/src/storage/LocalEventStore.ts
+++ b/extension/src/storage/LocalEventStore.ts
@@ -37,6 +37,8 @@ const COLLECTION_EVENT_TYPES: CollectionEventType[] = [
   "element",
 ];
 const STORAGE_SIZE_SAMPLE_LIMIT = 200;
+const RECENT_FOCUS_VISIT_LIMIT = 5;
+const AGGREGATE_FAVICON_URL_LENGTH_LIMIT = 2048;
 
 type UploadState = typeof UPLOAD_STATE_PENDING | typeof UPLOAD_STATE_UPLOADED;
 type StatsBackfillState = "running" | "complete";
@@ -120,6 +122,20 @@ export interface DomainStatsAggregate {
   uniqueUrlCount: number;
   /** Number of local calendar days with at least one focused visit */
   activeDayCount: number;
+  /** Latest bounded favicon observed for domain-level milestone UI. */
+  latestFaviconUrl?: string;
+  /** Most recent focused visit on up to five distinct local days. */
+  recentFocusVisits?: number[];
+  /** Compact daily activity used by the global milestone check. */
+  milestoneActivity?: MilestoneActivityAggregate;
+}
+
+export interface MilestoneActivityAggregate {
+  localDayKey: string;
+  cursorDistancePx: number;
+  lastCursorPosition: { x: number; y: number } | null;
+  screenTimeMs: number;
+  pendingFocusTs: number | null;
 }
 
 function domainStatsKey(domain: string): string {
@@ -1469,6 +1485,8 @@ export class LocalEventStore {
       sessionCount: number;
       activeDayCount: number;
       eventCounts: Record<string, number>;
+      latestFaviconUrl?: string;
+      recentFocusVisits: number[];
     }>
   > {
     await this.ensureInitialized();
@@ -1493,6 +1511,8 @@ export class LocalEventStore {
         sessionCount: number;
         activeDayCount: number;
         eventCounts: Record<string, number>;
+        latestFaviconUrl?: string;
+        recentFocusVisits: number[];
       }> = [];
 
       request.onsuccess = (event) => {
@@ -1520,6 +1540,10 @@ export class LocalEventStore {
               sessionCount: aggregate.sessionCount,
               activeDayCount: aggregate.activeDayCount ?? 0,
               eventCounts,
+              ...(aggregate.latestFaviconUrl
+                ? { latestFaviconUrl: aggregate.latestFaviconUrl }
+                : {}),
+              recentFocusVisits: aggregate.recentFocusVisits ?? [],
             });
           }
 
@@ -2349,6 +2373,7 @@ export class LocalEventStore {
     agg.storageSizeBytes ??= 0;
 
     for (const evt of events) {
+      const previousLastVisit = agg.lastVisit;
       agg.eventsByType[evt.type] = (agg.eventsByType[evt.type] ?? 0) + 1;
       agg.storageSizeBytes += JSON.stringify(evt).length;
       if (agg.firstVisit === 0 || evt.ts < agg.firstVisit) {
@@ -2361,6 +2386,30 @@ export class LocalEventStore {
       if (evt.type === "navigation") {
         const d = evt.data as NavigationEventData;
         if (d.event === "focus") {
+          if (agg.domain && !agg.key.includes("::")) {
+            const faviconUrl = d.favicon_url;
+            if (
+              typeof faviconUrl === "string" &&
+              faviconUrl.length > 0 &&
+              faviconUrl.length <= AGGREGATE_FAVICON_URL_LENGTH_LIMIT
+            ) {
+              agg.latestFaviconUrl = faviconUrl;
+            }
+
+            const visitDay = localDayKey(evt.ts, evt.meta.tz);
+            const recentVisits =
+              agg.recentFocusVisits ??
+              (previousLastVisit > 0 && previousLastVisit < evt.ts
+                ? [previousLastVisit]
+                : []);
+            agg.recentFocusVisits = [
+              evt.ts,
+              ...recentVisits.filter(
+                (timestamp) => localDayKey(timestamp, evt.meta.tz) !== visitDay,
+              ),
+            ].slice(0, RECENT_FOCUS_VISIT_LIMIT);
+          }
+
           agg.pendingFocusTs = evt.ts;
           agg.pendingFocusUrl = evt.meta?.url ?? "";
         } else if (
@@ -2376,6 +2425,56 @@ export class LocalEventStore {
           }
           agg.pendingFocusTs = null;
           agg.pendingFocusUrl = "";
+        }
+      }
+    }
+
+    if (agg.key === GLOBAL_STATS_KEY) {
+      LocalEventStore.applyEventsToMilestoneActivity(agg, events);
+    }
+  }
+
+  private static applyEventsToMilestoneActivity(
+    agg: DomainStatsAggregate,
+    events: CollectionEvent[],
+  ): void {
+    for (const evt of [...events].sort((a, b) => a.ts - b.ts)) {
+      const eventDay = localDayKey(evt.ts, evt.meta.tz);
+      if (agg.milestoneActivity?.localDayKey !== eventDay) {
+        agg.milestoneActivity = {
+          localDayKey: eventDay,
+          cursorDistancePx: 0,
+          lastCursorPosition: null,
+          screenTimeMs: 0,
+          pendingFocusTs: null,
+        };
+      }
+
+      const activity = agg.milestoneActivity;
+      if (evt.type === "cursor") {
+        const data = evt.data as CursorEventData;
+        if (
+          data.event === "move" &&
+          Number.isFinite(data.x) &&
+          Number.isFinite(data.y)
+        ) {
+          if (activity.lastCursorPosition) {
+            const dx = (data.x - activity.lastCursorPosition.x) * 1920;
+            const dy = (data.y - activity.lastCursorPosition.y) * 1080;
+            activity.cursorDistancePx += Math.sqrt(dx * dx + dy * dy);
+          }
+          activity.lastCursorPosition = { x: data.x, y: data.y };
+        }
+      } else if (evt.type === "navigation") {
+        const data = evt.data as NavigationEventData;
+        if (data.event === "focus") {
+          activity.pendingFocusTs = evt.ts;
+        } else if (data.event === "blur" && activity.pendingFocusTs !== null) {
+          activity.screenTimeMs += Math.max(
+            0,
+            evt.ts - activity.pendingFocusTs,
+          );
+          activity.pendingFocusTs = null;
         }
       }
     }


### PR DESCRIPTION
## Summary

- maintain bounded daily activity and recent-domain aggregates as events are stored
- read milestone data from those aggregates instead of repeatedly scanning raw cursor and navigation history
- batch routine extension storage writes once per second while keeping clicks immediate
- defer cursor selectors and computed styles until they are needed

## Why

Chrome reported that WWO was using substantial resources. Controlled traces identified cursor collection as the largest active-page JavaScript cost. The milestone alarm also replayed raw history every five minutes, making an auxiliary feature progressively more expensive as local history grew.

The aggregate fields add bounded storage: one daily global activity record, up to five visit timestamps per domain, and one favicon URL capped at 2,048 characters. Existing installations begin daily counters after updating and do not scan old raw events to backfill them.

## Performance

In the same three-run Chrome interaction trace, mean extension ScriptDuration changed from 51.6 ms to 40.7 ms, a 21% reduction. TaskDuration remained noisy, so this does not claim an equivalent end-to-end improvement.

## Validation

- 104 extension test files, 618 tests
- `bun run build-packages`
- production Chrome MV3 extension build
- unpacked build synchronized and checksum-verified
- `git diff --check`

The repository-wide type-check still reports unrelated errors in untouched extension UI, shared visualization, and Worker files. None of the reported errors are in this PR's files.