### PR TITLE
playhtml: strengthen presence regression coverage

### DIFF
--- a/.changeset/calm-presence-tests.md
+++ b/.changeset/calm-presence-tests.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Strengthen presence regression coverage across navigation, cursor modes, transport folding, teardown, and element-awareness shard limits.

--- a/packages/playhtml/src/__tests__/element-awareness-client.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-client.test.ts
@@ -9,13 +9,7 @@ import {
   MAX_ELEMENT_PRESENCE_SHARDS,
   type ElementAwarenessMap,
 } from "../element-awareness";
-
-// Publishes are coalesced across a microtask, so drain it before asserting on
-// what reached the socket. Local emits stay synchronous, so emitted-map
-// assertions do not need this.
-function flushPublish(): Promise<void> {
-  return Promise.resolve();
-}
+import { flushPresencePublishes } from "./presence-test-utils";
 
 class FakeSocket {
   sent: string[] = [];
@@ -92,7 +86,7 @@ describe("ElementAwarenessClient", () => {
     expect(entry.byStableId.get("pk_local")).toEqual({ active: true });
     expect(client.getLocalAwareness("can-play", "card")).toEqual({ active: true });
     // Publish is coalesced onto a microtask.
-    await flushPublish();
+    await flushPresencePublishes();
     expect(parsedSent().at(-1)).toMatchObject({
       type: "presence-update",
       channel: "element:shard:0",
@@ -106,10 +100,10 @@ describe("ElementAwarenessClient", () => {
     const { client, socket } = createClient();
     const value = { active: true };
     client.setLocalAwareness("can-play", "card", value);
-    await flushPublish();
+    await flushPresencePublishes();
     const sentCount = socket.sent.length;
     client.setLocalAwareness("can-play", "card", value);
-    await flushPublish();
+    await flushPresencePublishes();
     expect(socket.sent.length).toBe(sentCount);
   });
 
@@ -118,7 +112,7 @@ describe("ElementAwarenessClient", () => {
     client.setLocalAwareness("can-play", "a", { n: 1 });
     client.setLocalAwareness("can-play", "b", { n: 2 });
     client.setLocalAwareness("can-play", "c", { n: 3 });
-    await flushPublish();
+    await flushPresencePublishes();
     const updates = parsedSent().filter(
       (message) => message.type === "presence-update",
     );
@@ -131,14 +125,14 @@ describe("ElementAwarenessClient", () => {
     client.setLocalAwareness("can-play", "a", { n: 1 });
     client.setLocalAwareness("can-play", "b", { n: 2 });
     client.removeLocalAwareness("can-play", "a");
-    await flushPublish();
+    await flushPresencePublishes();
     expect(parsedSent().at(-1)).toMatchObject({
       type: "presence-update",
       channel: "element:shard:0",
       value: { v: 1, entries: [["can-play", "b", { n: 2 }]] },
     });
     client.removeLocalAwareness("can-play", "b");
-    await flushPublish();
+    await flushPresencePublishes();
     expect(parsedSent().at(-1)).toEqual({
       type: "presence-clear",
       channel: "element:shard:0",
@@ -254,7 +248,7 @@ describe("ElementAwarenessClient", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const huge = { blob: "x".repeat(5000) };
     expect(() => client.setLocalAwareness("can-play", "card", huge)).not.toThrow();
-    await flushPublish();
+    await flushPresencePublishes();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
@@ -264,9 +258,9 @@ describe("ElementAwarenessClient", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     client.setLocalAwareness("can-play", "card", { active: true });
-    await flushPublish();
+    await flushPresencePublishes();
     client.setLocalAwareness("can-play", "card", { blob: "x".repeat(5000) });
-    await flushPublish();
+    await flushPresencePublishes();
 
     expect(warn).toHaveBeenCalled();
     expect(parsedSent().at(-1)).toEqual({
@@ -287,7 +281,7 @@ describe("ElementAwarenessClient", () => {
         focus: false,
       });
     }
-    await flushPublish();
+    await flushPresencePublishes();
 
     const updates = parsedSent().filter(
       (message) =>
@@ -307,12 +301,57 @@ describe("ElementAwarenessClient", () => {
     error.mockRestore();
   });
 
+  it("includes the timestamp envelope when splitting shards at the byte limit", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    try {
+      const { client, parsedSent } = createClient();
+      const emptyByteLength = jsonByteLength({
+        v: 1,
+        entries: [
+          ["can-play", "first", { value: "" }],
+          ["can-play", "second", { value: "" }],
+        ],
+      });
+      const fillToUnstampedLimit = "x".repeat(
+        MAX_PRESENCE_VALUE_BYTES - emptyByteLength,
+      );
+
+      client.setLocalAwareness("can-play", "first", { value: "" });
+      client.setLocalAwareness("can-play", "second", {
+        value: fillToUnstampedLimit,
+      });
+      await flushPresencePublishes();
+
+      expect(
+        jsonByteLength({
+          v: 1,
+          entries: [
+            ["can-play", "first", { value: "" }],
+            ["can-play", "second", { value: fillToUnstampedLimit }],
+          ],
+        }),
+      ).toBe(MAX_PRESENCE_VALUE_BYTES);
+      const updates = parsedSent().filter(
+        (message) => message.type === "presence-update",
+      );
+      expect(updates).toHaveLength(2);
+      for (const update of updates) {
+        expect(update.value.at).toBe(1_700_000_000_000);
+        expect(jsonByteLength(update.value)).toBeLessThanOrEqual(
+          MAX_PRESENCE_VALUE_BYTES,
+        );
+      }
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("coalesces N element inits into one bounded burst of channel updates", async () => {
     const { client, parsedSent } = createClient();
     for (let i = 0; i < 100; i += 1) {
       client.setLocalAwareness("can-mirror", `tile-${i}`, { hover: false });
     }
-    await flushPublish();
+    await flushPresencePublishes();
     const updates = parsedSent().filter(
       (message) =>
         message.type === "presence-update" &&
@@ -340,7 +379,7 @@ describe("ElementAwarenessClient", () => {
         ...bigValue,
       });
     }
-    await flushPublish();
+    await flushPresencePublishes();
 
     const updates = parsedSent().filter(
       (message) =>
@@ -444,6 +483,7 @@ describe("ElementAwarenessClient", () => {
   it("drops a ghost peer's element awareness after the staleness window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const { socket, emitted } = createClient();
       socket.receive({
@@ -469,7 +509,11 @@ describe("ElementAwarenessClient", () => {
       // No further message from the ghost; after the window the sweep drops it.
       vi.advanceTimersByTime(31_000);
       expect(emitted.at(-1)!.has("can-play:card")).toBe(false);
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("presence transport unreachable"),
+      );
     } finally {
+      error.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/packages/playhtml/src/__tests__/element-awareness-navigation.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-navigation.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { elementHandlers, playhtml, resetPlayHTML } from "../index";
 import {
-  flushMicrotasks,
+  flushPresencePublishes,
   getPresenceSocketForRoom,
   getPresenceSockets,
   sentChannelUpdates,
@@ -54,7 +54,7 @@ describe("element awareness across navigation", () => {
     await playhtml.setupPlayElementForTag(el, "can-play");
     elementHandlers.get("can-play")!.get("nav-card")!
       .setMyAwareness({ here: true } as any);
-    await flushMicrotasks();
+    await flushPresencePublishes();
     expect(sentChannelUpdates(socketB, "element:shard:0").at(-1)).toMatchObject({
       v: 1,
       entries: [["can-play", "nav-card", { here: true }]],

--- a/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { elementHandlers, playhtml, resetPlayHTML } from "../index";
 import {
-  flushMicrotasks,
+  flushPresencePublishes,
   getPresenceSocketForRoom,
   getPresenceSockets,
   sentChannelUpdates,
@@ -92,7 +92,7 @@ describe("element awareness sync", () => {
       .get("room-scoped-presence")!;
     handler.setMyAwareness({ active: true } as any);
     // Publishing is coalesced onto a microtask.
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     const pageSocket = getPresenceSocketForRoom(playhtml.roomId);
     const cursorSocket = getPresenceSockets().find(
@@ -223,7 +223,7 @@ describe("element awareness sync", () => {
       document.body.appendChild(el);
     }
     playhtml.setupPlayElements();
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     const socket = getPresenceSocketForRoom(playhtml.roomId);
     const updates = sentChannelUpdates(socket, "element:shard:0");

--- a/packages/playhtml/src/__tests__/presence-client.test.ts
+++ b/packages/playhtml/src/__tests__/presence-client.test.ts
@@ -567,6 +567,7 @@ describe("PresenceClient", () => {
   it("drops a ghost peer's presence after the staleness window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       const { socket, client } = createClient();
       socket.receive({
@@ -585,7 +586,11 @@ describe("PresenceClient", () => {
       vi.advanceTimersByTime(31_000);
       const status = (client.getPresences().get("pk_ghost") as any)?.status;
       expect(status).toBeUndefined();
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining("presence transport unreachable"),
+      );
     } finally {
+      error.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/packages/playhtml/src/__tests__/presence-navigation.test.ts
+++ b/packages/playhtml/src/__tests__/presence-navigation.test.ts
@@ -4,14 +4,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { elementHandlers, playhtml, resetPlayHTML } from "../index";
 import {
-  flushMicrotasks,
+  cursorTestModes,
+  flushPresencePublishes,
   getPresenceSocketForRoom,
   getPresenceSockets,
   sentChannelUpdates,
   sentPresenceValues,
 } from "./presence-test-utils";
 
-describe("presence across navigation", () => {
+describe.each(cursorTestModes)("presence across navigation with cursors $cursorMode", ({ cursors }) => {
   const origPath = window.location.pathname + window.location.search;
 
   beforeEach(async () => {
@@ -38,7 +39,7 @@ describe("presence across navigation", () => {
 
   it("returns the SAME presence object before and after navigation", async () => {
     history.replaceState(null, "", "/facade-a");
-    await playhtml.init({ cursors: { enabled: false } });
+    await playhtml.init({ cursors });
     const before = playhtml.presence;
 
     history.replaceState(null, "", "/facade-b");
@@ -49,7 +50,7 @@ describe("presence across navigation", () => {
 
   it("routes a write from a captured reference to the NEW room after navigation", async () => {
     history.replaceState(null, "", "/write-a");
-    await playhtml.init({ cursors: { enabled: false } });
+    await playhtml.init({ cursors });
     const roomA = playhtml.roomId;
     const capturedPresence = playhtml.presence;
 
@@ -74,7 +75,7 @@ describe("presence across navigation", () => {
 
   it("delivers post-navigation updates to a subscription registered before navigation", async () => {
     history.replaceState(null, "", "/sub-a");
-    await playhtml.init({ cursors: { enabled: false } });
+    await playhtml.init({ cursors });
 
     const received: Array<Map<string, unknown>> = [];
     // Subscribe before navigation.
@@ -124,19 +125,19 @@ describe("presence across navigation", () => {
 
   it("reseeds retained element awareness into the new room without a user action", async () => {
     history.replaceState(null, "", "/seed-a");
-    await playhtml.init({ cursors: { enabled: false } });
+    await playhtml.init({ cursors });
 
     const el = addCanPlayElement("retained-card");
     await playhtml.setupPlayElementForTag(el, "can-play");
     elementHandlers.get("can-play")!.get("retained-card")!
       .setMyAwareness({ here: true } as any);
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     // Element stays mounted across navigation.
     history.replaceState(null, "", "/seed-b");
     await playhtml.handleNavigation();
     const roomB = playhtml.roomId;
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     // The new room's socket receives the retained awareness with no further
     // setMyAwareness call.
@@ -149,7 +150,7 @@ describe("presence across navigation", () => {
 
   it("seeds all retained handlers in a single coalesced publish", async () => {
     history.replaceState(null, "", "/seed-batch-a");
-    await playhtml.init({ cursors: { enabled: false } });
+    await playhtml.init({ cursors });
 
     for (let i = 0; i < 5; i += 1) {
       const el = addCanPlayElement(`batch-${i}`);
@@ -157,14 +158,14 @@ describe("presence across navigation", () => {
       elementHandlers.get("can-play")!.get(`batch-${i}`)!
         .setMyAwareness({ i } as any);
     }
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     history.replaceState(null, "", "/seed-batch-b");
     await playhtml.handleNavigation();
     const roomB = playhtml.roomId;
     const socketB = getPresenceSocketForRoom(roomB);
     const before = sentChannelUpdates(socketB, "element:shard:0").length;
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     const after = sentChannelUpdates(socketB, "element:shard:0");
     // The seed is one coalesced publish, not one per element.
@@ -180,7 +181,7 @@ describe("presence across navigation", () => {
     // client is NOT rebuilt. A disconnected element's awareness must be removed
     // in the sweep, or it rebroadcasts forever.
     history.replaceState(null, "", "/same-room");
-    await playhtml.init({ cursors: { enabled: false }, room: "/pinned-room" });
+    await playhtml.init({ cursors, room: "/pinned-room" });
 
     const keep = addCanPlayElement("keep");
     const gone = addCanPlayElement("gone");
@@ -188,7 +189,7 @@ describe("presence across navigation", () => {
     await playhtml.setupPlayElementForTag(gone, "can-play");
     elementHandlers.get("can-play")!.get("keep")!.setMyAwareness({ v: 1 } as any);
     elementHandlers.get("can-play")!.get("gone")!.setMyAwareness({ v: 2 } as any);
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     const room = playhtml.roomId;
     const socket = getPresenceSocketForRoom(room);
@@ -197,7 +198,7 @@ describe("presence across navigation", () => {
     gone.remove();
     history.replaceState(null, "", "/same-room-elsewhere");
     await playhtml.handleNavigation();
-    await flushMicrotasks();
+    await flushPresencePublishes();
 
     const publishes = sentChannelUpdates(socket, "element:shard:0");
     const latest = JSON.stringify(publishes.at(-1));

--- a/packages/playhtml/src/__tests__/presence-test-utils.ts
+++ b/packages/playhtml/src/__tests__/presence-test-utils.ts
@@ -1,5 +1,58 @@
 // ABOUTME: Shared helpers for driving fake presence PartySockets in tests.
-// ABOUTME: Finds sockets by room and parses sent presence protocol messages.
+// ABOUTME: Builds presence transports, flushes publishes, and parses protocol messages.
+
+import type { PresenceServerMessage } from "@playhtml/common";
+import { PeerStore } from "../peer-store";
+import type { PresenceJoinInput } from "../presence-transport";
+
+export const cursorTestModes = [
+  { cursorMode: "disabled", cursors: { enabled: false } },
+  { cursorMode: "enabled", cursors: { enabled: true } },
+] as const;
+
+export type FakePresenceTransport = {
+  updates: Array<{ channel: string; value: unknown }>;
+  clears: string[];
+  joins: PresenceJoinInput[];
+  peers: PeerStore;
+  join(input: PresenceJoinInput): void;
+  update(channel: string, value: unknown): void;
+  clear(channel: string): void;
+  subscribe(listener: (message: PresenceServerMessage) => void): () => void;
+  emit(message: PresenceServerMessage): void;
+  destroy(): void;
+};
+
+export function createFakePresenceTransport(): FakePresenceTransport {
+  const listeners = new Set<(message: PresenceServerMessage) => void>();
+  const transport = {
+    updates: [] as Array<{ channel: string; value: unknown }>,
+    clears: [] as string[],
+    joins: [] as PresenceJoinInput[],
+    join(input: PresenceJoinInput) {
+      this.joins.push(input);
+    },
+    update(channel: string, value: unknown) {
+      this.updates.push({ channel, value });
+    },
+    clear(channel: string) {
+      this.clears.push(channel);
+    },
+    subscribe(listener: (message: PresenceServerMessage) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit(message: PresenceServerMessage) {
+      for (const listener of listeners) listener(message);
+    },
+    destroy() {
+      transport.peers.destroy();
+      listeners.clear();
+    },
+  } as FakePresenceTransport;
+  transport.peers = new PeerStore(transport);
+  return transport;
+}
 
 export type FakePresenceSocket = {
   options: Record<string, unknown>;
@@ -52,6 +105,6 @@ export function sentPresenceValues(
   );
 }
 
-export function flushMicrotasks(): Promise<void> {
+export function flushPresencePublishes(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/packages/playhtml/src/__tests__/presence-transport-identity.test.ts
+++ b/packages/playhtml/src/__tests__/presence-transport-identity.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Verifies identity broadcasting is a transport concern: one re-join
 // ABOUTME: per socket on users.me change, no per-consumer identity wiring.
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toPublicPlayerIdentity } from "@playhtml/common";
 import { playhtml, resetPlayHTML } from "../index";
 import { getPresenceSocketForRoom, sentMessages } from "./presence-test-utils";
@@ -49,6 +49,7 @@ describe("identity broadcasting on the shared transport", () => {
   });
 
   it("re-joins after the extension injects an identity via CustomEvent", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const socket = getPresenceSocketForRoom(playhtml.roomId);
     const before = sentMessages(socket).filter(
       (m) => m.type === "presence-join",
@@ -67,6 +68,10 @@ describe("identity broadcasting on the shared transport", () => {
     const joins = sentMessages(socket).filter((m) => m.type === "presence-join");
     expect(joins.length).toBeGreaterThan(before);
     expect(joins.at(-1)!.identity.publicKey).toBe("pk_extension");
+    expect(log).toHaveBeenCalledWith(
+      "[playhtml] Merged extension identity via CustomEvent",
+    );
+    log.mockRestore();
   });
 
   it("keeps element awareness re-keyed under the new identity after a change", async () => {

--- a/packages/playhtml/src/cursors/__tests__/cursor-network-pacing.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/cursor-network-pacing.test.ts
@@ -7,7 +7,7 @@ import {
   getCursorNetworkHz,
   getCursorNetworkIntervalMs,
 } from "../cursor-network-pacing";
-import { PeerStore } from "../../peer-store";
+import { createFakePresenceTransport } from "../../__tests__/presence-test-utils";
 
 function makeIdentity(publicKey: string, color: string) {
   return {
@@ -74,33 +74,6 @@ function dispatchMouseMove(x: number, y: number) {
       bubbles: true,
     }),
   );
-}
-
-function makeFakePresenceTransport() {
-  const listeners = new Set<(message: unknown) => void>();
-  const transport: any = {
-    updates: [] as Array<{ channel: string; value: unknown }>,
-    clears: [] as string[],
-    join: vi.fn(),
-    update(channel: string, value: unknown) {
-      this.updates.push({ channel, value });
-    },
-    clear(channel: string) {
-      this.clears.push(channel);
-    },
-    subscribe: vi.fn((listener: (message: unknown) => void) => {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    }),
-    emit(message: unknown) {
-      for (const listener of listeners) listener(message);
-    },
-    destroy: vi.fn(),
-  };
-  // The real transport owns a PeerStore fed by its own message stream; mirror
-  // that here so the cursor client's PeerStore-backed cursor view works.
-  transport.peers = new PeerStore(transport);
-  return transport;
 }
 
 describe("cursor network pacing", () => {
@@ -210,7 +183,7 @@ describe("cursor network pacing", () => {
 
   it("publishes movement through presence transport instead of cursor awareness when available", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -242,7 +215,7 @@ describe("cursor network pacing", () => {
 
   it("notifies local cursor presence listeners without waiting for transport echo", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -271,7 +244,7 @@ describe("cursor network pacing", () => {
 
   it("renders remote cursors from presence transport sync messages", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -307,7 +280,7 @@ describe("cursor network pacing", () => {
 
   it("ignores unsafe remote custom cursor URLs", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -343,7 +316,7 @@ describe("cursor network pacing", () => {
 
   it("backs off transport-backed cursor publishing when about fifty peers are present", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -386,7 +359,7 @@ describe("cursor network pacing", () => {
 
   it("keeps transport publishing at 60Hz when joined peers have no active cursor", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -419,7 +392,7 @@ describe("cursor network pacing", () => {
   it("expires stale transport cursor positions", () => {
     vi.setSystemTime(100_000);
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -452,7 +425,7 @@ describe("cursor network pacing", () => {
 
   it("checks proximity immediately after local transport cursor movement", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const onProximityEntered = vi.fn();
     const client = new CursorClientAwareness(
       provider,
@@ -489,7 +462,7 @@ describe("cursor network pacing", () => {
 
   it("uses server cursor rate messages as an additional publish cap", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -518,7 +491,7 @@ describe("cursor network pacing", () => {
     // happens on every socket, not just the cursor client's. The cursor client
     // only layers hz pacing; it must not duplicate the rejection warning.
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const client = new CursorClientAwareness(
       provider,
@@ -542,7 +515,7 @@ describe("cursor network pacing", () => {
 
   it("omits overlong page paths from transport messages", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const identity = makeIdentity("local", "#ff0000");
     const originalPath = window.location.pathname;
     window.history.pushState(null, "", `/${"x".repeat(600)}`);
@@ -559,7 +532,7 @@ describe("cursor network pacing", () => {
       dispatchMouseMove(10, 20);
       vi.advanceTimersByTime(Math.ceil(1000 / 60));
 
-      expect(transport.join).toHaveBeenCalledWith({
+      expect(transport.joins).toContainEqual({
         identity,
         page: undefined,
       });
@@ -578,7 +551,7 @@ describe("cursor network pacing", () => {
 
   it("repositions transport-backed remote cursors after viewport changes", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -634,7 +607,7 @@ describe("cursor network pacing", () => {
     // to identity changes for rendering + CursorEvents, and must NOT also push
     // the identity channel — that would be a second broadcaster on the socket.
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {
@@ -670,7 +643,7 @@ describe("cursor network pacing", () => {
 
   it("keeps the local player in allColors on the presence transport path", () => {
     const provider = makeFakeProvider();
-    const transport = makeFakePresenceTransport();
+    const transport = createFakePresenceTransport();
     const client = new CursorClientAwareness(
       provider,
       {

--- a/packages/playhtml/src/cursors/__tests__/cursor-presence-store.test.ts
+++ b/packages/playhtml/src/cursors/__tests__/cursor-presence-store.test.ts
@@ -2,12 +2,8 @@
 // ABOUTME: channels — decode, per-player collapse, and stale-cursor expiry.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type {
-  PlayerIdentity,
-  PresenceServerMessage,
-  PresenceSnapshot,
-} from "@playhtml/common";
-import { PeerStore } from "../../peer-store";
+import type { PlayerIdentity, PresenceSnapshot } from "@playhtml/common";
+import { createFakePresenceTransport } from "../../__tests__/presence-test-utils";
 import { CursorPresenceStore } from "../cursor-presence-store";
 
 // Pin the clock near the small `at` values used below so PeerStore's staleness
@@ -41,35 +37,20 @@ function makeIdentity(publicKey: string): PlayerIdentity {
   };
 }
 
-/** A message source (transport stand-in) driven directly in tests. */
-function makeSource() {
-  const listeners = new Set<(message: PresenceServerMessage) => void>();
-  return {
-    subscribe(listener: (message: PresenceServerMessage) => void) {
-      listeners.add(listener);
-      return () => listeners.delete(listener);
-    },
-    emit(message: PresenceServerMessage) {
-      for (const listener of listeners) listener(message);
-    },
-  };
-}
-
 /** Build a cursor view over a PeerStore, plus helpers to feed sync/changes. */
 function makeStore() {
-  const source = makeSource();
-  const peerStore = new PeerStore(source);
-  const store = new CursorPresenceStore(peerStore);
+  const transport = createFakePresenceTransport();
+  const store = new CursorPresenceStore(transport.peers);
   return {
     store,
     applySync(peers: PresenceSnapshot) {
-      source.emit({ type: "presence-sync", peers });
+      transport.emit({ type: "presence-sync", peers });
     },
     applyChanges(
       updates: PresenceSnapshot,
       removes: Record<string, string[]> = {},
     ) {
-      source.emit({ type: "presence-changes", updates, removes });
+      transport.emit({ type: "presence-changes", updates, removes });
     },
   };
 }


### PR DESCRIPTION
## Summary

- add a shared fake presence transport backed by the real `PeerStore`
- add a named helper for flushing microtask-coalesced presence publishes
- run navigation and retained-awareness coverage with cursors enabled and disabled
- verify element-awareness shard sizing includes its timestamp envelope
- capture expected transport logs so presence test output stays clean

## Why

Several presence regressions were difficult to test consistently because each test rebuilt transport fixtures or assumed one cursor configuration. The shared helpers keep tests on the same receive-side folding path as production and make asynchronous publish assertions explicit.

The cursor subscriber reset regression is already covered on `main` by `presence-cursor-channel-lifecycle.test.ts`, so this PR does not duplicate that test or change production behavior.

## Validation

- `bun run build-packages`
- focused presence suite: 102 tests passed
- `bun run --cwd packages/playhtml test`: 515 tests passed
- `bun run --cwd packages/playhtml build`
- `git diff --check`

No public API or runtime behavior changed, so the docs and starter templates do not need updates.