### PR TITLE
Improve Wikipedia live presence

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,3 +14,5 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
+
+- Wikipedia now keeps your article-name consistent across tabs, shows other readers' live text selections in their cursor colors, keeps editing sessions separate by URL, and counts each connected reader once across pages.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -15,4 +15,6 @@ extension/website/public/changelog/media/ and reference them here:
 ![video: Demo title](/changelog/media/file.mp4)
 -->
 
-- Wikipedia now keeps your article-name consistent across tabs, shows other readers' live text selections in their cursor colors, keeps editing sessions separate by URL, and counts each connected reader once across pages.
+- Wikipedia now keeps your article-name consistent across tabs and counts each connected reader once across pages.
+- Wikipedia shows other readers' live text selections in their cursor colors.
+- Wikipedia editing sessions now stay separate from article-reading rooms.

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -123,6 +123,23 @@ describe("ChatManager", () => {
     mgr.destroy();
   });
 
+  it("does not overwrite a rename that arrives during initialization", async () => {
+    let resolveInitialHandle!: (value: unknown) => void;
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(
+      () => new Promise((resolve) => { resolveInitialHandle = resolve; }),
+    );
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+
+    const initializing = mgr.init();
+    emitHandleChange("Shared Name");
+    resolveInitialHandle({ handle: "Stale Name" });
+    await initializing;
+
+    expect(mgr.getState().handle).toBe("Shared Name");
+    mgr.destroy();
+  });
+
   it("send broadcasts via setMyPresence and appends locally", async () => {
     const fake = makeFakePresence();
     const mgr = new ChatManager(fake.api, "Octopus");

--- a/extension/src/__tests__/ChatManager.test.ts
+++ b/extension/src/__tests__/ChatManager.test.ts
@@ -5,27 +5,26 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import browser from "webextension-polyfill";
 import type { PresenceAPI, PresenceView } from "@playhtml/common";
 import { ChatManager } from "../features/ChatManager";
-import { _resetForTest as resetHandle } from "../features/chat-handle";
 
-function setupStorage(value: string | null = null): Record<string, unknown> {
-  const data: Record<string, unknown> = {};
-  if (value !== null) data["wiki_chat_handle"] = value;
-  vi.mocked(browser.storage.local.get).mockImplementation((keys: any) => {
-    if (typeof keys === "string") return Promise.resolve({ [keys]: data[keys] });
-    if (Array.isArray(keys)) {
-      const out: Record<string, unknown> = {};
-      keys.forEach((k) => {
-        out[k] = data[k];
-      });
-      return Promise.resolve(out);
+let emitHandleChange: (handle: string) => void = () => {};
+
+function setupHandleMessages(handle = "TestHandle"): void {
+  vi.mocked(browser.runtime.sendMessage).mockImplementation((message: any) => {
+    if (message.type === "REROLL_WIKIPEDIA_HANDLE") {
+      return Promise.resolve({ handle: "Rerolled Name" });
     }
-    return Promise.resolve({ ...data });
+    if (message.type === "SET_WIKIPEDIA_HANDLE") {
+      return Promise.resolve({ handle: message.title });
+    }
+    return Promise.resolve({ handle });
   });
-  vi.mocked(browser.storage.local.set).mockImplementation((items: any) => {
-    Object.assign(data, items);
-    return Promise.resolve();
+  let listener: ((changes: Record<string, { newValue?: unknown }>, areaName: string) => void) | null = null;
+  vi.mocked(browser.storage.onChanged.addListener).mockImplementation((nextListener: any) => {
+    listener = nextListener;
   });
-  return data;
+  emitHandleChange = (nextHandle) => {
+    listener?.({ wiki_chat_handle: { newValue: nextHandle } }, "local");
+  };
 }
 
 function makeFakePresence(
@@ -92,8 +91,7 @@ function peerView(pid: string, color: string, chat: unknown): PresenceView {
 describe("ChatManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    setupStorage("TestHandle");
-    resetHandle();
+    setupHandleMessages();
     vi.useFakeTimers();
   });
 
@@ -111,6 +109,17 @@ describe("ChatManager", () => {
     expect(mgr.getState().articleTitle).toBe("Octopus");
     expect(mgr.getState().isOpen).toBe(false);
     expect(mgr.getState().unread).toBe(false);
+    mgr.destroy();
+  });
+
+  it("updates an open tab when another tab changes the handle", async () => {
+    const fake = makeFakePresence();
+    const mgr = new ChatManager(fake.api, "Octopus");
+    await mgr.init();
+
+    emitHandleChange("Shared Name");
+
+    expect(mgr.getState().handle).toBe("Shared Name");
     mgr.destroy();
   });
 
@@ -324,10 +333,6 @@ describe("ChatManager", () => {
 
   it("reroll updates handle and notifies", async () => {
     const fake = makeFakePresence();
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ title: "Rerolled Name" }),
-    } as Response) as typeof fetch;
     const mgr = new ChatManager(fake.api, "Octopus");
     await mgr.init();
     await mgr.reroll();

--- a/extension/src/__tests__/PresenceCountPill.test.ts
+++ b/extension/src/__tests__/PresenceCountPill.test.ts
@@ -62,6 +62,7 @@ describe("PresenceCountPill", () => {
           {
             isMe: false,
             playerIdentity: identity("peer"),
+            online: true,
             page: {
               url: "https://en.wikipedia.org/wiki/Stale",
               title: "Stale",
@@ -103,6 +104,7 @@ describe("PresenceCountPill", () => {
           {
             isMe: false,
             playerIdentity: identity("peer"),
+            online: true,
             page: {
               url: "https://en.wikipedia.org/wiki/Hidden",
               title: "Hidden",
@@ -144,6 +146,7 @@ describe("PresenceCountPill", () => {
           {
             isMe: false,
             playerIdentity: identity("peer"),
+            online: true,
             page: {
               url: "https://en.wikipedia.org/wiki/Octopus#/media/File:Octopus.jpg",
               title: "Octopus",
@@ -186,6 +189,7 @@ describe("PresenceCountPill", () => {
           {
             isMe: false,
             playerIdentity: identity("stale-peer"),
+            online: true,
             page: {
               url: "https://en.wikipedia.org/wiki/Stale",
               title: "Stale",
@@ -199,6 +203,7 @@ describe("PresenceCountPill", () => {
           {
             isMe: false,
             playerIdentity: identity("fresh-peer"),
+            online: true,
             page: {
               url: "https://en.wikipedia.org/wiki/Fresh",
               title: "Fresh",
@@ -236,6 +241,7 @@ describe("PresenceCountPill", () => {
       ["peer", {
         isMe: false,
         playerIdentity: identity("peer"),
+        online: true,
         page: {
           url: "https://en.wikipedia.org/wiki/Elsewhere",
           title: "Elsewhere",
@@ -262,9 +268,9 @@ describe("PresenceCountPill", () => {
     ]));
     const lobbyPresence = presenceApi("me", new Map([
       ["me", { isMe: true, playerIdentity: identity("me") }],
-      ["peer-here", { isMe: false, playerIdentity: identity("peer-here") }],
-      ["peer-a", { isMe: false, playerIdentity: identity("peer-a") }],
-      ["peer-b", { isMe: false, playerIdentity: identity("peer-b") }],
+      ["peer-here", { isMe: false, playerIdentity: identity("peer-here"), online: true }],
+      ["peer-a", { isMe: false, playerIdentity: identity("peer-a"), online: true }],
+      ["peer-b-connection", { isMe: false, online: true }],
     ]));
 
     const pill = new PresenceCountPill(pagePresence, lobbyPresence);
@@ -272,6 +278,24 @@ describe("PresenceCountPill", () => {
 
     expect(document.body.textContent).toContain("2 here");
     expect(document.body.textContent).toContain("2 elsewhere");
+
+    pill.destroy();
+  });
+
+  it("does not count an identity after its stamped online presence expires", () => {
+    setLocation("https://en.wikipedia.org/wiki/Current");
+    const pagePresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me") }],
+    ]));
+    const lobbyPresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me"), online: true }],
+      ["ghost", { isMe: false, playerIdentity: identity("ghost") }],
+    ]));
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(document.body.textContent).not.toContain("elsewhere");
 
     pill.destroy();
   });

--- a/extension/src/__tests__/PresenceCountPill.test.ts
+++ b/extension/src/__tests__/PresenceCountPill.test.ts
@@ -221,4 +221,58 @@ describe("PresenceCountPill", () => {
 
     pill.destroy();
   });
+
+  it("does not count someone elsewhere when they are already on this page", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-30T12:00:00Z"));
+    setLocation("https://en.wikipedia.org/wiki/Current");
+
+    const pagePresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me") }],
+      ["peer", { isMe: false, playerIdentity: identity("peer") }],
+    ]));
+    const lobbyPresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me") }],
+      ["peer", {
+        isMe: false,
+        playerIdentity: identity("peer"),
+        page: {
+          url: "https://en.wikipedia.org/wiki/Elsewhere",
+          title: "Elsewhere",
+          visible: true,
+          lastSeenAt: Date.now(),
+        },
+      }],
+    ]));
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(document.body.textContent).toContain("2 here");
+    expect(document.body.textContent).not.toContain("elsewhere");
+
+    pill.destroy();
+  });
+
+  it("counts each connected lobby identity once without requiring a page payload", () => {
+    setLocation("https://en.wikipedia.org/wiki/Current");
+    const pagePresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me") }],
+      ["peer-here", { isMe: false, playerIdentity: identity("peer-here") }],
+    ]));
+    const lobbyPresence = presenceApi("me", new Map([
+      ["me", { isMe: true, playerIdentity: identity("me") }],
+      ["peer-here", { isMe: false, playerIdentity: identity("peer-here") }],
+      ["peer-a", { isMe: false, playerIdentity: identity("peer-a") }],
+      ["peer-b", { isMe: false, playerIdentity: identity("peer-b") }],
+    ]));
+
+    const pill = new PresenceCountPill(pagePresence, lobbyPresence);
+    pill.init();
+
+    expect(document.body.textContent).toContain("2 here");
+    expect(document.body.textContent).toContain("2 elsewhere");
+
+    pill.destroy();
+  });
 });

--- a/extension/src/__tests__/WikipediaLiveSelections.test.ts
+++ b/extension/src/__tests__/WikipediaLiveSelections.test.ts
@@ -77,6 +77,7 @@ describe("WikipediaLiveSelections", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     window.getSelection()?.removeAllRanges();
     Object.defineProperty(globalThis, "CSS", {
       configurable: true,
@@ -127,6 +128,39 @@ describe("WikipediaLiveSelections", () => {
     selection.removeAllRanges();
     document.dispatchEvent(new Event("selectionchange"));
     await vi.waitFor(() => expect(presence.writes.at(-1)?.data).toBeNull());
+    liveSelections.destroy();
+  });
+
+  it("publishes at most every 250ms and skips unchanged selections", async () => {
+    vi.useFakeTimers();
+    const presence = setupPresence();
+    const liveSelections = new WikipediaLiveSelections(presence.api, "#c4724e");
+    liveSelections.init();
+    const text = document.querySelector("p")!.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 7);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    for (let index = 0; index < 5; index++) {
+      document.dispatchEvent(new Event("selectionchange"));
+    }
+    await vi.advanceTimersByTimeAsync(249);
+    expect(presence.writes).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(presence.writes).toHaveLength(2);
+
+    document.dispatchEvent(new Event("selectionchange"));
+    await vi.advanceTimersByTimeAsync(250);
+    expect(presence.writes).toHaveLength(2);
+
+    range.setEnd(text, 8);
+    document.dispatchEvent(new Event("selectionchange"));
+    await vi.advanceTimersByTimeAsync(250);
+    expect(presence.writes).toHaveLength(3);
+
     liveSelections.destroy();
   });
 

--- a/extension/src/__tests__/WikipediaLiveSelections.test.ts
+++ b/extension/src/__tests__/WikipediaLiveSelections.test.ts
@@ -1,0 +1,168 @@
+// ABOUTME: Tests ephemeral Wikipedia text-selection sharing and rendering.
+// ABOUTME: Verifies DOM-safe ranges, presence cleanup, and readable cursor-color tinting.
+
+import type {
+  PlayerIdentity,
+  PresenceAPI,
+  PresenceView,
+} from "@playhtml/common";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deserializeSelectionRange,
+  serializeSelectionRange,
+  WikipediaLiveSelections,
+} from "../features/WikipediaLiveSelections";
+
+function identity(publicKey: string, color: string): PlayerIdentity {
+  return {
+    publicKey,
+    playerStyle: { colorPalette: [color] },
+  } as PlayerIdentity;
+}
+
+function setupPresence(): {
+  api: PresenceAPI;
+  emit: (presences: Map<string, PresenceView>) => void;
+  writes: Array<{ channel: string; data: unknown }>;
+} {
+  let callback: ((presences: Map<string, PresenceView>) => void) | null = null;
+  const writes: Array<{ channel: string; data: unknown }> = [];
+  return {
+    api: {
+      setMyPresence: (channel, data) => writes.push({ channel, data }),
+      getPresences: () => new Map(),
+      onPresenceChange: (_channel, nextCallback) => {
+        callback = nextCallback;
+        nextCallback(new Map());
+        return () => {
+          callback = null;
+        };
+      },
+      getMyIdentity: () => identity("me", "#c4724e"),
+    },
+    emit: (presences) => callback?.(presences),
+    writes,
+  };
+}
+
+describe("WikipediaLiveSelections", () => {
+  const highlights = new Map<string, unknown>();
+  const originalCss = globalThis.CSS;
+
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML =
+      '<main id="mw-content-text"><p>Octopus intelligence</p></main>';
+    highlights.clear();
+    if (!globalThis.CSS) {
+      Object.defineProperty(globalThis, "CSS", {
+        configurable: true,
+        value: {},
+      });
+    }
+    Object.defineProperty(globalThis.CSS, "highlights", {
+      configurable: true,
+      value: {
+        set: (name: string, highlight: unknown) =>
+          highlights.set(name, highlight),
+        delete: (name: string) => highlights.delete(name),
+      },
+    });
+    Object.defineProperty(globalThis, "Highlight", {
+      configurable: true,
+      value: class {
+        constructor(public range: Range) {}
+      },
+    });
+  });
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    Object.defineProperty(globalThis, "CSS", {
+      configurable: true,
+      value: originalCss,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("round-trips a text range without serializing article text", () => {
+    const root = document.querySelector("#mw-content-text")!;
+    const text = root.querySelector("p")!.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 7);
+
+    const serialized = serializeSelectionRange(root, range);
+
+    expect(serialized).toEqual({
+      start: { path: [0, 0], offset: 0 },
+      end: { path: [0, 0], offset: 7 },
+    });
+    expect(JSON.stringify(serialized)).not.toContain("Octopus");
+    expect(deserializeSelectionRange(root, serialized)?.toString()).toBe(
+      "Octopus",
+    );
+  });
+
+  it("broadcasts the current selection and clears it when collapsed", async () => {
+    const presence = setupPresence();
+    const liveSelections = new WikipediaLiveSelections(presence.api, "#c4724e");
+    liveSelections.init();
+    const text = document.querySelector("p")!.firstChild!;
+    const range = document.createRange();
+    range.setStart(text, 0);
+    range.setEnd(text, 7);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    document.dispatchEvent(new Event("selectionchange"));
+    await vi.waitFor(() =>
+      expect(presence.writes.at(-1)?.data).toEqual({
+        start: { path: [0, 0], offset: 0 },
+        end: { path: [0, 0], offset: 7 },
+      }),
+    );
+
+    selection.removeAllRanges();
+    document.dispatchEvent(new Event("selectionchange"));
+    await vi.waitFor(() => expect(presence.writes.at(-1)?.data).toBeNull());
+    liveSelections.destroy();
+  });
+
+  it("renders peer ranges with transparent cursor-color tints", () => {
+    const presence = setupPresence();
+    const liveSelections = new WikipediaLiveSelections(presence.api, "#c4724e");
+    liveSelections.init();
+    presence.emit(
+      new Map([
+        [
+          "peer",
+          {
+            isMe: false,
+            cursor: null,
+            playerIdentity: identity("peer", "#4a9a8a"),
+            selection: {
+              start: { path: [0, 0], offset: 0 },
+              end: { path: [0, 0], offset: 7 },
+            },
+          } as PresenceView,
+        ],
+      ]),
+    );
+
+    expect(highlights.size).toBe(1);
+    const css = document.querySelector(
+      "#wwo-live-selection-styles",
+    )?.textContent;
+    expect(css).toContain("rgb(74, 154, 138) 32%, transparent");
+    expect(css).toContain("color: inherit");
+
+    liveSelections.destroy();
+    expect(highlights.size).toBe(0);
+    expect(presence.writes.at(-1)).toEqual({
+      channel: "selection",
+      data: null,
+    });
+  });
+});

--- a/extension/src/__tests__/chat-handle.test.ts
+++ b/extension/src/__tests__/chat-handle.test.ts
@@ -1,19 +1,26 @@
-// ABOUTME: Tests for the chat-handle module — storage, roll, reroll, profanity filter.
-// ABOUTME: Mocks browser.storage.local with an in-memory backing store and globalThis.fetch.
+// ABOUTME: Tests for the background-owned Wikipedia article-name storage.
+// ABOUTME: Covers persistence, filtering, rerolls, and concurrent tab initialization.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import browser from "webextension-polyfill";
-import { getOrCreateHandle, rerollHandle, _resetForTest } from "../features/chat-handle";
+import {
+  getOrCreateWikipediaHandle,
+  rerollWikipediaHandle,
+  _resetWikipediaHandleForTest,
+} from "../storage/wikipediaHandle";
 
 const STORAGE_KEY = "wiki_chat_handle";
 
 function setupStorage(): { data: Record<string, unknown> } {
   const data: Record<string, unknown> = {};
   vi.mocked(browser.storage.local.get).mockImplementation((keys: any) => {
-    if (typeof keys === "string") return Promise.resolve({ [keys]: data[keys] });
+    if (typeof keys === "string")
+      return Promise.resolve({ [keys]: data[keys] });
     if (Array.isArray(keys)) {
       const out: Record<string, unknown> = {};
-      keys.forEach((k) => { out[k] = data[k]; });
+      keys.forEach((k) => {
+        out[k] = data[k];
+      });
       return Promise.resolve(out);
     }
     return Promise.resolve({ ...data });
@@ -36,7 +43,7 @@ describe("chat-handle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setupStorage();
-    _resetForTest();
+    _resetWikipediaHandleForTest();
   });
   afterEach(() => {
     vi.restoreAllMocks();
@@ -45,25 +52,33 @@ describe("chat-handle", () => {
   it("returns stored handle if present", async () => {
     const { data } = setupStorage();
     data[STORAGE_KEY] = "Tundra Swan";
-    _resetForTest();
-    const handle = await getOrCreateHandle();
+    _resetWikipediaHandleForTest();
+    const handle = await getOrCreateWikipediaHandle();
     expect(handle).toBe("Tundra Swan");
   });
 
   it("rolls a new handle on miss and persists it", async () => {
     globalThis.fetch = mockFetchOnce("Pyotr Stolypin") as typeof fetch;
-    const handle = await getOrCreateHandle();
+    const handle = await getOrCreateWikipediaHandle();
     expect(handle).toBe("Pyotr Stolypin");
-    expect(browser.storage.local.set).toHaveBeenCalledWith({ [STORAGE_KEY]: "Pyotr Stolypin" });
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
+      [STORAGE_KEY]: "Pyotr Stolypin",
+    });
   });
 
   it("retries on profane rolls and returns a clean one", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ title: "Shit Article" }) } as Response)
-      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ title: "Octopus" }) } as Response);
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ title: "Shit Article" }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ title: "Octopus" }),
+      } as Response);
     globalThis.fetch = fetchMock as typeof fetch;
-    const handle = await getOrCreateHandle();
+    const handle = await getOrCreateWikipediaHandle();
     expect(handle).toBe("Octopus");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -74,24 +89,53 @@ describe("chat-handle", () => {
       json: () => Promise.resolve({ title: "shit" }),
     } as Response);
     globalThis.fetch = fetchMock as typeof fetch;
-    const handle = await getOrCreateHandle();
+    const handle = await getOrCreateWikipediaHandle();
     expect(handle).toBe("Anonymous");
     expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
   it("falls back to Anonymous on network failure", async () => {
-    globalThis.fetch = vi.fn().mockRejectedValue(new Error("net down")) as typeof fetch;
-    const handle = await getOrCreateHandle();
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("net down")) as typeof fetch;
+    const handle = await getOrCreateWikipediaHandle();
     expect(handle).toBe("Anonymous");
   });
 
   it("rerollHandle ignores stored value and refetches", async () => {
     const { data } = setupStorage();
     data[STORAGE_KEY] = "Old Name";
-    _resetForTest();
+    _resetWikipediaHandleForTest();
     globalThis.fetch = mockFetchOnce("New Name") as typeof fetch;
-    const handle = await rerollHandle();
+    const handle = await rerollWikipediaHandle();
     expect(handle).toBe("New Name");
-    expect(browser.storage.local.set).toHaveBeenCalledWith({ [STORAGE_KEY]: "New Name" });
+    expect(browser.storage.local.set).toHaveBeenCalledWith({
+      [STORAGE_KEY]: "New Name",
+    });
+  });
+
+  it("creates one name when multiple tabs initialize together", async () => {
+    let resolveFetch!: (response: Response) => void;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const first = getOrCreateWikipediaHandle();
+    const second = getOrCreateWikipediaHandle();
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ title: "Stable Name" }),
+    } as Response);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      "Stable Name",
+      "Stable Name",
+    ]);
   });
 });

