### PR TITLE
Stabilize movement audio playback

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -18,4 +18,3 @@ extension/website/public/changelog/media/ and reference them here:
 - Wikipedia now keeps your article-name consistent across tabs and counts each connected reader once across pages.
 - Wikipedia shows other readers' live text selections in their cursor colors.
 - Wikipedia editing sessions now stay separate from article-reading rooms.
-- Sound on live and archive portraits now stays smooth during playback slowdowns and longer sessions.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -18,3 +18,4 @@ extension/website/public/changelog/media/ and reference them here:
 - Wikipedia now keeps your article-name consistent across tabs and counts each connected reader once across pages.
 - Wikipedia shows other readers' live text selections in their cursor colors.
 - Wikipedia editing sessions now stay separate from article-reading rooms.
+- Sound on live and archive portraits now stays smooth during playback slowdowns and longer sessions.

--- a/extension/website/shared/components/AnimatedTrails.tsx
+++ b/extension/website/shared/components/AnimatedTrails.tsx
@@ -653,7 +653,7 @@ export const AnimatedTrails: React.FC<AnimatedTrailsProps> = memo(
         }
 
         // Feed sound engine with collected trail frames
-        if (soundFrames.length > 0 && soundEngine) {
+        if (soundEngine) {
           soundEngine.tick(loopedElapsed, soundFrames);
         }
 

--- a/extension/website/shared/components/__tests__/AnimatedTrails.test.tsx
+++ b/extension/website/shared/components/__tests__/AnimatedTrails.test.tsx
@@ -1,0 +1,79 @@
+// ABOUTME: Tests archive trail audio behavior across active and silent frames.
+// ABOUTME: Verifies inactive playback releases sustained sound-engine voices.
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { TrailState } from "../../types";
+import type { SoundEngine } from "../../sound/SoundEngine";
+import { AnimatedTrails } from "../AnimatedTrails";
+import { DEFAULT_SETTINGS } from "../settingsDefaults";
+
+describe("AnimatedTrails sound", () => {
+  it("ticks the sound engine when no trail is active", async () => {
+    const testGlobal = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    const scheduledFrames: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        scheduledFrames.push(callback);
+        return scheduledFrames.length;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const trailState: TrailState = {
+      trail: {
+        id: "trail",
+        points: [
+          { x: 0, y: 0, ts: 0 },
+          { x: 100, y: 100, ts: 1000 },
+        ],
+        color: "#123456",
+        opacity: 1,
+        startTime: 0,
+        endTime: 1000,
+        clicks: [],
+      },
+      startOffsetMs: 1000,
+      durationMs: 1000,
+      variedPoints: [
+        { x: 0, y: 0 },
+        { x: 100, y: 100 },
+      ],
+      clicksWithProgress: [],
+    };
+    const soundEngine = {
+      isEnabled: vi.fn(() => true),
+      reset: vi.fn(),
+      tick: vi.fn(),
+    } as unknown as SoundEngine;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AnimatedTrails, {
+          trailStates: [trailState],
+          timeRange: { duration: 3000 },
+          showClickRipples: false,
+          soundEngine,
+          settings: DEFAULT_SETTINGS,
+        }),
+      );
+    });
+
+    act(() => scheduledFrames.shift()?.(1000));
+
+    expect(soundEngine.tick).toHaveBeenCalledWith(0, []);
+
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
+  });
+});

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -23,6 +23,9 @@ const SILENCE_VELOCITY_THRESHOLD = 0.05;
 /** Reference frame duration used to make cursor velocity independent of rAF lag. */
 const REFERENCE_FRAME_DURATION_MS = 1000 / 60;
 
+/** Interval between continuous gain and pan updates for each voice. */
+const VOICE_CONTROL_INTERVAL_MS = 50;
+
 /** Interval between repeated plucks for percussive cursor types like text (ms) */
 const PLUCK_REPEAT_INTERVAL_MS = 120;
 
