### PR TITLE
Allow the fridge owner to delete words without a limit

### DIFF
--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -10,9 +10,11 @@ import {
   PlayContext,
   withSharedState,
   useCursorPresences,
+  usePlayerIdentity,
 } from "../packages/react/src";
 import React, { useContext, useEffect, useState, useRef } from "react";
 import { PlayProvider } from "../packages/react/src";
+import { canDeleteFridgeWord, DeleteWordLimit } from "./fridgeDeletion";
 import { useLocation } from "./useLocation";
 
 // Detect mobile viewport
@@ -228,7 +230,6 @@ interface Props extends FridgeWordType {
 }
 
 const DefaultRoom = "fridge";
-const DeleteWordLimit = 3;
 const DeleteWordInterval = 1000 * 60 * 10; // 10 minutes
 const DeleteLimitReachedKey = "fridge-lastDeleteTime";
 const RestrictedWords = [...profaneWords];
@@ -468,6 +469,7 @@ const WordControls = withSharedState<FridgeWordType[]>(
     const [wallInputValue, setWallInputValue] = React.useState(wall);
     const [showWallControls, setShowWallControls] = React.useState(true);
     const { deleteElementData } = useContext(PlayContext);
+    const { pid } = usePlayerIdentity();
     const userColor =
       window.cursors?.color || localStorage.getItem("userColor") || undefined;
     const isMobile = useIsMobile();
@@ -587,7 +589,7 @@ const WordControls = withSharedState<FridgeWordType[]>(
       word: string,
       color: string | undefined,
     ) {
-      if (deleteCount >= DeleteWordLimit) {
+      if (!canDeleteFridgeWord(deleteCount, pid)) {
         // Track delete overload
         window.plausible?.("DeleteWordOverload", {
           props: {
@@ -631,9 +633,11 @@ const WordControls = withSharedState<FridgeWordType[]>(
       setData((d) => {
         d.splice(idxToDelete, 1);
       });
-      setDeleteCount(deleteCount + 1);
-      if (deleteCount + 1 === DeleteWordLimit) {
-        localStorage.setItem(DeleteLimitReachedKey, Date.now().toString());
+      if (!canDeleteFridgeWord(DeleteWordLimit, pid)) {
+        setDeleteCount(deleteCount + 1);
+        if (deleteCount + 1 === DeleteWordLimit) {
+          localStorage.setItem(DeleteLimitReachedKey, Date.now().toString());
+        }
       }
     }
 

--- a/website/fridgeDeletion.ts
+++ b/website/fridgeDeletion.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Defines the fridge word-deletion policy for visitors and the fridge owner.
+// ABOUTME: Keeps visitor moderation bounded while allowing the fridge owner cleanup access.
+export const DeleteWordLimit = 3;
+
+const FridgeOwnerPublicKey =
+  "pk_04934976d2bc13f0a3a1e62a9124a3edb1e236b2eef64b618c646e25e3ade8ec77d2b56bedb39b78150d141be1b6b41a85b86010930941e02e82e96ce61af35d53";
+
+export function canDeleteFridgeWord(
+  deleteCount: number,
+  publicKey: string | undefined,
+): boolean {
+  return publicKey === FridgeOwnerPublicKey || deleteCount < DeleteWordLimit;
+}

--- a/website/test/fridgeDeletion.test.ts
+++ b/website/test/fridgeDeletion.test.ts
@@ -1,0 +1,20 @@
+// ABOUTME: Verifies deletion limits for visitors and the fridge owner.
+// ABOUTME: Ensures only the owner's public key receives unlimited cleanup access.
+import { describe, expect, test } from "bun:test";
+import { canDeleteFridgeWord } from "../fridgeDeletion";
+
+const FridgeOwnerPublicKey =
+  "pk_04934976d2bc13f0a3a1e62a9124a3edb1e236b2eef64b618c646e25e3ade8ec77d2b56bedb39b78150d141be1b6b41a85b86010930941e02e82e96ce61af35d53";
+
+describe("fridge word deletion", () => {
+  test("limits public sessions to three deletions", () => {
+    expect(canDeleteFridgeWord(2, "pk_someone_else")).toBe(true);
+    expect(canDeleteFridgeWord(3, "pk_someone_else")).toBe(false);
+    expect(canDeleteFridgeWord(3, undefined)).toBe(false);
+  });
+
+  test("does not limit the fridge owner", () => {
+    expect(canDeleteFridgeWord(3, FridgeOwnerPublicKey)).toBe(true);
+    expect(canDeleteFridgeWord(10_000, FridgeOwnerPublicKey)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Allow Spencer's player public key to delete any number of fridge words.
- Keep the three-word deletion limit for anonymous visitors and other player identities.
- Keep `?admin` scoped to the existing Admin Settings panel instead of using it to bypass deletion limits.

## Why

The fridge deletion limit was based only on a local deletion count. The owner needs to moderate more than three words without granting the same access to everyone who adds `?admin` to the URL.

This is a client-side identity check, not cryptographic authorization. It controls the fridge UI behavior but does not prevent a modified client from writing shared data directly.

## Validation

- `bun test website/test/fridgeDeletion.test.ts`
- `node_modules/.bin/tsc -p website/tsconfig.json --noEmit`
- `node_modules/.bin/vite build website --config vite.config.site.mts`
- `git diff --check`

## Screenshots

Not captured because the browser controller was unavailable in this session. This change does not alter the visual layout.