--- a/extension/src/__tests__/chat-handle.test.ts
+++ b/extension/src/__tests__/chat-handle.test.ts
@@ -3,9 +3,11 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import browser from "webextension-polyfill";
+import { getOrCreateHandle as requestWikipediaHandle } from "../features/chat-handle";
 import {
   getOrCreateWikipediaHandle,
   rerollWikipediaHandle,
+  setWikipediaHandle,
   _resetWikipediaHandleForTest,
 } from "../storage/wikipediaHandle";
 
@@ -137,5 +139,21 @@ describe("chat-handle", () => {
       "Stable Name",
       "Stable Name",
     ]);
+  });
+
+  it("handles a missing title without rejecting", async () => {
+    globalThis.fetch = mockFetchOnce("Fallback Name") as typeof fetch;
+
+    await expect(setWikipediaHandle(undefined)).resolves.toBe("Fallback Name");
+  });
+
+  it("surfaces background storage errors to the caller", async () => {
+    vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
+      error: "Storage unavailable",
+    });
+
+    await expect(requestWikipediaHandle()).rejects.toThrow(
+      "Storage unavailable",
+    );
   });
 });

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -4,6 +4,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getCustomSiteSettingsForHostname,
+  getCustomSiteSettingsForLocation,
   initCustomSite,
   resolveCustomSiteSettingsForHostname,
   shouldEnableCursorsForHostname,
