### PR TITLE
website: experiment 10 framing + cinderblock site diary

### DIFF
--- a/website/experiments/cinderblock/__tests__/model.test.js
+++ b/website/experiments/cinderblock/__tests__/model.test.js
@@ -5,19 +5,44 @@ import {
   SNAPSHOT_COOLDOWN_MS,
   applySnapshotToDraft,
   canSaveSnapshot,
+  compactBlocksSnapshot,
   createDefaultYard,
   createSnapshotRecord,
   formatCooldown,
   getLatestSnapshotTime,
+  getSnapshotBlockCount,
   getSnapshotCooldownRemainingMs,
+  isBlockSnapshot,
   listSnapshotsNewestFirst,
 } from "../model.js";
+
+const sampleBlocks = {
+  "block-1": { x: 180, y: 642, angle: 0 },
+  "block-2": { x: 390.12, y: 641.88, angle: 0.12345 },
+};
 
 describe("cinderblock site diary", () => {
   test("default yard includes an empty snapshots map", () => {
     const yard = createDefaultYard();
     expect(yard.snapshots).toEqual({});
     expect(Object.keys(yard.blocks).length).toBeGreaterThan(0);
+  });
+
+  test("stores compact block transforms instead of image bytes", () => {
+    const record = createSnapshotRecord({
+      id: "snap-1",
+      blocks: sampleBlocks,
+      createdAt: 100,
+    });
+
+    expect(record.imageDataUrl).toBeUndefined();
+    expect(record.blocks["block-2"]).toEqual({
+      x: 390.1,
+      y: 641.9,
+      angle: 0.1235,
+    });
+    expect(getSnapshotBlockCount(record)).toBe(2);
+    expect(JSON.stringify(record).length).toBeLessThan(250);
   });
 
   test("cooldown is ready when no snapshots exist", () => {
@@ -31,7 +56,7 @@ describe("cinderblock site diary", () => {
       snapshots: {
         "snap-1": createSnapshotRecord({
           id: "snap-1",
-          imageDataUrl: "data:image/jpeg;base64,abc",
+          blocks: sampleBlocks,
           createdAt,
         }),
       },
@@ -49,14 +74,19 @@ describe("cinderblock site diary", () => {
       snapshots: {
         older: createSnapshotRecord({
           id: "older",
-          imageDataUrl: "data:image/jpeg;base64,a",
+          blocks: sampleBlocks,
           createdAt: 10,
         }),
         newer: createSnapshotRecord({
           id: "newer",
-          imageDataUrl: "data:image/jpeg;base64,b",
+          blocks: sampleBlocks,
           createdAt: 50,
         }),
+        legacy: {
+          id: "legacy",
+          createdAt: 99,
+          imageDataUrl: "data:image/jpeg;base64,aaaaaaaaaaaaaaaa",
+        },
       },
     };
 
@@ -65,21 +95,30 @@ describe("cinderblock site diary", () => {
       "older",
     ]);
     expect(getLatestSnapshotTime(data)).toBe(50);
+    expect(isBlockSnapshot(data.snapshots.legacy)).toBe(false);
   });
 
-  test("prunes the oldest snapshots when the diary exceeds the cap", () => {
-    const snapshots = {};
+  test("prunes oldest snapshots and strips legacy image entries", () => {
+    const snapshots = {
+      legacy: {
+        id: "legacy",
+        createdAt: 1,
+        imageDataUrl: "data:image/jpeg;base64," + "x".repeat(20_000),
+      },
+    };
+
     for (let index = 0; index < MAX_SNAPSHOTS + 3; index += 1) {
       applySnapshotToDraft(
         snapshots,
         createSnapshotRecord({
           id: `snap-${index}`,
-          imageDataUrl: `data:image/jpeg;base64,${index}`,
+          blocks: compactBlocksSnapshot(sampleBlocks),
           createdAt: index + 1,
         }),
       );
     }
 
+    expect(snapshots.legacy).toBeUndefined();
     expect(Object.keys(snapshots)).toHaveLength(MAX_SNAPSHOTS);
     expect(snapshots["snap-0"]).toBeUndefined();
     expect(snapshots["snap-1"]).toBeUndefined();

--- a/website/experiments/cinderblock/__tests__/model.test.js
+++ b/website/experiments/cinderblock/__tests__/model.test.js
@@ -1,0 +1,101 @@
+// ABOUTME: Tests cinderblock site-diary snapshot helpers and cooldown rules.
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_SNAPSHOTS,
+  SNAPSHOT_COOLDOWN_MS,
+  applySnapshotToDraft,
+  canSaveSnapshot,
+  createDefaultYard,
+  createSnapshotRecord,
+  formatCooldown,
+  getLatestSnapshotTime,
+  getSnapshotCooldownRemainingMs,
+  listSnapshotsNewestFirst,
+} from "../model.js";
+
+describe("cinderblock site diary", () => {
+  test("default yard includes an empty snapshots map", () => {
+    const yard = createDefaultYard();
+    expect(yard.snapshots).toEqual({});
+    expect(Object.keys(yard.blocks).length).toBeGreaterThan(0);
+  });
+
+  test("cooldown is ready when no snapshots exist", () => {
+    expect(canSaveSnapshot({ snapshots: {} }, 1_000)).toBe(true);
+    expect(getSnapshotCooldownRemainingMs({ snapshots: {} }, 1_000)).toBe(0);
+  });
+
+  test("cooldown blocks saves until the threshold elapses", () => {
+    const createdAt = 1_000_000;
+    const data = {
+      snapshots: {
+        "snap-1": createSnapshotRecord({
+          id: "snap-1",
+          imageDataUrl: "data:image/jpeg;base64,abc",
+          createdAt,
+        }),
+      },
+    };
+
+    expect(canSaveSnapshot(data, createdAt + 1_000)).toBe(false);
+    expect(getSnapshotCooldownRemainingMs(data, createdAt + 1_000)).toBe(
+      SNAPSHOT_COOLDOWN_MS - 1_000,
+    );
+    expect(canSaveSnapshot(data, createdAt + SNAPSHOT_COOLDOWN_MS)).toBe(true);
+  });
+
+  test("lists snapshots newest first and tracks the latest time", () => {
+    const data = {
+      snapshots: {
+        older: createSnapshotRecord({
+          id: "older",
+          imageDataUrl: "data:image/jpeg;base64,a",
+          createdAt: 10,
+        }),
+        newer: createSnapshotRecord({
+          id: "newer",
+          imageDataUrl: "data:image/jpeg;base64,b",
+          createdAt: 50,
+        }),
+      },
+    };
+
+    expect(listSnapshotsNewestFirst(data).map((snap) => snap.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+    expect(getLatestSnapshotTime(data)).toBe(50);
+  });
+
+  test("prunes the oldest snapshots when the diary exceeds the cap", () => {
+    const snapshots = {};
+    for (let index = 0; index < MAX_SNAPSHOTS + 3; index += 1) {
+      applySnapshotToDraft(
+        snapshots,
+        createSnapshotRecord({
+          id: `snap-${index}`,
+          imageDataUrl: `data:image/jpeg;base64,${index}`,
+          createdAt: index + 1,
+        }),
+      );
+    }
+
+    expect(Object.keys(snapshots)).toHaveLength(MAX_SNAPSHOTS);
+    expect(snapshots["snap-0"]).toBeUndefined();
+    expect(snapshots["snap-1"]).toBeUndefined();
+    expect(snapshots["snap-2"]).toBeUndefined();
+    expect(snapshots[`snap-${MAX_SNAPSHOTS + 2}`]).toBeDefined();
+  });
+
+  test("formats cooldown labels for the save status", () => {
+    expect(formatCooldown(5_000)).toBe("5s");
+    expect(formatCooldown(65_000)).toBe("1m 05s");
+    expect(formatCooldown(15 * 60 * 1000)).toBe("15m 00s");
+  });
+
+  test("treats missing or invalid snapshots as empty", () => {
+    expect(listSnapshotsNewestFirst({})).toEqual([]);
+    expect(listSnapshotsNewestFirst({ snapshots: [] })).toEqual([]);
+    expect(getLatestSnapshotTime(null)).toBe(0);
+  });
+});

--- a/website/experiments/cinderblock/cinderblock.css
+++ b/website/experiments/cinderblock/cinderblock.css
@@ -398,7 +398,6 @@ kbd {
   overflow: hidden;
   width: 100%;
   aspect-ratio: 5 / 3;
-  container-type: inline-size;
   background-color: #b7b7b1;
   background-image:
     linear-gradient(rgba(0, 0, 0, 0.07) 1px, transparent 1px),
@@ -412,7 +411,8 @@ kbd {
   left: 0;
   width: 1200px;
   height: 720px;
-  transform: scale(calc(100cqw / 1200));
+  /* --preview-scale is set from JS (card/lightbox width ÷ 1200). */
+  transform: scale(var(--preview-scale, 0.2));
   transform-origin: top left;
   pointer-events: none;
 }

--- a/website/experiments/cinderblock/cinderblock.css
+++ b/website/experiments/cinderblock/cinderblock.css
@@ -226,10 +226,6 @@ kbd {
   background-size: 60px 60px;
 }
 
-#cinderblock-yard.is-capturing .cinderblock.is-selected::after {
-  display: none;
-}
-
 #cinderblock-yard::before {
   display: none;
 }
@@ -397,12 +393,37 @@ kbd {
   cursor: zoom-in;
 }
 
-.snapshot-card img {
-  display: block;
+.snapshot-stage {
+  position: relative;
+  overflow: hidden;
   width: 100%;
   aspect-ratio: 5 / 3;
-  object-fit: cover;
-  background: #b7b7b1;
+  container-type: inline-size;
+  background-color: #b7b7b1;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.07) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.07) 1px, transparent 1px);
+  background-size: 10px 10px;
+}
+
+.snapshot-yard {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1200px;
+  height: 720px;
+  transform: scale(calc(100cqw / 1200));
+  transform-origin: top left;
+  pointer-events: none;
+}
+
+.snapshot-block {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 200px;
+  height: 96px;
+  transform-origin: center;
 }
 
 .snapshot-meta {
@@ -436,12 +457,8 @@ kbd {
   background: #f1f1ec;
 }
 
-.lightbox-dialog img {
-  display: block;
+.lightbox-stage {
   width: 100%;
-  max-height: min(70vh, 720px);
-  object-fit: contain;
-  background: #b7b7b1;
   border: 2px solid #000;
 }
 

--- a/website/experiments/cinderblock/cinderblock.css
+++ b/website/experiments/cinderblock/cinderblock.css
@@ -1,5 +1,5 @@
 /* ABOUTME: Styles the collaborative cinder-block experiment and its masonry pieces. */
-/* ABOUTME: Scales a fixed physics surface into a tactile, responsive construction scene. */
+/* ABOUTME: Scales a fixed physics surface into a tactile construction scene with a site diary. */
 
 :root {
   color: #000;
@@ -16,7 +16,17 @@ body {
   min-width: 320px;
   min-height: 100vh;
   margin: 0;
-  background: #deded8;
+  background:
+    radial-gradient(ellipse at 18% 0%, rgba(255, 255, 255, 0.45), transparent 42%),
+    radial-gradient(ellipse at 88% 12%, rgba(0, 0, 0, 0.06), transparent 38%),
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 3px,
+      rgba(0, 0, 0, 0.015) 3px,
+      rgba(0, 0, 0, 0.015) 4px
+    ),
+    #deded8;
 }
 
 button,
@@ -31,7 +41,7 @@ button {
 .page-shell {
   width: min(1400px, calc(100% - 24px));
   margin: 0 auto;
-  padding: 12px 0;
+  padding: 12px 0 28px;
 }
 
 .title-row {
@@ -39,7 +49,7 @@ button {
   align-items: flex-end;
   justify-content: space-between;
   gap: 32px;
-  padding: 12px;
+  padding: 14px 14px 16px;
   border: 2px solid #000;
   border-bottom: 0;
   background: #f1f1ec;
@@ -55,6 +65,12 @@ button {
   text-transform: uppercase;
 }
 
+.eyebrow a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 h1 {
   margin: 0;
   font-family: Arial Black, Arial, Helvetica, sans-serif;
@@ -63,6 +79,15 @@ h1 {
   letter-spacing: -0.065em;
   line-height: 0.82;
   text-transform: uppercase;
+}
+
+.lede {
+  max-width: 42ch;
+  margin: 12px 0 0;
+  color: #222;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 .instructions {
@@ -107,7 +132,8 @@ kbd {
   margin: 0 4px 0 0;
 }
 
-.toolbar button {
+.toolbar button,
+.diary-actions button {
   display: inline-flex;
   min-height: 34px;
   align-items: center;
@@ -123,17 +149,20 @@ kbd {
   font-weight: 700;
 }
 
-.toolbar button:hover:not(:disabled) {
+.toolbar button:hover:not(:disabled),
+.diary-actions button:hover:not(:disabled) {
   color: #fff;
   background: #000;
 }
 
-.toolbar button:active:not(:disabled) {
+.toolbar button:active:not(:disabled),
+.diary-actions button:active:not(:disabled) {
   color: #000;
   background: #fff;
 }
 
-.toolbar button:disabled {
+.toolbar button:disabled,
+.diary-actions button:disabled {
   cursor: default;
   opacity: 0.38;
 }
@@ -195,6 +224,10 @@ kbd {
     linear-gradient(rgba(0, 0, 0, 0.07) 1px, transparent 1px),
     linear-gradient(90deg, rgba(0, 0, 0, 0.07) 1px, transparent 1px);
   background-size: 60px 60px;
+}
+
+#cinderblock-yard.is-capturing .cinderblock.is-selected::after {
+  display: none;
 }
 
 #cinderblock-yard::before {
@@ -263,6 +296,177 @@ kbd {
   pointer-events: none;
 }
 
+.site-diary {
+  margin-top: 0;
+  padding: 14px;
+  border: 2px solid #000;
+  border-top: 0;
+  background: #ebebe5;
+}
+
+.diary-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 14px;
+}
+
+.site-diary h2 {
+  margin: 0;
+  font-family: Arial Black, Arial, Helvetica, sans-serif;
+  font-size: clamp(22px, 3.4vw, 34px);
+  font-weight: 900;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.diary-copy {
+  max-width: 54ch;
+  margin: 8px 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.diary-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.diary-actions button {
+  min-width: 96px;
+  justify-content: center;
+  background: #fff;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+}
+
+.diary-actions button.is-saving {
+  opacity: 0.7;
+}
+
+#save-status {
+  margin: 0;
+  min-height: 1.2em;
+  color: #333;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.snapshot-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.gallery-empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 28px 12px;
+  border: 2px dashed #000;
+  background: rgba(255, 255, 255, 0.35);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  text-align: center;
+}
+
+.snapshot-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.snapshot-card button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 2px solid #000;
+  background: #b7b7b1;
+  cursor: zoom-in;
+}
+
+.snapshot-card img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 5 / 3;
+  object-fit: cover;
+  background: #b7b7b1;
+}
+
+.snapshot-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.72);
+}
+
+.lightbox[hidden] {
+  display: none;
+}
+
+.lightbox-dialog {
+  width: min(960px, 100%);
+  padding: 10px;
+  border: 2px solid #000;
+  background: #f1f1ec;
+}
+
+.lightbox-dialog img {
+  display: block;
+  width: 100%;
+  max-height: min(70vh, 720px);
+  object-fit: contain;
+  background: #b7b7b1;
+  border: 2px solid #000;
+}
+
+.lightbox-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.lightbox-bar button {
+  min-height: 30px;
+  padding: 4px 10px;
+  border: 2px solid #000;
+  background: #fff;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
 footer {
   display: flex;
   justify-content: space-between;
@@ -288,15 +492,25 @@ footer a {
 @media (max-width: 820px) {
   .page-shell {
     width: calc(100% - 8px);
-    padding: 4px 0;
+    padding: 4px 0 18px;
   }
 
-  .title-row {
+  .title-row,
+  .diary-header {
     display: block;
   }
 
-  .instructions {
+  .instructions,
+  .diary-actions {
     margin-top: 12px;
+  }
+
+  .diary-actions {
+    align-items: stretch;
+  }
+
+  #save-status {
+    text-align: left;
   }
 
   .toolbar {
@@ -315,6 +529,10 @@ footer a {
     display: none;
   }
 
+  .snapshot-gallery {
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+  }
+
   footer {
     display: block;
   }
@@ -326,7 +544,8 @@ footer a {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .toolbar button {
+  .toolbar button,
+  .diary-actions button {
     transition: none;
   }
 }

--- a/website/experiments/cinderblock/cinderblock.js
+++ b/website/experiments/cinderblock/cinderblock.js
@@ -278,13 +278,35 @@ class CinderblockYard {
       piece.style.transform = `translate(${block.x - BLOCK_WIDTH / 2}px, ${
         block.y - BLOCK_HEIGHT / 2
       }px) rotate(${block.angle}rad)`;
+      // Eager load: lazy + overflow/scale made thumbs look empty (blocks sit near
+      // the bottom of the 1200×720 surface and never entered the tiny clip).
       piece.innerHTML =
-        '<img src="/cinderblock-realistic.png" alt="" draggable="false" loading="lazy" />';
+        '<img src="/cinderblock-realistic.png" alt="" draggable="false" />';
       yard.appendChild(piece);
     }
 
     stage.appendChild(yard);
+    this.bindFrozenStageScale(stage);
     return stage;
+  }
+
+  /**
+   * Fit the fixed 1200×720 freeze-frame into whatever card/lightbox width we get.
+   * container-query `cqw` inside `transform: scale()` was unreliable here and left
+   * thumbs showing only the empty top of the unscaled yard.
+   */
+  bindFrozenStageScale(stage) {
+    const syncScale = () => {
+      const width = stage.clientWidth;
+      if (width <= 0) return;
+      stage.style.setProperty("--preview-scale", String(width / WORLD_WIDTH));
+    };
+
+    syncScale();
+    const observer = new ResizeObserver(syncScale);
+    observer.observe(stage);
+    stage._previewScaleObserver = observer;
+    requestAnimationFrame(syncScale);
   }
 
   openLightbox(snapshot) {
@@ -294,6 +316,15 @@ class CinderblockYard {
     stageHost.replaceChildren(this.createFrozenStage(snapshot));
     meta.textContent = this.formatSnapshotLabel(snapshot);
     this.lightbox.hidden = false;
+    // Scale after unhiding so clientWidth is non-zero.
+    requestAnimationFrame(() => {
+      const stage = stageHost.querySelector(".snapshot-stage");
+      if (!stage) return;
+      const width = stage.clientWidth;
+      if (width > 0) {
+        stage.style.setProperty("--preview-scale", String(width / WORLD_WIDTH));
+      }
+    });
   }
 
   closeLightbox() {

--- a/website/experiments/cinderblock/cinderblock.js
+++ b/website/experiments/cinderblock/cinderblock.js
@@ -1,6 +1,6 @@
 // ABOUTME: Runs the cinder-block experiment with Matter.js physics and PlayHTML state.
 // ABOUTME: Publishes locally controlled blocks at a throttled rate while interpolating remote motion.
-// ABOUTME: Captures shared site-diary snapshots with a cooldown so the gallery stays sparse.
+// ABOUTME: Saves site-diary freeze-frames as compact block transforms (no image bytes in the room).
 
 import Matter from "matter-js";
 import { playhtml } from "playhtml";
@@ -8,8 +8,6 @@ import "./cinderblock.css";
 import {
   BLOCK_HEIGHT,
   BLOCK_WIDTH,
-  SNAPSHOT_CAPTURE_SCALE,
-  SNAPSHOT_JPEG_QUALITY,
   WORLD_HEIGHT,
   WORLD_WIDTH,
   applySnapshotToDraft,
@@ -19,8 +17,10 @@ import {
   createSnapshotRecord,
   formatCooldown,
   getChangedTransforms,
+  getSnapshotBlockCount,
   getSnapshotCooldownRemainingMs,
   interpolateTransform,
+  isBlockSnapshot,
   listSnapshotsNewestFirst,
   roundTransform,
 } from "./model";
@@ -151,11 +151,34 @@ class CinderblockYard {
     this.resizeObserver.observe(this.frame);
     this.scaleToFrame();
     this.status.textContent = "yard is live";
+    this.purgeLegacySnapshotsOnce();
     this.refreshSaveControls();
     this.cooldownTimer = window.setInterval(this.refreshSaveControls, 1000);
     this.animationFrame = requestAnimationFrame(this.animate);
 
     return () => this.destroy();
+  }
+
+  /**
+   * One-shot cleanup for rooms that still hold the early JPEG diary entries.
+   * Do not call from applySharedState — that re-runs on every data change.
+   */
+  purgeLegacySnapshotsOnce() {
+    const data = this.getData?.();
+    const snapshots = data?.snapshots;
+    if (!snapshots || typeof snapshots !== "object") return;
+
+    const legacyIds = Object.keys(snapshots).filter(
+      (id) => !isBlockSnapshot(snapshots[id]),
+    );
+    if (legacyIds.length === 0) return;
+
+    this.setData((draft) => {
+      if (!draft.snapshots) return;
+      for (const id of legacyIds) {
+        delete draft.snapshots[id];
+      }
+    });
   }
 
   destroy() {
@@ -216,7 +239,7 @@ class CinderblockYard {
     lightbox.hidden = true;
     lightbox.innerHTML = `
       <div class="lightbox-dialog" role="dialog" aria-modal="true" aria-label="Yard snapshot">
-        <img alt="Saved yard snapshot" />
+        <div class="lightbox-stage" data-lightbox-stage></div>
         <div class="lightbox-bar">
           <span data-lightbox-meta></span>
           <button type="button" data-lightbox-close>CLOSE</button>
@@ -232,11 +255,43 @@ class CinderblockYard {
     this.lightbox = lightbox;
   }
 
+  /**
+   * Render a frozen yard from stored block transforms — DOM only, no Matter.js.
+   * Gallery thumbs and the lightbox share this so diary frames stay cheap.
+   */
+  createFrozenStage(snapshot) {
+    const stage = document.createElement("div");
+    stage.className = "snapshot-stage";
+
+    const yard = document.createElement("div");
+    yard.className = "snapshot-yard";
+    yard.setAttribute("aria-hidden", "true");
+
+    const ground = document.createElement("div");
+    ground.className = "ground";
+    yard.appendChild(ground);
+
+    for (const [id, block] of Object.entries(snapshot.blocks || {})) {
+      const piece = document.createElement("div");
+      piece.className = "snapshot-block real-block";
+      piece.dataset.blockId = id;
+      piece.style.transform = `translate(${block.x - BLOCK_WIDTH / 2}px, ${
+        block.y - BLOCK_HEIGHT / 2
+      }px) rotate(${block.angle}rad)`;
+      piece.innerHTML =
+        '<img src="/cinderblock-realistic.png" alt="" draggable="false" loading="lazy" />';
+      yard.appendChild(piece);
+    }
+
+    stage.appendChild(yard);
+    return stage;
+  }
+
   openLightbox(snapshot) {
-    if (!this.lightbox || !snapshot?.imageDataUrl) return;
-    const image = this.lightbox.querySelector("img");
+    if (!this.lightbox || !snapshot?.blocks) return;
+    const stageHost = this.lightbox.querySelector("[data-lightbox-stage]");
     const meta = this.lightbox.querySelector("[data-lightbox-meta]");
-    image.src = snapshot.imageDataUrl;
+    stageHost.replaceChildren(this.createFrozenStage(snapshot));
     meta.textContent = this.formatSnapshotLabel(snapshot);
     this.lightbox.hidden = false;
   }
@@ -244,6 +299,7 @@ class CinderblockYard {
   closeLightbox() {
     if (!this.lightbox) return;
     this.lightbox.hidden = true;
+    this.lightbox.querySelector("[data-lightbox-stage]")?.replaceChildren();
   }
 
   formatSnapshotLabel(snapshot) {
@@ -256,14 +312,14 @@ class CinderblockYard {
           hour: "numeric",
           minute: "2-digit",
         });
-    const count = Number(snapshot.blockCount) || 0;
+    const count = getSnapshotBlockCount(snapshot);
     return `${stamp} · ${count} block${count === 1 ? "" : "s"}`;
   }
 
   renderGallery(data) {
     const snapshots = listSnapshotsNewestFirst(data);
     const signature = snapshots
-      .map((snapshot) => `${snapshot.id}:${snapshot.createdAt}`)
+      .map((snapshot) => `${snapshot.id}:${snapshot.createdAt}:${getSnapshotBlockCount(snapshot)}`)
       .join("|");
     if (signature === this.renderedSnapshotSignature) return;
     this.renderedSnapshotSignature = signature;
@@ -278,7 +334,6 @@ class CinderblockYard {
     }
 
     for (const snapshot of snapshots) {
-      if (!snapshot?.imageDataUrl) continue;
       const figure = document.createElement("figure");
       figure.className = "snapshot-card";
 
@@ -289,20 +344,14 @@ class CinderblockYard {
         `Open snapshot from ${this.formatSnapshotLabel(snapshot)}`,
       );
       button.addEventListener("click", () => this.openLightbox(snapshot));
-
-      const image = document.createElement("img");
-      image.src = snapshot.imageDataUrl;
-      image.alt = "";
-      image.loading = "lazy";
-      button.appendChild(image);
+      button.appendChild(this.createFrozenStage(snapshot));
 
       const meta = document.createElement("figcaption");
       meta.className = "snapshot-meta";
       const when = document.createElement("span");
       when.textContent = this.formatSnapshotLabel(snapshot).split(" · ")[0];
       const count = document.createElement("span");
-      const blockCount = Number(snapshot.blockCount) || 0;
-      count.textContent = `${blockCount} blk`;
+      count.textContent = `${getSnapshotBlockCount(snapshot)} blk`;
       meta.append(when, count);
 
       figure.append(button, meta);
@@ -319,11 +368,11 @@ class CinderblockYard {
     this.saveButton.disabled = !ready;
     this.saveButton.textContent = ready ? "SAVE" : "WAIT";
     this.saveStatus.textContent = ready
-      ? "ready to save a frame"
+      ? "ready to freeze the yard"
       : `next save in ${formatCooldown(remaining)}`;
   }
 
-  async saveSnapshot() {
+  saveSnapshot() {
     if (!this.getData || !this.setData || this.isSavingSnapshot) return;
     const data = this.getData();
     if (!canSaveSnapshot(data)) {
@@ -335,44 +384,18 @@ class CinderblockYard {
     this.saveButton.disabled = true;
     this.saveButton.classList.add("is-saving");
     this.saveButton.textContent = "SAVING…";
-    this.saveStatus.textContent = "capturing the yard";
-    this.board.classList.add("is-capturing");
+    this.saveStatus.textContent = "freezing the yard";
 
     try {
-      // Wait one paint so selection outlines hide before html2canvas runs.
-      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
-      const previousScale = this.board.style.getPropertyValue("--yard-scale");
-      // Temporarily unscale so the capture matches the fixed 1200×720 physics surface
-      // instead of the viewport-fitted stage.
-      this.board.style.setProperty("--yard-scale", "1");
-      const { default: html2canvas } = await import("html2canvas");
-      let canvas;
-      try {
-        canvas = await html2canvas(this.board, {
-          backgroundColor: "#b7b7b1",
-          useCORS: true,
-          allowTaint: true,
-          logging: false,
-          scale: SNAPSHOT_CAPTURE_SCALE,
-          width: WORLD_WIDTH,
-          height: WORLD_HEIGHT,
-          windowWidth: WORLD_WIDTH,
-          windowHeight: WORLD_HEIGHT,
-        });
-      } finally {
-        if (previousScale) {
-          this.board.style.setProperty("--yard-scale", previousScale);
-        } else {
-          this.scaleToFrame();
-        }
-      }
-      const imageDataUrl = canvas.toDataURL("image/jpeg", SNAPSHOT_JPEG_QUALITY);
+      // Prefer live body transforms so a mid-settle structure is what gets logged.
+      const live = this.getCurrentTransforms();
+      const sourceBlocks =
+        Object.keys(live).length > 0 ? live : data.blocks || {};
       const id = `snap-${crypto.randomUUID()}`;
       const record = createSnapshotRecord({
         id,
-        imageDataUrl,
+        blocks: sourceBlocks,
         createdAt: Date.now(),
-        blockCount: Object.keys(data.blocks || {}).length,
       });
 
       this.setData((draft) => {
@@ -386,7 +409,6 @@ class CinderblockYard {
       console.error("Failed to save yard snapshot", error);
       this.saveStatus.textContent = "save failed — try again";
     } finally {
-      this.board.classList.remove("is-capturing");
       this.saveButton.classList.remove("is-saving");
       this.isSavingSnapshot = false;
       this.refreshSaveControls();

--- a/website/experiments/cinderblock/cinderblock.js
+++ b/website/experiments/cinderblock/cinderblock.js
@@ -1,5 +1,6 @@
 // ABOUTME: Runs the cinder-block experiment with Matter.js physics and PlayHTML state.
 // ABOUTME: Publishes locally controlled blocks at a throttled rate while interpolating remote motion.
+// ABOUTME: Captures shared site-diary snapshots with a cooldown so the gallery stays sparse.
 
 import Matter from "matter-js";
 import { playhtml } from "playhtml";
@@ -7,12 +8,20 @@ import "./cinderblock.css";
 import {
   BLOCK_HEIGHT,
   BLOCK_WIDTH,
+  SNAPSHOT_CAPTURE_SCALE,
+  SNAPSHOT_JPEG_QUALITY,
   WORLD_HEIGHT,
   WORLD_WIDTH,
+  applySnapshotToDraft,
+  canSaveSnapshot,
   createBlock,
   createDefaultYard,
+  createSnapshotRecord,
+  formatCooldown,
   getChangedTransforms,
+  getSnapshotCooldownRemainingMs,
   interpolateTransform,
+  listSnapshotsNewestFirst,
   roundTransform,
 } from "./model";
 
@@ -49,11 +58,14 @@ function validateYardData(data) {
 }
 
 class CinderblockYard {
-  constructor({ board, layer, frame, status }) {
+  constructor({ board, layer, frame, status, gallery, saveButton, saveStatus }) {
     this.board = board;
     this.layer = layer;
     this.frame = frame;
     this.status = status;
+    this.gallery = gallery;
+    this.saveButton = saveButton;
+    this.saveStatus = saveStatus;
     this.engine = Engine.create({ enableSleeping: true });
     this.engine.gravity.y = 1.08;
     this.bodies = new Map();
@@ -74,6 +86,10 @@ class CinderblockYard {
     this.accumulator = 0;
     this.animationFrame = null;
     this.resizeObserver = null;
+    this.isSavingSnapshot = false;
+    this.cooldownTimer = null;
+    this.lightbox = null;
+    this.renderedSnapshotSignature = "";
 
     this.addBoundaries();
     this.handlePointerDown = this.handlePointerDown.bind(this);
@@ -81,6 +97,7 @@ class CinderblockYard {
     this.handlePointerUp = this.handlePointerUp.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.animate = this.animate.bind(this);
+    this.refreshSaveControls = this.refreshSaveControls.bind(this);
   }
 
   addBoundaries() {
@@ -125,11 +142,17 @@ class CinderblockYard {
     document.querySelector('[data-action="reset-all"]').addEventListener("click", () => {
       this.resetAllBlocks();
     });
+    this.saveButton.addEventListener("click", () => {
+      void this.saveSnapshot();
+    });
 
+    this.ensureLightbox();
     this.resizeObserver = new ResizeObserver(() => this.scaleToFrame());
     this.resizeObserver.observe(this.frame);
     this.scaleToFrame();
-    this.status.textContent = "live physics sync";
+    this.status.textContent = "yard is live";
+    this.refreshSaveControls();
+    this.cooldownTimer = window.setInterval(this.refreshSaveControls, 1000);
     this.animationFrame = requestAnimationFrame(this.animate);
 
     return () => this.destroy();
@@ -137,12 +160,14 @@ class CinderblockYard {
 
   destroy() {
     if (this.animationFrame !== null) cancelAnimationFrame(this.animationFrame);
+    if (this.cooldownTimer !== null) window.clearInterval(this.cooldownTimer);
     this.resizeObserver?.disconnect();
     this.board.removeEventListener("pointerdown", this.handlePointerDown);
     this.board.removeEventListener("pointermove", this.handlePointerMove);
     this.board.removeEventListener("pointerup", this.handlePointerUp);
     this.board.removeEventListener("pointercancel", this.handlePointerUp);
     window.removeEventListener("keydown", this.handleKeyDown);
+    this.lightbox?.remove();
   }
 
   scaleToFrame() {
@@ -179,7 +204,193 @@ class CinderblockYard {
     }
 
     document.querySelector('[data-action="reset-all"]').disabled = sharedIds.size === 0;
+    this.renderGallery(data);
+    this.refreshSaveControls();
     this.render();
+  }
+
+  ensureLightbox() {
+    if (this.lightbox) return;
+    const lightbox = document.createElement("div");
+    lightbox.className = "lightbox";
+    lightbox.hidden = true;
+    lightbox.innerHTML = `
+      <div class="lightbox-dialog" role="dialog" aria-modal="true" aria-label="Yard snapshot">
+        <img alt="Saved yard snapshot" />
+        <div class="lightbox-bar">
+          <span data-lightbox-meta></span>
+          <button type="button" data-lightbox-close>CLOSE</button>
+        </div>
+      </div>
+    `;
+    lightbox.addEventListener("click", (event) => {
+      if (event.target === lightbox || event.target.closest("[data-lightbox-close]")) {
+        this.closeLightbox();
+      }
+    });
+    document.body.appendChild(lightbox);
+    this.lightbox = lightbox;
+  }
+
+  openLightbox(snapshot) {
+    if (!this.lightbox || !snapshot?.imageDataUrl) return;
+    const image = this.lightbox.querySelector("img");
+    const meta = this.lightbox.querySelector("[data-lightbox-meta]");
+    image.src = snapshot.imageDataUrl;
+    meta.textContent = this.formatSnapshotLabel(snapshot);
+    this.lightbox.hidden = false;
+  }
+
+  closeLightbox() {
+    if (!this.lightbox) return;
+    this.lightbox.hidden = true;
+  }
+
+  formatSnapshotLabel(snapshot) {
+    const when = new Date(snapshot.createdAt);
+    const stamp = Number.isNaN(when.getTime())
+      ? "unknown time"
+      : when.toLocaleString(undefined, {
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+        });
+    const count = Number(snapshot.blockCount) || 0;
+    return `${stamp} · ${count} block${count === 1 ? "" : "s"}`;
+  }
+
+  renderGallery(data) {
+    const snapshots = listSnapshotsNewestFirst(data);
+    const signature = snapshots
+      .map((snapshot) => `${snapshot.id}:${snapshot.createdAt}`)
+      .join("|");
+    if (signature === this.renderedSnapshotSignature) return;
+    this.renderedSnapshotSignature = signature;
+
+    this.gallery.replaceChildren();
+    if (snapshots.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "gallery-empty";
+      empty.textContent = "No frames yet — build something, then SAVE.";
+      this.gallery.appendChild(empty);
+      return;
+    }
+
+    for (const snapshot of snapshots) {
+      if (!snapshot?.imageDataUrl) continue;
+      const figure = document.createElement("figure");
+      figure.className = "snapshot-card";
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.setAttribute(
+        "aria-label",
+        `Open snapshot from ${this.formatSnapshotLabel(snapshot)}`,
+      );
+      button.addEventListener("click", () => this.openLightbox(snapshot));
+
+      const image = document.createElement("img");
+      image.src = snapshot.imageDataUrl;
+      image.alt = "";
+      image.loading = "lazy";
+      button.appendChild(image);
+
+      const meta = document.createElement("figcaption");
+      meta.className = "snapshot-meta";
+      const when = document.createElement("span");
+      when.textContent = this.formatSnapshotLabel(snapshot).split(" · ")[0];
+      const count = document.createElement("span");
+      const blockCount = Number(snapshot.blockCount) || 0;
+      count.textContent = `${blockCount} blk`;
+      meta.append(when, count);
+
+      figure.append(button, meta);
+      this.gallery.appendChild(figure);
+    }
+  }
+
+  refreshSaveControls() {
+    if (!this.getData || this.isSavingSnapshot) return;
+    const data = this.getData();
+    const remaining = getSnapshotCooldownRemainingMs(data);
+    const ready = remaining === 0;
+
+    this.saveButton.disabled = !ready;
+    this.saveButton.textContent = ready ? "SAVE" : "WAIT";
+    this.saveStatus.textContent = ready
+      ? "ready to save a frame"
+      : `next save in ${formatCooldown(remaining)}`;
+  }
+
+  async saveSnapshot() {
+    if (!this.getData || !this.setData || this.isSavingSnapshot) return;
+    const data = this.getData();
+    if (!canSaveSnapshot(data)) {
+      this.refreshSaveControls();
+      return;
+    }
+
+    this.isSavingSnapshot = true;
+    this.saveButton.disabled = true;
+    this.saveButton.classList.add("is-saving");
+    this.saveButton.textContent = "SAVING…";
+    this.saveStatus.textContent = "capturing the yard";
+    this.board.classList.add("is-capturing");
+
+    try {
+      // Wait one paint so selection outlines hide before html2canvas runs.
+      await new Promise((resolve) => requestAnimationFrame(() => resolve()));
+      const previousScale = this.board.style.getPropertyValue("--yard-scale");
+      // Temporarily unscale so the capture matches the fixed 1200×720 physics surface
+      // instead of the viewport-fitted stage.
+      this.board.style.setProperty("--yard-scale", "1");
+      const { default: html2canvas } = await import("html2canvas");
+      let canvas;
+      try {
+        canvas = await html2canvas(this.board, {
+          backgroundColor: "#b7b7b1",
+          useCORS: true,
+          allowTaint: true,
+          logging: false,
+          scale: SNAPSHOT_CAPTURE_SCALE,
+          width: WORLD_WIDTH,
+          height: WORLD_HEIGHT,
+          windowWidth: WORLD_WIDTH,
+          windowHeight: WORLD_HEIGHT,
+        });
+      } finally {
+        if (previousScale) {
+          this.board.style.setProperty("--yard-scale", previousScale);
+        } else {
+          this.scaleToFrame();
+        }
+      }
+      const imageDataUrl = canvas.toDataURL("image/jpeg", SNAPSHOT_JPEG_QUALITY);
+      const id = `snap-${crypto.randomUUID()}`;
+      const record = createSnapshotRecord({
+        id,
+        imageDataUrl,
+        createdAt: Date.now(),
+        blockCount: Object.keys(data.blocks || {}).length,
+      });
+
+      this.setData((draft) => {
+        if (!draft.snapshots || typeof draft.snapshots !== "object") {
+          draft.snapshots = {};
+        }
+        applySnapshotToDraft(draft.snapshots, record);
+      });
+      this.saveStatus.textContent = "saved to the site diary";
+    } catch (error) {
+      console.error("Failed to save yard snapshot", error);
+      this.saveStatus.textContent = "save failed — try again";
+    } finally {
+      this.board.classList.remove("is-capturing");
+      this.saveButton.classList.remove("is-saving");
+      this.isSavingSnapshot = false;
+      this.refreshSaveControls();
+    }
   }
 
   addLocalBlock(id, block) {
@@ -343,6 +554,7 @@ class CinderblockYard {
     if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
       return;
     }
+    if (event.key === "Escape") this.closeLightbox();
     if (event.key.toLowerCase() === "r") this.rotateSelected();
     if (event.key === "Backspace" || event.key === "Delete") {
       event.preventDefault();
@@ -508,6 +720,9 @@ const yard = new CinderblockYard({
   layer: requireElement("block-layer"),
   frame: requireElement("stage-frame"),
   status: requireElement("yard-status"),
+  gallery: requireElement("snapshot-gallery"),
+  saveButton: requireElement("save-snapshot"),
+  saveStatus: requireElement("save-status"),
 });
 
 yardElement.defaultData = createDefaultYard();

--- a/website/experiments/cinderblock/index.html
+++ b/website/experiments/cinderblock/index.html
@@ -1,5 +1,5 @@
-<!-- ABOUTME: Hosts the collaborative cinder-block construction yard experiment. -->
-<!-- ABOUTME: Provides the accessible toolbar and fixed-size physics stage for the vanilla app. -->
+<!-- ABOUTME: Hosts experiment 10 — collaborative cinder-block construction yard. -->
+<!-- ABOUTME: Includes a shared site-diary gallery of yard snapshots over time. -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -7,21 +7,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Build, topple, and rebuild a shared cinder-block structure."
+      content="Experiment 10: build, topple, and rebuild a shared cinder-block structure over time."
+    />
+    <meta
+      name="og:image"
+      content="https://playhtml.fun/experiments/index-previews/ex-10.png"
     />
     <link rel="icon" type="image/png" href="/icon.png" />
-    <title>Cinderblock Yard · playhtml</title>
+    <title>cinderblock yard — playhtml experiment 10</title>
   </head>
   <body>
     <main class="page-shell">
       <header class="title-row">
         <div>
-          <p class="eyebrow">PLAYHTML / SHARED ROOM / LIVE</p>
+          <p class="eyebrow">
+            <a href="/experiments/">playhtml experiment</a> 10
+          </p>
           <h1>Cinderblock Yard</h1>
+          <p class="lede">
+            A shared construction site that keeps growing — or collapsing —
+            as people pass through.
+          </p>
         </div>
         <p class="instructions">
-          01. DRAG TO BUILD OR DEMOLISH<br />
-          02. SELECT + <kbd>R</kbd> TO ROTATE 90°
+          DRAG TO BUILD OR DEMOLISH<br />
+          SELECT + <kbd>R</kbd> TO ROTATE 90°<br />
+          SAVE A FRAME OF THE YARD TO THE DIARY
         </p>
       </header>
 
@@ -59,8 +70,37 @@
         </div>
       </section>
 
+      <section class="site-diary" aria-labelledby="diary-heading">
+        <div class="diary-header">
+          <div>
+            <p class="tool-label">site diary</p>
+            <h2 id="diary-heading">Snapshots of the yard</h2>
+            <p class="diary-copy">
+              Capture the structure as it stands. One save every 15 minutes —
+              so the gallery reads like a construction log, not a flood.
+            </p>
+          </div>
+          <div class="diary-actions">
+            <button type="button" data-action="save-snapshot" id="save-snapshot">
+              SAVE
+            </button>
+            <p id="save-status" role="status" aria-live="polite"></p>
+          </div>
+        </div>
+        <div
+          id="snapshot-gallery"
+          class="snapshot-gallery"
+          aria-live="polite"
+        >
+          <p class="gallery-empty">No frames yet — build something, then SAVE.</p>
+        </div>
+      </section>
+
       <footer>
-        <p>SHARED CONSTRUCTION ROOM / POSITIONS PERSIST</p>
+        <p>
+          this is <a href="/experiments/">experiment 10</a> made with
+          <a href="/">playhtml</a>
+        </p>
         <a href="/experiments/">&larr; ALL EXPERIMENTS</a>
       </footer>
     </main>

--- a/website/experiments/cinderblock/index.html
+++ b/website/experiments/cinderblock/index.html
@@ -32,7 +32,7 @@
         <p class="instructions">
           DRAG TO BUILD OR DEMOLISH<br />
           SELECT + <kbd>R</kbd> TO ROTATE 90°<br />
-          SAVE A FRAME OF THE YARD TO THE DIARY
+          SAVE THE STRUCTURE TO THE DIARY
         </p>
       </header>
 
@@ -76,8 +76,8 @@
             <p class="tool-label">site diary</p>
             <h2 id="diary-heading">Snapshots of the yard</h2>
             <p class="diary-copy">
-              Capture the structure as it stands. One save every 15 minutes —
-              so the gallery reads like a construction log, not a flood.
+              Freeze the yard as block positions — a quiet static copy, no
+              physics and no image bytes in the room. One save every 15 minutes.
             </p>
           </div>
           <div class="diary-actions">

--- a/website/experiments/cinderblock/model.js
+++ b/website/experiments/cinderblock/model.js
@@ -10,10 +10,6 @@ export const BLOCK_HEIGHT = 96;
 export const SNAPSHOT_COOLDOWN_MS = 15 * 60 * 1000;
 /** Keep the diary from growing without bound in the synced room. */
 export const MAX_SNAPSHOTS = 48;
-/** JPEG quality for diary thumbnails stored in shared state. */
-export const SNAPSHOT_JPEG_QUALITY = 0.62;
-/** Capture scale relative to the 1200×720 physics surface. */
-export const SNAPSHOT_CAPTURE_SCALE = 0.42;
 
 const POSITION_SYNC_THRESHOLD = 0.35;
 const ANGLE_SYNC_THRESHOLD = 0.004;
@@ -43,6 +39,42 @@ export function createDefaultYard() {
   };
 }
 
+export function compactBlockTransform(block) {
+  return {
+    x: Math.round(Number(block.x) * 10) / 10,
+    y: Math.round(Number(block.y) * 10) / 10,
+    angle: Math.round(Number(block.angle) * 10_000) / 10_000,
+  };
+}
+
+/**
+ * Freeze the live yard into a compact keyed transform map for the site diary.
+ * Avoids storing image bytes in the synced room.
+ */
+export function compactBlocksSnapshot(blocks) {
+  return Object.fromEntries(
+    Object.entries(blocks || {}).map(([id, block]) => [
+      id,
+      compactBlockTransform(block),
+    ]),
+  );
+}
+
+export function isBlockSnapshot(snapshot) {
+  return Boolean(
+    snapshot &&
+      typeof snapshot === "object" &&
+      snapshot.blocks &&
+      typeof snapshot.blocks === "object" &&
+      !Array.isArray(snapshot.blocks),
+  );
+}
+
+export function getSnapshotBlockCount(snapshot) {
+  if (!isBlockSnapshot(snapshot)) return 0;
+  return Object.keys(snapshot.blocks).length;
+}
+
 export function getSnapshots(data) {
   if (!data || typeof data !== "object" || !data.snapshots) return {};
   if (typeof data.snapshots !== "object" || Array.isArray(data.snapshots)) {
@@ -52,14 +84,14 @@ export function getSnapshots(data) {
 }
 
 export function listSnapshotsNewestFirst(data) {
-  return Object.values(getSnapshots(data)).sort(
-    (a, b) => (b?.createdAt ?? 0) - (a?.createdAt ?? 0),
-  );
+  return Object.values(getSnapshots(data))
+    .filter(isBlockSnapshot)
+    .sort((a, b) => (b?.createdAt ?? 0) - (a?.createdAt ?? 0));
 }
 
 export function getLatestSnapshotTime(data) {
   let latest = 0;
-  for (const snapshot of Object.values(getSnapshots(data))) {
+  for (const snapshot of listSnapshotsNewestFirst(data)) {
     const createdAt = Number(snapshot?.createdAt) || 0;
     if (createdAt > latest) latest = createdAt;
   }
@@ -86,26 +118,30 @@ export function formatCooldown(ms) {
 
 export function createSnapshotRecord({
   id,
-  imageDataUrl,
+  blocks,
   createdAt = Date.now(),
-  blockCount = 0,
 }) {
   return {
     id,
     createdAt,
-    imageDataUrl,
-    blockCount,
+    blocks: compactBlocksSnapshot(blocks),
   };
 }
 
 /**
  * Apply a new snapshot into a draft snapshots map, pruning oldest when over cap.
+ * Also drops legacy image-byte snapshots so they don't keep bloating the room.
  * Mutates `snapshots` in place for SyncedStore draft writes.
  */
 export function applySnapshotToDraft(snapshots, record) {
+  for (const [id, existing] of Object.entries(snapshots)) {
+    if (!isBlockSnapshot(existing)) delete snapshots[id];
+  }
+
   snapshots[record.id] = record;
 
   const idsByAge = Object.values(snapshots)
+    .filter(isBlockSnapshot)
     .sort((a, b) => (a?.createdAt ?? 0) - (b?.createdAt ?? 0))
     .map((snapshot) => snapshot.id);
 

--- a/website/experiments/cinderblock/model.js
+++ b/website/experiments/cinderblock/model.js
@@ -6,6 +6,15 @@ export const WORLD_HEIGHT = 720;
 export const BLOCK_WIDTH = 200;
 export const BLOCK_HEIGHT = 96;
 
+/** Shared site-diary saves must wait this long between captures. */
+export const SNAPSHOT_COOLDOWN_MS = 15 * 60 * 1000;
+/** Keep the diary from growing without bound in the synced room. */
+export const MAX_SNAPSHOTS = 48;
+/** JPEG quality for diary thumbnails stored in shared state. */
+export const SNAPSHOT_JPEG_QUALITY = 0.62;
+/** Capture scale relative to the 1200×720 physics surface. */
+export const SNAPSHOT_CAPTURE_SCALE = 0.42;
+
 const POSITION_SYNC_THRESHOLD = 0.35;
 const ANGLE_SYNC_THRESHOLD = 0.004;
 
@@ -29,7 +38,81 @@ export function createDefaultYard() {
         { x, y, angle: 0, style: "photo" },
       ]),
     ),
+    // New field: rooms that already have blocks hydrate without this key.
+    snapshots: {},
   };
+}
+
+export function getSnapshots(data) {
+  if (!data || typeof data !== "object" || !data.snapshots) return {};
+  if (typeof data.snapshots !== "object" || Array.isArray(data.snapshots)) {
+    return {};
+  }
+  return data.snapshots;
+}
+
+export function listSnapshotsNewestFirst(data) {
+  return Object.values(getSnapshots(data)).sort(
+    (a, b) => (b?.createdAt ?? 0) - (a?.createdAt ?? 0),
+  );
+}
+
+export function getLatestSnapshotTime(data) {
+  let latest = 0;
+  for (const snapshot of Object.values(getSnapshots(data))) {
+    const createdAt = Number(snapshot?.createdAt) || 0;
+    if (createdAt > latest) latest = createdAt;
+  }
+  return latest;
+}
+
+export function getSnapshotCooldownRemainingMs(data, now = Date.now()) {
+  const latest = getLatestSnapshotTime(data);
+  if (!latest) return 0;
+  return Math.max(0, SNAPSHOT_COOLDOWN_MS - (now - latest));
+}
+
+export function canSaveSnapshot(data, now = Date.now()) {
+  return getSnapshotCooldownRemainingMs(data, now) === 0;
+}
+
+export function formatCooldown(ms) {
+  const totalSeconds = Math.ceil(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes <= 0) return `${seconds}s`;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+export function createSnapshotRecord({
+  id,
+  imageDataUrl,
+  createdAt = Date.now(),
+  blockCount = 0,
+}) {
+  return {
+    id,
+    createdAt,
+    imageDataUrl,
+    blockCount,
+  };
+}
+
+/**
+ * Apply a new snapshot into a draft snapshots map, pruning oldest when over cap.
+ * Mutates `snapshots` in place for SyncedStore draft writes.
+ */
+export function applySnapshotToDraft(snapshots, record) {
+  snapshots[record.id] = record;
+
+  const idsByAge = Object.values(snapshots)
+    .sort((a, b) => (a?.createdAt ?? 0) - (b?.createdAt ?? 0))
+    .map((snapshot) => snapshot.id);
+
+  while (idsByAge.length > MAX_SNAPSHOTS) {
+    const oldestId = idsByAge.shift();
+    if (oldestId) delete snapshots[oldestId];
+  }
 }
 
 export function createBlock(id, blockCount) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Turns `/experiments/cinderblock/` from a demo-style shared room into experiment 10, and adds a collaborative **site diary** gallery.

- Removes the `SHARED ROOM / LIVE` header chrome and related “positions persist” framing
- Labels the page as **playhtml experiment 10**, matching the experiments index / archive entry
- **SAVE** freezes the yard as compact keyed block transforms in shared state (~400 bytes for 9 blocks), not JPEGs
- Gallery/lightbox re-render those transforms as **static DOM freeze-frames** (same block art, no Matter.js, no physics)
- Preview scale is measured from card/lightbox width (so gallery thumbs actually show the blocks)
- **15-minute shared cooldown**; diary capped at 48 frames
- Mount purges any legacy image-byte diary entries from earlier experiments

## Screenshots

[Header and experiment 10 framing](https://cursor.com/agents/bc-fc7f0089-d028-430b-ac38-1a9139c848a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcinderblock-now-header.png)

[Live yard with blocks](https://cursor.com/agents/bc-fc7f0089-d028-430b-ac38-1a9139c848a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcinderblock-now-yard.png)

[Diary thumbnail with visible blocks](https://cursor.com/agents/bc-fc7f0089-d028-430b-ac38-1a9139c848a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcinderblock-thumb-fixed.png)

[Lightbox freeze-frame](https://cursor.com/agents/bc-fc7f0089-d028-430b-ac38-1a9139c848a2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcinderblock-thumb-lightbox.png)

## Test plan
- [x] Experiment 10 framing, no SHARED ROOM copy
- [x] SAVE creates a static gallery thumb that shows the blocks
- [x] Lightbox shows a larger static freeze-frame
- [x] Cooldown switches SAVE → WAIT
- [ ] Second tab sees the same diary entry


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc7f0089-d028-430b-ac38-1a9139c848a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc7f0089-d028-430b-ac38-1a9139c848a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

