### PR TITLE
partykit: prevent writes before room hydration

### DIFF
--- a/partykit/__tests__/persistenceMode.test.ts
+++ b/partykit/__tests__/persistenceMode.test.ts
@@ -128,6 +128,8 @@ describe("formatPersistenceFailureLog", () => {
     expect(message).toContain("attempts=3");
     expect(message).toContain("connection timeout");
     expect(message).toContain("TRANSIENT MODE");
+    expect(message).toContain("awareness may continue");
+    expect(message).toContain("shared-data writes disabled");
     expect(message).toContain("autosave disabled");
   });
 });
@@ -147,7 +149,7 @@ describe("createPersistenceUnavailableResponse", () => {
     expect(body).toEqual({
       error: "persistence_unavailable",
       message:
-        "Supabase persistence is unavailable for this room; admin writes are disabled while realtime runs in transient mode.",
+        "Supabase persistence is unavailable for this room; shared-data and admin writes are disabled while awareness runs in transient mode.",
       roomId: "example-room",
       failedAt: "2026-05-26T21:05:45.000Z",
       reason: "connection timeout",

--- a/partykit/__tests__/persistenceMode.test.ts
+++ b/partykit/__tests__/persistenceMode.test.ts
@@ -80,6 +80,27 @@ describe("retryWithTimeout", () => {
     expect(failures).toEqual([1]);
   });
 
+  test("can recover on the final configured attempt", async () => {
+    const attempts: number[] = [];
+
+    const result = await retryWithTimeout(
+      (_signal, attempt) => {
+        attempts.push(attempt);
+        if (attempt < 3) throw new Error(`failure ${attempt}`);
+        return Promise.resolve("loaded");
+      },
+      {
+        attempts: 3,
+        timeoutMs: 100,
+        retryDelayMs: 1,
+        errorMessage: "timed out",
+      }
+    );
+
+    expect(result).toBe("loaded");
+    expect(attempts).toEqual([1, 2, 3]);
+  });
+
   test("throws only after every attempt fails", async () => {
     const attempts: number[] = [];
 

--- a/partykit/__tests__/persistenceMode.test.ts
+++ b/partykit/__tests__/persistenceMode.test.ts
@@ -4,13 +4,14 @@ import { describe, expect, test } from "bun:test";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
+  retryWithTimeout,
   withTimeout,
 } from "../persistenceMode";
 
 describe("withTimeout", () => {
   test("rejects when the operation exceeds the configured timeout", async () => {
     await expect(
-      withTimeout(new Promise(() => {}), {
+      withTimeout(() => new Promise(() => {}), {
         timeoutMs: 1,
         errorMessage: "Supabase document load timed out after 1ms",
       })
@@ -19,11 +20,96 @@ describe("withTimeout", () => {
 
   test("returns the operation value before the timeout", async () => {
     await expect(
-      withTimeout(Promise.resolve("loaded"), {
+      withTimeout(() => Promise.resolve("loaded"), {
         timeoutMs: 100,
         errorMessage: "should not time out",
       })
     ).resolves.toBe("loaded");
+  });
+
+  test("aborts an operation that exceeds the timeout", async () => {
+    let signal: AbortSignal | undefined;
+
+    await expect(
+      withTimeout(
+        (operationSignal) => {
+          signal = operationSignal;
+          return new Promise(() => {});
+        },
+        { timeoutMs: 1, errorMessage: "timed out" }
+      )
+    ).rejects.toThrow("timed out");
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test("does not abort an operation that completes", async () => {
+    let signal: AbortSignal | undefined;
+
+    await withTimeout(
+      (operationSignal) => {
+        signal = operationSignal;
+        return Promise.resolve("loaded");
+      },
+      { timeoutMs: 100, errorMessage: "timed out" }
+    );
+
+    expect(signal?.aborted).toBe(false);
+  });
+});
+
+describe("retryWithTimeout", () => {
+  test("returns a later successful attempt", async () => {
+    const failures: number[] = [];
+
+    const result = await retryWithTimeout(
+      (_signal, attempt) => {
+        if (attempt === 1) throw new Error("temporary failure");
+        return Promise.resolve("loaded");
+      },
+      {
+        attempts: 3,
+        timeoutMs: 100,
+        retryDelayMs: 1,
+        errorMessage: "timed out",
+        onRetry: ({ attempt }) => failures.push(attempt),
+      }
+    );
+
+    expect(result).toBe("loaded");
+    expect(failures).toEqual([1]);
+  });
+
+  test("throws only after every attempt fails", async () => {
+    const attempts: number[] = [];
+
+    await expect(
+      retryWithTimeout(
+        (_signal, attempt) => {
+          attempts.push(attempt);
+          throw new Error(`failure ${attempt}`);
+        },
+        {
+          attempts: 3,
+          timeoutMs: 100,
+          retryDelayMs: 1,
+          errorMessage: "timed out",
+        }
+      )
+    ).rejects.toThrow("failure 3");
+
+    expect(attempts).toEqual([1, 2, 3]);
+  });
+
+  test("rejects an invalid attempt count", async () => {
+    await expect(
+      retryWithTimeout(() => Promise.resolve("loaded"), {
+        attempts: 0,
+        timeoutMs: 100,
+        retryDelayMs: 1,
+        errorMessage: "timed out",
+      })
+    ).rejects.toThrow("Persistence load attempts must be a positive integer");
   });
 });
 
@@ -32,12 +118,14 @@ describe("formatPersistenceFailureLog", () => {
     const message = formatPersistenceFailureLog({
       roomName: "example-room",
       timeoutMs: 5000,
+      attempts: 3,
       error: new Error("connection timeout"),
     });
 
     expect(message).toContain("SUPABASE PERSISTENCE UNAVAILABLE");
     expect(message).toContain("room=example-room");
     expect(message).toContain("timeoutMs=5000");
+    expect(message).toContain("attempts=3");
     expect(message).toContain("connection timeout");
     expect(message).toContain("TRANSIENT MODE");
     expect(message).toContain("autosave disabled");

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -232,6 +232,188 @@ beforeEach(() => {
   kvFailure = null;
 });
 
+describe("hydration write guards", () => {
+  test("a delayed autosave after hydration failure performs zero database writes", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    documentReadErrors = [
+      new Error("hydration timed out"),
+      new Error("hydration timed out"),
+      new Error("hydration timed out"),
+    ];
+    const { room } = createRoom();
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const originalLog = console.log;
+    console.warn = (message: unknown) => warnings.push(String(message));
+    console.error = (message: unknown) => errors.push(String(message));
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+    const logs: string[] = [];
+    console.log = (message: unknown) => logs.push(String(message));
+    try {
+      room.markPersistenceAvailable();
+    } finally {
+      console.log = originalLog;
+    }
+
+    const autosaveWarnings: string[] = [];
+    console.warn = (message: unknown) => autosaveWarnings.push(String(message));
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          void room.onSave().then(resolve);
+        }, 0);
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(room.documentLoadCompleted).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(documentReadCount).toBe(3);
+    expect(warnings).toHaveLength(2);
+    expect(errors).toEqual([
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
+    ]);
+    expect(logs).toEqual([
+      "[PartyServer] Supabase persistence restored for room=example-room; leaving transient mode.",
+    ]);
+    expect(autosaveWarnings).toEqual([
+      "[PartyServer] Autosave skipped for room example-room: room document has not completed hydration or persistence is unavailable.",
+    ]);
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("bridge flushes do not run before hydration completes", async () => {
+    const { room } = createRoom();
+    let pruneCalls = 0;
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    room.pruneBridgeLeases = async () => {
+      pruneCalls += 1;
+      return [];
+    };
+
+    console.warn = (message: unknown) => warnings.push(String(message));
+    try {
+      await room.flushBridgeUpdates(room.document);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(pruneCalls).toBe(0);
+    expect(warnings).toEqual([
+      "[PartyServer] Bridge flush skipped for room example-room: document hydration or persistence unavailable.",
+    ]);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  test("automatic compaction does not run before hydration completes", async () => {
+    const { room } = createRoom();
+    let compactionCalls = 0;
+    room.runAutomaticCompaction = async () => {
+      compactionCalls += 1;
+    };
+
+    await room.compactEmptyRoomDocument();
+
+    expect(compactionCalls).toBe(0);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  test("unhydrated rooms are read-only until persistence is writable", () => {
+    const { room } = createRoom();
+
+    expect(room.isReadOnly({})).toBe(true);
+
+    room.documentLoadCompleted = true;
+    expect(room.isReadOnly({})).toBe(false);
+
+    room.persistenceMode = {
+      kind: "transient",
+      reason: "database unavailable",
+      failedAt: Date.now(),
+    };
+    expect(room.isReadOnly({})).toBe(true);
+  });
+
+  test("bridge subscription and apply writes return 503 before hydration", async () => {
+    const { room, storage } = createRoom();
+
+    const subscribeResponse = await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "subscribe",
+          consumerRoomId: "consumer-room",
+          elementIds: ["shared"],
+        }),
+      })
+    );
+    const applyResponse = await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({
+          action: "apply-subtrees-immediate",
+          subtrees: { "can-play": { shared: { value: "blocked" } } },
+          sender: "consumer-room",
+          originKind: "consumer",
+        }),
+      })
+    );
+
+    expect(subscribeResponse.status).toBe(503);
+    expect(applyResponse.status).toBe(503);
+    expect(storage.values.get("subscribers")).toBeUndefined();
+    expect(docIsEmpty(room.document)).toBe(true);
+  });
+
+  test("custom bridge registration writes are ignored before hydration", async () => {
+    const { room, storage } = createRoom();
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (message: unknown) => warnings.push(String(message));
+
+    try {
+      await room.onCustomMessage(
+        {},
+        JSON.stringify({
+          type: "add-shared-reference",
+          reference: {
+            domain: "source.example",
+            path: "/",
+            elementId: "shared",
+          },
+        })
+      );
+      await room.onCustomMessage(
+        {},
+        JSON.stringify({
+          type: "register-shared-element",
+          element: { elementId: "shared", permissions: "read-write" },
+        })
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(storage.values.get("sharedReferences")).toBeUndefined();
+    expect(storage.values.get("sharedPermissions")).toBeUndefined();
+    expect(warnings).toEqual([
+      "[Bridge] Ignoring add-shared-reference for room example-room: document hydration or persistence unavailable.",
+      "[Bridge] Ignoring register-shared-element for room example-room: document hydration or persistence unavailable.",
+    ]);
+  });
+});
+
 describe("load path", () => {
   // The central correction: rooms in the 6-8MB band load successfully in
   // production, so size must never block hydration.
@@ -515,6 +697,7 @@ describe("automatic compaction breaker", () => {
     persistedRow.document = encodeDoc(doc);
     const storage = new FakeStorage();
     const room = buildRoom(storage, "example-room", doc);
+    room.documentLoadCompleted = true;
 
     await room.compactEmptyRoomDocument();
 
@@ -568,6 +751,7 @@ describe("automatic compaction breaker", () => {
 
   test("an observed exception clears the compaction attempt marker", async () => {
     const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
     room.buildCompactedDocument = () => {
       throw new Error("observed compaction failure");
     };
@@ -821,7 +1005,7 @@ describe("hardening", () => {
       "[PartyServer] Supabase document load attempt 2/3 failed for room=example-room; retrying in 2ms: failure 2",
     ]);
     expect(errors).toEqual([
-      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: realtime sync and awareness may continue, autosave disabled, admin writes disabled.",
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
     ]);
   });
 
@@ -1045,6 +1229,8 @@ describe("admin quarantine endpoints", () => {
     expect(body.quarantineCleared).toBe(true);
     expect(body.compactionFailureCleared).toBe(true);
     expect(room.circuitBreaker.isQuarantined()).toBe(false);
+    expect(room.documentLoadCompleted).toBe(true);
+    expect(room.isPersistenceAvailable()).toBe(true);
     expect(await room.circuitBreaker.getCompactionFailureCount()).toBe(0);
     expect(await room.circuitBreaker.getCompactionRetryAfter()).toBeNull();
     expect(await room.circuitBreaker.getCompactionDisabledAt()).toBeNull();
@@ -1053,6 +1239,7 @@ describe("admin quarantine endpoints", () => {
   test("the compaction retry endpoint clears the breaker and runs compaction", async () => {
     const { room } = createRoom();
     persistedRow.document = SMALL_DOCUMENT;
+    room.documentLoadCompleted = true;
     room.document.getMap("play").set("greeting", "hello");
     await room.ctx.storage.put("compactionAttempts", 3);
     await room.ctx.storage.put("compactionDisabledAt", Date.now());

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -33,8 +33,14 @@ const quarantineKvStub = {
   },
 };
 
+const workerEnv: Record<string, unknown> = {
+  QUARANTINE_CONTROL: quarantineKvStub,
+  SUPABASE_LOAD_ATTEMPTS: "3",
+  SUPABASE_LOAD_RETRY_DELAY_MS: "1",
+};
+
 mock.module("cloudflare:workers", () => ({
-  env: { QUARANTINE_CONTROL: quarantineKvStub },
+  env: workerEnv,
   DurableObject: FakeDurableObject,
   WorkerEntrypoint: class {},
 }));
@@ -48,6 +54,31 @@ let upsertCalls: Array<{ name: string; document: string }> = [];
 // Counts reads of the documents row. The load-backoff contract requires that a
 // deferred room never touches Supabase at all, which this makes observable.
 let documentReadCount = 0;
+let documentReadErrors: Error[] = [];
+
+function createDocumentRead() {
+  const maybeSingle = async () => {
+    documentReadCount += 1;
+    const error = documentReadErrors.shift();
+    if (error) {
+      return { data: null, error: { message: error.message } };
+    }
+    return {
+      data:
+        persistedRow.document === null
+          ? null
+          : { document: persistedRow.document },
+      error: null,
+    };
+  };
+
+  return {
+    maybeSingle,
+    abortSignal() {
+      return { maybeSingle };
+    },
+  };
+}
 
 const supabaseStub = {
   from() {
@@ -55,18 +86,7 @@ const supabaseStub = {
       select() {
         return {
           eq() {
-            return {
-              maybeSingle: async () => {
-                documentReadCount += 1;
-                return {
-                  data:
-                    persistedRow.document === null
-                      ? null
-                      : { document: persistedRow.document },
-                  error: null,
-                };
-              },
-            };
+            return createDocumentRead();
           },
         };
       },
@@ -207,6 +227,7 @@ beforeEach(() => {
   persistedRow.document = null;
   upsertCalls = [];
   documentReadCount = 0;
+  documentReadErrors = [];
   kvStore.clear();
   kvFailure = null;
 });
@@ -742,6 +763,68 @@ describe("alarm failure backoff", () => {
 });
 
 describe("hardening", () => {
+  test("a temporary Supabase failure recovers before transient mode", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    documentReadErrors = [new Error("temporary failure")];
+    const { room } = createRoom();
+    const warnings: string[] = [];
+    const logs: string[] = [];
+    const originalWarn = console.warn;
+    const originalLog = console.log;
+    console.warn = (message: unknown) => warnings.push(String(message));
+    console.log = (message: unknown) => logs.push(String(message));
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.warn = originalWarn;
+      console.log = originalLog;
+    }
+
+    expect(documentReadCount).toBe(2);
+    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(docIsEmpty(room.document)).toBe(false);
+    expect(warnings).toEqual([
+      "[PartyServer] Supabase document load attempt 1/3 failed for room=example-room; retrying in 1ms: temporary failure",
+    ]);
+    expect(logs).toEqual([
+      "[PartyServer] Supabase document load recovered for room=example-room after 2 attempts.",
+    ]);
+  });
+
+  test("transient mode starts only after every Supabase attempt fails", async () => {
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const { room } = createRoom();
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    console.warn = (message: unknown) => warnings.push(String(message));
+    console.error = (message: unknown) => errors.push(String(message));
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+
+    expect(documentReadCount).toBe(3);
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(docIsEmpty(room.document)).toBe(true);
+    expect(warnings).toEqual([
+      "[PartyServer] Supabase document load attempt 1/3 failed for room=example-room; retrying in 1ms: failure 1",
+      "[PartyServer] Supabase document load attempt 2/3 failed for room=example-room; retrying in 2ms: failure 2",
+    ]);
+    expect(errors).toEqual([
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: realtime sync and awareness may continue, autosave disabled, admin writes disabled.",
+    ]);
+  });
+
   // F5: admin force-reload calls markPersistenceAvailable, which would otherwise
   // silently lift the write park on a quarantined room.
   test("markPersistenceAvailable cannot lift a quarantine write park", async () => {
@@ -790,12 +873,16 @@ describe("hardening", () => {
     const originalFrom = supabaseStub.from;
     (supabaseStub as any).from = () => ({
       select: () => ({
-        eq: () => ({
-          maybeSingle: async () => ({
+        eq: () => {
+          const maybeSingle = async () => ({
             data: null,
             error: { message: "connection refused" },
-          }),
-        }),
+          });
+          return {
+            maybeSingle,
+            abortSignal: () => ({ maybeSingle }),
+          };
+        },
       }),
     });
 

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1,8 +1,15 @@
 // ABOUTME: Drives the real PartyServer load and alarm paths to verify breaker behavior.
 // ABOUTME: Asserts rooms stay available while failed work backs off or is disabled.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as encoding from "lib0/encoding";
+import * as awarenessProtocol from "y-protocols/awareness";
+import * as syncProtocol from "y-protocols/sync";
 import * as Y from "yjs";
 import { Buffer } from "node:buffer";
+import {
+  parseSharedElementsFromUrl,
+  parseSharedReferencesFromUrl,
+} from "../sharing";
 
 // PartyServer imports Cloudflare-only modules and constructs a Supabase client at
 // module scope. Stub both so the real class can be exercised under bun test.
@@ -345,6 +352,85 @@ describe("hydration write guards", () => {
     expect(room.isReadOnly({})).toBe(true);
   });
 
+  test("awareness messages still apply while shared-data writes are read-only", () => {
+    const { room } = createRoom();
+    const sourceDoc = new Y.Doc();
+    const sourceAwareness = new awarenessProtocol.Awareness(sourceDoc);
+    sourceAwareness.setLocalState({ online: true });
+    const awarenessUpdate = awarenessProtocol.encodeAwarenessUpdate(
+      sourceAwareness,
+      [sourceDoc.clientID]
+    );
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 1);
+    encoding.writeVarUint8Array(encoder, awarenessUpdate);
+    const connectionState: Record<string, unknown> = {};
+    const connection = {
+      id: "awareness-client",
+      send: () => {},
+      state: connectionState,
+      setState: (next: unknown) => {
+        Object.assign(
+          connectionState,
+          typeof next === "function" ? next(connectionState) : next
+        );
+      },
+    };
+    room.document.awareness = new awarenessProtocol.Awareness(room.document);
+
+    room.handleMessage(connection, encoding.toUint8Array(encoder));
+
+    expect(room.isReadOnly(connection)).toBe(true);
+    expect(room.document.awareness.getStates().get(sourceDoc.clientID)).toEqual({
+      online: true,
+    });
+    sourceAwareness.destroy();
+    room.document.awareness.destroy();
+    sourceDoc.destroy();
+  });
+
+  test("Yjs document updates are rejected while awareness remains available", () => {
+    const { room } = createRoom();
+    const sourceDoc = new Y.Doc();
+    sourceDoc.getMap("play").set("danger", "must not be applied");
+    const encoder = encoding.createEncoder();
+    encoding.writeVarUint(encoder, 0);
+    syncProtocol.writeUpdate(encoder, Y.encodeStateAsUpdate(sourceDoc));
+    const connection = {
+      id: "document-client",
+      send: () => {},
+      state: {},
+      setState: () => {},
+    };
+
+    room.handleMessage(connection, encoding.toUint8Array(encoder));
+
+    expect(room.isReadOnly(connection)).toBe(true);
+    expect(room.document.getMap("play").has("danger")).toBe(false);
+    sourceDoc.destroy();
+  });
+
+  test("admin writes remain blocked when persistence recovers before hydration", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    room.markPersistenceAvailable();
+
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/force-save-live",
+        { method: "POST" }
+      )
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: "shared_data_unavailable",
+      roomId: "example-room",
+    });
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
   test("bridge subscription and apply writes return 503 before hydration", async () => {
     const { room, storage } = createRoom();
 
@@ -411,6 +497,42 @@ describe("hydration write guards", () => {
       "[Bridge] Ignoring add-shared-reference for room example-room: document hydration or persistence unavailable.",
       "[Bridge] Ignoring register-shared-element for room example-room: document hydration or persistence unavailable.",
     ]);
+  });
+
+  test("connection URL bridge metadata is not stored before hydration", async () => {
+    const { room, storage } = createRoom();
+    room.getResetEpoch = async () => null;
+    room.clearEmptyRoomCompactAfter = async () => {};
+    room.ensureAlarmScheduled = async () => {};
+    room.waitForEmptyRoomCompaction = async () => {};
+    room.document.awareness = new awarenessProtocol.Awareness(room.document);
+    const connection = {
+      id: "bridge-client",
+      send: () => {},
+      setState: () => {},
+      state: {},
+    };
+    const params = new URLSearchParams({
+      sharedReferences: JSON.stringify([
+        { domain: "source.example", path: "/", elementId: "shared" },
+      ]),
+      sharedElements: JSON.stringify([
+        { elementId: "shared", permissions: "read-write" },
+      ]),
+    });
+    const requestUrl =
+      `https://example.com/parties/main/example-room?${params.toString()}`;
+
+    expect(parseSharedReferencesFromUrl(requestUrl)).toHaveLength(1);
+    expect(parseSharedElementsFromUrl(requestUrl)).toHaveLength(1);
+
+    await room.onConnect(connection, {
+      request: new Request(requestUrl),
+    });
+
+    expect(storage.values.get("sharedReferences")).toBeUndefined();
+    expect(storage.values.get("sharedPermissions")).toBeUndefined();
+    room.document.awareness.destroy();
   });
 });
 
@@ -1283,6 +1405,9 @@ describe("admin quarantine endpoints", () => {
     expect(body.ok).toBe(true);
     expect(body.quarantineCleared).toBe(false);
     expect(body.cleanupError).toContain("kv down");
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(room.isReadOnly({})).toBe(true);
   });
 
   test("the response reports whether the external flag was written", async () => {
@@ -1548,6 +1673,7 @@ describe("quarantine data safety", () => {
     persistedRow.document = COMPACT_LETHAL_DOCUMENT;
     const storage = new FakeStorage();
     const room = buildRoom(storage, "example-room", COMPACT_LETHAL_DOC);
+    room.documentLoadCompleted = true;
 
     const response = await room.onRequest(
       new Request(

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -57,6 +57,7 @@ mock.module("cloudflare:workers", () => ({
 type PersistedRow = { document: string | null };
 const persistedRow: PersistedRow = { document: null };
 let upsertCalls: Array<{ name: string; document: string }> = [];
+let upsertError: Error | null = null;
 
 // Counts reads of the documents row. The load-backoff contract requires that a
 // deferred room never touches Supabase at all, which this makes observable.
@@ -99,6 +100,9 @@ const supabaseStub = {
       },
       async upsert(row: { name: string; document: string }) {
         upsertCalls.push(row);
+        if (upsertError) {
+          return { error: { message: upsertError.message } };
+        }
         persistedRow.document = row.document;
         return { error: null };
       },
@@ -233,6 +237,7 @@ const COMPACT_LETHAL_DOCUMENT = encodeDoc(COMPACT_LETHAL_DOC);
 beforeEach(() => {
   persistedRow.document = null;
   upsertCalls = [];
+  upsertError = null;
   documentReadCount = 0;
   documentReadErrors = [];
   kvStore.clear();
@@ -240,6 +245,34 @@ beforeEach(() => {
 });
 
 describe("hydration write guards", () => {
+  test("room state has one precedence order for every write guard", async () => {
+    const { room } = createRoom();
+
+    expect(room.roomState()).toBe("loading");
+
+    room.documentLoadCompleted = true;
+    expect(room.roomState()).toBe("ready");
+
+    room.isSkippingSave = true;
+    expect(room.roomState()).toBe("save-paused");
+
+    room.isSkippingSave = false;
+    room.persistenceMode = {
+      kind: "transient",
+      reason: "database unavailable",
+      failedAt: Date.now(),
+    };
+    expect(room.roomState()).toBe("transient");
+
+    await room.circuitBreaker.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    expect(room.roomState()).toBe("quarantined");
+  });
+
   test("a delayed autosave after hydration failure performs zero database writes", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     documentReadErrors = [
@@ -293,7 +326,7 @@ describe("hydration write guards", () => {
       "[PartyServer] Supabase persistence restored for room=example-room; leaving transient mode.",
     ]);
     expect(autosaveWarnings).toEqual([
-      "[PartyServer] Autosave skipped for room example-room: room document has not completed hydration or persistence is unavailable.",
+      "[PartyServer] Autosave skipped for room example-room: room state is loading.",
     ]);
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
@@ -427,6 +460,28 @@ describe("hydration write guards", () => {
       error: "shared_data_unavailable",
       roomId: "example-room",
     });
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("the reset lock blocks autosave and admin writes until finally releases it", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    room.isSkippingSave = true;
+
+    const autosaveResult = await room.persistLiveDocument({
+      allowCompaction: false,
+    });
+    const adminResponse = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/force-save-live",
+        { method: "POST" }
+      )
+    );
+
+    expect(autosaveResult).toBe(false);
+    expect(adminResponse.status).toBe(503);
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
@@ -1621,6 +1676,29 @@ describe("manual quarantine", () => {
 });
 
 describe("quarantine data safety", () => {
+  test("force-save-live cannot bypass quarantine protection", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    await room.circuitBreaker.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+
+    const response = await room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/force-save-live",
+        { method: "POST" }
+      )
+    );
+
+    expect(response.status).toBe(503);
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
   test("autosave cannot overwrite the persisted document while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
@@ -1651,6 +1729,44 @@ describe("quarantine data safety", () => {
       /Refusing to persist document for quarantined room/
     );
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("the document write helper refuses unhydrated shared-data writes", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+
+    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
+      /Cannot persist document while room state is loading/
+    );
+    expect(upsertCalls).toEqual([]);
+    expect(persistedRow.document).toBe(SMALL_DOCUMENT);
+  });
+
+  test("snapshot restore releases the save lock before returning", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+
+    await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
+
+    expect(room.isSkippingSave).toBe(false);
+  });
+
+  test("snapshot restore releases the save lock when persistence fails", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    upsertError = new Error("database unavailable");
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await expect(
+        room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+      ).rejects.toThrow("database unavailable");
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(room.isSkippingSave).toBe(false);
   });
 
   test("a hard reset refuses to run while quarantined", async () => {
@@ -1689,6 +1805,30 @@ describe("quarantine data safety", () => {
     });
     expect(upsertCalls).toHaveLength(1);
     expect(persistedRow.document).not.toBe(COMPACT_LETHAL_DOCUMENT);
+    expect(room.isSkippingSave).toBe(false);
+  });
+
+  test("a hard reset releases the save lock when persistence fails", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    Y.applyUpdate(
+      room.document,
+      new Uint8Array(Buffer.from(SMALL_DOCUMENT, "base64"))
+    );
+    upsertError = new Error("database unavailable");
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await expect(room.performHardReset()).rejects.toThrow(
+        "database unavailable"
+      );
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(room.isSkippingSave).toBe(false);
   });
 
   test("loading a committed reset repairs a stale server epoch", async () => {

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -55,14 +55,18 @@ const supabaseStub = {
         return {
           eq() {
             return {
-              maybeSingle: async () => {
-                documentReadCount += 1;
+              abortSignal() {
                 return {
-                  data:
-                    persistedRow.document === null
-                      ? null
-                      : { document: persistedRow.document },
-                  error: null,
+                  maybeSingle: async () => {
+                    documentReadCount += 1;
+                    return {
+                      data:
+                        persistedRow.document === null
+                          ? null
+                          : { document: persistedRow.document },
+                      error: null,
+                    };
+                  },
                 };
               },
             };

--- a/partykit/__tests__/quarantinePolicy.test.ts
+++ b/partykit/__tests__/quarantinePolicy.test.ts
@@ -236,6 +236,8 @@ describe("formatQuarantineLog", () => {
     expect(message).toContain("exhausted the retry backoff");
     expect(message).toContain("will NOT be overwritten");
     expect(message).toContain("TRANSIENT MODE");
+    expect(message).toContain("awareness continues");
+    expect(message).toContain("shared-data writes are blocked");
   });
 });
 

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -137,7 +137,7 @@ export class AdminHandler {
   }
 
   private checkPersistenceWriteAvailable(): Response | null {
-    return this.context.getPersistenceUnavailableResponse();
+    return this.context.getSharedDataWriteUnavailableResponse();
   }
 
   private async loadDatabasePlayData(): Promise<{

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -1038,6 +1038,7 @@ export class AdminHandler {
         if (this.context.circuitBreaker.isQuarantined()) {
           await this.context.circuitBreaker.clearQuarantine();
           quarantineCleared = true;
+          this.context.markDocumentHydrated();
         }
       } catch (error) {
         cleanupError = error instanceof Error ? error.message : String(error);

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -478,15 +478,7 @@ export class AdminHandler {
     try {
       const liveYDoc = this.context.document;
       const base64 = encodeDocToBase64(liveYDoc);
-      const { error } = await supabase.from("documents").upsert(
-        {
-          name: this.context.name,
-          document: base64,
-        },
-        { onConflict: "name" }
-      );
-      if (error) throw new Error(error.message);
-      this.context.markDocumentPersisted(base64);
+      await this.context.saveDocumentBase64(base64);
       return new Response(JSON.stringify({ ok: true }), {
         headers: { "content-type": "application/json" },
       });

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -105,6 +105,12 @@ export const DEFAULT_FAILURE_BACKOFF_MAX_MS = (() => {
 export const DEFAULT_SUPABASE_LOAD_TIMEOUT_MS = (() => {
   return 5000;
 })();
+export const DEFAULT_SUPABASE_LOAD_ATTEMPTS = (() => {
+  return 3;
+})();
+export const DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS = (() => {
+  return 250;
+})();
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -132,6 +132,17 @@ type PersistLiveDocumentOptions = {
   allowCompaction: boolean;
 };
 
+type RoomState =
+  | "quarantined"
+  | "loading"
+  | "transient"
+  | "save-paused"
+  | "ready";
+
+type SaveDocumentOptions = {
+  operation?: "shared-data" | "reset" | "quarantine-repair";
+};
+
 type UsefulCompactedDocumentOptions = {
   sourceBase64?: string;
   documentSize: number;
@@ -506,8 +517,16 @@ export class PartyServer extends YServer {
     return this.persistenceMode.kind === "available";
   }
 
+  private roomState(): RoomState {
+    if (this.circuitBreaker.isQuarantined()) return "quarantined";
+    if (!this.documentLoadCompleted) return "loading";
+    if (!this.isPersistenceAvailable()) return "transient";
+    if (this.isSkippingSave) return "save-paused";
+    return "ready";
+  }
+
   private canWriteSharedData(): boolean {
-    return this.documentLoadCompleted && this.isPersistenceAvailable();
+    return this.roomState() === "ready";
   }
 
   override isReadOnly(_connection: Party.Connection): boolean {
@@ -533,7 +552,8 @@ export class PartyServer extends YServer {
   }
 
   getSharedDataWriteUnavailableResponse(): Response | null {
-    if (this.canWriteSharedData()) return null;
+    const state = this.roomState();
+    if (state === "ready") return null;
     if (this.persistenceMode.kind === "transient") {
       return createPersistenceUnavailableResponse({
         ...this.persistenceMode,
@@ -729,8 +749,25 @@ export class PartyServer extends YServer {
     return typeof data?.document === "string" ? data.document : null;
   }
 
-  private async saveDocumentBase64(documentBase64: string): Promise<void> {
-    this.circuitBreaker.assertNotQuarantined("persist document");
+  async saveDocumentBase64(
+    documentBase64: string,
+    options: SaveDocumentOptions = {}
+  ): Promise<void> {
+    const operation = options.operation ?? "shared-data";
+    const state = this.roomState();
+
+    if (operation !== "quarantine-repair") {
+      this.circuitBreaker.assertNotQuarantined("persist document");
+    }
+    const stateAllowsSave =
+      operation === "quarantine-repair" ||
+      state === "ready" ||
+      (operation === "reset" && state === "save-paused");
+    if (!stateAllowsSave) {
+      throw new Error(
+        `Cannot persist document while room state is ${state} (operation=${operation})`
+      );
+    }
 
     const { error } = await supabase.from("documents").upsert(
       {
@@ -743,6 +780,8 @@ export class PartyServer extends YServer {
     if (error) {
       throw new Error(error.message);
     }
+
+    this.markDocumentPersisted(documentBase64);
   }
 
   private async commitCompactedDocument({
@@ -795,12 +834,13 @@ export class PartyServer extends YServer {
       }
 
       await this.setResetEpoch(compactedDocument.resetEpoch);
-      await this.saveDocumentBase64(compactedDocument.base64);
+      await this.saveDocumentBase64(compactedDocument.base64, {
+        operation: "reset",
+      });
 
       this.compactionAutosaveSnapshot = compactedDocument.base64;
       replaceDocFromSnapshot(this.document, compactedDocument.base64);
       liveDocumentReplaced = true;
-      this.markDocumentPersisted(compactedDocument.base64);
       await afterReplace?.();
       return true;
     } catch (error) {
@@ -1015,24 +1055,21 @@ export class PartyServer extends YServer {
 
       // Save to database
       console.log(`[Restore Snapshot] Saving snapshot to database...`);
-      const { error: saveError } = await supabase.from("documents").upsert(
-        {
-          name: this.name,
-          document: updatedBase64,
-        },
-        { onConflict: "name" }
-      );
-
-      if (saveError) {
+      try {
+        await this.saveDocumentBase64(updatedBase64, {
+          operation: options?.allowQuarantined
+            ? "quarantine-repair"
+            : "reset",
+        });
+      } catch (saveError) {
         console.error(
           `[Restore Snapshot] Database save failed:`,
-          saveError.message,
+          getErrorMessage(saveError),
           saveError
         );
-        throw new Error(`Failed to save snapshot: ${saveError.message}`);
+        throw new Error(`Failed to save snapshot: ${getErrorMessage(saveError)}`);
       }
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
-      this.markDocumentPersisted(updatedBase64);
 
       // Set reset epoch for client detection
       await this.setResetEpoch(resetEpoch);
@@ -1083,11 +1120,8 @@ export class PartyServer extends YServer {
 
       throw error;
     } finally {
-      // Re-enable autosave after a short delay
-      setTimeout(() => {
-        this.isSkippingSave = false;
-        console.log("[Restore Snapshot] Autosave re-enabled");
-      }, 1000);
+      this.isSkippingSave = false;
+      console.log("[Restore Snapshot] Autosave re-enabled");
     }
   }
 
@@ -1136,7 +1170,6 @@ export class PartyServer extends YServer {
   }
 
   private async scheduleEmptyRoomCompaction(): Promise<void> {
-    if (this.isSkippingSave) return;
     if (!this.canWriteSharedData()) return;
     if (this.getOpenConnectionCount() !== 0) return;
     if ((await this.circuitBreaker.getCompactionDisabledAt()) !== null) return;
@@ -1947,17 +1980,10 @@ export class PartyServer extends YServer {
   }: PersistLiveDocumentOptions): Promise<boolean> {
     const doc = this.document;
 
-    if (!this.canWriteSharedData()) {
+    const state = this.roomState();
+    if (state !== "ready") {
       console.warn(
-        `[PartyServer] Autosave skipped for room ${this.name}: room document has not completed hydration or persistence is unavailable.`
-      );
-      return false;
-    }
-
-    // Skip autosave if we are performing a reset operation
-    if (this.isSkippingSave) {
-      console.log(
-        "[PartyServer] Skipping autosave due to active reset operation"
+        `[PartyServer] Autosave skipped for room ${this.name}: room state is ${state}.`
       );
       return false;
     }
@@ -2070,8 +2096,6 @@ export class PartyServer extends YServer {
       );
       return false;
     }
-    this.markDocumentPersisted(documentBase64);
-
     if (allowCompaction && activeConnectionCount > 0) {
       const compacted = await this.maybeCompactLargeConnectedRoom({
         documentSize,
@@ -2630,24 +2654,19 @@ export class PartyServer extends YServer {
 
       // Save to database
       console.log(`[Hard Reset] Saving fresh doc to database...`);
-      const { error: saveError } = await supabase.from("documents").upsert(
-        {
-          name: this.name,
-          document: freshBase64,
-        },
-        { onConflict: "name" }
-      );
-
-      if (saveError) {
+      try {
+        await this.saveDocumentBase64(freshBase64, { operation: "reset" });
+      } catch (saveError) {
         console.error(
           `[Hard Reset] Database save failed:`,
-          saveError.message,
+          getErrorMessage(saveError),
           saveError
         );
-        throw new Error(`Failed to save reset document: ${saveError.message}`);
+        throw new Error(
+          `Failed to save reset document: ${getErrorMessage(saveError)}`
+        );
       }
       console.log(`[Hard Reset] Successfully saved fresh doc to database`);
-      this.markDocumentPersisted(freshBase64);
 
       // Set reset epoch for client detection
       await this.setResetEpoch(resetEpoch);
@@ -2699,12 +2718,8 @@ export class PartyServer extends YServer {
 
       throw error;
     } finally {
-      // Re-enable autosave after a short delay to let the dust settle
-      // Use setTimeout to ensure any pending callbacks have been processed
-      setTimeout(() => {
-        this.isSkippingSave = false;
-        console.log("[Hard Reset] Autosave re-enabled");
-      }, 1000);
+      this.isSkippingSave = false;
+      console.log("[Hard Reset] Autosave re-enabled");
     }
   }
 
@@ -2757,7 +2772,6 @@ export class PartyServer extends YServer {
       return;
     }
 
-    if (this.isSkippingSave) return;
     if (!this.canWriteSharedData()) return;
     if (this.getOpenConnectionCount() !== 0) return;
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -506,6 +506,14 @@ export class PartyServer extends YServer {
     return this.persistenceMode.kind === "available";
   }
 
+  private canWriteSharedData(): boolean {
+    return this.documentLoadCompleted && this.isPersistenceAvailable();
+  }
+
+  override isReadOnly(_connection: Party.Connection): boolean {
+    return !this.canWriteSharedData();
+  }
+
   markPersistenceAvailable(): void {
     // A quarantined room's transient mode IS the write park. Lifting it here
     // would re-enable autosave against a document that was never hydrated.
@@ -517,6 +525,11 @@ export class PartyServer extends YServer {
       );
     }
     this.persistenceMode = { kind: "available" };
+  }
+
+  markDocumentHydrated(): void {
+    this.documentLoadCompleted = true;
+    this.markPersistenceAvailable();
   }
 
   getPersistenceUnavailableResponse(): Response | null {
@@ -1031,6 +1044,7 @@ export class PartyServer extends YServer {
       const liveYDoc = this.document;
       replaceDocFromSnapshot(liveYDoc, updatedBase64);
       setDocResetEpoch(liveYDoc, resetEpoch);
+      this.markDocumentHydrated();
       console.log(`[Restore Snapshot] Successfully reloaded live server`);
 
       console.log(
@@ -1109,7 +1123,7 @@ export class PartyServer extends YServer {
 
   private async scheduleEmptyRoomCompaction(): Promise<void> {
     if (this.isSkippingSave) return;
-    if (!this.isPersistenceAvailable()) return;
+    if (!this.canWriteSharedData()) return;
     if (this.getOpenConnectionCount() !== 0) return;
     if ((await this.circuitBreaker.getCompactionDisabledAt()) !== null) return;
 
@@ -1123,9 +1137,9 @@ export class PartyServer extends YServer {
   }
 
   async retryAutomaticCompaction() {
-    if (!this.isPersistenceAvailable()) {
+    if (!this.canWriteSharedData()) {
       throw new Error(
-        "Cannot retry automatic compaction while persistence is unavailable"
+        "Cannot retry automatic compaction until the room document has loaded and persistence is available"
       );
     }
     if (this.getOpenConnectionCount() !== 0) {
@@ -1348,6 +1362,12 @@ export class PartyServer extends YServer {
         const parsed = JSON.parse(message);
 
         if (parsed.type === "add-shared-reference") {
+          if (!this.canWriteSharedData()) {
+            console.warn(
+              `[Bridge] Ignoring add-shared-reference for room ${this.name}: document hydration or persistence unavailable.`
+            );
+            return;
+          }
           // Handle dynamic addition of shared reference
           // TODO: this MIGHT still has some data inconsistencies when a source renders a dynamic element and changes it and then when we add the shared reference, it doesn't get the updated data
           await this.handleAddSharedReference(parsed.reference, sender);
@@ -1355,6 +1375,12 @@ export class PartyServer extends YServer {
           // Handle individual permission requests
           await this.handleExportPermissions(parsed.elementIds, sender);
         } else if (parsed.type === "register-shared-element") {
+          if (!this.canWriteSharedData()) {
+            console.warn(
+              `[Bridge] Ignoring register-shared-element for room ${this.name}: document hydration or persistence unavailable.`
+            );
+            return;
+          }
           // Handle dynamic registration of shared source element
           // TODO: this still has some data inconsistencies when a consumer renders a dynamic element and changes it and then when we register the shared element, it doesn't get the updated data
           await this.handleRegisterSharedElement(parsed.element, sender);
@@ -1523,8 +1549,9 @@ export class PartyServer extends YServer {
     // Parse from the WebSocket request URL
     const sharedReferences = parseSharedReferencesFromUrl(ctx.request.url);
 
-    // Persist consumer interest mapping for later pulls/mirroring
-    if (sharedReferences.length) {
+    // Persist consumer interest mapping for later pulls/mirroring only after
+    // the room has loaded. Transient rooms remain awareness-only.
+    if (this.canWriteSharedData() && sharedReferences.length) {
       const entries = this.groupRefsToEntries(sharedReferences);
       const { entries: merged } = await this.mergeAndStoreSharedRefs(entries);
       await this.subscribeAndHydrate(merged);
@@ -1532,7 +1559,7 @@ export class PartyServer extends YServer {
 
     // Persist source-declared permissions for simple global read-only
     const sharedElements = parseSharedElementsFromUrl(ctx.request.url);
-    if (sharedElements.length) {
+    if (this.canWriteSharedData() && sharedElements.length) {
       const permissionsByElementId: Record<string, SharedElementPermissions> =
         {};
       for (const el of sharedElements) {
@@ -1765,7 +1792,7 @@ export class PartyServer extends YServer {
     // Hydration completed without killing the isolate, so the failure history
     // and any pending backoff are cleared.
     await this.circuitBreaker.completeRiskyOperation("load");
-    this.documentLoadCompleted = true;
+    this.markDocumentHydrated();
   }
 
   // Undoes this start's increment when the load ended before hydration could be
@@ -1906,9 +1933,9 @@ export class PartyServer extends YServer {
   }: PersistLiveDocumentOptions): Promise<boolean> {
     const doc = this.document;
 
-    if (!this.isPersistenceAvailable()) {
+    if (!this.canWriteSharedData()) {
       console.warn(
-        `[PartyServer] Autosave skipped for room ${this.name}: Supabase persistence unavailable, room is in transient mode.`
+        `[PartyServer] Autosave skipped for room ${this.name}: room document has not completed hydration or persistence is unavailable.`
       );
       return false;
     }
@@ -2191,6 +2218,24 @@ export class PartyServer extends YServer {
         return body;
       }
 
+      if (
+        !this.canWriteSharedData() &&
+        (isSubscribeRequest(body) || isApplySubtreesImmediateRequest(body))
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "shared_data_unavailable",
+            message:
+              "Shared-data writes are unavailable until the room document has loaded and persistence is available.",
+            roomId: this.name,
+          }),
+          {
+            status: 503,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+
       if (isSubscribeRequest(body)) {
         // Called on SOURCE room; registers a consumer room id
         const {
@@ -2273,9 +2318,9 @@ export class PartyServer extends YServer {
       }
 
       if (isApplySubtreesImmediateRequest(body)) {
-        if (!this.isPersistenceAvailable()) {
+        if (!this.canWriteSharedData()) {
           console.warn(
-            `[Bridge] Ignoring apply-subtrees for transient room ${this.name}: Supabase persistence unavailable.`
+            `[Bridge] Ignoring apply-subtrees for room ${this.name}: document hydration or persistence unavailable.`
           );
           const response: ApplySubtreesResponse = { ok: true, applied: false };
           return new Response(JSON.stringify(response), {
@@ -2699,7 +2744,7 @@ export class PartyServer extends YServer {
     }
 
     if (this.isSkippingSave) return;
-    if (!this.isPersistenceAvailable()) return;
+    if (!this.canWriteSharedData()) return;
     if (this.getOpenConnectionCount() !== 0) return;
 
     const run = async () => {
@@ -2787,9 +2832,9 @@ export class PartyServer extends YServer {
 
   // Flush batched bridge updates to subscribers and source rooms
   private async flushBridgeUpdates(yDoc: Y.Doc): Promise<void> {
-    if (!this.isPersistenceAvailable()) {
+    if (!this.canWriteSharedData()) {
       console.warn(
-        `[PartyServer] Bridge flush skipped for room ${this.name}: Supabase persistence unavailable, room is in transient mode.`
+        `[PartyServer] Bridge flush skipped for room ${this.name}: document hydration or persistence unavailable.`
       );
       return;
     }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -532,12 +532,26 @@ export class PartyServer extends YServer {
     this.markPersistenceAvailable();
   }
 
-  getPersistenceUnavailableResponse(): Response | null {
-    if (this.persistenceMode.kind !== "transient") return null;
-    return createPersistenceUnavailableResponse({
-      ...this.persistenceMode,
-      roomName: this.name,
-    });
+  getSharedDataWriteUnavailableResponse(): Response | null {
+    if (this.canWriteSharedData()) return null;
+    if (this.persistenceMode.kind === "transient") {
+      return createPersistenceUnavailableResponse({
+        ...this.persistenceMode,
+        roomName: this.name,
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        error: "shared_data_unavailable",
+        message:
+          "Shared-data and admin writes are unavailable until the room document has loaded.",
+        roomId: this.name,
+      }),
+      {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      }
+    );
   }
 
   private enterTransientPersistenceMode(error: unknown): void {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -37,6 +37,8 @@ import {
   DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
   DEFAULT_FAILURE_BACKOFF_MS,
   DEFAULT_FAILURE_BACKOFF_MAX_MS,
+  DEFAULT_SUPABASE_LOAD_ATTEMPTS,
+  DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
@@ -92,7 +94,7 @@ import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
   getErrorMessage,
-  withTimeout,
+  retryWithTimeout,
   type PersistenceMode,
 } from "./persistenceMode";
 import { getConnectionCloseDiagnostic } from "./connectionDiagnostics";
@@ -481,6 +483,25 @@ export class PartyServer extends YServer {
     );
   }
 
+  private getSupabaseLoadAttempts(): number {
+    return Math.max(
+      1,
+      Math.floor(
+        readPositiveNumberEnv(
+          "SUPABASE_LOAD_ATTEMPTS",
+          DEFAULT_SUPABASE_LOAD_ATTEMPTS
+        )
+      )
+    );
+  }
+
+  private getSupabaseLoadRetryDelayMs(): number {
+    return readPositiveNumberEnv(
+      "SUPABASE_LOAD_RETRY_DELAY_MS",
+      DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS
+    );
+  }
+
   isPersistenceAvailable(): boolean {
     return this.persistenceMode.kind === "available";
   }
@@ -508,6 +529,7 @@ export class PartyServer extends YServer {
 
   private enterTransientPersistenceMode(error: unknown): void {
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
+    const attempts = this.getSupabaseLoadAttempts();
     this.persistenceMode = {
       kind: "transient",
       reason: getErrorMessage(error),
@@ -517,6 +539,7 @@ export class PartyServer extends YServer {
       formatPersistenceFailureLog({
         roomName: this.name,
         timeoutMs,
+        attempts,
         error,
       })
     );
@@ -1655,15 +1678,36 @@ export class PartyServer extends YServer {
 
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
-    const query = supabase
-      .from("documents")
-      .select("document")
-      .eq("name", this.name)
-      .maybeSingle();
-    const result = await withTimeout(Promise.resolve(query), {
-      timeoutMs,
-      errorMessage: `Supabase document load timed out after ${timeoutMs}ms`,
-    }).catch((error) => {
+    const attempts = this.getSupabaseLoadAttempts();
+    const retryDelayMs = this.getSupabaseLoadRetryDelayMs();
+    let successfulAttempt = 1;
+    const result = await retryWithTimeout(
+      async (signal, attempt) => {
+        successfulAttempt = attempt;
+        const queryResult = await supabase
+          .from("documents")
+          .select("document")
+          .eq("name", this.name)
+          .abortSignal(signal)
+          .maybeSingle();
+        if (queryResult.error) {
+          throw new Error(queryResult.error.message);
+        }
+        return queryResult;
+      },
+      {
+        attempts,
+        timeoutMs,
+        retryDelayMs,
+        errorMessage: `Supabase document load timed out after ${timeoutMs}ms`,
+        onRetry: ({ attempt, retryAfterMs, error }) => {
+          console.warn(
+            `[PartyServer] Supabase document load attempt ${attempt}/${attempts} failed for room=${this.name}; ` +
+              `retrying in ${retryAfterMs}ms: ${getErrorMessage(error)}`
+          );
+        },
+      }
+    ).catch((error) => {
       this.enterTransientPersistenceMode(error);
       return null;
     });
@@ -1676,10 +1720,10 @@ export class PartyServer extends YServer {
       return;
     }
 
-    if (result.error) {
-      this.enterTransientPersistenceMode(new Error(result.error.message));
-      await this.releaseLoadAttempt(loadAttempts);
-      return;
+    if (successfulAttempt > 1) {
+      console.log(
+        `[PartyServer] Supabase document load recovered for room=${this.name} after ${successfulAttempt} attempts.`
+      );
     }
 
     this.markPersistenceAvailable();

--- a/partykit/persistenceMode.ts
+++ b/partykit/persistenceMode.ts
@@ -11,6 +11,14 @@ export type PersistenceMode =
 export type PersistenceFailureDetails = {
   roomName: string;
   timeoutMs: number;
+  attempts: number;
+  error: unknown;
+};
+
+export type PersistenceRetryDetails = {
+  attempt: number;
+  attempts: number;
+  retryAfterMs: number;
   error: unknown;
 };
 
@@ -19,7 +27,7 @@ export function getErrorMessage(error: unknown): string {
 }
 
 export async function withTimeout<T>(
-  operation: PromiseLike<T>,
+  operation: (signal: AbortSignal) => PromiseLike<T>,
   {
     timeoutMs,
     errorMessage,
@@ -29,12 +37,17 @@ export async function withTimeout<T>(
   }
 ): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
 
   try {
     return await Promise.race([
-      operation,
+      Promise.resolve().then(() => operation(controller.signal)),
       new Promise<never>((_, reject) => {
-        timeout = setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+        timeout = setTimeout(() => {
+          const error = new Error(errorMessage);
+          reject(error);
+          controller.abort(error);
+        }, timeoutMs);
       }),
     ]);
   } finally {
@@ -44,14 +57,57 @@ export async function withTimeout<T>(
   }
 }
 
+export async function retryWithTimeout<T>(
+  operation: (signal: AbortSignal, attempt: number) => PromiseLike<T>,
+  {
+    attempts,
+    timeoutMs,
+    retryDelayMs,
+    errorMessage,
+    onRetry,
+  }: {
+    attempts: number;
+    timeoutMs: number;
+    retryDelayMs: number;
+    errorMessage: string;
+    onRetry?: (details: PersistenceRetryDetails) => void;
+  }
+): Promise<T> {
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error("Persistence load attempts must be a positive integer");
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await withTimeout((signal) => operation(signal, attempt), {
+        timeoutMs,
+        errorMessage,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) break;
+
+      const retryAfterMs = retryDelayMs * 2 ** (attempt - 1);
+      onRetry?.({ attempt, attempts, retryAfterMs, error });
+      await new Promise((resolve) => setTimeout(resolve, retryAfterMs));
+    }
+  }
+
+  throw lastError;
+}
+
 export function formatPersistenceFailureLog({
   roomName,
   timeoutMs,
+  attempts,
   error,
 }: PersistenceFailureDetails): string {
   return [
     `[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=${roomName}`,
     `timeoutMs=${timeoutMs}`,
+    `attempts=${attempts}`,
     `reason=${getErrorMessage(error)}`,
     "Entering TRANSIENT MODE: realtime sync and awareness may continue, autosave disabled, admin writes disabled.",
   ].join(" ");

--- a/partykit/persistenceMode.ts
+++ b/partykit/persistenceMode.ts
@@ -109,7 +109,7 @@ export function formatPersistenceFailureLog({
     `timeoutMs=${timeoutMs}`,
     `attempts=${attempts}`,
     `reason=${getErrorMessage(error)}`,
-    "Entering TRANSIENT MODE: realtime sync and awareness may continue, autosave disabled, admin writes disabled.",
+    "Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
   ].join(" ");
 }
 
@@ -120,7 +120,7 @@ export function createPersistenceUnavailableResponse(
     JSON.stringify({
       error: "persistence_unavailable",
       message:
-        "Supabase persistence is unavailable for this room; admin writes are disabled while realtime runs in transient mode.",
+        "Supabase persistence is unavailable for this room; shared-data and admin writes are disabled while awareness runs in transient mode.",
       roomId: mode.roomName,
       failedAt: new Date(mode.failedAt).toISOString(),
       reason: mode.reason,

--- a/partykit/quarantinePolicy.ts
+++ b/partykit/quarantinePolicy.ts
@@ -192,7 +192,7 @@ export function formatQuarantineLog({
     `consecutiveFailures=${failureCount}`,
     `cause=${cause}.`,
     "The persisted document is NOT loaded and will NOT be overwritten.",
-    "The room runs in TRANSIENT MODE: visitors sync live with each other, nothing persists, alarms are parked.",
+    "The room runs in TRANSIENT MODE: awareness continues, shared-data writes are blocked, nothing persists, alarms are parked.",
     `To recover: repair or shrink the document (GET admin/raw-data, compact offline, POST admin/restore-raw-document), then POST admin/quarantine-clear for room=${roomName}.`,
   ].join(" ");
 }


### PR DESCRIPTION
## Summary

- Retry Supabase document hydration up to three times before entering transient mode.
- Abort timed-out reads so stale requests cannot overlap later attempts.
- Derive every shared-data write decision from one room state: `quarantined`, `loading`, `transient`, `save-paused`, or `ready`.
- Route every document database write through `saveDocumentBase64`, including autosave, compaction, snapshot restore, hard reset, and `admin/force-save-live`.
- Release reset save locks with `try/finally` instead of a one-second timer.
- Keep awareness updates available while Yjs document writes are read-only.
- Keep restored rooms writable after an authoritative snapshot replaces the live document.

## Why

The `playhtml.fun-fridge` incident showed a persisted document shrinking from a normal snapshot to a nearly empty snapshot after a Supabase load timeout. The room entered transient mode correctly, but a later lifecycle callback marked persistence available without proving that hydration completed. A delayed autosave then persisted the empty or partial in-memory document.

This change makes hydration completion an independent, required condition for writes. Persistence recovery alone cannot reopen autosave, Yjs updates, bridge writes, compaction, or admin mutations.

The write guard now also lives at the database boundary. Callers cannot bypass quarantine or hydration checks by issuing a direct document upsert. The only exception is an explicit quarantine-repair restore, which must be able to replace the document that caused the quarantine.

## Failure coverage

| Failure case | Expected behavior |
| --- | --- |
| First or second Supabase read fails | Retry with bounded exponential delay. |
| Final configured read succeeds | Hydrate normally and leave transient mode disabled. |
| All reads fail | Enter transient mode after the final attempt. |
| A read exceeds its timeout | Abort that attempt before retrying. |
| Persistence later reports available without hydration | Keep every shared-data write path closed. |
| A delayed autosave runs after failed hydration | Perform zero Supabase upserts and preserve the stored row. |
| A client sends a Yjs update before hydration | Reject the document update. |
| A client sends awareness before hydration | Apply and broadcast awareness normally. |
| Bridge subscribe, apply, flush, registration, or URL metadata runs before hydration | Reject or skip the write without changing room state. |
| Automatic compaction runs before hydration | Skip compaction. |
| An admin mutation runs before hydration | Return 503 without persisting the live document. |
| `admin/force-save-live` runs while quarantined | Return 503 and preserve the protected document. |
| A caller invokes the document save function before hydration | Reject the write before Supabase is called. |
| Autosave or an admin write runs during a reset | Treat the room as `save-paused`, perform zero upserts, and preserve the stored row. |
| Snapshot restore succeeds | Release the save lock immediately and reopen writes. |
| Snapshot restore database write fails | Release the save lock in `finally` and propagate the failure. |
| Hard reset succeeds | Release the save lock immediately after installing the authoritative document. |
| Hard reset database write fails | Release the save lock in `finally` and preserve the previous document. |
| A quarantined snapshot restore succeeds | Use the explicit repair operation, install the authoritative document, clear recovery state, and reopen writes. |
| Snapshot restore succeeds but quarantine cleanup fails | Report the durable restore while leaving the room quarantined and read-only. |

## Database write boundary

`saveDocumentBase64` is the only production `documents.upsert` call. It enforces the room state before writing and records the persisted snapshot only after Supabase succeeds.

| Operation | Allowed room state |
| --- | --- |
| Autosave and `admin/force-save-live` | `ready` |
| Compaction, hard reset, and normal snapshot restore | `ready` or `save-paused` |
| Explicit quarantine-repair restore | Any state, because it replaces the document that caused the write park |

## Validation

- `bun test partykit/__tests__` (234 passed, 1,220 assertions)
- `bunx tsc -p partykit --noEmit`
- `bunx wrangler deploy --config partykit/wrangler.jsonc --env="" --dry-run --outdir <temp-dir>`
- `git diff --check origin/wip/transient-mode-retries...HEAD`
- Source audit: one production `documents.upsert`, inside `saveDocumentBase64`

No public API, package, docs, or visual UI changed. No deployment was performed.

Browser-side offline persistence is not included. Adding IndexedDB requires a separate design for reset epochs and stale-client reconciliation.