@@ -88,6 +89,24 @@ describe("shouldEnableCursors", () => {
 describe("custom site settings", () => {
   it("uses default supported-site settings for Wikipedia", () => {
     expect(getCustomSiteSettingsForHostname("en.wikipedia.org")).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: false },
+    });
+  });
+
+  it("preserves query parameters for Wikipedia index.php editing rooms", () => {
+    expect(
+      getCustomSiteSettingsForLocation("en.wikipedia.org", "/w/index.php"),
+    ).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: true },
+    });
+    expect(
+      getCustomSiteSettingsForLocation(
+        "en.wikipedia.org",
+        "/wiki/Max_Polyakov",
+      ),
+    ).toEqual({
       cursorsEnabled: true,
       defaultRoomOptions: { includeSearch: false },
     });

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -94,9 +94,13 @@ describe("custom site settings", () => {
     });
   });
 
-  it("preserves query parameters for Wikipedia index.php editing rooms", () => {
+  it("preserves query parameters for Wikipedia editing rooms", () => {
     expect(
-      getCustomSiteSettingsForLocation("en.wikipedia.org", "/w/index.php"),
+      getCustomSiteSettingsForLocation(
+        "en.wikipedia.org",
+        "/w/index.php",
+        "?title=Max_Polyakov&gesuggestededit=1&veaction=edit",
+      ),
     ).toEqual({
       cursorsEnabled: true,
       defaultRoomOptions: { includeSearch: true },
@@ -105,6 +109,27 @@ describe("custom site settings", () => {
       getCustomSiteSettingsForLocation(
         "en.wikipedia.org",
         "/wiki/Max_Polyakov",
+        "?veaction=edit",
+      ),
+    ).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: true },
+    });
+    expect(
+      getCustomSiteSettingsForLocation(
+        "en.wikipedia.org",
+        "/wiki/Max_Polyakov",
+        "?action=edit",
+      ),
+    ).toEqual({
+      cursorsEnabled: true,
+      defaultRoomOptions: { includeSearch: true },
+    });
+    expect(
+      getCustomSiteSettingsForLocation(
+        "en.wikipedia.org",
+        "/w/index.php",
+        "?title=Max_Polyakov&oldid=123",
       ),
     ).toEqual({
       cursorsEnabled: true,

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -79,12 +79,19 @@ export function getCustomSiteSettingsForHostname(
 export function getCustomSiteSettingsForLocation(
   hostname: string,
   pathname: string,
+  search: string,
 ): CustomSiteSettings | null {
   const settings = getCustomSiteSettingsForHostname(hostname);
   if (!settings) return null;
-  if (!isWikipediaHostname(hostname) || pathname !== "/w/index.php") {
+  if (!isWikipediaHostname(hostname)) {
     return settings;
   }
+  const isArticleRoute = pathname === "/w/index.php" || pathname.startsWith("/wiki/");
+  if (!isArticleRoute) return settings;
+  const searchParams = new URLSearchParams(search);
+  const isEditing =
+    searchParams.get("action") === "edit" || searchParams.has("veaction");
+  if (!isEditing) return settings;
   return {
     ...settings,
     defaultRoomOptions: {
@@ -95,7 +102,11 @@ export function getCustomSiteSettingsForLocation(
 }
 
 export function getCustomSiteSettings(): CustomSiteSettings | null {
-  return getCustomSiteSettingsForLocation(location.hostname, location.pathname);
+  return getCustomSiteSettingsForLocation(
+    location.hostname,
+    location.pathname,
+    location.search,
+  );
 }
 
 // Returns true if the current domain should have collaborative cursors enabled.

--- a/extension/src/custom-sites/index.ts
+++ b/extension/src/custom-sites/index.ts
@@ -76,8 +76,26 @@ export function getCustomSiteSettingsForHostname(
   return resolveCustomSiteSettingsForHostname(hostname, CUSTOM_SITE_POLICIES);
 }
 
+export function getCustomSiteSettingsForLocation(
+  hostname: string,
+  pathname: string,
+): CustomSiteSettings | null {
+  const settings = getCustomSiteSettingsForHostname(hostname);
+  if (!settings) return null;
+  if (!isWikipediaHostname(hostname) || pathname !== "/w/index.php") {
+    return settings;
+  }
+  return {
+    ...settings,
+    defaultRoomOptions: {
+      ...settings.defaultRoomOptions,
+      includeSearch: true,
+    },
+  };
+}
+
 export function getCustomSiteSettings(): CustomSiteSettings | null {
-  return getCustomSiteSettingsForHostname(location.hostname);
+  return getCustomSiteSettingsForLocation(location.hostname, location.pathname);
 }
 
 // Returns true if the current domain should have collaborative cursors enabled.

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -374,6 +374,11 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
     });
   }
 
+  const { WikipediaLiveSelections } = await import("../features/WikipediaLiveSelections");
+  const liveSelections = new WikipediaLiveSelections(deps.presence, deps.playerColor);
+  liveSelections.init();
+  cleanups.push(() => liveSelections.destroy());
+
   // === Chat: per-article live chat (manager first, pill wired to it) ===
   const { ChatManager } = await import("../features/ChatManager");
   const { ChatEchoRenderer } = await import("../features/chat-echo-renderer");

--- a/extension/src/custom-sites/wikipedia.ts
+++ b/extension/src/custom-sites/wikipedia.ts
@@ -8,6 +8,7 @@ import { FollowManager } from "../features/FollowManager";
 export interface WikiPresenceFields {
   navigatingTo?: { url: string; title: string } | null;
   following?: string | null;
+  online?: true | null;
   page?: {
     url: string;
     title: string;
@@ -291,6 +292,7 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
   if (typeof deps.createPresenceRoom === "function") {
     const lobby = deps.createPresenceRoom("lobby");
     const publishLobbyPage = () => {
+      lobby.presence.setMyPresence("online", true);
       if (
         document.visibilityState !== "visible" ||
         !isWikipediaPortalArticleUrl(location.href)
@@ -307,20 +309,22 @@ export async function initWikipedia(deps: CustomSiteDeps): Promise<() => void> {
         lastSeenAt: Date.now(),
       });
     };
-    const clearLobbyPage = () => {
+    const clearLobbyPresence = () => {
       lobby.presence.setMyPresence("page", null);
+      lobby.presence.setMyPresence("online", null);
     };
     publishLobbyPage();
     const lobbyHeartbeat = window.setInterval(publishLobbyPage, 10_000);
     window.addEventListener("focus", publishLobbyPage);
-    window.addEventListener("pagehide", clearLobbyPage);
+    window.addEventListener("pagehide", clearLobbyPresence);
     document.addEventListener("visibilitychange", publishLobbyPage);
     lobbyPresence = lobby.presence;
     cleanups.push(() => {
       window.clearInterval(lobbyHeartbeat);
       window.removeEventListener("focus", publishLobbyPage);
-      window.removeEventListener("pagehide", clearLobbyPage);
+      window.removeEventListener("pagehide", clearLobbyPresence);
       document.removeEventListener("visibilitychange", publishLobbyPage);
+      clearLobbyPresence();
       lobby.destroy();
     });
   }

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -43,6 +43,17 @@ import {
   setWikipediaHandle,
 } from '../storage/wikipediaHandle'
 
+function replyWithWikipediaHandle(
+  request: Promise<string>,
+  reply: (response: { handle?: string; error?: string }) => void,
+): void {
+  request
+    .then((handle) => reply({ handle }))
+    .catch((error: unknown) =>
+      reply({ error: error instanceof Error ? error.message : String(error) }),
+    )
+}
+
 interface ScrapRecordBase {
   id: string
   key: string
@@ -525,17 +536,17 @@ export default defineBackground(() => {
     }
 
     if (message.type === 'GET_OR_CREATE_WIKIPEDIA_HANDLE') {
-      getOrCreateWikipediaHandle().then((handle) => reply({ handle }))
+      replyWithWikipediaHandle(getOrCreateWikipediaHandle(), reply)
       return true
     }
 
     if (message.type === 'REROLL_WIKIPEDIA_HANDLE') {
-      rerollWikipediaHandle().then((handle) => reply({ handle }))
+      replyWithWikipediaHandle(rerollWikipediaHandle(), reply)
       return true
     }
 
     if (message.type === 'SET_WIKIPEDIA_HANDLE') {
-      setWikipediaHandle(message.title).then((handle) => reply({ handle }))
+      replyWithWikipediaHandle(setWikipediaHandle(message.title), reply)
       return true
     }
 

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -37,6 +37,11 @@ import {
 import { getSessionId } from '../storage/participant'
 import { recordAnnouncementInstall } from '../announcements/announcement-storage'
 import { isUserActive } from '../utils/userActivity'
+import {
+  getOrCreateWikipediaHandle,
+  rerollWikipediaHandle,
+  setWikipediaHandle,
+} from '../storage/wikipediaHandle'
 
 interface ScrapRecordBase {
   id: string
@@ -517,6 +522,21 @@ export default defineBackground(() => {
     if (message.type === 'GET_PLAYER_PROFILE') {
       getPlayerProfile().then(reply)
       return true // Will respond asynchronously
+    }
+
+    if (message.type === 'GET_OR_CREATE_WIKIPEDIA_HANDLE') {
+      getOrCreateWikipediaHandle().then((handle) => reply({ handle }))
+      return true
+    }
+
+    if (message.type === 'REROLL_WIKIPEDIA_HANDLE') {
+      rerollWikipediaHandle().then((handle) => reply({ handle }))
+      return true
+    }
+
+    if (message.type === 'SET_WIKIPEDIA_HANDLE') {
+      setWikipediaHandle(message.title).then((handle) => reply({ handle }))
+      return true
     }
 
     if (message.type === 'UPDATE_SITE_DISCOVERY') {

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -88,11 +88,13 @@ export class ChatManager {
   }
 
   async init(): Promise<void> {
-    const handle = await getOrCreateHandle();
-    this.setState({ handle });
+    let handleChanged = false;
     this.unsubHandle = onHandleChange((nextHandle) => {
+      handleChanged = true;
       if (nextHandle !== this.state.handle) this.setState({ handle: nextHandle });
     });
+    const handle = await getOrCreateHandle();
+    if (!handleChanged) this.setState({ handle });
     this.unsubPresence = this.presence.onPresenceChange(CHAT_CHANNEL, (presences) => {
       this.onPresences(presences);
     });

--- a/extension/src/features/ChatManager.ts
+++ b/extension/src/features/ChatManager.ts
@@ -3,7 +3,7 @@
 
 import type { PresenceAPI, PresenceView } from "@playhtml/common";
 import { containsProfanity } from "@movement/profanity";
-import { getOrCreateHandle, rerollHandle, setHandle } from "./chat-handle";
+import { getOrCreateHandle, onHandleChange, rerollHandle, setHandle } from "./chat-handle";
 
 const CHAT_CHANNEL = "chat";
 const MAX_MESSAGE_LENGTH = 400;
@@ -57,6 +57,7 @@ export class ChatManager {
   private state: ChatManagerState;
   private listeners = new Set<Listener>();
   private unsubPresence: (() => void) | null = null;
+  private unsubHandle: (() => void) | null = null;
   private lastSendAt = 0;
   private seenIds = new Set<string>();
   // onPresenceChange replays the current snapshot on subscribe. We intentionally
@@ -89,6 +90,9 @@ export class ChatManager {
   async init(): Promise<void> {
     const handle = await getOrCreateHandle();
     this.setState({ handle });
+    this.unsubHandle = onHandleChange((nextHandle) => {
+      if (nextHandle !== this.state.handle) this.setState({ handle: nextHandle });
+    });
     this.unsubPresence = this.presence.onPresenceChange(CHAT_CHANNEL, (presences) => {
       this.onPresences(presences);
     });
@@ -97,6 +101,8 @@ export class ChatManager {
   destroy(): void {
     this.unsubPresence?.();
     this.unsubPresence = null;
+    this.unsubHandle?.();
+    this.unsubHandle = null;
     this.listeners.clear();
   }
 

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -136,7 +136,13 @@ export class PresenceCountPill {
     myKey: string | null,
     pageOtherKeys: Set<string>,
   ): Set<string> {
-    const keys = this.uniqueOtherKeys(presences, myKey);
+    const keys = new Set<string>();
+    presences.forEach((presence, connectionId) => {
+      if (presence.isMe || presence.online !== true) return;
+      const key = this.pidOf(presence);
+      if (key && myKey && key === myKey) return;
+      keys.add(key ?? `conn:${connectionId}`);
+    });
     pageOtherKeys.forEach((key) => keys.delete(key));
     return keys;
   }

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -38,15 +38,16 @@ export class PresenceCountPill {
 
       const myKey = this.getMyPublicKey(pagePresences, lobbyPresences);
       const pageOtherKeys = this.uniqueOtherKeys(pagePresences, myKey);
-      const lobbyOtherPageKeys = this.uniqueOtherPageKeys(lobbyPresences, myKey);
+      const elsewhereKeys = this.uniqueElsewhereKeys(lobbyPresences, myKey, pageOtherKeys);
 
       const pageOthers = pageOtherKeys.size;
-      const elsewhere = lobbyOtherPageKeys.size;
-      const fingerprint = `${pageOthers}:${elsewhere}`;
+      const elsewhere = elsewhereKeys.size;
+      const hasJumpTarget = this.hasJumpTarget(lobbyPresences, myKey, pageOtherKeys);
+      const fingerprint = `${pageOthers}:${elsewhere}:${hasJumpTarget}`;
 
       if (fingerprint !== this.lastFingerprint) {
         this.lastFingerprint = fingerprint;
-        this.render(pageOthers, elsewhere, pagePresences, pageOtherKeys, myKey);
+        this.render(pageOthers, elsewhere, hasJumpTarget, pagePresences, myKey);
       }
     };
 
@@ -131,17 +132,30 @@ export class PresenceCountPill {
     }
   }
 
-  private uniqueOtherPageKeys(presences: Map<string, any>, myKey: string | null): Set<string> {
-    const keys = new Set<string>();
-    presences.forEach((p, connectionId) => {
-      if (p.isMe) return;
-      const key = this.pidOf(p);
-      if (key && myKey && key === myKey) return;
-      const page = (p as WikiPresenceView).page;
-      if (!this.isFreshLobbyPage(page) || this.isCurrentPageUrl(page.url)) return;
-      keys.add(key ?? `conn:${connectionId}`);
-    });
+  private uniqueElsewhereKeys(
+    presences: Map<string, any>,
+    myKey: string | null,
+    pageOtherKeys: Set<string>,
+  ): Set<string> {
+    const keys = this.uniqueOtherKeys(presences, myKey);
+    pageOtherKeys.forEach((key) => keys.delete(key));
     return keys;
+  }
+
+  private hasJumpTarget(
+    presences: Map<string, any>,
+    myKey: string | null,
+    pageOtherKeys: Set<string>,
+  ): boolean {
+    for (const p of presences.values()) {
+      if (p.isMe) continue;
+      const key = this.pidOf(p);
+      if (key && myKey && key === myKey) continue;
+      if (key && pageOtherKeys.has(key)) continue;
+      const page = (p as WikiPresenceView).page;
+      if (this.isFreshLobbyPage(page) && !this.isCurrentPageUrl(page.url)) return true;
+    }
+    return false;
   }
 
   destroy(): void {
@@ -155,8 +169,8 @@ export class PresenceCountPill {
   private render(
     pageOthers: number,
     elsewhere: number,
+    hasJumpTarget: boolean,
     pagePresences: Map<string, any>,
-    pageOtherKeys: Set<string>,
     myKey: string | null,
   ): void {
     const totalOthers = pageOthers + elsewhere;
@@ -222,9 +236,12 @@ export class PresenceCountPill {
       elsewhereLabel.textContent = `\u00b7 ${elsewhere} elsewhere`;
       this.element.appendChild(elsewhereLabel);
 
-      // Jump button
-      this.jumpBtn = this.createJumpButton();
-      this.element.appendChild(this.jumpBtn);
+      if (hasJumpTarget) {
+        this.jumpBtn = this.createJumpButton();
+        this.element.appendChild(this.jumpBtn);
+      } else {
+        this.jumpBtn = null;
+      }
     } else {
       this.jumpBtn = null;
     }
@@ -307,11 +324,12 @@ export class PresenceCountPill {
     const lobbyPresences = this.lobbyPresence.getPresences();
     const myKey = this.getMyPublicKey(pagePresences, lobbyPresences);
     const pageOtherKeys = this.uniqueOtherKeys(pagePresences, myKey);
-    const lobbyOtherPageKeys = this.uniqueOtherPageKeys(lobbyPresences, myKey);
+    const elsewhereKeys = this.uniqueElsewhereKeys(lobbyPresences, myKey, pageOtherKeys);
     const pageOthers = pageOtherKeys.size;
-    const elsewhere = lobbyOtherPageKeys.size;
+    const elsewhere = elsewhereKeys.size;
+    const hasJumpTarget = this.hasJumpTarget(lobbyPresences, myKey, pageOtherKeys);
     this.lastFingerprint = "";
-    this.render(pageOthers, elsewhere, pagePresences, pageOtherKeys, myKey);
+    this.render(pageOthers, elsewhere, hasJumpTarget, pagePresences, myKey);
   }
 
   private createDot(color: string): HTMLElement {

--- a/extension/src/features/PresenceCountPill.ts
+++ b/extension/src/features/PresenceCountPill.ts
@@ -90,9 +90,8 @@ export class PresenceCountPill {
     return null;
   }
 
-  // Lobby presences don't carry __playhtml_cursors__ for remote peers, so
-  // playerIdentity is undefined there. We piggy-back the pid on the `page`
-  // payload (set in wikipedia.ts) and read it back here.
+  // PresenceClient supplies the public identity when available. The page pid
+  // also keeps identity stable when a lobby payload arrives without it.
   private pidOf(p: any): string | null {
     return p?.playerIdentity?.publicKey ?? p?.page?.pid ?? null;
   }

--- a/extension/src/features/WikipediaLiveSelections.ts
+++ b/extension/src/features/WikipediaLiveSelections.ts
@@ -1,0 +1,236 @@
+// ABOUTME: Shares each reader's current Wikipedia text selection through presence.
+// ABOUTME: Renders peer selections without changing article markup or text color.
+
+import type { PresenceAPI, PresenceView } from "@playhtml/common";
+
+const CHANNEL = "selection";
+const CONTENT_SELECTOR = "#mw-content-text";
+const HIGHLIGHT_PREFIX = "wwo-live-selection-";
+const FALLBACK_COLOR = "#8a8279";
+const PUBLISH_INTERVAL_MS = 50;
+
+type SelectionPoint = {
+  path: number[];
+  offset: number;
+};
+
+export type LiveSelection = {
+  start: SelectionPoint;
+  end: SelectionPoint;
+};
+
+type HighlightRegistry = {
+  delete(name: string): boolean;
+  set(name: string, highlight: unknown): void;
+};
+
+type HighlightConstructor = new (...ranges: Range[]) => unknown;
+
+function pathFromRoot(root: Node, node: Node): number[] | null {
+  const path: number[] = [];
+  let current: Node | null = node;
+  while (current && current !== root) {
+    const parentNode: Node | null = current.parentNode;
+    if (!parentNode) return null;
+    const index = Array.prototype.indexOf.call(parentNode.childNodes, current);
+    if (index < 0) return null;
+    path.unshift(index);
+    current = parentNode;
+  }
+  return current === root ? path : null;
+}
+
+function nodeFromPath(root: Node, path: number[]): Node | null {
+  let current = root;
+  for (const index of path) {
+    const next = current.childNodes.item(index);
+    if (!next) return null;
+    current = next;
+  }
+  return current;
+}
+
+function isSelectionPoint(value: unknown): value is SelectionPoint {
+  if (!value || typeof value !== "object") return false;
+  const point = value as { path?: unknown; offset?: unknown };
+  return (
+    Array.isArray(point.path) &&
+    point.path.length <= 64 &&
+    point.path.every(
+      (part) => Number.isInteger(part) && part >= 0 && part <= 10_000,
+    ) &&
+    Number.isInteger(point.offset) &&
+    (point.offset as number) >= 0 &&
+    (point.offset as number) <= 1_000_000
+  );
+}
+
+function isLiveSelection(value: unknown): value is LiveSelection {
+  if (!value || typeof value !== "object") return false;
+  const selection = value as { start?: unknown; end?: unknown };
+  return isSelectionPoint(selection.start) && isSelectionPoint(selection.end);
+}
+
+export function serializeSelectionRange(
+  root: Node,
+  range: Range,
+): LiveSelection | null {
+  if (range.collapsed) return null;
+  const startPath = pathFromRoot(root, range.startContainer);
+  const endPath = pathFromRoot(root, range.endContainer);
+  if (!startPath || !endPath) return null;
+  return {
+    start: { path: startPath, offset: range.startOffset },
+    end: { path: endPath, offset: range.endOffset },
+  };
+}
+
+export function deserializeSelectionRange(
+  root: Node,
+  value: unknown,
+): Range | null {
+  if (!isLiveSelection(value)) return null;
+  const startNode = nodeFromPath(root, value.start.path);
+  const endNode = nodeFromPath(root, value.end.path);
+  if (!startNode || !endNode) return null;
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, value.start.offset);
+    range.setEnd(endNode, value.end.offset);
+    return range.collapsed ? null : range;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedColor(value: unknown): string {
+  if (typeof value !== "string") return FALLBACK_COLOR;
+  const probe = document.createElement("span");
+  probe.style.color = value;
+  return probe.style.color || FALLBACK_COLOR;
+}
+
+function highlightRegistry(): HighlightRegistry | null {
+  const css = globalThis.CSS as typeof CSS & {
+    highlights?: HighlightRegistry;
+  };
+  return css?.highlights ?? null;
+}
+
+function highlightConstructor(): HighlightConstructor | null {
+  return (
+    (globalThis as typeof globalThis & { Highlight?: HighlightConstructor })
+      .Highlight ?? null
+  );
+}
+
+export class WikipediaLiveSelections {
+  private root: HTMLElement | null = null;
+  private styleElement: HTMLStyleElement | null = null;
+  private highlightNames = new Set<string>();
+  private unsubscribe: (() => void) | null = null;
+  private selectionTimer: number | null = null;
+
+  constructor(
+    private presence: PresenceAPI,
+    private playerColor: string,
+  ) {}
+
+  init(): void {
+    this.root = document.querySelector<HTMLElement>(CONTENT_SELECTOR);
+    if (!this.root) return;
+
+    this.styleElement = document.createElement("style");
+    this.styleElement.id = "wwo-live-selection-styles";
+    document.head.appendChild(this.styleElement);
+    this.updateStyles([]);
+
+    document.addEventListener("selectionchange", this.handleSelectionChange);
+    this.unsubscribe = this.presence.onPresenceChange(CHANNEL, (presences) => {
+      this.renderRemoteSelections(presences);
+    });
+    this.publishSelection();
+  }
+
+  destroy(): void {
+    if (this.selectionTimer !== null) window.clearTimeout(this.selectionTimer);
+    this.selectionTimer = null;
+    document.removeEventListener("selectionchange", this.handleSelectionChange);
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    if (this.root) this.presence.setMyPresence(CHANNEL, null);
+    this.clearRemoteSelections();
+    this.styleElement?.remove();
+    this.styleElement = null;
+    this.root = null;
+  }
+
+  private handleSelectionChange = () => {
+    if (this.selectionTimer !== null) return;
+    this.selectionTimer = window.setTimeout(() => {
+      this.selectionTimer = null;
+      this.publishSelection();
+    }, PUBLISH_INTERVAL_MS);
+  };
+
+  private publishSelection(): void {
+    if (!this.root) return;
+    const selection = window.getSelection();
+    const range =
+      selection && selection.rangeCount > 0
+        ? serializeSelectionRange(this.root, selection.getRangeAt(0))
+        : null;
+    this.presence.setMyPresence(CHANNEL, range);
+  }
+
+  private renderRemoteSelections(presences: Map<string, PresenceView>): void {
+    if (!this.root) return;
+    this.clearRemoteSelections();
+    const registry = highlightRegistry();
+    const Highlight = highlightConstructor();
+    if (!registry || !Highlight) return;
+
+    const styles: Array<{ name: string; color: string }> = [];
+    let index = 0;
+    presences.forEach((view) => {
+      if (view.isMe) return;
+      const range = deserializeSelectionRange(
+        this.root!,
+        (view as Record<string, unknown>)[CHANNEL],
+      );
+      if (!range) return;
+      const name = `${HIGHLIGHT_PREFIX}${index++}`;
+      const color = normalizedColor(
+        view.playerIdentity?.playerStyle?.colorPalette?.[0],
+      );
+      registry.set(name, new Highlight(range));
+      this.highlightNames.add(name);
+      styles.push({ name, color });
+    });
+    this.updateStyles(styles);
+  }
+
+  private clearRemoteSelections(): void {
+    const registry = highlightRegistry();
+    if (registry) {
+      this.highlightNames.forEach((name) => registry.delete(name));
+    }
+    this.highlightNames.clear();
+    this.updateStyles([]);
+  }
+
+  private updateStyles(
+    remoteSelections: Array<{ name: string; color: string }>,
+  ): void {
+    if (!this.styleElement) return;
+    const ownColor = normalizedColor(this.playerColor);
+    const rules = [
+      `#mw-content-text ::selection { background-color: color-mix(in srgb, ${ownColor} 32%, transparent); color: inherit; }`,
+      ...remoteSelections.map(
+        ({ name, color }) =>
+          `::highlight(${name}) { background-color: color-mix(in srgb, ${color} 32%, transparent); color: inherit; }`,
+      ),
+    ];
+    this.styleElement.textContent = rules.join("\n");
+  }
+}

--- a/extension/src/features/WikipediaLiveSelections.ts
+++ b/extension/src/features/WikipediaLiveSelections.ts
@@ -7,7 +7,7 @@ const CHANNEL = "selection";
 const CONTENT_SELECTOR = "#mw-content-text";
 const HIGHLIGHT_PREFIX = "wwo-live-selection-";
 const FALLBACK_COLOR = "#8a8279";
-const PUBLISH_INTERVAL_MS = 50;
+const PUBLISH_INTERVAL_MS = 250;
 
 type SelectionPoint = {
   path: number[];
@@ -130,6 +130,7 @@ export class WikipediaLiveSelections {
   private highlightNames = new Set<string>();
   private unsubscribe: (() => void) | null = null;
   private selectionTimer: number | null = null;
+  private lastPublishedSelection: string | null | undefined;
 
   constructor(
     private presence: PresenceAPI,
@@ -159,6 +160,7 @@ export class WikipediaLiveSelections {
     this.unsubscribe?.();
     this.unsubscribe = null;
     if (this.root) this.presence.setMyPresence(CHANNEL, null);
+    this.lastPublishedSelection = undefined;
     this.clearRemoteSelections();
     this.styleElement?.remove();
     this.styleElement = null;
@@ -180,6 +182,9 @@ export class WikipediaLiveSelections {
       selection && selection.rangeCount > 0
         ? serializeSelectionRange(this.root, selection.getRangeAt(0))
         : null;
+    const serialized = range ? JSON.stringify(range) : null;
+    if (serialized === this.lastPublishedSelection) return;
+    this.lastPublishedSelection = serialized;
     this.presence.setMyPresence(CHANNEL, range);
   }
 

--- a/extension/src/features/chat-handle.ts
+++ b/extension/src/features/chat-handle.ts
@@ -7,6 +7,13 @@ const STORAGE_KEY = "wiki_chat_handle";
 
 function readHandleResponse(response: unknown): string {
   if (
+    response &&
+    typeof response === "object" &&
+    typeof (response as { error?: unknown }).error === "string"
+  ) {
+    throw new Error((response as { error: string }).error);
+  }
+  if (
     !response ||
     typeof response !== "object" ||
     typeof (response as { handle?: unknown }).handle !== "string"

--- a/extension/src/features/chat-handle.ts
+++ b/extension/src/features/chat-handle.ts
@@ -1,70 +1,53 @@
-// ABOUTME: Random Wikipedia-article handle for chat. Persists to browser.storage.local.
-// ABOUTME: Filters profane rolls; falls back to "Anonymous" on persistent failure.
+// ABOUTME: Reads and changes the background-owned Wikipedia chat article-name.
+// ABOUTME: Relays storage changes so every open Wikipedia tab stays in sync.
 
 import browser from "webextension-polyfill";
-import { containsProfanity } from "@movement/profanity";
 
 const STORAGE_KEY = "wiki_chat_handle";
-const RANDOM_URL = "https://en.wikipedia.org/api/rest_v1/page/random/summary";
-const MAX_ROLL_RETRIES = 5;
-const FALLBACK = "Anonymous";
 
-let cached: string | null = null;
-
-export function _resetForTest(): void {
-  cached = null;
-}
-
-async function rollOnce(): Promise<string | null> {
-  try {
-    const res = await fetch(RANDOM_URL);
-    if (!res.ok) return null;
-    const data = (await res.json()) as { title?: string };
-    if (typeof data.title !== "string" || data.title.length === 0) return null;
-    return data.title;
-  } catch {
-    return null;
+function readHandleResponse(response: unknown): string {
+  if (
+    !response ||
+    typeof response !== "object" ||
+    typeof (response as { handle?: unknown }).handle !== "string"
+  ) {
+    throw new Error("Wikipedia article-name response is missing a handle.");
   }
-}
-
-async function rollHandle(): Promise<string> {
-  for (let i = 0; i < MAX_ROLL_RETRIES; i++) {
-    const title = await rollOnce();
-    if (title && !containsProfanity(title)) return title;
-  }
-  return FALLBACK;
+  return (response as { handle: string }).handle;
 }
 
 export async function getOrCreateHandle(): Promise<string> {
-  if (cached) return cached;
-  const stored = (await browser.storage.local.get(STORAGE_KEY)) as Record<string, unknown>;
-  const existing = stored[STORAGE_KEY];
-  if (typeof existing === "string" && existing.length > 0) {
-    cached = existing;
-    return existing;
-  }
-  const fresh = await rollHandle();
-  cached = fresh;
-  await browser.storage.local.set({ [STORAGE_KEY]: fresh });
-  return fresh;
+  return readHandleResponse(
+    await browser.runtime.sendMessage({
+      type: "GET_OR_CREATE_WIKIPEDIA_HANDLE",
+    }),
+  );
 }
 
 export async function rerollHandle(): Promise<string> {
-  const fresh = await rollHandle();
-  cached = fresh;
-  await browser.storage.local.set({ [STORAGE_KEY]: fresh });
-  return fresh;
+  return readHandleResponse(
+    await browser.runtime.sendMessage({ type: "REROLL_WIKIPEDIA_HANDLE" }),
+  );
 }
 
-// Adopt a specific article title as the handle (e.g. "be this page"). Falls
-// back to a reroll if the chosen title is empty or profane, so we never
-// persist an unusable name.
 export async function setHandle(title: string): Promise<string> {
-  const trimmed = title.trim();
-  if (trimmed.length === 0 || containsProfanity(trimmed)) {
-    return rerollHandle();
-  }
-  cached = trimmed;
-  await browser.storage.local.set({ [STORAGE_KEY]: trimmed });
-  return trimmed;
+  return readHandleResponse(
+    await browser.runtime.sendMessage({
+      type: "SET_WIKIPEDIA_HANDLE",
+      title,
+    }),
+  );
+}
+
+export function onHandleChange(listener: (handle: string) => void): () => void {
+  const handleStorageChange = (
+    changes: Record<string, { newValue?: unknown }>,
+    areaName: string,
+  ) => {
+    if (areaName !== "local") return;
+    const next = changes[STORAGE_KEY]?.newValue;
+    if (typeof next === "string" && next.length > 0) listener(next);
+  };
+  browser.storage.onChanged.addListener(handleStorageChange);
+  return () => browser.storage.onChanged.removeListener(handleStorageChange);
 }

--- a/extension/src/storage/wikipediaHandle.ts
+++ b/extension/src/storage/wikipediaHandle.ts
@@ -1,0 +1,76 @@
+// ABOUTME: Owns the persisted Wikipedia article-name used by live chat.
+// ABOUTME: Serializes reads and writes so simultaneous tabs share one name.
+
+import browser from "webextension-polyfill";
+import { containsProfanity } from "@movement/profanity";
+
+const STORAGE_KEY = "wiki_chat_handle";
+const RANDOM_URL = "https://en.wikipedia.org/api/rest_v1/page/random/summary";
+const MAX_ROLL_RETRIES = 5;
+const FALLBACK = "Anonymous";
+
+let operations: Promise<void> = Promise.resolve();
+
+export function _resetWikipediaHandleForTest(): void {
+  operations = Promise.resolve();
+}
+
+function enqueue<T>(operation: () => Promise<T>): Promise<T> {
+  const result = operations.then(operation, operation);
+  operations = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function rollOnce(): Promise<string | null> {
+  try {
+    const response = await fetch(RANDOM_URL);
+    if (!response.ok) return null;
+    const data = (await response.json()) as { title?: string };
+    if (typeof data.title !== "string" || data.title.length === 0) return null;
+    return data.title;
+  } catch {
+    return null;
+  }
+}
+
+async function rollHandle(): Promise<string> {
+  for (let attempt = 0; attempt < MAX_ROLL_RETRIES; attempt++) {
+    const title = await rollOnce();
+    if (title && !containsProfanity(title)) return title;
+  }
+  return FALLBACK;
+}
+
+async function persistHandle(handle: string): Promise<string> {
+  await browser.storage.local.set({ [STORAGE_KEY]: handle });
+  return handle;
+}
+
+export function getOrCreateWikipediaHandle(): Promise<string> {
+  return enqueue(async () => {
+    const stored = (await browser.storage.local.get(STORAGE_KEY)) as Record<
+      string,
+      unknown
+    >;
+    const existing = stored[STORAGE_KEY];
+    if (typeof existing === "string" && existing.length > 0) return existing;
+    return persistHandle(await rollHandle());
+  });
+}
+
+export function rerollWikipediaHandle(): Promise<string> {
+  return enqueue(async () => persistHandle(await rollHandle()));
+}
+
+export function setWikipediaHandle(title: string): Promise<string> {
+  return enqueue(async () => {
+    const trimmed = title.trim();
+    if (trimmed.length === 0 || containsProfanity(trimmed)) {
+      return persistHandle(await rollHandle());
+    }
+    return persistHandle(trimmed);
+  });
+}

--- a/extension/src/storage/wikipediaHandle.ts
+++ b/extension/src/storage/wikipediaHandle.ts
@@ -65,9 +65,9 @@ export function rerollWikipediaHandle(): Promise<string> {
   return enqueue(async () => persistHandle(await rollHandle()));
 }
 
-export function setWikipediaHandle(title: string): Promise<string> {
+export function setWikipediaHandle(title: unknown): Promise<string> {
   return enqueue(async () => {
-    const trimmed = title.trim();
+    const trimmed = typeof title === "string" ? title.trim() : "";
     if (trimmed.length === 0 || containsProfanity(trimmed)) {
       return persistHandle(await rollHandle());
     }

--- a/extension/vitest.setup.ts
+++ b/extension/vitest.setup.ts
@@ -10,10 +10,24 @@ Object.defineProperty(window, "scrollX", { value: 0, writable: true });
 Object.defineProperty(window, "scrollY", { value: 0, writable: true });
 
 // Mock document dimensions
-Object.defineProperty(document.documentElement, "scrollWidth", { value: 1024, writable: true, configurable: true });
-Object.defineProperty(document.documentElement, "scrollHeight", { value: 2000, writable: true, configurable: true });
-Object.defineProperty(document.documentElement, "scrollLeft", { value: 0, writable: true });
-Object.defineProperty(document.documentElement, "scrollTop", { value: 0, writable: true });
+Object.defineProperty(document.documentElement, "scrollWidth", {
+  value: 1024,
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(document.documentElement, "scrollHeight", {
+  value: 2000,
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(document.documentElement, "scrollLeft", {
+  value: 0,
+  writable: true,
+});
+Object.defineProperty(document.documentElement, "scrollTop", {
+  value: 0,
+  writable: true,
+});
 
 // Mock devicePixelRatio
 Object.defineProperty(window, "devicePixelRatio", { value: 1, writable: true });
@@ -53,6 +67,10 @@ vi.mock("webextension-polyfill", () => ({
         get: vi.fn().mockResolvedValue({}),
         set: vi.fn().mockResolvedValue(undefined),
         remove: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
       },
     },
     runtime: {


### PR DESCRIPTION
## Summary

- keep one Wikipedia article-name stable across every open extension tab
- show other readers' active text selections in real time using their cursor colors
- count each connected identity once in the "elsewhere" total, including readers without a current page payload
- preserve the full query string for Wikipedia `/w/index.php` editing rooms while keeping normal article tracking parameters normalized

## Why

Wikipedia chat names could race during simultaneous tab startup, live selections were not visible to peers, and the lobby count omitted connected people when their page metadata was missing or stale. Editing URLs also collapsed distinct query-based sessions into the same room.

## Implementation

The background worker now owns article-name generation and persistence, which serializes simultaneous initialization and broadcasts storage changes to open tabs. Wikipedia selections use presence data containing DOM paths and offsets only. Remote selections render through the CSS Custom Highlight API and disappear when the selection or connection ends.

The presence pill counts lobby identities independently from jump destinations. A fresh, visible page payload is required only to show the jump button.

Wikipedia routes with `action=edit` or `veaction` preserve the full query string in the room key. This covers both `/w/index.php` and `/wiki/Title` editor URLs without fragmenting ordinary reading rooms. Selection updates publish at most every 250ms and unchanged ranges are not sent again.

## Validation

- `bun run build-packages`
- full extension suite: 105 files, 630 tests
- focused review suite: 4 files, 43 tests
- `bunx tsc --noEmit`
- Chrome MV3 production build
- Firefox MV2 production build
- generated manifests still declare `chrome_url_overrides.newtab = newtab.html` for both browsers
- `git diff --check`

## Screenshots

Pending live installed-extension verification. Chrome is not connected to Codex, so the required multi-reader selection and presence screenshots could not be captured yet.
