### PR TITLE
Remove test-only changeset

### DIFF
--- a/.changeset/calm-presence-tests.md
+++ b/.changeset/calm-presence-tests.md
@@ -1,5 +1,0 @@
----
-"playhtml": patch
----
-
-Strengthen presence regression coverage across navigation, cursor modes, transport folding, teardown, and element-awareness shard limits.


### PR DESCRIPTION
## Summary

Remove the changeset added by PR #377.

## Why

PR #377 only added regression-test coverage and did not change package behavior. Publishing a `playhtml` patch for test-only changes would create an unnecessary release.

## Validation

- Confirmed the branch diff contains only the changeset deletion
- `git diff --check`
