### PR TITLE
Archive: show natural playback time and preserve trails between batches

### DIFF
--- a/extension/website/archive/archive.tsx
+++ b/extension/website/archive/archive.tsx
@@ -73,6 +73,7 @@ const InternetMovement = () => {
     refresh,
     advanceBatch,
     batchKey,
+    batchContextKey,
   } = useArchiveEvents({
     selectedDay,
     timeOfDay,
@@ -115,6 +116,7 @@ const InternetMovement = () => {
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
         playbackKey={batchKey}
+        playbackContextKey={batchContextKey}
         onPlaybackCycleComplete={advanceBatch}
       />
     </>

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -58,52 +58,11 @@ import {
   DEFAULT_CINEMATIC_CONFIG,
   type CinematicConfig,
 } from "../utils/cinematicCamera";
+import { formatWordmarkTimestamp } from "./WordmarkClock";
 
 export { CLICK_DEFAULTS } from "./clickDefaults";
 
 const EMPTY_EVENTS: CollectionEvent[] = [];
-
-const READOUT_WRAPPER_STYLE: React.CSSProperties = {
-  position: "absolute",
-  top: "20px",
-  left: "50%",
-  transform: "translateX(-50%)",
-  zIndex: 100,
-  padding: "10px 16px",
-  background: "#faf9f6",
-  border: "1px solid rgba(0, 0, 0, 0.12)",
-  boxShadow:
-    "inset 1px 1px 2px rgba(255, 255, 255, 0.8), inset -1px -1px 2px rgba(0, 0, 0, 0.05), 0 1px 3px rgba(0, 0, 0, 0.08)",
-  fontFamily: '"Martian Mono", "Space Mono", "Courier New", monospace',
-  fontSize: "11px",
-  fontWeight: 600,
-  color: "#333",
-  letterSpacing: "0.5px",
-  textTransform: "uppercase",
-  overflow: "hidden",
-};
-
-const ReadoutNoise: React.FC<{ id: string }> = ({ id }) => (
-  <svg
-    style={{
-      position: "absolute",
-      inset: 0,
-      width: "100%",
-      height: "100%",
-      opacity: 0.15,
-      pointerEvents: "none",
-    }}
-  >
-    <filter id={id}>
-      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" />
-      <feColorMatrix type="saturate" values="0" />
-      <feComponentTransfer>
-        <feFuncA type="discrete" tableValues="0 0.3 0.5 0.7" />
-      </feComponentTransfer>
-    </filter>
-    <rect width="100%" height="100%" filter={`url(#${id})`} />
-  </svg>
-);
 
 /** Live clock readout shown when trails play in their natural-timestamp order.
  * Mirrors AnimatedTrails' `(realElapsed * speed) % duration` math so the time
@@ -126,20 +85,13 @@ const NaturalTimeReadout: React.FC<{
     let timeout = 0;
     let startedAt: number | null = null;
 
-    const formatter = new Intl.DateTimeFormat(undefined, {
-      hour: "numeric",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: true,
-    });
-
     const tick = (ts: number) => {
       if (startedAt === null) startedAt = ts;
       const realElapsed = ts - startedAt;
       const looped = (realElapsed * speedRef.current) % durationMs;
       const node = textRef.current;
       if (node) {
-        node.textContent = formatter.format(
+        node.textContent = formatWordmarkTimestamp(
           new Date(startTimestampMs + looped),
         );
       }
@@ -162,10 +114,24 @@ const NaturalTimeReadout: React.FC<{
   }, [startTimestampMs, durationMs]);
 
   return (
-    <div style={{ ...READOUT_WRAPPER_STYLE, pointerEvents: "none" }}>
-      <ReadoutNoise id="timeNoise" />
-      <span ref={textRef} style={{ position: "relative", zIndex: 1 }} />
-    </div>
+    <span
+      ref={textRef}
+      style={{
+        position: "absolute",
+        bottom: 16,
+        right: 20,
+        zIndex: 200,
+        fontFamily: "'Source Serif 4', 'Lora', Georgia, serif",
+        fontStyle: "italic",
+        fontWeight: 200,
+        fontSize: "20px",
+        letterSpacing: "-0.01em",
+        color: "#3d3833",
+        pointerEvents: "none",
+        userSelect: "none",
+        whiteSpace: "nowrap",
+      }}
+    />
   );
 };
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -59,6 +59,8 @@ import {
   type CinematicConfig,
 } from "../utils/cinematicCamera";
 import { formatWordmarkTimestamp } from "./WordmarkClock";
+import { useArchiveTrailHandoff } from "../hooks/useArchiveTrailHandoff";
+import { COMPLETION_FADE_MS } from "./trailPrimitives";
 
 export { CLICK_DEFAULTS } from "./clickDefaults";
 
@@ -934,6 +936,13 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     timeBounds: cursorTimeBounds,
     cycleDuration: cursorCycleDuration,
   } = useCursorTrails(activeTrailEvents, viewportSize, cursorSettings);
+  const renderedTrailStates = useArchiveTrailHandoff(
+    trailStates,
+    playbackKey,
+    onPlaybackCycleComplete !== undefined,
+    settings.maxConcurrentTrails * 2,
+    COMPLETION_FADE_MS,
+  );
 
   // Recent activity (live mode) from the raw event stream, not the capped drawn
   // trails: how many people + the geographic spread of their timezones.
@@ -1579,8 +1588,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             />
           ) : (
             <AnimatedTrails
-              key={`trails-${playbackKey}-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
-              trailStates={trailStates}
+              key={`trails-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
+              trailStates={renderedTrailStates}
               timeRange={timeRange}
               showClickRipples={!showClicks}
               windowSize={settings.maxConcurrentTrails * 2}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -362,6 +362,8 @@ interface MovementCanvasProps {
   getInstallationElapsedMs?: (animationSpeed: number) => number | null;
   /** Restarts finite archive playback when the parent swaps event batches. */
   playbackKey?: string;
+  /** Identifies playback batches that belong to the same archive query. */
+  playbackContextKey?: string;
   /** Called when finite archive playback reaches the end of its batch. */
   onPlaybackCycleComplete?: () => boolean;
 }
@@ -386,6 +388,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   connected = false,
   getInstallationElapsedMs,
   playbackKey = "fixed",
+  playbackContextKey = playbackKey,
   onPlaybackCycleComplete,
 }) => {
   const settingsDefaults = useMemo(
@@ -939,6 +942,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   const renderedTrailStates = useArchiveTrailHandoff(
     trailStates,
     playbackKey,
+    playbackContextKey,
     onPlaybackCycleComplete !== undefined,
     settings.maxConcurrentTrails * 2,
     COMPLETION_FADE_MS,

--- a/extension/website/shared/components/WordmarkClock.tsx
+++ b/extension/website/shared/components/WordmarkClock.tsx
@@ -19,6 +19,10 @@ const timeFmt = new Intl.DateTimeFormat(undefined, {
   hour12: false,
 });
 
+export function formatWordmarkTimestamp(date: Date): string {
+  return `${dateFmt.format(date)} · ${timeFmt.format(date)} UTC`;
+}
+
 export function WordmarkClock({ style }: { style?: React.CSSProperties }) {
   const [now, setNow] = useState(() => new Date());
   useEffect(() => {
@@ -41,7 +45,7 @@ export function WordmarkClock({ style }: { style?: React.CSSProperties }) {
         ...style,
       }}
     >
-      {dateFmt.format(now)} · {timeFmt.format(now)} UTC
+      {formatWordmarkTimestamp(now)}
     </span>
   );
 }

--- a/extension/website/shared/components/__tests__/WordmarkClock.test.ts
+++ b/extension/website/shared/components/__tests__/WordmarkClock.test.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Verifies the shared portrait timestamp includes its UTC date and time.
+// ABOUTME: Keeps live and historical wordmark clocks formatted consistently.
+
+import { describe, expect, it } from "vitest";
+import { formatWordmarkTimestamp } from "../WordmarkClock";
+
+describe("formatWordmarkTimestamp", () => {
+  it("formats the full UTC portrait timestamp", () => {
+    expect(formatWordmarkTimestamp(new Date("2026-08-15T19:55:08Z"))).toBe(
+      "Saturday, August 15 · 19:55:08 UTC",
+    );
+  });
+});

--- a/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
+++ b/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
@@ -3,7 +3,10 @@
 
 import { describe, expect, it } from "vitest";
 import type { TrailState } from "../../types";
-import { createCompletedTrailResidue } from "../useArchiveTrailHandoff";
+import {
+  createCompletedTrailResidue,
+  selectArchiveTrailHandoffAction,
+} from "../useArchiveTrailHandoff";
 
 function trailState(id: string, startOffsetMs: number): TrailState {
   return {
@@ -29,7 +32,7 @@ function trailState(id: string, startOffsetMs: number): TrailState {
   };
 }
 
-describe("createCompletedTrailResidue", () => {
+describe("archive trail handoff", () => {
   it("keeps the latest trails as already-dimmed completed paths", () => {
     const residue = createCompletedTrailResidue(
       [
@@ -51,5 +54,38 @@ describe("createCompletedTrailResidue", () => {
     expect(
       createCompletedTrailResidue([trailState("trail", 0)], 0, 3000),
     ).toEqual([]);
+  });
+
+  it("retains an automatic batch advance in the same query", () => {
+    expect(
+      selectArchiveTrailHandoffAction(
+        "1:0:first",
+        "1:1:second",
+        "1",
+        "1",
+        false,
+      ),
+    ).toBe("retain");
+  });
+
+  it("clears trails while a new query waits for its first batch", () => {
+    expect(
+      selectArchiveTrailHandoffAction(
+        "1:1:second",
+        "1:1:second",
+        "1",
+        "2",
+        false,
+      ),
+    ).toBe("clear-and-wait");
+    expect(
+      selectArchiveTrailHandoffAction(
+        "1:1:second",
+        "2:0:new-query",
+        "2",
+        "2",
+        true,
+      ),
+    ).toBe("clear");
   });
 });

--- a/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
+++ b/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { TrailState } from "../../types";
 import {
   createCompletedTrailResidue,
+  getArchiveTrailHandoffOutput,
   selectArchiveTrailHandoffAction,
 } from "../useArchiveTrailHandoff";
 
@@ -78,6 +79,9 @@ describe("archive trail handoff", () => {
         false,
       ),
     ).toBe("clear-and-wait");
+    expect(
+      getArchiveTrailHandoffOutput([trailState("old-query", 100)], [], true),
+    ).toEqual([]);
     expect(
       selectArchiveTrailHandoffAction(
         "1:1:second",

--- a/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
+++ b/extension/website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts
@@ -1,0 +1,55 @@
+// ABOUTME: Verifies archive batch handoffs retain the most recent completed trails.
+// ABOUTME: Keeps prior trails eligible for the renderer's normal displacement fade.
+
+import { describe, expect, it } from "vitest";
+import type { TrailState } from "../../types";
+import { createCompletedTrailResidue } from "../useArchiveTrailHandoff";
+
+function trailState(id: string, startOffsetMs: number): TrailState {
+  return {
+    trail: {
+      id,
+      points: [
+        { x: 0, y: 0, ts: 0 },
+        { x: 1, y: 1, ts: 100 },
+      ],
+      color: "blue",
+      opacity: 1,
+      startTime: 0,
+      endTime: 100,
+      clicks: [],
+    },
+    startOffsetMs,
+    durationMs: 100,
+    variedPoints: [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ],
+    clicksWithProgress: [],
+  };
+}
+
+describe("createCompletedTrailResidue", () => {
+  it("keeps the latest trails as already-dimmed completed paths", () => {
+    const residue = createCompletedTrailResidue(
+      [
+        trailState("latest", 300),
+        trailState("oldest", 100),
+        trailState("middle", 200),
+      ],
+      2,
+      3000,
+    );
+
+    expect(residue.map(({ trail }) => trail.id)).toEqual(["middle", "latest"]);
+    expect(residue.map(({ startOffsetMs }) => startOffsetMs)).toEqual([
+      -3100, -3100,
+    ]);
+  });
+
+  it("keeps no residue when the renderer has no completed-trail window", () => {
+    expect(
+      createCompletedTrailResidue([trailState("trail", 0)], 0, 3000),
+    ).toEqual([]);
+  });
+});

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -93,6 +93,8 @@ export interface ArchiveEventsState {
   advanceBatch: () => boolean;
   /** Stable identity for restarting finite archive playback after a swap. */
   batchKey: string;
+  /** Stable identity for batches fetched from the same archive query. */
+  batchContextKey: string;
 }
 
 /** Owns browsing-event fetches for archive surfaces. Fixed mode keeps missing
@@ -525,5 +527,6 @@ export function useArchiveEvents(params: {
     refresh,
     advanceBatch,
     batchKey,
+    batchContextKey: String(batchQueue.generation),
   };
 }

--- a/extension/website/shared/hooks/useArchiveTrailHandoff.ts
+++ b/extension/website/shared/hooks/useArchiveTrailHandoff.ts
@@ -4,6 +4,28 @@
 import { useMemo, useRef } from "react";
 import type { TrailState } from "../types";
 
+export type ArchiveTrailHandoffAction =
+  | "clear"
+  | "clear-and-wait"
+  | "retain"
+  | "track";
+
+export function selectArchiveTrailHandoffAction(
+  previousCycleKey: string,
+  cycleKey: string,
+  previousContextKey: string,
+  contextKey: string,
+  contextResetPending: boolean,
+): ArchiveTrailHandoffAction {
+  if (previousContextKey !== contextKey) {
+    return previousCycleKey === cycleKey ? "clear-and-wait" : "clear";
+  }
+  if (previousCycleKey !== cycleKey) {
+    return contextResetPending ? "clear" : "retain";
+  }
+  return contextResetPending ? "clear-and-wait" : "track";
+}
+
 export function createCompletedTrailResidue(
   trailStates: TrailState[],
   limit: number,
@@ -26,28 +48,54 @@ export function createCompletedTrailResidue(
 export function useArchiveTrailHandoff(
   trailStates: TrailState[],
   cycleKey: string,
+  contextKey: string,
   enabled: boolean,
   residueLimit: number,
   completionFadeMs: number,
 ): TrailState[] {
   const cycleKeyRef = useRef(cycleKey);
+  const contextKeyRef = useRef(contextKey);
+  const contextResetPendingRef = useRef(false);
   const activeTrailStatesRef = useRef(trailStates);
   const residueRef = useRef<TrailState[]>([]);
 
   if (!enabled) {
     cycleKeyRef.current = cycleKey;
+    contextKeyRef.current = contextKey;
+    contextResetPendingRef.current = false;
     activeTrailStatesRef.current = trailStates;
     residueRef.current = [];
-  } else if (cycleKeyRef.current !== cycleKey) {
-    residueRef.current = createCompletedTrailResidue(
-      activeTrailStatesRef.current,
-      residueLimit,
-      completionFadeMs,
-    );
-    cycleKeyRef.current = cycleKey;
-    activeTrailStatesRef.current = trailStates;
   } else {
-    activeTrailStatesRef.current = trailStates;
+    const action = selectArchiveTrailHandoffAction(
+      cycleKeyRef.current,
+      cycleKey,
+      contextKeyRef.current,
+      contextKey,
+      contextResetPendingRef.current,
+    );
+
+    if (action === "clear") {
+      contextKeyRef.current = contextKey;
+      contextResetPendingRef.current = false;
+      cycleKeyRef.current = cycleKey;
+      activeTrailStatesRef.current = trailStates;
+      residueRef.current = [];
+    } else if (action === "clear-and-wait") {
+      contextKeyRef.current = contextKey;
+      contextResetPendingRef.current = true;
+      residueRef.current = [];
+    } else if (action === "retain") {
+      residueRef.current = createCompletedTrailResidue(
+        activeTrailStatesRef.current,
+        residueLimit,
+        completionFadeMs,
+      );
+      contextResetPendingRef.current = false;
+      cycleKeyRef.current = cycleKey;
+      activeTrailStatesRef.current = trailStates;
+    } else {
+      activeTrailStatesRef.current = trailStates;
+    }
   }
 
   return useMemo(
@@ -55,6 +103,6 @@ export function useArchiveTrailHandoff(
       residueRef.current.length > 0
         ? [...residueRef.current, ...trailStates]
         : trailStates,
-    [cycleKey, enabled, trailStates],
+    [contextKey, cycleKey, enabled, trailStates],
   );
 }

--- a/extension/website/shared/hooks/useArchiveTrailHandoff.ts
+++ b/extension/website/shared/hooks/useArchiveTrailHandoff.ts
@@ -1,0 +1,60 @@
+// ABOUTME: Carries completed cursor trails across archive batch boundaries.
+// ABOUTME: Lets the next batch displace prior trails through the normal fade lifecycle.
+
+import { useMemo, useRef } from "react";
+import type { TrailState } from "../types";
+
+export function createCompletedTrailResidue(
+  trailStates: TrailState[],
+  limit: number,
+  completionFadeMs: number,
+): TrailState[] {
+  if (limit <= 0) return [];
+
+  return [...trailStates]
+    .sort(
+      (a, b) =>
+        a.startOffsetMs + a.durationMs - (b.startOffsetMs + b.durationMs),
+    )
+    .slice(-limit)
+    .map((trailState) => ({
+      ...trailState,
+      startOffsetMs: -trailState.durationMs - completionFadeMs,
+    }));
+}
+
+export function useArchiveTrailHandoff(
+  trailStates: TrailState[],
+  cycleKey: string,
+  enabled: boolean,
+  residueLimit: number,
+  completionFadeMs: number,
+): TrailState[] {
+  const cycleKeyRef = useRef(cycleKey);
+  const activeTrailStatesRef = useRef(trailStates);
+  const residueRef = useRef<TrailState[]>([]);
+
+  if (!enabled) {
+    cycleKeyRef.current = cycleKey;
+    activeTrailStatesRef.current = trailStates;
+    residueRef.current = [];
+  } else if (cycleKeyRef.current !== cycleKey) {
+    residueRef.current = createCompletedTrailResidue(
+      activeTrailStatesRef.current,
+      residueLimit,
+      completionFadeMs,
+    );
+    cycleKeyRef.current = cycleKey;
+    activeTrailStatesRef.current = trailStates;
+  } else {
+    activeTrailStatesRef.current = trailStates;
+  }
+
+  return useMemo(
+    () =>
+      residueRef.current.length > 0
+        ? [...residueRef.current, ...trailStates]
+        : trailStates,
+    [cycleKey, enabled, trailStates],
+  );
+}

--- a/extension/website/shared/hooks/useArchiveTrailHandoff.ts
+++ b/extension/website/shared/hooks/useArchiveTrailHandoff.ts
@@ -45,6 +45,15 @@ export function createCompletedTrailResidue(
     }));
 }
 
+export function getArchiveTrailHandoffOutput(
+  trailStates: TrailState[],
+  residue: TrailState[],
+  contextResetPending: boolean,
+): TrailState[] {
+  if (contextResetPending) return [];
+  return residue.length > 0 ? [...residue, ...trailStates] : trailStates;
+}
+
 export function useArchiveTrailHandoff(
   trailStates: TrailState[],
   cycleKey: string,
@@ -98,11 +107,11 @@ export function useArchiveTrailHandoff(
     }
   }
 
+  const residue = residueRef.current;
+  const contextResetPending = contextResetPendingRef.current;
   return useMemo(
     () =>
-      residueRef.current.length > 0
-        ? [...residueRef.current, ...trailStates]
-        : trailStates,
-    [contextKey, cycleKey, enabled, trailStates],
+      getArchiveTrailHandoffOutput(trailStates, residue, contextResetPending),
+    [contextResetPending, residue, trailStates],
   );
 }


### PR DESCRIPTION
## Summary

- Show the natural playback timestamp in the bottom-right portrait style, including the UTC date and time.
- Keep faded completed trails visible when archive playback advances to the next event batch.
- Clear retained trails when the day, time window, domain, visualization, or refresh changes the archive query.
- Let new completed trails displace retained trails through the existing eviction fade.

## Root cause

Archive batch changes included `playbackKey` in the trail renderer key. Each batch therefore remounted the renderer and cleared every completed trail. The first handoff implementation also treated automatic batch advances and new archive queries as the same transition. The natural playback clock used a separate centered time-only presentation instead of the portrait timestamp formatter.

## Impact

Natural archive playback now reads as one continuous sequence across fetched batches without mixing trails from different archive selections. The playback clock also identifies the historical date instead of showing only a time of day.

## Verification

- `bun run --cwd extension test --run website/shared/hooks/__tests__/useArchiveTrailHandoff.test.ts website/shared/components/__tests__/WordmarkClock.test.ts website/shared/utils/__tests__/archiveEventBatches.test.ts website/shared/utils/__tests__/trailAnimation.test.ts website/shared/hooks/__tests__/usePlaybackCycle.test.ts` (22 tests)
- `bunx tsc --noEmit -p extension/website/tsconfig.json`
- `bun run build-extension:website`
- Verified the real `/archive/` route at 100x playback speed. Automatic batch changes retained the completed-trail window, while changing from August 15 to August 14 retained no faded trails from the previous query. The browser console had no errors.