@@ -72,6 +75,7 @@ interface Voice {
   lastCursorType: string | undefined;
   /** Last time a percussive pluck was triggered (ms) */
   lastPluckMs: number;
+  lastControlTimeMs: number;
   active: boolean;
 }
 
@@ -187,8 +191,10 @@ export class SoundEngine {
     }
 
     const activeIndices = new Set(activeTrails.map((t) => t.trailIndex));
-    this.lastActiveTrailCount = activeTrails.length;
-    this.updateMasterGainForPolyphony(activeTrails.length);
+    if (activeTrails.length !== this.lastActiveTrailCount) {
+      this.lastActiveTrailCount = activeTrails.length;
+      this.updateMasterGainForPolyphony(activeTrails.length);
+    }
 
     for (const [idx, voice] of this.voices) {
       if (!activeIndices.has(idx) && voice.active) {
@@ -273,6 +279,9 @@ export class SoundEngine {
       // a sustained tone — like typing rhythm
       const isPercussive = this.config.cursorInstruments &&
         PERCUSSIVE_CURSOR_TYPES.has(frame.cursorType ?? "");
+      const shouldUpdateContinuousParams =
+        !voice.active ||
+        sampleTimeMs - voice.lastControlTimeMs >= VOICE_CONTROL_INTERVAL_MS;
 
       if (isPercussive) {
         if (elapsedMs - voice.lastPluckMs > PLUCK_REPEAT_INTERVAL_MS) {
@@ -288,11 +297,14 @@ export class SoundEngine {
             now + 0.005 + instrument.attack + instrument.decay + instrument.release,
           );
         }
-      } else {
+      } else if (shouldUpdateContinuousParams) {
         this.rampParam(voice.gainNode.gain, gain * instrument.gain, 0.05);
       }
 
-      this.rampParam(voice.panNode.pan, pan, 0.05);
+      if (shouldUpdateContinuousParams) {
+        this.rampParam(voice.panNode.pan, pan, 0.05);
+        voice.lastControlTimeMs = sampleTimeMs;
+      }
 
       voice.active = true;
     }
@@ -527,6 +539,7 @@ export class SoundEngine {
       lastNoteTimeMs: 0,
       lastCursorType: undefined,
       lastPluckMs: 0,
+      lastControlTimeMs: Number.NEGATIVE_INFINITY,
       active: false,
     };
   }

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -20,6 +20,9 @@ const OSCILLATOR_CROSSFADE_SECONDS = 0.03;
 /** Minimum velocity to trigger any sound (pixels per frame at ~60fps) */
 const SILENCE_VELOCITY_THRESHOLD = 0.05;
 
+/** Reference frame duration used to make cursor velocity independent of rAF lag. */
+const REFERENCE_FRAME_DURATION_MS = 1000 / 60;
+
 /** Interval between repeated plucks for percussive cursor types like text (ms) */
 const PLUCK_REPEAT_INTERVAL_MS = 120;
 
@@ -84,6 +87,7 @@ export class SoundEngine {
   private baseVolume: number = DEFAULT_MASTER_VOLUME;
   private lastActiveTrailCount: number = 0;
   private prevPositions: Map<number, { x: number; y: number }> = new Map();
+  private prevSampleTimesMs: Map<number, number> = new Map();
   /** Accumulated path history per trail for crossing detection */
   private trailPaths: Map<number, Array<{ x: number; y: number }>> = new Map();
   private config: SoundConfig = { ...DEFAULT_CONFIG };
@@ -196,11 +200,18 @@ export class SoundEngine {
       const prev = this.prevPositions.get(frame.trailIndex);
       const prevX = prev?.x ?? frame.x;
       const prevY = prev?.y ?? frame.y;
-
-      const velocity = computeVelocity(prevX, prevY, frame.x, frame.y);
+      const sampleTimeMs = this.ctx.currentTime * 1000;
+      const prevSampleTimeMs = this.prevSampleTimesMs.get(frame.trailIndex);
+      const sampleIntervalMs = prevSampleTimeMs === undefined
+        ? REFERENCE_FRAME_DURATION_MS
+        : Math.max(1, sampleTimeMs - prevSampleTimeMs);
+      const velocity =
+        computeVelocity(prevX, prevY, frame.x, frame.y) *
+        (REFERENCE_FRAME_DURATION_MS / sampleIntervalMs);
       const gain = velocityToGain(velocity);
 
       this.prevPositions.set(frame.trailIndex, { x: frame.x, y: frame.y });
+      this.prevSampleTimesMs.set(frame.trailIndex, sampleTimeMs);
 
       // Accumulate path history for crossing detection (sample every few pixels)
       if (this.config.crossingDissonance) {
@@ -644,18 +655,8 @@ export class SoundEngine {
 
   private releaseVoice(voice: Voice): void {
     if (!this.ctx) return;
-    const now = this.ctx.currentTime;
-    voice.gainNode.gain.linearRampToValueAtTime(0, now + 0.5);
+    this.rampParam(voice.gainNode.gain, 0, 0.5);
     voice.active = false;
-
-    if (voice.oscillator) {
-      voice.oscillator.stop(now + 0.6);
-      voice.oscillator = null;
-    }
-    if (voice.fifthOscillator) {
-      voice.fifthOscillator.stop(now + 0.6);
-      voice.fifthOscillator = null;
-    }
   }
 
   /** Permanently remove a trail's audio graph and cached motion state. */
@@ -691,6 +692,7 @@ export class SoundEngine {
       this.voices.delete(trailIndex);
     }
     this.prevPositions.delete(trailIndex);
+    this.prevSampleTimesMs.delete(trailIndex);
     this.trailPaths.delete(trailIndex);
     for (const key of this.crossingCooldowns.keys()) {
       if (
@@ -769,6 +771,7 @@ export class SoundEngine {
     }
     this.voices.clear();
     this.prevPositions.clear();
+    this.prevSampleTimesMs.clear();
     this.crossingCooldowns.clear();
     this.trailPaths.clear();
     if (this.ctx) {
@@ -782,22 +785,31 @@ export class SoundEngine {
     // overlaps with newly-created voices on data changes like day swaps.
     const now = this.ctx?.currentTime ?? 0;
     for (const [, voice] of this.voices) {
+      let disconnectWhenStopped = false;
       if (this.ctx) {
-        voice.gainNode.gain.cancelScheduledValues(now);
+        this.holdParam(voice.gainNode.gain, now);
         voice.gainNode.gain.linearRampToValueAtTime(0, now + 0.03);
       }
       if (voice.oscillator) {
-        try { voice.oscillator.stop(now + 0.04); } catch { /* already stopped */ }
+        voice.oscillator.onended = () => this.disconnectVoice(voice);
+        try {
+          voice.oscillator.stop(now + 0.04);
+          disconnectWhenStopped = true;
+        } catch { /* already stopped */ }
         voice.oscillator = null;
       }
       if (voice.fifthOscillator) {
         try { voice.fifthOscillator.stop(now + 0.04); } catch { /* already stopped */ }
         voice.fifthOscillator = null;
       }
+      if (!disconnectWhenStopped) {
+        this.disconnectVoice(voice);
+      }
       voice.active = false;
     }
     this.voices.clear();
     this.prevPositions.clear();
+    this.prevSampleTimesMs.clear();
     this.crossingCooldowns.clear();
     this.trailPaths.clear();
   }

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -94,6 +94,7 @@ class TestAudioContext {
   destination = new TestAudioNode();
   sampleRate = 100;
   state: AudioContextState = "running";
+  gains: TestGainNode[] = [];
   oscillators: TestOscillatorNode[] = [];
 
   createBiquadFilter(): BiquadFilterNode {
@@ -115,7 +116,9 @@ class TestAudioContext {
   }
 
   createGain(): GainNode {
-    return new TestGainNode() as unknown as GainNode;
+    const gain = new TestGainNode();
+    this.gains.push(gain);
+    return gain as unknown as GainNode;
   }
 
   createOscillator(): OscillatorNode {
@@ -154,6 +157,74 @@ afterEach(() => {
 });
 
 describe("SoundEngine cursor instruments", () => {
+  it("does not restart the master gain ramp when trail count is unchanged", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+
+    const frame = {
+      trailIndex: 0,
+      x: 0,
+      y: 0,
+      prevX: 0,
+      prevY: 0,
+      cursorType: "pointer",
+      progress: 0,
+      color: "#000",
+      isNewlyActive: true,
+    };
+    engine.tick(0, [frame]);
+    const masterGainEvents = context.gains[0].gain.events;
+    const eventCount = masterGainEvents.length;
+
+    context.currentTime += 1 / 60;
+    engine.tick(100, [frame]);
+
+    expect(masterGainEvents).toHaveLength(eventCount);
+  });
+
+  it("updates continuous voice parameters at audio control rate", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+
+    const frame = (x: number) => ({
+      trailIndex: 0,
+      x,
+      y: 0,
+      prevX: 0,
+      prevY: 0,
+      cursorType: "pointer",
+      progress: 0,
+      color: "#000",
+      isNewlyActive: false,
+    });
+    engine.tick(0, [frame(0)]);
+    context.currentTime += 1 / 60;
+    engine.tick(100, [frame(10)]);
+
+    const state = engine as unknown as {
+      voices: Map<
+        number,
+        { gainNode: TestGainNode; panNode: TestStereoPannerNode }
+      >;
+    };
+    const voice = state.voices.get(0)!;
+    const gainEventCount = voice.gainNode.gain.events.length;
+    const panEventCount = voice.panNode.pan.events.length;
+
+    context.currentTime += 1 / 60;
+    engine.tick(200, [frame(20)]);
+
+    expect(voice.gainNode.gain.events).toHaveLength(gainEventCount);
+    expect(voice.panNode.pan.events).toHaveLength(panEventCount);
+
+    context.currentTime += 0.05;
+    engine.tick(300, [frame(30)]);
+
+    expect(voice.gainNode.gain.events.length).toBeGreaterThan(gainEventCount);
+    expect(voice.panNode.pan.events.length).toBeGreaterThan(panEventCount);
+  });
+
   it("crossfades both oscillators when the cursor timbre changes", async () => {
     const engine = new SoundEngine();
     await engine.init();

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -228,7 +228,7 @@ describe("SoundEngine cursor instruments", () => {
     }
   });
 
-  it("recreates a released voice when a live trail resumes", async () => {
+  it("reuses a faded voice when a live trail resumes", async () => {
     const engine = new SoundEngine();
     await engine.init();
     engine.setCanvasWidth(100);
@@ -274,9 +274,28 @@ describe("SoundEngine cursor instruments", () => {
       },
     ]);
 
-    expect(context.oscillators).toHaveLength(4);
-    expect(context.oscillators[2].startTimes).toEqual([context.currentTime]);
-    expect(context.oscillators[3].startTimes).toEqual([context.currentTime]);
+    for (let cycle = 0; cycle < 100; cycle++) {
+      context.currentTime += 0.1;
+      engine.tick(400 + cycle * 200, []);
+      context.currentTime += 0.1;
+      engine.tick(500 + cycle * 200, [
+        {
+          trailIndex: 0,
+          x: 21 + cycle,
+          y: 0,
+          prevX: 20 + cycle,
+          prevY: 0,
+          cursorType: "pointer",
+          progress: 0.6,
+          color: "#000",
+          isNewlyActive: false,
+        },
+      ]);
+    }
+
+    expect(context.oscillators).toHaveLength(2);
+    expect(context.oscillators[0].stopTimes).toEqual([]);
+    expect(context.oscillators[1].stopTimes).toEqual([]);
   });
 
   it("retires all state for a finished live trail", async () => {
@@ -330,6 +349,105 @@ describe("SoundEngine cursor instruments", () => {
     expect(state.crossingCooldowns).toEqual(new Map());
     expect(primaryLevel.connections).not.toEqual([]);
 
+    context.oscillators[0].onended?.();
+
+    expect(primaryLevel.connections).toEqual([]);
+  });
+
+  it("normalizes movement gain across delayed animation frames", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+
+    engine.tick(0, [
+      {
+        trailIndex: 0,
+        x: 0,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0,
+        color: "#000",
+        isNewlyActive: true,
+      },
+    ]);
+
+    context.currentTime += 1 / 60;
+    engine.tick(100, [
+      {
+        trailIndex: 0,
+        x: 4,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.1,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const state = engine as unknown as {
+      voices: Map<number, { gainNode: TestGainNode }>;
+    };
+    const gain = state.voices.get(0)!.gainNode.gain;
+    const regularFrameTarget = gain.events.at(-1)?.value;
+
+    context.currentTime += 0.25;
+    engine.tick(350, [
+      {
+        trailIndex: 0,
+        x: 8,
+        y: 0,
+        prevX: 4,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.2,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const delayedFrameTarget = gain.events.at(-1)?.value;
+    expect(delayedFrameTarget).toBeLessThan(regularFrameTarget! / 2);
+  });
+
+  it("disconnects voice graphs after a playback reset", async () => {
+    const engine = new SoundEngine();
+    await engine.init();
+    engine.setCanvasWidth(100);
+
+    engine.tick(0, [
+      {
+        trailIndex: 0,
+        x: 0,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0,
+        color: "#000",
+        isNewlyActive: true,
+      },
+    ]);
+    context.currentTime += 1 / 60;
+    engine.tick(100, [
+      {
+        trailIndex: 0,
+        x: 10,
+        y: 0,
+        prevX: 0,
+        prevY: 0,
+        cursorType: "pointer",
+        progress: 0.1,
+        color: "#000",
+        isNewlyActive: false,
+      },
+    ]);
+
+    const primaryLevel = context.oscillators[0].connections[0];
+    engine.reset();
     context.oscillators[0].onended?.();
 
     expect(primaryLevel.connections).toEqual([]);


### PR DESCRIPTION
## Summary

- reuse faded trail voices instead of replacing them after short inactive gaps
- normalize movement gain against audio time so delayed frames do not create full-volume spikes
- release archive voices on silent frames and disconnect playback graphs after resets
- add regression coverage for repeated gap/resume cycles, delayed frames, silent archive playback, and reset cleanup
- add the user-facing extension release note

## Root cause

Short inactive gaps stopped and forgot a trail's oscillators. If the trail resumed before the fade completed, the sound engine created replacement oscillators while the previous graph remained connected. Repeated gaps accumulated overlapping audio graphs over time.

Archive playback also skipped sound-engine ticks when no trail was active and cleared stopped voices without disconnecting their graph. Main-thread delays amplified the problem because cursor distance was treated as per-frame velocity regardless of how long the frame took.

## Impact

Live portrait and archive sound remains stable through playback slowdowns, inactive gaps, and longer sessions. The fix applies to the common audio path, independent of the optional chord, cursor-instrument, and crossing settings.

## Validation

- `bun run build-packages`
- `bun run --cwd extension test --run` (642 tests)
- focused audio and trail lifecycle tests (11 tests)
- `bun run lint`
- `bun run --cwd extension/website build`
- prolonged local browser runs on `/portrait/` and `/archive/` with sound enabled and no console warnings or errors

This is an audio-only behavior change. Screenshots do not demonstrate the result, and the affected portrait contains live browsing-activity traces, so no public media was uploaded.