### PR TITLE
website: fix experiment 8 intro scroll jump after letter load

### DIFF
--- a/website/experiments/8/8.scss
+++ b/website/experiments/8/8.scss
@@ -18,6 +18,41 @@ body {
   padding-bottom: var(--bottom-scroll-clearance, 128px);
 }
 
+.loading-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    repeating-linear-gradient(#e0e0e0 0 1px, transparent 1px 32px),
+    repeating-linear-gradient(90deg, #e0e0e0 0 1px, transparent 1px 32px),
+    #fff;
+
+  p {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    border: 1px solid #c8c8c8;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.96);
+    color: #444;
+    font-size: 0.85rem;
+    letter-spacing: 0.02em;
+    animation: loading-pulse 1.4s ease-in-out infinite;
+  }
+}
+
+@keyframes loading-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 .intro-message {
   position: fixed;
   top: 50%;

--- a/website/experiments/8/8.tsx
+++ b/website/experiments/8/8.tsx
@@ -25,6 +25,7 @@ import {
   INTRO_CONTENT_SETTLE_MS,
   INTRO_FADE_DURATION_MS,
   INTRO_SCROLL_DURATION_MS,
+  isPlayhtmlHostReady,
 } from "./intro";
 
 interface CellData {
@@ -137,6 +138,10 @@ const Main = withSharedState(
 
     useEffect(() => {
       const updateScrollEndState = () => {
+        // Ignore scroll-end pinning until the intro finishes. On first paint the
+        // empty grid fits in one viewport so we would look "at end", then jump
+        // when letters arrive after the intro.
+        if (introState !== "hidden") return;
         shouldFollowScrollEndRef.current = isScrollAtEnd({
           scrollY: window.scrollY,
           scrollHeight: document.documentElement.scrollHeight,
@@ -152,7 +157,7 @@ const Main = withSharedState(
         window.removeEventListener("scroll", updateScrollEndState);
         window.removeEventListener("resize", updateScrollEndState);
       };
-    }, []);
+    }, [introState]);
 
     // Minimum cells to fill the page
     const minCells = gridDimensions.cols * gridDimensions.rows;
@@ -165,21 +170,39 @@ const Main = withSharedState(
 
     const cursorPosition = getTypingCursorPosition(data.letters.length);
 
-    // Wait until synced letter data has been applied and the grid height is
-    // quiet. Starting earlier animates a short empty page, then jumps to the
-    // real bottom once letters hydrate (can-play setup is a parent effect and
-    // may hash the element id asynchronously before applying store data).
+    // Wait until the can-play host is set up (synced data applied) and the grid
+    // height is quiet. Starting earlier animates a short empty page, then jumps
+    // once letters hydrate.
     useEffect(() => {
       if (isLoading || !hasMeasuredGrid) {
         setHasSettledContent(false);
         return;
       }
 
-      const settleTimeout = window.setTimeout(() => {
-        setHasSettledContent(true);
-      }, INTRO_CONTENT_SETTLE_MS);
+      let cancelled = false;
+      let settleTimeout = 0;
+      let raf = 0;
+
+      const armSettleTimer = () => {
+        settleTimeout = window.setTimeout(() => {
+          if (!cancelled) setHasSettledContent(true);
+        }, INTRO_CONTENT_SETTLE_MS);
+      };
+
+      const waitForHost = () => {
+        if (cancelled) return;
+        if (!isPlayhtmlHostReady(document.getElementById("experiment-8"))) {
+          raf = window.requestAnimationFrame(waitForHost);
+          return;
+        }
+        armSettleTimer();
+      };
+
+      waitForHost();
 
       return () => {
+        cancelled = true;
+        window.cancelAnimationFrame(raf);
         window.clearTimeout(settleTimeout);
       };
     }, [isLoading, hasMeasuredGrid, data.letters.length, totalCells]);
@@ -216,20 +239,18 @@ const Main = withSharedState(
       ).matches;
       const durationMs = reducedMotion ? 0 : INTRO_SCROLL_DURATION_MS;
       let animationFrame = 0;
-      let fadeTimeout = 0;
       let startTime: number | undefined;
+      let cancelled = false;
 
       const finishIntro = () => {
+        if (cancelled) return;
         window.scrollTo(0, destinationY);
         shouldFollowScrollEndRef.current = true;
         setIntroState("fading");
-        fadeTimeout = window.setTimeout(() => {
-          shouldFollowScrollEndRef.current = true;
-          setIntroState("hidden");
-        }, reducedMotion ? 800 : INTRO_FADE_DURATION_MS);
       };
 
       const animateScroll = (timestamp: number) => {
+        if (cancelled) return;
         startTime ??= timestamp;
         const elapsedMs = timestamp - startTime;
         window.scrollTo(
@@ -255,7 +276,28 @@ const Main = withSharedState(
       }
 
       return () => {
+        cancelled = true;
         window.cancelAnimationFrame(animationFrame);
+        // Allow a remount/re-run to restart the animation instead of leaving
+        // the intro stuck on "scrolling".
+        introStartedRef.current = false;
+      };
+    }, [introState]);
+
+    // Keep fade timing in its own effect so changing introState to "fading"
+    // does not clear the hide timeout via the scroll effect's cleanup.
+    useEffect(() => {
+      if (introState !== "fading") return;
+
+      const reducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+      ).matches;
+      const fadeTimeout = window.setTimeout(() => {
+        shouldFollowScrollEndRef.current = true;
+        setIntroState("hidden");
+      }, reducedMotion ? 800 : INTRO_FADE_DURATION_MS);
+
+      return () => {
         window.clearTimeout(fadeTimeout);
       };
     }, [introState]);

--- a/website/experiments/8/8.tsx
+++ b/website/experiments/8/8.tsx
@@ -20,7 +20,9 @@ import {
   type TypingCursorAwareness,
 } from "./layout";
 import {
+  canStartIntroScroll,
   getIntroScrollY,
+  INTRO_CONTENT_SETTLE_MS,
   INTRO_FADE_DURATION_MS,
   INTRO_SCROLL_DURATION_MS,
 } from "./intro";
@@ -31,7 +33,7 @@ interface CellData {
   timestamp: number;
 }
 
-type IntroState = "scrolling" | "fading" | "hidden";
+type IntroState = "loading" | "scrolling" | "fading" | "hidden";
 
 const PLAYER_COLORS = [
   { name: "red", value: "hsl(0, 70%, 60%)" },
@@ -50,7 +52,7 @@ const Main = withSharedState(
     myDefaultAwareness: undefined as undefined | TypingCursorAwareness,
   },
   ({ data, setData, awareness, myAwareness, setMyAwareness }) => {
-    const { cursors } = usePlayContext();
+    const { cursors, isLoading } = usePlayContext();
     const myColor = cursors.color;
     const gridRef = useRef<HTMLDivElement>(null);
     const bottomBarRef = useRef<HTMLDivElement>(null);
@@ -61,13 +63,32 @@ const Main = withSharedState(
       rows: 40,
     });
     const [hasMeasuredGrid, setHasMeasuredGrid] = useState(false);
-    const [introState, setIntroState] = useState<IntroState>("scrolling");
+    const [hasSettledContent, setHasSettledContent] = useState(false);
+    const [introState, setIntroState] = useState<IntroState>("loading");
     const [bottomBarHeightPx, setBottomBarHeightPx] =
       useState(BOTTOM_BAR_HEIGHT_PX);
 
     useLayoutEffect(() => {
       window.scrollTo(0, 0);
     }, []);
+
+    // Keep the viewport pinned while the loading cover is up so the tall paper
+    // can lay out underneath without the user scrolling ahead of the intro.
+    useEffect(() => {
+      if (introState !== "loading") return;
+
+      const { body, documentElement } = document;
+      const previousBodyOverflow = body.style.overflow;
+      const previousHtmlOverflow = documentElement.style.overflow;
+      body.style.overflow = "hidden";
+      documentElement.style.overflow = "hidden";
+      window.scrollTo(0, 0);
+
+      return () => {
+        body.style.overflow = previousBodyOverflow;
+        documentElement.style.overflow = previousHtmlOverflow;
+      };
+    }, [introState]);
 
     // Calculate grid dimensions based on window size
     useEffect(() => {
@@ -144,10 +165,48 @@ const Main = withSharedState(
 
     const cursorPosition = getTypingCursorPosition(data.letters.length);
 
+    // Wait until synced letter data has been applied and the grid height is
+    // quiet. Starting earlier animates a short empty page, then jumps to the
+    // real bottom once letters hydrate (can-play setup is a parent effect and
+    // may hash the element id asynchronously before applying store data).
     useEffect(() => {
-      if (!hasMeasuredGrid || introStartedRef.current) return;
+      if (isLoading || !hasMeasuredGrid) {
+        setHasSettledContent(false);
+        return;
+      }
+
+      const settleTimeout = window.setTimeout(() => {
+        setHasSettledContent(true);
+      }, INTRO_CONTENT_SETTLE_MS);
+
+      return () => {
+        window.clearTimeout(settleTimeout);
+      };
+    }, [isLoading, hasMeasuredGrid, data.letters.length, totalCells]);
+
+    // Leave the loading cover only after content has settled so the scroll
+    // animation effect below measures the full paper with overflow unlocked.
+    useEffect(() => {
+      if (introState !== "loading") return;
+      if (
+        !canStartIntroScroll({
+          isLoading,
+          hasMeasuredGrid,
+          hasSettledContent,
+        })
+      ) {
+        return;
+      }
+
+      setIntroState("scrolling");
+    }, [hasMeasuredGrid, hasSettledContent, introState, isLoading]);
+
+    useEffect(() => {
+      if (introState !== "scrolling" || introStartedRef.current) return;
 
       introStartedRef.current = true;
+
+      // Content has settled; capture the destination once so easing stays smooth.
       const destinationY = getScrollEndY({
         scrollHeight: document.documentElement.scrollHeight,
         viewportHeight: window.innerHeight,
@@ -199,7 +258,7 @@ const Main = withSharedState(
         window.cancelAnimationFrame(animationFrame);
         window.clearTimeout(fadeTimeout);
       };
-    }, [hasMeasuredGrid]);
+    }, [introState]);
 
     useLayoutEffect(() => {
       if (introState !== "hidden") return;
@@ -317,7 +376,17 @@ const Main = withSharedState(
           } as React.CSSProperties
         }
       >
-        {introState !== "hidden" && (
+        {introState === "loading" && (
+          <div
+            className="loading-screen"
+            role="status"
+            aria-live="polite"
+            aria-busy="true"
+          >
+            <p>loading the paper…</p>
+          </div>
+        )}
+        {(introState === "scrolling" || introState === "fading") && (
           <section
             className={`intro-message ${
               introState === "fading" ? "fading" : ""
@@ -336,6 +405,7 @@ const Main = withSharedState(
         <div
           ref={gridRef}
           className="grid-container"
+          aria-hidden={introState === "loading"}
           style={{
             gridTemplateColumns: `repeat(${gridDimensions.cols}, ${GRID_CELL_SIZE_PX}px)`,
             gridAutoRows: `${getGridRowHeightPx({

--- a/website/experiments/8/__tests__/intro.test.ts
+++ b/website/experiments/8/__tests__/intro.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Verifies the Experiment 8 opening scroll animation.
 // ABOUTME: Covers its starting point, eased midpoint, and destination.
 import { describe, expect, it } from "vitest";
-import { canStartIntroScroll, getIntroScrollY } from "../intro";
+import { canStartIntroScroll, getIntroScrollY, isPlayhtmlHostReady } from "../intro";
 
 describe("experiment 8 introduction", () => {
   it("starts at the top of the paper", () => {
@@ -51,5 +51,13 @@ describe("experiment 8 introduction", () => {
         hasSettledContent: true,
       }),
     ).toBe(true);
+  });
+
+  it("detects when the paper host has finished playhtml setup", () => {
+    expect(isPlayhtmlHostReady(null)).toBe(false);
+    const host = document.createElement("div");
+    expect(isPlayhtmlHostReady(host)).toBe(false);
+    host.classList.add("__playhtml-element");
+    expect(isPlayhtmlHostReady(host)).toBe(true);
   });
 });

--- a/website/experiments/8/__tests__/intro.test.ts
+++ b/website/experiments/8/__tests__/intro.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Verifies the Experiment 8 opening scroll animation.
 // ABOUTME: Covers its starting point, eased midpoint, and destination.
 import { describe, expect, it } from "vitest";
-import { getIntroScrollY } from "../intro";
+import { canStartIntroScroll, getIntroScrollY } from "../intro";
 
 describe("experiment 8 introduction", () => {
   it("starts at the top of the paper", () => {
@@ -20,5 +20,36 @@ describe("experiment 8 introduction", () => {
     expect(
       getIntroScrollY({ destinationY: 800, elapsedMs: 3000, durationMs: 2000 }),
     ).toBe(800);
+  });
+
+  it("waits for sync, grid measurement, and settled letter content", () => {
+    expect(
+      canStartIntroScroll({
+        isLoading: true,
+        hasMeasuredGrid: true,
+        hasSettledContent: true,
+      }),
+    ).toBe(false);
+    expect(
+      canStartIntroScroll({
+        isLoading: false,
+        hasMeasuredGrid: false,
+        hasSettledContent: true,
+      }),
+    ).toBe(false);
+    expect(
+      canStartIntroScroll({
+        isLoading: false,
+        hasMeasuredGrid: true,
+        hasSettledContent: false,
+      }),
+    ).toBe(false);
+    expect(
+      canStartIntroScroll({
+        isLoading: false,
+        hasMeasuredGrid: true,
+        hasSettledContent: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/website/experiments/8/intro.ts
+++ b/website/experiments/8/intro.ts
@@ -2,6 +2,11 @@
 // ABOUTME: Keeps the grid-paper introduction timing deterministic and testable.
 export const INTRO_SCROLL_DURATION_MS = 2200;
 export const INTRO_FADE_DURATION_MS = 500;
+// After playhtml sync, React can-play may still be applying letter data (setup
+// runs in a parent effect, and missing element ids are hashed asynchronously).
+// Wait this quiet period after the last content change before measuring the
+// intro destination so we scroll the full paper instead of jumping later.
+export const INTRO_CONTENT_SETTLE_MS = 150;
 
 export function getIntroScrollY({
   destinationY,
@@ -27,4 +32,16 @@ export function getIntroScrollY({
       : 1 - Math.pow(-2 * progress + 2, 3) / 2;
 
   return destinationY * easedProgress;
+}
+
+export function canStartIntroScroll({
+  isLoading,
+  hasMeasuredGrid,
+  hasSettledContent,
+}: {
+  isLoading: boolean;
+  hasMeasuredGrid: boolean;
+  hasSettledContent: boolean;
+}): boolean {
+  return !isLoading && hasMeasuredGrid && hasSettledContent;
 }

--- a/website/experiments/8/intro.ts
+++ b/website/experiments/8/intro.ts
@@ -45,3 +45,8 @@ export function canStartIntroScroll({
 }): boolean {
   return !isLoading && hasMeasuredGrid && hasSettledContent;
 }
+
+/** True once playhtml has finished setupPlayElement for the paper host. */
+export function isPlayhtmlHostReady(host: Element | null): boolean {
+  return Boolean(host?.classList.contains("__playhtml-element"));
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The experiment 8 opening scroll started as soon as the grid was measured, before synced letters hydrated into React. That animated a short empty page, then the follow-to-end behavior jumped to the real bottom once letters arrived.

## Changes
- Show a brief “loading the paper…” cover until playhtml sync + host setup + content settle
- Start the intro scroll only after letters are laid out, so destination height is correct
- Keep scroll-end pinning disabled until the intro is fully hidden (empty first paint looks “at end”)
- Move intro fade into its own effect so scroll-effect cleanup cannot cancel the hide timer
- Helpers/tests: `canStartIntroScroll`, `isPlayhtmlHostReady`

## Screenshots
Loading cover, then intro card while scrolling through a tall filled paper (~17% progress), then settled at the bottom:

[Loading the paper](https://cursor.com/agents/bc-3ea87246-0b1c-484c-ba08-134dbf55a3a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fexperiment-8-loading.png)
[Intro card mid-scroll over tall letter grid](https://cursor.com/agents/bc-3ea87246-0b1c-484c-ba08-134dbf55a3a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fexperiment-8-intro-scrolling.png)
[After intro at bottom of paper](https://cursor.com/agents/bc-3ea87246-0b1c-484c-ba08-134dbf55a3a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fexperiment-8-after-intro.png)

## Verification
Puppeteer reload with ~3700 letters: loading → gradual scroll with intro visible (`jumpCount: 0`) → intro hides at bottom.

## Test plan
- [x] `bunx vitest run website/experiments/8/__tests__ --config website/vitest.config.mts`
- [x] Puppeteer tall-paper reload screenshots above
- [ ] Manual: filled room on `/experiments/8/`
- [ ] Manual: empty room still works

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ea87246-0b1c-484c-ba08-134dbf55a3a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ea87246-0b1c-484c-ba08-134dbf55a3a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

