### PR TITLE
Fix live portrait trail lifecycle

### DIFF
--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -1,6 +1,6 @@
 // ABOUTME: Shared ripple effect for click/hold visualization
 // ABOUTME: Used by AnimatedTrails and AnimatedClicks so ripple logic stays DRY
-import { useState, useEffect, useMemo, useRef, memo } from "react";
+import { useState, useEffect, useRef, memo } from "react";
 import { ClickEffect } from "../types";
 
 export interface RippleSettings {
@@ -20,6 +20,44 @@ export interface RippleSettings {
   clickAnimationStopPoint: number;
 }
 
+const MAX_HOLD_MULTIPLIER = 3;
+export const RIPPLE_FADE_MS = 3000;
+
+export function getRippleLifecycle(
+  effect: ClickEffect,
+  rippleSettings: RippleSettings,
+  now: number,
+) {
+  const holdMultiplier = effect.holdDuration
+    ? Math.min(MAX_HOLD_MULTIPLIER, 1 + effect.holdDuration / 1000)
+    : 1;
+  const baseTotalDuration =
+    rippleSettings.clickMinDuration +
+    effect.durationFactor *
+      (rippleSettings.clickMaxDuration - rippleSettings.clickMinDuration);
+  const effectTotalDuration = baseTotalDuration * holdMultiplier;
+  const expansionDuration =
+    rippleSettings.clickExpansionDuration * holdMultiplier;
+  const outerRingStartDelay =
+    Math.max(0, rippleSettings.clickNumRings - 1) *
+    rippleSettings.clickRingDelayMs;
+  const fadeStartedAt =
+    effect.startTime +
+    Math.min(effectTotalDuration, outerRingStartDelay + expansionDuration);
+  const fadeProgress = Math.min(
+    1,
+    Math.max(0, (now - fadeStartedAt) / RIPPLE_FADE_MS),
+  );
+
+  return {
+    holdMultiplier,
+    effectTotalDuration,
+    expansionDuration,
+    opacity: rippleSettings.clickOpacity * (1 - fadeProgress),
+    complete: fadeProgress >= 1,
+  };
+}
+
 export const RippleEffect = memo(
   ({
     effect,
@@ -35,11 +73,8 @@ export const RippleEffect = memo(
     /** Ensures onComplete runs once — render-phase callbacks can run twice in Strict Mode. */
     const completionFiredRef = useRef(false);
 
-    // Scale by hold duration if present.
-    // 250ms = 1.25x, 1000ms = 2x, 2000ms = 3x
-    const holdMultiplier = effect.holdDuration
-      ? 1 + effect.holdDuration / 1000
-      : 1;
+    const lifecycle = getRippleLifecycle(effect, rippleSettings, now);
+    const { holdMultiplier, expansionDuration } = lifecycle;
 
     const baseMaxRadius =
       rippleSettings.clickMinRadius +
@@ -47,39 +82,11 @@ export const RippleEffect = memo(
         (rippleSettings.clickMaxRadius - rippleSettings.clickMinRadius);
     const effectMaxRadius = baseMaxRadius * holdMultiplier;
 
-    const baseTotalDuration =
-      rippleSettings.clickMinDuration +
-      effect.durationFactor *
-        (rippleSettings.clickMaxDuration - rippleSettings.clickMinDuration);
-    const effectTotalDuration = baseTotalDuration * holdMultiplier;
-
-    const expansionDuration =
-      rippleSettings.clickExpansionDuration * holdMultiplier;
-
     // Honor the configured ring delay directly — staggering is when each ring
     // BEGINS expanding. The visual density comes from each ring freezing at
     // a different target radius (see ring rendering below), not time stagger.
     const ringStaggerMs = rippleSettings.clickRingDelayMs;
     const numRings = Math.max(1, rippleSettings.clickNumRings);
-
-    // The outermost ring travels the farthest, so it dictates when the whole
-    // ripple has finished animating.
-    const allRingsComplete = useMemo(() => {
-      const totalElapsed = now - effect.startTime;
-      if (totalElapsed >= effectTotalDuration) return true;
-
-      const outerIndex = numRings - 1;
-      const outerStartTime = effect.startTime + outerIndex * ringStaggerMs;
-      const outerElapsed = now - outerStartTime;
-      return outerElapsed >= expansionDuration;
-    }, [
-      now,
-      effect.startTime,
-      effectTotalDuration,
-      expansionDuration,
-      numRings,
-      ringStaggerMs,
-    ]);
 
     useEffect(() => {
       let animationFrameId: number;
@@ -105,11 +112,11 @@ export const RippleEffect = memo(
     }, [effect.id]);
 
     useEffect(() => {
-      if (!allRingsComplete || completionFiredRef.current) return;
+      if (!lifecycle.complete || completionFiredRef.current) return;
       completionFiredRef.current = true;
       onComplete?.(effect.id);
       setIsAnimating(false);
-    }, [allRingsComplete, effect.id, onComplete]);
+    }, [effect.id, lifecycle.complete, onComplete]);
 
     const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 
@@ -160,7 +167,7 @@ export const RippleEffect = memo(
           fill="none"
           stroke={effect.color}
           strokeWidth={rippleSettings.clickStrokeWidth}
-          opacity={Math.max(0, rippleSettings.clickOpacity)}
+          opacity={Math.max(0, lifecycle.opacity)}
           style={{ mixBlendMode: "multiply" }}
         />
       );

--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -21,7 +21,6 @@ export interface RippleSettings {
 }
 
 const MAX_HOLD_MULTIPLIER = 3;
-export const RIPPLE_FADE_MS = 3000;
 
 export function getRippleLifecycle(
   effect: ClickEffect,
@@ -41,20 +40,16 @@ export function getRippleLifecycle(
   const outerRingStartDelay =
     Math.max(0, rippleSettings.clickNumRings - 1) *
     rippleSettings.clickRingDelayMs;
-  const fadeStartedAt =
+  const completedAt =
     effect.startTime +
     Math.min(effectTotalDuration, outerRingStartDelay + expansionDuration);
-  const fadeProgress = Math.min(
-    1,
-    Math.max(0, (now - fadeStartedAt) / RIPPLE_FADE_MS),
-  );
 
   return {
     holdMultiplier,
     effectTotalDuration,
     expansionDuration,
-    opacity: rippleSettings.clickOpacity * (1 - fadeProgress),
-    complete: fadeProgress >= 1,
+    opacity: rippleSettings.clickOpacity,
+    complete: now >= completedAt,
   };
 }
 

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Animates id-keyed live cursor trails and their click ripples.
 // ABOUTME: React owns trail lifetimes while one frame loop draws current progress.
 
-import React, { useCallback, useEffect, useRef, useState, memo } from "react";
+import React, { useEffect, useRef, useState, memo } from "react";
 import type { TrailState } from "../types";
 import type { SoundEngine } from "../sound/SoundEngine";
 import type { TrailSoundFrame } from "../sound/types";
@@ -9,9 +9,10 @@ import { getTrailRenderer } from "../styles/trailRenderers";
 import { RippleEffect, type RippleSettings } from "./ClickRipple";
 import {
   collectDueClickEffects,
-  removeCompletedClickEffect,
+  retainClickEffectsForActiveTrails,
   type LiveClickEffect,
 } from "./clickEffects";
+import { pathLength } from "../utils/trailSequence";
 import {
   TrailPath,
   TrailCursor,
@@ -41,6 +42,7 @@ const DIM_FADE_MS = 1200;
 // so a flick still reads and a very long idle span doesn't take minutes to draw.
 const MIN_DRAW_MS = 600;
 const MAX_DRAW_MS = 30000;
+const MAX_DRAW_SPEED_PX_PER_SECOND = 600;
 
 // Once a trail has settled (dimmed, done tracing), keep it on screen this long
 // before removing it, so finished trails persist as a dim backdrop rather than
@@ -51,12 +53,14 @@ const REMOVE_AFTER_DIM_MS = 60_000;
 export interface LiveTrailDrawState {
   seenAt: number;
   total: number;
+  variedTotal: number;
+  drawProgress: number;
   grewAt: number;
   caughtUpAt: number | null;
   settled: boolean;
   settledAt: number | null;
   dimmedAt: number | null;
-  activeFromPoint: number | null;
+  activeFromVariedPoint: number | null;
   activeDimmedAt: number | null;
 }
 
@@ -87,7 +91,7 @@ export function getActiveTrailOpacity(
   draw: LiveTrailDrawState,
   clockMs: number,
 ): number {
-  if (draw.activeFromPoint === null) return 0;
+  if (draw.activeFromVariedPoint === null) return 0;
   if (draw.activeDimmedAt === null) return 1;
 
   return Math.max(0, 1 - (clockMs - draw.activeDimmedAt) / DIM_FADE_MS);
@@ -96,23 +100,39 @@ export function getActiveTrailOpacity(
 export function advanceDrawState(
   draw: LiveTrailDrawState,
   pointCount: number,
+  variedPointCount: number,
   clockMs: number,
   drawDuration: number,
 ): void {
   if (pointCount <= draw.total) return;
 
+  const priorLastIndex = Math.max(1, draw.variedTotal - 1);
+  const nextLastIndex = Math.max(1, variedPointCount - 1);
+  const preservedProgress =
+    (draw.drawProgress * priorLastIndex) / nextLastIndex;
+  draw.seenAt = clockMs - preservedProgress * drawDuration;
+  draw.drawProgress = preservedProgress;
+
   if (draw.settled) {
-    const completedProgress = Math.min(1, draw.total / pointCount);
-    draw.seenAt = clockMs - completedProgress * drawDuration;
-    draw.activeFromPoint = Math.max(0, draw.total - 1);
+    draw.activeFromVariedPoint = priorLastIndex;
     draw.activeDimmedAt = null;
     draw.settled = false;
     draw.settledAt = null;
   }
 
   draw.total = pointCount;
+  draw.variedTotal = variedPointCount;
   draw.grewAt = clockMs;
   draw.caughtUpAt = null;
+}
+
+export function getLiveDrawDuration(trailState: TrailState): number {
+  const spatialDuration =
+    (pathLength(trailState.variedPoints) / MAX_DRAW_SPEED_PX_PER_SECOND) * 1000;
+  return Math.min(
+    MAX_DRAW_MS,
+    Math.max(MIN_DRAW_MS, trailState.durationMs, spatialDuration),
+  );
 }
 
 export function advanceSettlingState(
@@ -130,7 +150,7 @@ export function advanceSettlingState(
 
   draw.settled = true;
   draw.settledAt = clockMs;
-  if (draw.activeFromPoint === null) {
+  if (draw.activeFromVariedPoint === null) {
     draw.dimmedAt ??= clockMs;
   } else {
     draw.activeDimmedAt = clockMs;
@@ -213,11 +233,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const [activeClickEffects, setActiveClickEffects] = useState<
       LiveClickEffect[]
     >([]);
-    const handleClickEffectComplete = useCallback((id: string) => {
-      setActiveClickEffects((effects) =>
-        removeCompletedClickEffect(effects, id),
-      );
-    }, []);
+    const activeClickEffectsRef = useRef(activeClickEffects);
+    useEffect(() => {
+      activeClickEffectsRef.current = activeClickEffects;
+    }, [activeClickEffects]);
     const svgRef = useRef<SVGSVGElement>(null);
     const pathLayerRef = useRef<SVGGElement>(null);
     const animationRef = useRef<number | undefined>(undefined);
@@ -307,6 +326,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       if (removedIdsRef.current.length > 0) {
         const ids = removedIdsRef.current;
         removedIdsRef.current = [];
+        const removed = new Set(ids);
+        setActiveClickEffects((effects) =>
+          retainClickEffectsForActiveTrails(effects, removed),
+        );
         onRemovedRef.current?.(ids);
       }
     }, [kept]);
@@ -433,6 +456,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const cursorHandles = useRef<Map<string, ImperativeTrailCursorHandle>>(
       new Map(),
     );
+    const rippleGroups = useRef<Map<string, SVGGElement>>(new Map());
 
     // Accumulated paused wall-clock, subtracted from the clock so trails don't
     // leap when resumed.
@@ -525,6 +549,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         const soundEngine = soundEngineRef.current;
         const soundFrames = soundFramesRef.current;
         soundFrames.length = 0;
+        const visibilityByTrail = new Map<string, number>();
 
         const present = new Set<string>();
 
@@ -537,26 +562,31 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
 
           const pts = ts.trail.points.length;
           let draw = drawMap.get(key);
-          const drawDuration = Math.min(
-            MAX_DRAW_MS,
-            Math.max(MIN_DRAW_MS, ts.durationMs),
-          );
+          const drawDuration = getLiveDrawDuration(ts);
           if (draw === undefined) {
             // New trail: anchor its draw clock to now.
             draw = {
               seenAt: clockMs,
               total: pts,
+              variedTotal: ts.variedPoints.length,
+              drawProgress: 0,
               grewAt: clockMs,
               caughtUpAt: null,
               settled: false,
               settledAt: null,
               dimmedAt: null,
-              activeFromPoint: null,
+              activeFromVariedPoint: null,
               activeDimmedAt: null,
             };
             drawMap.set(key, draw);
           } else {
-            advanceDrawState(draw, pts, clockMs, drawDuration);
+            advanceDrawState(
+              draw,
+              pts,
+              ts.variedPoints.length,
+              clockMs,
+              drawDuration,
+            );
           }
 
           // Draw over the trail's real duration (clamped), like the archive: a
@@ -573,16 +603,18 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           // A settled trail always shows its full current geometry (dimmed); a
           // live one draws progressively toward its tip.
           const progress = draw.settled ? 1 : drawProgress;
+          draw.drawProgress = progress;
 
           // Completed ink remains dim while a resumed portion draws at the live
           // opacity. When that portion settles, it fades into the dim base.
           const settleOpacity = getLiveTrailOpacity(draw, clockMs);
           const activeOpacity = getActiveTrailOpacity(draw, clockMs);
           const visibility = getTrailVisibility(entry.visibility, clockMs);
+          visibilityByTrail.set(key, visibility);
           const activeStartProgress =
-            draw.activeFromPoint === null || pts < 2
+            draw.activeFromVariedPoint === null || ts.variedPoints.length < 2
               ? null
-              : draw.activeFromPoint / (pts - 1);
+              : draw.activeFromVariedPoint / (ts.variedPoints.length - 1);
 
           const result = handle.update(
             0,
@@ -678,6 +710,15 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           }
         }
 
+        for (const effect of activeClickEffectsRef.current) {
+          const group = rippleGroups.current.get(effect.id);
+          if (!group) continue;
+          const opacity = String(visibilityByTrail.get(effect.trailId) ?? 0);
+          if (group.getAttribute("opacity") !== opacity) {
+            group.setAttribute("opacity", opacity);
+          }
+        }
+
         soundEngine?.tick(clockMs, soundFrames);
 
         // Prune draw tracking for trails that left so the map can't grow.
@@ -709,12 +750,15 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       >
         {showClickRipples &&
           activeClickEffects.map((effect) => (
-            <RippleEffect
+            <g
               key={effect.id}
-              effect={effect}
-              settings={settings}
-              onComplete={handleClickEffectComplete}
-            />
+              ref={(group) => {
+                if (group) rippleGroups.current.set(effect.id, group);
+                else rippleGroups.current.delete(effect.id);
+              }}
+            >
+              <RippleEffect effect={effect} settings={settings} />
+            </g>
           ))}
         <g ref={pathLayerRef}>
           {kept.map((entry) => {

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -1,7 +1,7 @@
 // ABOUTME: Animates id-keyed live cursor trails and their click ripples.
 // ABOUTME: React owns trail lifetimes while one frame loop draws current progress.
 
-import React, { useEffect, useRef, useState, memo } from "react";
+import React, { useCallback, useEffect, useRef, useState, memo } from "react";
 import type { TrailState } from "../types";
 import type { SoundEngine } from "../sound/SoundEngine";
 import type { TrailSoundFrame } from "../sound/types";
@@ -52,9 +52,12 @@ export interface LiveTrailDrawState {
   seenAt: number;
   total: number;
   grewAt: number;
+  caughtUpAt: number | null;
   settled: boolean;
   settledAt: number | null;
   dimmedAt: number | null;
+  activeFromPoint: number | null;
+  activeDimmedAt: number | null;
 }
 
 export function shouldDepartTrail(
@@ -80,6 +83,16 @@ export function getLiveTrailOpacity(
   return 1 - (1 - COMPLETED_OPACITY) * dimProgress;
 }
 
+export function getActiveTrailOpacity(
+  draw: LiveTrailDrawState,
+  clockMs: number,
+): number {
+  if (draw.activeFromPoint === null) return 0;
+  if (draw.activeDimmedAt === null) return 1;
+
+  return Math.max(0, 1 - (clockMs - draw.activeDimmedAt) / DIM_FADE_MS);
+}
+
 export function advanceDrawState(
   draw: LiveTrailDrawState,
   pointCount: number,
@@ -91,12 +104,37 @@ export function advanceDrawState(
   if (draw.settled) {
     const completedProgress = Math.min(1, draw.total / pointCount);
     draw.seenAt = clockMs - completedProgress * drawDuration;
+    draw.activeFromPoint = Math.max(0, draw.total - 1);
+    draw.activeDimmedAt = null;
     draw.settled = false;
     draw.settledAt = null;
   }
 
   draw.total = pointCount;
   draw.grewAt = clockMs;
+  draw.caughtUpAt = null;
+}
+
+export function advanceSettlingState(
+  draw: LiveTrailDrawState,
+  caughtUp: boolean,
+  clockMs: number,
+): void {
+  if (!caughtUp) {
+    draw.caughtUpAt = null;
+    return;
+  }
+
+  draw.caughtUpAt ??= clockMs;
+  if (draw.settled || clockMs - draw.caughtUpAt < SETTLE_MS) return;
+
+  draw.settled = true;
+  draw.settledAt = clockMs;
+  if (draw.activeFromPoint === null) {
+    draw.dimmedAt ??= clockMs;
+  } else {
+    draw.activeDimmedAt = clockMs;
+  }
 }
 
 export function getDrawClockTime(
@@ -175,6 +213,11 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     const [activeClickEffects, setActiveClickEffects] = useState<
       LiveClickEffect[]
     >([]);
+    const handleClickEffectComplete = useCallback((id: string) => {
+      setActiveClickEffects((effects) =>
+        effects.filter((effect) => effect.id !== id),
+      );
+    }, []);
     const svgRef = useRef<SVGSVGElement>(null);
     const pathLayerRef = useRef<SVGGElement>(null);
     const animationRef = useRef<number | undefined>(undefined);
@@ -508,9 +551,12 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               seenAt: clockMs,
               total: pts,
               grewAt: clockMs,
+              caughtUpAt: null,
               settled: false,
               settledAt: null,
               dimmedAt: null,
+              activeFromPoint: null,
+              activeDimmedAt: null,
             };
             drawMap.set(key, draw);
           } else {
@@ -527,31 +573,37 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           );
           const caughtUp = drawProgress >= 1;
 
-          // Latch "settled" once a trail has fully drawn and gone quiet for
-          // SETTLE_MS. Settling is one-way: a settled trail stays dimmed for the
-          // rest of its life (it never un-dims), per the design.
-          if (!draw.settled && caughtUp && clockMs - draw.grewAt >= SETTLE_MS) {
-            draw.settled = true;
-            draw.settledAt = clockMs;
-            draw.dimmedAt ??= clockMs;
-          }
+          advanceSettlingState(draw, caughtUp, clockMs);
           // A settled trail always shows its full current geometry (dimmed); a
           // live one draws progressively toward its tip.
           const progress = draw.settled ? 1 : drawProgress;
 
-          // Trails ease to COMPLETED_OPACITY after first settling and remain dim
-          // if later points resume their draw. Visibility transitions multiply
-          // on top for smooth departure and return.
+          // Completed ink remains dim while a resumed portion draws at the live
+          // opacity. When that portion settles, it fades into the dim base.
           const settleOpacity = getLiveTrailOpacity(draw, clockMs);
+          const activeOpacity = getActiveTrailOpacity(draw, clockMs);
           const visibility = getTrailVisibility(entry.visibility, clockMs);
-          const groupFade = settleOpacity * visibility;
+          const activeStartProgress =
+            draw.activeFromPoint === null || pts < 2
+              ? null
+              : draw.activeFromPoint / (pts - 1);
 
           const result = handle.update(
             0,
-            trailOpacity,
+            trailOpacity * settleOpacity,
             strokeWidth,
-            groupFade,
+            visibility,
             progress,
+            activeStartProgress === null || activeOpacity <= 0
+              ? undefined
+              : {
+                  startProgress: activeStartProgress,
+                  baseProgress:
+                    draw.activeDimmedAt === null
+                      ? activeStartProgress
+                      : progress,
+                  opacity: trailOpacity * activeOpacity,
+                },
           );
 
           const activelyTracing =
@@ -623,7 +675,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               ts.trail.points[cpIdx]?.cursor,
               false,
               progress,
-              groupFade,
+              visibility,
             );
           } else {
             cursorHandle?.hide();
@@ -665,6 +717,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               key={effect.id}
               effect={effect}
               settings={settings}
+              onComplete={handleClickEffectComplete}
             />
           ))}
         <g ref={pathLayerRef}>

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -9,7 +9,7 @@ import { getTrailRenderer } from "../styles/trailRenderers";
 import { RippleEffect, type RippleSettings } from "./ClickRipple";
 import {
   collectDueClickEffects,
-  retainClickEffectsForActiveTrails,
+  removeCompletedClickEffect,
   type LiveClickEffect,
 } from "./clickEffects";
 import {
@@ -215,7 +215,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     >([]);
     const handleClickEffectComplete = useCallback((id: string) => {
       setActiveClickEffects((effects) =>
-        effects.filter((effect) => effect.id !== id),
+        removeCompletedClickEffect(effects, id),
       );
     }, []);
     const svgRef = useRef<SVGSVGElement>(null);
@@ -307,10 +307,6 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       if (removedIdsRef.current.length > 0) {
         const ids = removedIdsRef.current;
         removedIdsRef.current = [];
-        const removed = new Set(ids);
-        setActiveClickEffects((effects) =>
-          retainClickEffectsForActiveTrails(effects, removed),
-        );
         onRemovedRef.current?.(ids);
       }
     }, [kept]);

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -133,14 +133,11 @@ export function getLiveDrawDuration(trailState: TrailState): number {
   const segmentDuration =
     Math.max(0, trailState.variedPoints.length - 1) *
     MIN_DRAW_MS_PER_SEGMENT;
-  return Math.min(
-    MAX_DRAW_MS,
-    Math.max(
-      MIN_DRAW_MS,
-      trailState.durationMs,
-      spatialDuration,
-      segmentDuration,
-    ),
+  return Math.max(
+    MIN_DRAW_MS,
+    Math.min(MAX_DRAW_MS, trailState.durationMs),
+    spatialDuration,
+    segmentDuration,
   );
 }
 

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -54,6 +54,7 @@ export interface LiveTrailDrawState {
   grewAt: number;
   settled: boolean;
   settledAt: number | null;
+  dimmedAt: number | null;
 }
 
 export function shouldDepartTrail(
@@ -67,6 +68,16 @@ export function shouldDepartTrail(
       draw.settledAt !== null &&
       clockMs - draw.settledAt >= REMOVE_AFTER_DIM_MS,
   );
+}
+
+export function getLiveTrailOpacity(
+  draw: LiveTrailDrawState,
+  clockMs: number,
+): number {
+  if (draw.dimmedAt === null) return 1;
+
+  const dimProgress = Math.min(1, (clockMs - draw.dimmedAt) / DIM_FADE_MS);
+  return 1 - (1 - COMPLETED_OPACITY) * dimProgress;
 }
 
 export function advanceDrawState(
@@ -482,6 +493,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               grewAt: clockMs,
               settled: false,
               settledAt: null,
+              dimmedAt: null,
             };
             drawMap.set(key, draw);
           } else {
@@ -504,6 +516,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           if (!draw.settled && caughtUp && clockMs - draw.grewAt >= SETTLE_MS) {
             draw.settled = true;
             draw.settledAt = clockMs;
+            draw.dimmedAt ??= clockMs;
           }
           // A settled trail always shows its full current geometry (dimmed); a
           // live one draws progressively toward its tip.
@@ -519,14 +532,9 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             );
           }
 
-          // Live (tracing) trails are full opacity; settled ones ease down to
-          // COMPLETED_OPACITY over DIM_FADE_MS (no jarring snap). Depart fade
-          // multiplies on top.
-          let settleOpacity = 1;
-          if (draw.settled && draw.settledAt !== null) {
-            const dimT = Math.min(1, (clockMs - draw.settledAt) / DIM_FADE_MS);
-            settleOpacity = 1 - (1 - COMPLETED_OPACITY) * dimT;
-          }
+          // Trails ease to COMPLETED_OPACITY after first settling and remain dim
+          // if later points resume their draw. Depart fade multiplies on top.
+          const settleOpacity = getLiveTrailOpacity(draw, clockMs);
           const groupFade = settleOpacity * departFade;
 
           const result = handle.update(

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -42,7 +42,7 @@ const MAX_DRAW_MS = 30000;
 // before removing it, so finished trails persist as a dim backdrop rather than
 // vanishing. After this it depart-fades out. (The maxGroups cap upstream also
 // bounds how many accumulate regardless.)
-const REMOVE_AFTER_DIM_MS = 20_000;
+const REMOVE_AFTER_DIM_MS = 60_000;
 
 // A removed trail fades out over this long instead of popping — matches the
 // archive's eviction fade (EVICTION_FADE_MS).
@@ -54,6 +54,19 @@ export interface LiveTrailDrawState {
   grewAt: number;
   settled: boolean;
   settledAt: number | null;
+}
+
+export function shouldDepartTrail(
+  draw: LiveTrailDrawState | undefined,
+  clockMs: number,
+  resumed = false,
+): boolean {
+  return Boolean(
+    !resumed &&
+      draw?.settled &&
+      draw.settledAt !== null &&
+      clockMs - draw.settledAt >= REMOVE_AFTER_DIM_MS,
+  );
 }
 
 export function advanceDrawState(
@@ -271,11 +284,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             live !== undefined &&
             d !== undefined &&
             live.trail.points.length > d.total;
-          const dimExpired =
-            !resumed &&
-            d?.settled &&
-            d.settledAt !== null &&
-            now - d.settledAt >= REMOVE_AFTER_DIM_MS;
+          const dimExpired = shouldDepartTrail(d, now, resumed);
           if (live && !dimExpired) {
             // Still live — refresh geometry, clear any departed mark.
             next.push({ trail: live, departedAt: null });
@@ -319,10 +328,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           for (const entry of prev) {
             const tid = entry.trail.trail.id;
             const d = draws.get(tid);
-            const dimExpired =
-              d?.settled &&
-              d.settledAt !== null &&
-              now - d.settledAt >= REMOVE_AFTER_DIM_MS;
+            const dimExpired = shouldDepartTrail(d, now);
             if (entry.departedAt === null) {
               if (dimExpired) {
                 next.push({ trail: entry.trail, departedAt: now });

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -48,6 +48,33 @@ const REMOVE_AFTER_DIM_MS = 20_000;
 // archive's eviction fade (EVICTION_FADE_MS).
 const KEEP_AFTER_DEPART_MS = EVICTION_FADE_MS;
 
+export interface LiveTrailDrawState {
+  seenAt: number;
+  total: number;
+  grewAt: number;
+  settled: boolean;
+  settledAt: number | null;
+}
+
+export function advanceDrawState(
+  draw: LiveTrailDrawState,
+  pointCount: number,
+  clockMs: number,
+  drawDuration: number,
+): void {
+  if (pointCount <= draw.total) return;
+
+  if (draw.settled) {
+    const completedProgress = Math.min(1, draw.total / pointCount);
+    draw.seenAt = clockMs - completedProgress * drawDuration;
+    draw.settled = false;
+    draw.settledAt = null;
+  }
+
+  draw.total = pointCount;
+  draw.grewAt = clockMs;
+}
+
 export function getDrawClockTime(
   performanceNow: number,
   pausedAccumMs: number,
@@ -181,18 +208,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     // draw keeps going (catches up) instead of snapping to the end. `total` and
     // `grewAt` track the latest point count and when it last grew, to decide when
     // a caught-up trail has settled.
-    const drawRef = useRef<
-      Map<
-        string,
-        {
-          seenAt: number;
-          total: number;
-          grewAt: number;
-          settled: boolean;
-          settledAt: number | null;
-        }
-      >
-    >(new Map());
+    const drawRef = useRef<Map<string, LiveTrailDrawState>>(new Map());
 
     // Trails LiveTrails keeps on screen — the current live trails plus recently
     // departed ones still fading out. Owned here (not just `trailStates`) so a
@@ -251,7 +267,12 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           // A trail that has been dimmed (settled) for REMOVE_AFTER_DIM_MS starts
           // departing even though it is still in the live data.
           const d = draws.get(id);
+          const resumed =
+            live !== undefined &&
+            d !== undefined &&
+            live.trail.points.length > d.total;
           const dimExpired =
+            !resumed &&
             d?.settled &&
             d.settledAt !== null &&
             now - d.settledAt >= REMOVE_AFTER_DIM_MS;
@@ -443,6 +464,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
 
           const pts = ts.trail.points.length;
           let draw = drawMap.get(key);
+          const drawDuration = Math.min(
+            MAX_DRAW_MS,
+            Math.max(MIN_DRAW_MS, ts.durationMs),
+          );
           if (draw === undefined) {
             // New trail: anchor its draw clock to now.
             draw = {
@@ -453,22 +478,14 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
               settledAt: null,
             };
             drawMap.set(key, draw);
-          } else if (pts > draw.total && !draw.settled) {
-            // Gained points while still live — there's more to draw, so refresh
-            // the activity clock. Once settled we IGNORE new points for liveness
-            // (a dimmed trail never brightens again, even if the person resumes).
-            draw.total = pts;
-            draw.grewAt = clockMs;
+          } else {
+            advanceDrawState(draw, pts, clockMs, drawDuration);
           }
 
           // Draw over the trail's real duration (clamped), like the archive: a
           // trail spanning 20s of activity traces over ~20s. As points arrive the
           // duration grows, so progress doesn't snap to the end — the draw keeps
           // going and naturally catches up to live.
-          const drawDuration = Math.min(
-            MAX_DRAW_MS,
-            Math.max(MIN_DRAW_MS, ts.durationMs),
-          );
           const drawProgress = Math.min(
             1,
             (clockMs - draw.seenAt) / drawDuration,

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -43,6 +43,7 @@ const DIM_FADE_MS = 1200;
 const MIN_DRAW_MS = 600;
 const MAX_DRAW_MS = 30000;
 const MAX_DRAW_SPEED_PX_PER_SECOND = 600;
+const MIN_DRAW_MS_PER_SEGMENT = 32;
 
 // Once a trail has settled (dimmed, done tracing), keep it on screen this long
 // before removing it, so finished trails persist as a dim backdrop rather than
@@ -129,9 +130,17 @@ export function advanceDrawState(
 export function getLiveDrawDuration(trailState: TrailState): number {
   const spatialDuration =
     (pathLength(trailState.variedPoints) / MAX_DRAW_SPEED_PX_PER_SECOND) * 1000;
+  const segmentDuration =
+    Math.max(0, trailState.variedPoints.length - 1) *
+    MIN_DRAW_MS_PER_SEGMENT;
   return Math.min(
     MAX_DRAW_MS,
-    Math.max(MIN_DRAW_MS, trailState.durationMs, spatialDuration),
+    Math.max(
+      MIN_DRAW_MS,
+      trailState.durationMs,
+      spatialDuration,
+      segmentDuration,
+    ),
   );
 }
 

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -16,10 +16,14 @@ import {
   TrailPath,
   TrailCursor,
   COMPLETED_OPACITY,
-  EVICTION_FADE_MS,
   type ImperativeTrailHandle,
   type ImperativeTrailCursorHandle,
 } from "./trailPrimitives";
+import {
+  getTrailVisibility,
+  startTrailVisibilityTransition,
+  type TrailVisibilityTransition,
+} from "./trailVisibility";
 
 // A trail that hasn't gained a point in this long (and has drawn up to its tip)
 // has finished tracing and settles from the live full opacity to the completed
@@ -43,10 +47,6 @@ const MAX_DRAW_MS = 30000;
 // vanishing. After this it depart-fades out. (The maxGroups cap upstream also
 // bounds how many accumulate regardless.)
 const REMOVE_AFTER_DIM_MS = 60_000;
-
-// A removed trail fades out over this long instead of popping — matches the
-// archive's eviction fade (EVICTION_FADE_MS).
-const KEEP_AFTER_DEPART_MS = EVICTION_FADE_MS;
 
 export interface LiveTrailDrawState {
   seenAt: number;
@@ -140,12 +140,11 @@ function hashKey(key: string): number {
   return Math.abs(h);
 }
 
-/** A trail LiveTrails is keeping on screen. `departedAt` is null while the trail
- * is still in the live window; once it leaves, it's the wall-clock time the fade
- * started. */
+/** A trail LiveTrails is keeping on screen, including its current arrival or
+ * departure transition. */
 interface KeptTrail {
   trail: TrailState;
-  departedAt: number | null;
+  visibility: TrailVisibilityTransition | null;
 }
 
 interface LiveTrailsProps {
@@ -237,10 +236,10 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
     // Trails LiveTrails keeps on screen — the current live trails plus recently
     // departed ones still fading out. Owned here (not just `trailStates`) so a
     // trail's lifetime is decoupled from the churning event window. Each entry
-    // tracks `departedAt` (null while still live). Updated ONLY in the effect
-    // below (never during render) so the rendered keys are always unique.
+    // tracks its current visibility transition. Updated ONLY in the effect below
+    // (never during render) so the rendered keys are always unique.
     const [kept, setKept] = useState<KeptTrail[]>(() =>
-      trailStates.map((trail) => ({ trail, departedAt: null })),
+      trailStates.map((trail) => ({ trail, visibility: null })),
     );
     const keptRef = useRef<KeptTrail[]>(kept);
 
@@ -297,12 +296,23 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             live.trail.points.length > d.total;
           const dimExpired = shouldDepartTrail(d, now, resumed);
           if (live && !dimExpired) {
-            // Still live — refresh geometry, clear any departed mark.
-            next.push({ trail: live, departedAt: null });
-          } else if (entry.departedAt === null) {
+            // Still live — refresh geometry and ease back if it was departing.
+            const visibility =
+              entry.visibility?.toOpacity === 0
+                ? startTrailVisibilityTransition(entry.visibility, now, true)
+                : entry.visibility;
+            next.push({ trail: live, visibility });
+          } else if (entry.visibility?.toOpacity !== 0) {
             // Left, or dimmed long enough — start its fade.
-            next.push({ trail: live ?? entry.trail, departedAt: now });
-          } else if (now - entry.departedAt < KEEP_AFTER_DEPART_MS) {
+            next.push({
+              trail: live ?? entry.trail,
+              visibility: startTrailVisibilityTransition(
+                entry.visibility,
+                now,
+                false,
+              ),
+            });
+          } else if (getTrailVisibility(entry.visibility, now) > 0) {
             // Still fading — keep.
             next.push(entry);
           } else {
@@ -315,7 +325,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         // Brand-new live trails not already in `kept`.
         for (const t of trailStates) {
           if (!handled.has(t.trail.id)) {
-            next.push({ trail: t, departedAt: null });
+            next.push({ trail: t, visibility: null });
           }
         }
         return next;
@@ -340,14 +350,21 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             const tid = entry.trail.trail.id;
             const d = draws.get(tid);
             const dimExpired = shouldDepartTrail(d, now);
-            if (entry.departedAt === null) {
-              if (dimExpired) {
-                next.push({ trail: entry.trail, departedAt: now });
-                changed = true;
-              } else {
-                next.push(entry);
-              }
-            } else if (now - entry.departedAt < KEEP_AFTER_DEPART_MS) {
+            const departing = entry.visibility?.toOpacity === 0;
+            if (dimExpired && !departing) {
+              next.push({
+                trail: entry.trail,
+                visibility: startTrailVisibilityTransition(
+                  entry.visibility,
+                  now,
+                  false,
+                ),
+              });
+              changed = true;
+            } else if (
+              !departing ||
+              getTrailVisibility(entry.visibility, now) > 0
+            ) {
               next.push(entry);
             } else {
               // Fully faded — drop, and report so its events can be freed.
@@ -522,20 +539,12 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           // live one draws progressively toward its tip.
           const progress = draw.settled ? 1 : drawProgress;
 
-          // Departed trails fade from their current opacity to 0 over the keep
-          // window, then the reconcile effect drops them.
-          let departFade = 1;
-          if (entry.departedAt !== null) {
-            departFade = Math.max(
-              0,
-              1 - (clockMs - entry.departedAt) / KEEP_AFTER_DEPART_MS,
-            );
-          }
-
           // Trails ease to COMPLETED_OPACITY after first settling and remain dim
-          // if later points resume their draw. Depart fade multiplies on top.
+          // if later points resume their draw. Visibility transitions multiply
+          // on top for smooth departure and return.
           const settleOpacity = getLiveTrailOpacity(draw, clockMs);
-          const groupFade = settleOpacity * departFade;
+          const visibility = getTrailVisibility(entry.visibility, clockMs);
+          const groupFade = settleOpacity * visibility;
 
           const result = handle.update(
             0,
@@ -549,7 +558,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             result &&
             !caughtUp &&
             !draw.settled &&
-            entry.departedAt === null;
+            entry.visibility?.toOpacity !== 0;
           if (soundEngine && activelyTracing) {
             let soundTrailIndex = soundTrailIndicesRef.current.get(key);
             if (soundTrailIndex === undefined) {
@@ -603,7 +612,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             result.cursorPosition &&
             !caughtUp &&
             !draw.settled &&
-            entry.departedAt === null
+            entry.visibility?.toOpacity !== 0
           ) {
             const cpIdx = Math.min(
               Math.floor((pts - 1) * (result.trailProgress ?? progress)),

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -8,7 +8,7 @@ import React, {
   useMemo,
   useCallback,
 } from "react";
-import { CollectionEvent, Trail } from "../types";
+import { CollectionEvent } from "../types";
 import { Controls } from "./Controls";
 import { AnimatedTrails } from "./AnimatedTrails";
 import { LiveTrails } from "./LiveTrails";
@@ -24,7 +24,10 @@ import { DaySelector } from "./DaySelector";
 import { ActivityStrip } from "./ActivityStrip";
 import { StatsConsole } from "./StatsConsole";
 import { DebugHoverProvider } from "./DebugHover";
-import { useCursorTrails } from "../hooks/useCursorTrails";
+import {
+  getAccumulationEvictions,
+  useCursorTrails,
+} from "../hooks/useCursorTrails";
 import { useAccumulatedEvents } from "../hooks/useAccumulatedEvents";
 import { useKeyboardTyping } from "../hooks/useKeyboardTyping";
 import { useViewportScroll } from "../hooks/useViewportScroll";
@@ -494,7 +497,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       ? settings.filters
       : [];
     if (filtersKey(filtersProp) !== filtersKey(cur)) {
-      setSettings((s: any) => ({ ...s, filters: filtersProp }));
+      setSettings((s) => ({ ...s, filters: filtersProp }));
     }
   }, [filtersProp]);
 
@@ -844,7 +847,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     const allowed = new Set(availableDomains);
     const next = cur.filter((c) => !c.domain || allowed.has(c.domain));
     if (next.length !== cur.length) {
-      setSettings((s: any) => ({ ...s, filters: next }));
+      setSettings((s) => ({ ...s, filters: next }));
     }
   }, [events.length]);
 
@@ -886,9 +889,6 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   // archive's event set is fixed, so it bypasses accumulation. A group's events
   // are freed when its trail has fully faded out (LiveTrails reports the id).
   const evictIdsRef = useRef<Set<string>>(new Set());
-  const handleTrailsRemoved = useCallback((ids: string[]) => {
-    for (const id of ids) evictIdsRef.current.add(id);
-  }, []);
   const trailEvents = useAccumulatedEvents(filteredEvents, {
     enabled: live,
     maxGroups: 60,
@@ -912,9 +912,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       overlapFactor: settings.overlapFactor,
       minGapBetweenTrails: settings.minGapBetweenTrails,
       documentSpace: settings.documentSpace,
-      // Live mode collapses each participant+url to one trail so ids stay
-      // unique/stable as the event window slides (the archive shows every
-      // segment). Prevents duplicate React keys and disappearing trails.
+      // Live mode renders only the latest segment for each participant+url.
+      // Each segment keeps its own identity while its accumulated points grow.
       singleSegmentPerGroup: live,
     }),
     [
@@ -939,6 +938,18 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     timeBounds: cursorTimeBounds,
     cycleDuration: cursorCycleDuration,
   } = useCursorTrails(activeTrailEvents, viewportSize, cursorSettings);
+  const activeTrailIds = useMemo(
+    () => new Set(trailStates.map(({ trail }) => trail.id)),
+    [trailStates],
+  );
+  const handleTrailsRemoved = useCallback(
+    (ids: string[]) => {
+      for (const groupId of getAccumulationEvictions(ids, activeTrailIds)) {
+        evictIdsRef.current.add(groupId);
+      }
+    },
+    [activeTrailIds],
+  );
   const renderedTrailStates = useArchiveTrailHandoff(
     trailStates,
     playbackKey,

--- a/extension/website/shared/components/__tests__/AnimatedTrails.test.tsx
+++ b/extension/website/shared/components/__tests__/AnimatedTrails.test.tsx
@@ -1,5 +1,6 @@
 // ABOUTME: Tests archive trail audio behavior across active and silent frames.
 // ABOUTME: Verifies inactive playback releases sustained sound-engine voices.
+// @vitest-environment jsdom
 
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";

--- a/extension/website/shared/components/__tests__/ClickRipple.test.ts
+++ b/extension/website/shared/components/__tests__/ClickRipple.test.ts
@@ -1,11 +1,8 @@
 // ABOUTME: Tests click and hold ripple timing independently from React animation scheduling.
-// ABOUTME: Covers bounded hold scaling and the visible fade at ripple completion.
+// ABOUTME: Covers bounded hold scaling and persistent residue after expansion.
 
 import { describe, expect, it } from "vitest";
-import {
-  RIPPLE_FADE_MS,
-  getRippleLifecycle,
-} from "../ClickRipple";
+import { getRippleLifecycle } from "../ClickRipple";
 import { CLICK_DEFAULTS } from "../clickDefaults";
 
 describe("getRippleLifecycle", () => {
@@ -32,7 +29,7 @@ describe("getRippleLifecycle", () => {
     );
   });
 
-  it("fades a completed ripple to transparent before removing it", () => {
+  it("keeps a completed ripple visible as trail residue", () => {
     const effect = {
       id: "click",
       x: 0,
@@ -43,24 +40,18 @@ describe("getRippleLifecycle", () => {
       startTime: 1000,
       trailIndex: 0,
     };
-    const completionTime = effect.startTime + CLICK_DEFAULTS.clickMinDuration;
+    const completionTime =
+      effect.startTime + CLICK_DEFAULTS.clickMinDuration + 10_000;
 
     expect(
-      getRippleLifecycle(effect, CLICK_DEFAULTS, completionTime).opacity,
-    ).toBe(CLICK_DEFAULTS.clickOpacity);
-    expect(
       getRippleLifecycle(
         effect,
         CLICK_DEFAULTS,
-        completionTime + RIPPLE_FADE_MS / 2,
-      ).opacity,
-    ).toBeCloseTo(CLICK_DEFAULTS.clickOpacity / 2);
-    expect(
-      getRippleLifecycle(
-        effect,
-        CLICK_DEFAULTS,
-        completionTime + RIPPLE_FADE_MS,
+        completionTime,
       ),
-    ).toMatchObject({ opacity: 0, complete: true });
+    ).toMatchObject({
+      opacity: CLICK_DEFAULTS.clickOpacity,
+      complete: true,
+    });
   });
 });

--- a/extension/website/shared/components/__tests__/ClickRipple.test.ts
+++ b/extension/website/shared/components/__tests__/ClickRipple.test.ts
@@ -1,0 +1,66 @@
+// ABOUTME: Tests click and hold ripple timing independently from React animation scheduling.
+// ABOUTME: Covers bounded hold scaling and the visible fade at ripple completion.
+
+import { describe, expect, it } from "vitest";
+import {
+  RIPPLE_FADE_MS,
+  getRippleLifecycle,
+} from "../ClickRipple";
+import { CLICK_DEFAULTS } from "../clickDefaults";
+
+describe("getRippleLifecycle", () => {
+  it("caps very long holds at three times the normal size and duration", () => {
+    const lifecycle = getRippleLifecycle(
+      {
+        id: "long-hold",
+        x: 0,
+        y: 0,
+        color: "#000",
+        radiusFactor: 0.5,
+        durationFactor: 0.5,
+        startTime: 1000,
+        trailIndex: 0,
+        holdDuration: 20 * 60 * 1000,
+      },
+      CLICK_DEFAULTS,
+      1000,
+    );
+
+    expect(lifecycle.holdMultiplier).toBe(3);
+    expect(lifecycle.expansionDuration).toBe(
+      CLICK_DEFAULTS.clickExpansionDuration * 3,
+    );
+  });
+
+  it("fades a completed ripple to transparent before removing it", () => {
+    const effect = {
+      id: "click",
+      x: 0,
+      y: 0,
+      color: "#000",
+      radiusFactor: 0.5,
+      durationFactor: 0,
+      startTime: 1000,
+      trailIndex: 0,
+    };
+    const completionTime = effect.startTime + CLICK_DEFAULTS.clickMinDuration;
+
+    expect(
+      getRippleLifecycle(effect, CLICK_DEFAULTS, completionTime).opacity,
+    ).toBe(CLICK_DEFAULTS.clickOpacity);
+    expect(
+      getRippleLifecycle(
+        effect,
+        CLICK_DEFAULTS,
+        completionTime + RIPPLE_FADE_MS / 2,
+      ).opacity,
+    ).toBeCloseTo(CLICK_DEFAULTS.clickOpacity / 2);
+    expect(
+      getRippleLifecycle(
+        effect,
+        CLICK_DEFAULTS,
+        completionTime + RIPPLE_FADE_MS,
+      ),
+    ).toMatchObject({ opacity: 0, complete: true });
+  });
+});

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -14,6 +14,7 @@ import {
   createLiveSoundFrame,
   getActiveTrailOpacity,
   getDrawClockTime,
+  getLiveDrawDuration,
   getLiveTrailOpacity,
   LiveTrails,
   shouldDepartTrail,
@@ -27,7 +28,7 @@ import {
 } from "../trailVisibility";
 import {
   collectDueClickEffects,
-  removeCompletedClickEffect,
+  retainClickEffectsForActiveTrails,
 } from "../clickEffects";
 
 describe("advanceDrawState", () => {
@@ -35,31 +36,69 @@ describe("advanceDrawState", () => {
     const draw = {
       seenAt: 0,
       total: 2,
+      variedTotal: 5,
+      drawProgress: 1,
       grewAt: 1000,
       caughtUpAt: 5000,
       settled: true,
       settledAt: 9000,
       dimmedAt: 9000,
-      activeFromPoint: null,
+      activeFromVariedPoint: null,
       activeDimmedAt: null,
     };
 
-    advanceDrawState(draw, 4, 10_000, 4000);
+    advanceDrawState(draw, 4, 10, 10_000, 4000);
 
     expect(draw).toEqual({
-      seenAt: 8000,
+      seenAt: 8222.222222222223,
       total: 4,
+      variedTotal: 10,
+      drawProgress: 4 / 9,
       grewAt: 10_000,
       caughtUpAt: null,
       settled: false,
       settledAt: null,
       dimmedAt: 9000,
-      activeFromPoint: 1,
+      activeFromVariedPoint: 4,
       activeDimmedAt: null,
     });
 
     expect(getLiveTrailOpacity(draw, 11_000)).toBe(COMPLETED_OPACITY);
     expect(getActiveTrailOpacity(draw, 11_000)).toBe(1);
+  });
+
+  it("preserves the current draw head when an unfinished trail grows", () => {
+    const draw = {
+      seenAt: 0,
+      total: 6,
+      variedTotal: 11,
+      drawProgress: 0.5,
+      grewAt: 1000,
+      caughtUpAt: null,
+      settled: false,
+      settledAt: null,
+      dimmedAt: null,
+      activeFromVariedPoint: null,
+      activeDimmedAt: null,
+    };
+
+    advanceDrawState(draw, 11, 21, 10_000, 4000);
+
+    expect(draw.seenAt).toBe(9000);
+    expect(draw.variedTotal).toBe(21);
+  });
+});
+
+describe("getLiveDrawDuration", () => {
+  it("slows a spatially long trail to at most 600 pixels per second", () => {
+    const state = trailState();
+    state.durationMs = 600;
+    state.variedPoints = [
+      { x: 0, y: 0 },
+      { x: 1200, y: 0 },
+    ];
+
+    expect(getLiveDrawDuration(state)).toBe(2000);
   });
 });
 
@@ -73,7 +112,7 @@ describe("advanceSettlingState", () => {
       settled: false,
       settledAt: null,
       dimmedAt: null,
-      activeFromPoint: null,
+      activeFromVariedPoint: null,
       activeDimmedAt: null,
     };
 
@@ -99,13 +138,13 @@ describe("advanceSettlingState", () => {
       settled: false,
       settledAt: null,
       dimmedAt: 1000,
-      activeFromPoint: 1,
+      activeFromVariedPoint: 1,
       activeDimmedAt: null,
     };
 
     advanceSettlingState(draw, true, 18_000);
 
-    expect(draw.activeFromPoint).toBe(1);
+    expect(draw.activeFromVariedPoint).toBe(1);
     expect(draw.activeDimmedAt).toBe(18_000);
     expect(getActiveTrailOpacity(draw, 18_000)).toBe(1);
     expect(getActiveTrailOpacity(draw, 19_200)).toBe(0);
@@ -116,12 +155,14 @@ describe("shouldDepartTrail", () => {
   const settledDraw = {
     seenAt: 0,
     total: 2,
+    variedTotal: 2,
+    drawProgress: 1,
     grewAt: 1000,
     caughtUpAt: 1000,
     settled: true,
     settledAt: 10_000,
     dimmedAt: 10_000,
-    activeFromPoint: null,
+    activeFromVariedPoint: null,
     activeDimmedAt: null,
   };
 
@@ -250,16 +291,15 @@ describe("collectDueClickEffects", () => {
       ),
     ).toEqual([]);
 
-    const secondEffect = {
-      ...firstEffects[0],
-      id: "second-effect",
-    };
     expect(
-      removeCompletedClickEffect(
-        [...firstEffects, secondEffect],
-        firstEffects[0].id,
+      retainClickEffectsForActiveTrails(firstEffects, new Set(["other-trail"])),
+    ).toBe(firstEffects);
+    expect(
+      retainClickEffectsForActiveTrails(
+        firstEffects,
+        new Set(["participant|https://example.com"]),
       ),
-    ).toEqual([secondEffect]);
+    ).toEqual([]);
 
     random.mockRestore();
   });

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -1,5 +1,6 @@
 // ABOUTME: Tests click spawning and lifecycle timing for the live cursor-trail renderer.
 // ABOUTME: Covers one-shot effects and clock pauses while the document is hidden.
+// @vitest-environment jsdom
 
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
@@ -8,6 +9,7 @@ import type { TrailState } from "../../types";
 import type { SoundEngine } from "../../sound/SoundEngine";
 import { DEFAULT_SETTINGS } from "../settingsDefaults";
 import {
+  advanceDrawState,
   createLiveSoundFrame,
   getDrawClockTime,
   LiveTrails,
@@ -16,6 +18,28 @@ import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
 } from "../clickEffects";
+
+describe("advanceDrawState", () => {
+  it("continues a settled trail from its already-drawn portion when it grows", () => {
+    const draw = {
+      seenAt: 0,
+      total: 2,
+      grewAt: 1000,
+      settled: true,
+      settledAt: 9000,
+    };
+
+    advanceDrawState(draw, 4, 10_000, 4000);
+
+    expect(draw).toEqual({
+      seenAt: 8000,
+      total: 4,
+      grewAt: 10_000,
+      settled: false,
+      settledAt: null,
+    });
+  });
+});
 
 function trailState(): TrailState {
   return {

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -100,6 +100,17 @@ describe("getLiveDrawDuration", () => {
 
     expect(getLiveDrawDuration(state)).toBe(2000);
   });
+
+  it("gives every rendered segment enough time to remain perceptible", () => {
+    const state = trailState();
+    state.durationMs = 600;
+    state.variedPoints = Array.from({ length: 101 }, (_, index) => ({
+      x: index,
+      y: 0,
+    }));
+
+    expect(getLiveDrawDuration(state)).toBe(3200);
+  });
 });
 
 describe("advanceSettlingState", () => {

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -18,6 +18,12 @@ import {
 } from "../LiveTrails";
 import { COMPLETED_OPACITY } from "../trailPrimitives";
 import {
+  DEPART_FADE_MS,
+  getTrailVisibility,
+  RETURN_FADE_MS,
+  startTrailVisibilityTransition,
+} from "../trailVisibility";
+import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
 } from "../clickEffects";
@@ -65,6 +71,28 @@ describe("shouldDepartTrail", () => {
 
   it("does not depart a trail that has resumed", () => {
     expect(shouldDepartTrail(settledDraw, 70_000, true)).toBe(false);
+  });
+});
+
+describe("trail visibility transitions", () => {
+  it("fades a departing trail over eight seconds", () => {
+    const transition = startTrailVisibilityTransition(null, 1000, false);
+
+    expect(transition.durationMs).toBe(DEPART_FADE_MS);
+    expect(getTrailVisibility(transition, 1000)).toBe(1);
+    expect(getTrailVisibility(transition, 5000)).toBe(0.5);
+    expect(getTrailVisibility(transition, 9000)).toBe(0);
+  });
+
+  it("eases a returning trail from its current opacity without a jump", () => {
+    const departure = startTrailVisibilityTransition(null, 1000, false);
+    const visibilityAtReturn = getTrailVisibility(departure, 5000);
+    const returning = startTrailVisibilityTransition(departure, 5000, true);
+
+    expect(returning.durationMs).toBe(RETURN_FADE_MS);
+    expect(getTrailVisibility(returning, 5000)).toBe(visibilityAtReturn);
+    expect(getTrailVisibility(returning, 7000)).toBe(0.75);
+    expect(getTrailVisibility(returning, 9000)).toBe(1);
   });
 });
 

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -13,6 +13,7 @@ import {
   createLiveSoundFrame,
   getDrawClockTime,
   LiveTrails,
+  shouldDepartTrail,
 } from "../LiveTrails";
 import {
   collectDueClickEffects,
@@ -38,6 +39,25 @@ describe("advanceDrawState", () => {
       settled: false,
       settledAt: null,
     });
+  });
+});
+
+describe("shouldDepartTrail", () => {
+  const settledDraw = {
+    seenAt: 0,
+    total: 2,
+    grewAt: 1000,
+    settled: true,
+    settledAt: 10_000,
+  };
+
+  it("keeps a settled trail for 60 seconds before departure", () => {
+    expect(shouldDepartTrail(settledDraw, 69_999)).toBe(false);
+    expect(shouldDepartTrail(settledDraw, 70_000)).toBe(true);
+  });
+
+  it("does not depart a trail that has resumed", () => {
+    expect(shouldDepartTrail(settledDraw, 70_000, true)).toBe(false);
   });
 });
 

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -10,7 +10,9 @@ import type { SoundEngine } from "../../sound/SoundEngine";
 import { DEFAULT_SETTINGS } from "../settingsDefaults";
 import {
   advanceDrawState,
+  advanceSettlingState,
   createLiveSoundFrame,
+  getActiveTrailOpacity,
   getDrawClockTime,
   getLiveTrailOpacity,
   LiveTrails,
@@ -34,9 +36,12 @@ describe("advanceDrawState", () => {
       seenAt: 0,
       total: 2,
       grewAt: 1000,
+      caughtUpAt: 5000,
       settled: true,
       settledAt: 9000,
       dimmedAt: 9000,
+      activeFromPoint: null,
+      activeDimmedAt: null,
     };
 
     advanceDrawState(draw, 4, 10_000, 4000);
@@ -45,12 +50,65 @@ describe("advanceDrawState", () => {
       seenAt: 8000,
       total: 4,
       grewAt: 10_000,
+      caughtUpAt: null,
       settled: false,
       settledAt: null,
       dimmedAt: 9000,
+      activeFromPoint: 1,
+      activeDimmedAt: null,
     });
 
     expect(getLiveTrailOpacity(draw, 11_000)).toBe(COMPLETED_OPACITY);
+    expect(getActiveTrailOpacity(draw, 11_000)).toBe(1);
+  });
+});
+
+describe("advanceSettlingState", () => {
+  it("waits until a trail has been fully drawn for eight seconds", () => {
+    const draw = {
+      seenAt: 0,
+      total: 20,
+      grewAt: 0,
+      caughtUpAt: null,
+      settled: false,
+      settledAt: null,
+      dimmedAt: null,
+      activeFromPoint: null,
+      activeDimmedAt: null,
+    };
+
+    advanceSettlingState(draw, false, 20_000);
+    advanceSettlingState(draw, true, 30_000);
+    expect(draw.settled).toBe(false);
+
+    advanceSettlingState(draw, true, 37_999);
+    expect(draw.settled).toBe(false);
+
+    advanceSettlingState(draw, true, 38_000);
+    expect(draw.settled).toBe(true);
+    expect(draw.settledAt).toBe(38_000);
+    expect(draw.dimmedAt).toBe(38_000);
+  });
+
+  it("fades only the resumed portion when an active trail settles again", () => {
+    const draw = {
+      seenAt: 0,
+      total: 4,
+      grewAt: 0,
+      caughtUpAt: 10_000,
+      settled: false,
+      settledAt: null,
+      dimmedAt: 1000,
+      activeFromPoint: 1,
+      activeDimmedAt: null,
+    };
+
+    advanceSettlingState(draw, true, 18_000);
+
+    expect(draw.activeFromPoint).toBe(1);
+    expect(draw.activeDimmedAt).toBe(18_000);
+    expect(getActiveTrailOpacity(draw, 18_000)).toBe(1);
+    expect(getActiveTrailOpacity(draw, 19_200)).toBe(0);
   });
 });
 
@@ -59,9 +117,12 @@ describe("shouldDepartTrail", () => {
     seenAt: 0,
     total: 2,
     grewAt: 1000,
+    caughtUpAt: 1000,
     settled: true,
     settledAt: 10_000,
     dimmedAt: 10_000,
+    activeFromPoint: null,
+    activeDimmedAt: null,
   };
 
   it("keeps a settled trail for 60 seconds before departure", () => {

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../trailVisibility";
 import {
   collectDueClickEffects,
-  retainClickEffectsForActiveTrails,
+  removeCompletedClickEffect,
 } from "../clickEffects";
 
 describe("advanceDrawState", () => {
@@ -250,15 +250,16 @@ describe("collectDueClickEffects", () => {
       ),
     ).toEqual([]);
 
+    const secondEffect = {
+      ...firstEffects[0],
+      id: "second-effect",
+    };
     expect(
-      retainClickEffectsForActiveTrails(firstEffects, new Set(["other-trail"])),
-    ).toBe(firstEffects);
-    expect(
-      retainClickEffectsForActiveTrails(
-        firstEffects,
-        new Set(["participant|https://example.com"]),
+      removeCompletedClickEffect(
+        [...firstEffects, secondEffect],
+        firstEffects[0].id,
       ),
-    ).toEqual([]);
+    ).toEqual([secondEffect]);
 
     random.mockRestore();
   });

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -12,9 +12,11 @@ import {
   advanceDrawState,
   createLiveSoundFrame,
   getDrawClockTime,
+  getLiveTrailOpacity,
   LiveTrails,
   shouldDepartTrail,
 } from "../LiveTrails";
+import { COMPLETED_OPACITY } from "../trailPrimitives";
 import {
   collectDueClickEffects,
   retainClickEffectsForActiveTrails,
@@ -28,6 +30,7 @@ describe("advanceDrawState", () => {
       grewAt: 1000,
       settled: true,
       settledAt: 9000,
+      dimmedAt: 9000,
     };
 
     advanceDrawState(draw, 4, 10_000, 4000);
@@ -38,7 +41,10 @@ describe("advanceDrawState", () => {
       grewAt: 10_000,
       settled: false,
       settledAt: null,
+      dimmedAt: 9000,
     });
+
+    expect(getLiveTrailOpacity(draw, 11_000)).toBe(COMPLETED_OPACITY);
   });
 });
 
@@ -49,6 +55,7 @@ describe("shouldDepartTrail", () => {
     grewAt: 1000,
     settled: true,
     settledAt: 10_000,
+    dimmedAt: 10_000,
   };
 
   it("keeps a settled trail for 60 seconds before departure", () => {

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -111,6 +111,17 @@ describe("getLiveDrawDuration", () => {
 
     expect(getLiveDrawDuration(state)).toBe(3200);
   });
+
+  it("does not cap the perceptible segment duration for very long trails", () => {
+    const state = trailState();
+    state.durationMs = 600;
+    state.variedPoints = Array.from({ length: 1001 }, (_, index) => ({
+      x: index,
+      y: 0,
+    }));
+
+    expect(getLiveDrawDuration(state)).toBe(32000);
+  });
 });
 
 describe("advanceSettlingState", () => {

--- a/extension/website/shared/components/clickEffects.ts
+++ b/extension/website/shared/components/clickEffects.ts
@@ -57,12 +57,9 @@ export function collectDueClickEffects(
   return effects;
 }
 
-export function retainClickEffectsForActiveTrails(
+export function removeCompletedClickEffect(
   effects: LiveClickEffect[],
-  removedTrailIds: Set<string>,
+  completedId: string,
 ): LiveClickEffect[] {
-  const retained = effects.filter(
-    (effect) => !removedTrailIds.has(effect.trailId),
-  );
-  return retained.length === effects.length ? effects : retained;
+  return effects.filter((effect) => effect.id !== completedId);
 }

--- a/extension/website/shared/components/clickEffects.ts
+++ b/extension/website/shared/components/clickEffects.ts
@@ -57,9 +57,12 @@ export function collectDueClickEffects(
   return effects;
 }
 
-export function removeCompletedClickEffect(
+export function retainClickEffectsForActiveTrails(
   effects: LiveClickEffect[],
-  completedId: string,
+  removedTrailIds: Set<string>,
 ): LiveClickEffect[] {
-  return effects.filter((effect) => effect.id !== completedId);
+  const retained = effects.filter(
+    (effect) => !removedTrailIds.has(effect.trailId),
+  );
+  return retained.length === effects.length ? effects : retained;
 }

--- a/extension/website/shared/components/trailPrimitives.tsx
+++ b/extension/website/shared/components/trailPrimitives.tsx
@@ -102,6 +102,44 @@ export function computeTrailFrame(
   };
 }
 
+export function computeTrailSegmentPath(
+  trailState: TrailState,
+  startProgress: number,
+  endProgress: number,
+  strokeSize: number,
+): string {
+  const points = trailState.variedPoints;
+  if (points.length < 2 || endProgress <= startProgress) return "";
+
+  const lastIndex = points.length - 1;
+  const clampedStart = Math.min(1, Math.max(0, startProgress));
+  const clampedEnd = Math.min(1, Math.max(0, endProgress));
+  const exactEnd = lastIndex * clampedEnd;
+  const endIndex = Math.floor(exactEnd);
+  const endFraction = exactEnd - endIndex;
+  const startIndex = Math.max(0, Math.floor(lastIndex * clampedStart) - 1);
+  const interpolatedHead =
+    endIndex < lastIndex && endFraction > 0
+      ? {
+          x:
+            points[endIndex].x +
+            (points[endIndex + 1].x - points[endIndex].x) * endFraction,
+          y:
+            points[endIndex].y +
+            (points[endIndex + 1].y - points[endIndex].y) * endFraction,
+        }
+      : undefined;
+
+  return buildFreehandPathSegment(
+    points,
+    startIndex,
+    Math.min(endIndex, lastIndex),
+    strokeSize,
+    clampedEnd >= 1,
+    interpolatedHead,
+  );
+}
+
 // Imperatively-updated trail. Renders SVG structure once on mount, then the
 // parent rAF loop updates DOM attributes directly via the ref handle.
 // Path and cursor are rendered as siblings (not nested) so they can live in
@@ -115,6 +153,11 @@ export interface ImperativeTrailHandle {
     // Live animator passes 0..1 directly so the frame doesn't depend on this
     // handle's `trailState.startOffsetMs` matching the caller's.
     progressOverride?: number,
+    activeSegment?: {
+      startProgress: number;
+      baseProgress: number;
+      opacity: number;
+    },
   ): { trailProgress: number; cursorPosition: { x: number; y: number } } | null;
   getGroup(): SVGGElement | null;
   hide(): void;
@@ -133,6 +176,8 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
     const groupRef = useRef<SVGGElement>(null);
     const pathRef = useRef<SVGPathElement>(null);
     const haloRef = useRef<SVGPathElement>(null);
+    const activePathRef = useRef<SVGPathElement>(null);
+    const activeHaloRef = useRef<SVGPathElement>(null);
     const lastGroupOpacityRef = useRef("");
     const lastPathDataRef = useRef("");
     const lastRendererIdRef = useRef("");
@@ -140,6 +185,9 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
     const lastStrokeWidthRef = useRef<number | null>(null);
     const lastCursorTypeRef = useRef<string | undefined>(undefined);
     const lastTrailColorRef = useRef("");
+    const lastActivePathDataRef = useRef("");
+    const lastActiveRendererIdRef = useRef("");
+    const lastActiveOpacityRef = useRef<number | null>(null);
     const finishedFrameRef = useRef<ReturnType<typeof computeTrailFrame>>(null);
     const finishedFrameSizeRef = useRef<number | null>(null);
 
@@ -152,6 +200,9 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
       lastStrokeWidthRef.current = null;
       lastCursorTypeRef.current = undefined;
       lastTrailColorRef.current = "";
+      lastActivePathDataRef.current = "";
+      lastActiveRendererIdRef.current = "";
+      lastActiveOpacityRef.current = null;
     }, [trailState]);
 
     const hideTrail = useCallback(() => {
@@ -169,7 +220,14 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
         getGroup() {
           return groupRef.current;
         },
-        update(elapsedTimeMs, trailOpacity, strokeWidth, evictionFade, progressOverride) {
+        update(
+          elapsedTimeMs,
+          trailOpacity,
+          strokeWidth,
+          evictionFade,
+          progressOverride,
+          activeSegment,
+        ) {
           const group = groupRef.current;
           if (!group) return null;
 
@@ -188,7 +246,9 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
               ? progressOverride >= 1
               : elapsedTimeMs - trailState.startOffsetMs >= trailState.durationMs;
           let frame =
-            isPastEnd && finishedFrameSizeRef.current === strokeSize
+            isPastEnd &&
+            !activeSegment &&
+            finishedFrameSizeRef.current === strokeSize
               ? finishedFrameRef.current
               : null;
           if (!frame) {
@@ -215,7 +275,16 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
             lastGroupOpacityRef.current = groupOpacity;
           }
 
-          const { pathData, trailProgress, cursorPosition } = frame;
+          const { trailProgress, cursorPosition } = frame;
+          const baseFrame = activeSegment
+            ? computeTrailFrame(
+                trailState,
+                elapsedTimeMs,
+                strokeSize,
+                activeSegment.baseProgress,
+              )
+            : frame;
+          const pathData = baseFrame?.pathData ?? "";
 
           const pathEl = pathRef.current;
           if (pathEl) {
@@ -253,6 +322,54 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
             }
           }
 
+          const activePathEl = activePathRef.current;
+          if (activePathEl && activeSegment) {
+            const activePathData = computeTrailSegmentPath(
+              trailState,
+              activeSegment.startProgress,
+              trailProgress,
+              strokeSize,
+            );
+            if (activePathData) {
+              if (
+                lastActivePathDataRef.current !== activePathData ||
+                lastActiveRendererIdRef.current !== renderer.id ||
+                lastActiveOpacityRef.current !== activeSegment.opacity ||
+                lastStrokeWidthRef.current !== strokeWidth ||
+                lastCursorTypeRef.current !== frame.cursorType ||
+                lastTrailColorRef.current !== trailState.trail.color
+              ) {
+                renderer.updatePath({
+                  pathEl: activePathEl,
+                  haloEl: activeHaloRef.current,
+                  pathData: activePathData,
+                  trailOpacity: activeSegment.opacity,
+                  strokeWidth,
+                  cursorType: frame.cursorType,
+                  trailProgress,
+                  trailColor: trailState.trail.color,
+                  fixedMonoStrokeWidth,
+                });
+                lastActivePathDataRef.current = activePathData;
+                lastActiveRendererIdRef.current = renderer.id;
+                lastActiveOpacityRef.current = activeSegment.opacity;
+              }
+            } else {
+              activePathEl.style.display = "none";
+              if (activeHaloRef.current) {
+                activeHaloRef.current.style.display = "none";
+              }
+              lastActivePathDataRef.current = "";
+            }
+          } else if (activePathEl) {
+            activePathEl.style.display = "none";
+            if (activeHaloRef.current) {
+              activeHaloRef.current.style.display = "none";
+            }
+            lastActivePathDataRef.current = "";
+            lastActiveOpacityRef.current = null;
+          }
+
           return { trailProgress, cursorPosition };
         },
       }),
@@ -270,6 +387,13 @@ export const TrailPath = React.forwardRef<ImperativeTrailHandle, TrailPathProps>
           style={{ display: "none" }}
         />
         <path ref={pathRef} fill={color} style={{ display: "none" }} />
+        <path
+          ref={activeHaloRef}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ display: "none" }}
+        />
+        <path ref={activePathRef} fill={color} style={{ display: "none" }} />
       </g>
     );
   },

--- a/extension/website/shared/components/trailVisibility.ts
+++ b/extension/website/shared/components/trailVisibility.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Calculates smooth visibility transitions for live cursor trails.
+// ABOUTME: Preserves the current opacity when a departure reverses into a return.
+
+export const DEPART_FADE_MS = 8000;
+export const RETURN_FADE_MS = 4000;
+
+export interface TrailVisibilityTransition {
+  startedAt: number;
+  fromOpacity: number;
+  toOpacity: number;
+  durationMs: number;
+}
+
+export function getTrailVisibility(
+  transition: TrailVisibilityTransition | null,
+  clockMs: number,
+): number {
+  if (transition === null) return 1;
+
+  const progress = Math.max(
+    0,
+    Math.min(1, (clockMs - transition.startedAt) / transition.durationMs),
+  );
+  return (
+    transition.fromOpacity +
+    (transition.toOpacity - transition.fromOpacity) * progress
+  );
+}
+
+export function startTrailVisibilityTransition(
+  current: TrailVisibilityTransition | null,
+  clockMs: number,
+  visible: boolean,
+): TrailVisibilityTransition {
+  return {
+    startedAt: clockMs,
+    fromOpacity: getTrailVisibility(current, clockMs),
+    toOpacity: visible ? 1 : 0,
+    durationMs: visible ? RETURN_FADE_MS : DEPART_FADE_MS,
+  };
+}

--- a/extension/website/shared/hooks/__tests__/accumulateEvents.test.ts
+++ b/extension/website/shared/hooks/__tests__/accumulateEvents.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect } from "vitest";
 import {
   accumulateEvents,
+  collectFinishedEventIds,
   type AccumulatedGroups,
 } from "../useAccumulatedEvents";
 import type { CollectionEvent } from "../../types";
@@ -66,6 +67,63 @@ describe("accumulateEvents", () => {
     acc = accumulateEvents(acc, [], ["p1|u1"]);
     expect(acc.has("p1|u1")).toBe(false);
     expect(acc.has("p2|u2")).toBe(true);
+  });
+
+  it("does not rebuild an evicted group from events still in the incoming window", () => {
+    const buffered = [
+      ev("a", "p1", "u1", 100),
+      ev("b", "p1", "u1", 200),
+      ev("c", "p2", "u2", 300),
+    ];
+    let acc: AccumulatedGroups = accumulateEvents(new Map(), buffered);
+    let finishedEventIds = collectFinishedEventIds(
+      new Set(),
+      acc,
+      buffered,
+      ["p1|u1"],
+    );
+
+    acc = accumulateEvents(
+      acc,
+      buffered,
+      ["p1|u1"],
+      undefined,
+      finishedEventIds,
+    );
+
+    expect(acc.has("p1|u1")).toBe(false);
+    expect(acc.has("p2|u2")).toBe(true);
+
+    const nextWindow = buffered.concat(ev("d", "p2", "u2", 400));
+    finishedEventIds = collectFinishedEventIds(
+      finishedEventIds,
+      acc,
+      nextWindow,
+    );
+    acc = accumulateEvents(
+      acc,
+      nextWindow,
+      undefined,
+      undefined,
+      finishedEventIds,
+    );
+    expect(acc.has("p1|u1")).toBe(false);
+
+    const freshEvent = ev("e", "p1", "u1", 500);
+    const freshWindow = nextWindow.concat(freshEvent);
+    finishedEventIds = collectFinishedEventIds(
+      finishedEventIds,
+      acc,
+      freshWindow,
+    );
+    acc = accumulateEvents(
+      acc,
+      freshWindow,
+      undefined,
+      undefined,
+      finishedEventIds,
+    );
+    expect(acc.get("p1|u1")?.events).toEqual([freshEvent]);
   });
 
   it("keeps each group's events sorted by ts", () => {

--- a/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
+++ b/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildLiveTrailId,
   buildTrailSchedulePositionLookup,
+  densifyGrowingTrail,
   getAccumulationEvictions,
   getLiveTrailGroupId,
 } from "../useCursorTrails";
@@ -15,6 +16,30 @@ describe("buildTrailSchedulePositionLookup", () => {
     const positions = buildTrailSchedulePositionLookup(orderedIndices, 4);
 
     expect(Array.from(positions)).toEqual([1, 3, 0, 2]);
+  });
+});
+
+describe("densifyGrowingTrail", () => {
+  it("keeps existing geometry stable while limiting segment length", () => {
+    const initial = densifyGrowingTrail([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ]);
+    const appended = densifyGrowingTrail([
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+
+    expect(appended.slice(0, initial.length)).toEqual(initial);
+    for (let index = 1; index < appended.length; index++) {
+      expect(
+        Math.hypot(
+          appended[index].x - appended[index - 1].x,
+          appended[index].y - appended[index - 1].y,
+        ),
+      ).toBeLessThanOrEqual(20);
+    }
   });
 });
 

--- a/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
+++ b/extension/website/shared/hooks/__tests__/useCursorTrails.test.ts
@@ -2,7 +2,12 @@
 // ABOUTME: Verifies stagger playback can use constant-time schedule lookup.
 
 import { describe, expect, it } from "vitest";
-import { buildTrailSchedulePositionLookup } from "../useCursorTrails";
+import {
+  buildLiveTrailId,
+  buildTrailSchedulePositionLookup,
+  getAccumulationEvictions,
+  getLiveTrailGroupId,
+} from "../useCursorTrails";
 
 describe("buildTrailSchedulePositionLookup", () => {
   it("maps trail indexes to their ordered stagger positions", () => {
@@ -10,5 +15,31 @@ describe("buildTrailSchedulePositionLookup", () => {
     const positions = buildTrailSchedulePositionLookup(orderedIndices, 4);
 
     expect(Array.from(positions)).toEqual([1, 3, 0, 2]);
+  });
+});
+
+describe("live trail identity", () => {
+  it("gives replacement segments distinct render identities", () => {
+    const groupId = "participant|https://example.com/page";
+    const firstSegmentId = buildLiveTrailId(groupId, 1000);
+    const nextSegmentId = buildLiveTrailId(groupId, 400_000);
+
+    expect(firstSegmentId).not.toBe(nextSegmentId);
+    expect(getLiveTrailGroupId(firstSegmentId)).toBe(groupId);
+    expect(getLiveTrailGroupId(nextSegmentId)).toBe(groupId);
+  });
+
+  it("only evicts accumulation when the active segment finishes", () => {
+    const groupId = "participant|https://example.com/page";
+    const previousSegmentId = buildLiveTrailId(groupId, 1000);
+    const activeSegmentId = buildLiveTrailId(groupId, 400_000);
+    const activeTrailIds = new Set([activeSegmentId]);
+
+    expect(
+      getAccumulationEvictions([previousSegmentId], activeTrailIds),
+    ).toEqual([]);
+    expect(getAccumulationEvictions([activeSegmentId], activeTrailIds)).toEqual([
+      groupId,
+    ]);
   });
 });

--- a/extension/website/shared/hooks/useAccumulatedEvents.ts
+++ b/extension/website/shared/hooks/useAccumulatedEvents.ts
@@ -22,6 +22,35 @@ function groupKey(e: CollectionEvent): string {
 }
 
 /**
+ * Track events from finished trails only while they remain in the live window.
+ * New event ids for the same participant+url are not included, so they can
+ * start a fresh trail after the prior one has left the screen.
+ */
+export function collectFinishedEventIds(
+  prev: ReadonlySet<string>,
+  groups: AccumulatedGroups,
+  incoming: CollectionEvent[],
+  finishedGroupIds?: Iterable<string>,
+): Set<string> {
+  const incomingIds = new Set(incoming.map((event) => event.id));
+  const next = new Set(
+    Array.from(prev).filter((eventId) => incomingIds.has(eventId)),
+  );
+
+  if (finishedGroupIds) {
+    for (const groupId of finishedGroupIds) {
+      const group = groups.get(groupId);
+      if (!group) continue;
+      for (const event of group.events) {
+        if (incomingIds.has(event.id)) next.add(event.id);
+      }
+    }
+  }
+
+  return next;
+}
+
+/**
  * Fold a batch of events into the accumulated per-group map (pure).
  *
  * - New events are appended to their group, deduped by event id.
@@ -40,6 +69,7 @@ export function accumulateEvents(
   incoming: CollectionEvent[],
   evictIds?: Iterable<string>,
   maxGroups?: number,
+  finishedEventIds?: ReadonlySet<string>,
 ): AccumulatedGroups {
   // Clone the prior map shallowly (group objects are replaced when they change).
   const next: AccumulatedGroups = new Map(prev);
@@ -62,6 +92,7 @@ export function accumulateEvents(
     }
   >();
   for (const e of incoming) {
+    if (finishedEventIds?.has(e.id)) continue;
     const key = groupKey(e);
     let group = touched.get(key);
     if (!group) {
@@ -162,6 +193,7 @@ export function useAccumulatedEvents(
   const evictIdsRef = options.evictIdsRef;
   const enabled = options.enabled ?? true;
   const groupsRef = useRef<AccumulatedGroups>(new Map());
+  const finishedEventIdsRef = useRef<Set<string>>(new Set());
 
   const flat = useMemo(() => {
     if (!enabled) return events;
@@ -176,11 +208,19 @@ export function useAccumulatedEvents(
         ? evictIdsRef.current
         : undefined;
 
+    finishedEventIdsRef.current = collectFinishedEventIds(
+      finishedEventIdsRef.current,
+      groupsRef.current,
+      events,
+      evict,
+    );
+
     groupsRef.current = accumulateEvents(
       groupsRef.current,
       events,
       evict,
       maxGroups,
+      finishedEventIdsRef.current,
     );
 
     // Flatten groups into a single ts-ordered array. The total-event budget is

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -8,6 +8,7 @@ import { CollectionEvent, Trail, TrailState } from "../types";
 // Replace with the minimum hold threshold so the event still renders as a hold.
 const MAX_REASONABLE_HOLD_MS = 3_600_000;
 const MIN_HOLD_THRESHOLD_MS = 250;
+const LIVE_SEGMENT_SEPARATOR = "|segment:";
 
 function sanitizeHoldDuration(duration: number | undefined): number | undefined {
   if (duration === undefined) return undefined;
@@ -49,9 +50,8 @@ export interface CursorTrailSettings {
   // so movements across a long scrollable page are shown relative to the full document.
   documentSpace: boolean;
   // When true, each participant+url group contributes only its most recent
-  // segment (the in-progress trail), so a group never yields two trails sharing
-  // the same id. Required for the live view, where trail id must be both unique
-  // and stable as the event window slides; the archive shows every segment.
+  // segment. The segment keeps a stable id while its accumulated points grow,
+  // and a replacement segment gets a distinct id.
   singleSegmentPerGroup?: boolean;
 }
 
@@ -80,6 +80,34 @@ export function buildTrailSchedulePositionLookup(
     positions[orderedIndices[position]] = position;
   }
   return positions;
+}
+
+export function buildLiveTrailId(
+  groupId: string,
+  segmentStartTime: number,
+): string {
+  return `${groupId}${LIVE_SEGMENT_SEPARATOR}${segmentStartTime}`;
+}
+
+export function getLiveTrailGroupId(trailId: string): string {
+  const separatorIndex = trailId.lastIndexOf(LIVE_SEGMENT_SEPARATOR);
+  if (separatorIndex === -1) {
+    throw new Error(`Live trail id is missing its segment identity: ${trailId}`);
+  }
+  return trailId.slice(0, separatorIndex);
+}
+
+export function getAccumulationEvictions(
+  removedTrailIds: string[],
+  activeTrailIds: ReadonlySet<string>,
+): string[] {
+  const groupIds = new Set<string>();
+  for (const trailId of removedTrailIds) {
+    if (activeTrailIds.has(trailId)) {
+      groupIds.add(getLiveTrailGroupId(trailId));
+    }
+  }
+  return Array.from(groupIds);
 }
 
 export interface UseCursorTrailsResult {
@@ -341,7 +369,9 @@ export function useCursorTrails(
           points: currentTrail,
           color: getTrailColor(startTime),
           opacity: 1,
-          id: groupKey,
+          id: settings.singleSegmentPerGroup
+            ? buildLiveTrailId(groupKey, startTime)
+            : groupKey,
           startTime,
           endTime,
           clicks: [...currentClicks],

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -9,6 +9,7 @@ import { CollectionEvent, Trail, TrailState } from "../types";
 const MAX_REASONABLE_HOLD_MS = 3_600_000;
 const MIN_HOLD_THRESHOLD_MS = 250;
 const LIVE_SEGMENT_SEPARATOR = "|segment:";
+const MAX_LIVE_SEGMENT_PX = 20;
 
 function sanitizeHoldDuration(duration: number | undefined): number | undefined {
   if (duration === undefined) return undefined;
@@ -108,6 +109,30 @@ export function getAccumulationEvictions(
     }
   }
   return Array.from(groupIds);
+}
+
+export function densifyGrowingTrail(
+  points: Array<{ x: number; y: number }>,
+): Array<{ x: number; y: number }> {
+  if (points.length < 2) return points;
+
+  const densified = [points[0]];
+  for (let index = 1; index < points.length; index++) {
+    const start = points[index - 1];
+    const end = points[index];
+    const distance = Math.hypot(end.x - start.x, end.y - start.y);
+    const segmentCount = Math.max(1, Math.ceil(distance / MAX_LIVE_SEGMENT_PX));
+
+    for (let segment = 1; segment <= segmentCount; segment++) {
+      const progress = segment / segmentCount;
+      densified.push({
+        x: start.x + (end.x - start.x) * progress,
+        y: start.y + (end.y - start.y) * progress,
+      });
+    }
+  }
+
+  return densified;
 }
 
 export interface UseCursorTrailsResult {
@@ -543,7 +568,9 @@ export function useCursorTrails(
       // A growing live path must remain prefix-stable: appending points cannot
       // reshape ink that is already on screen. Archive paths are fixed, so they
       // can still round and resample their complete geometry before playback.
-      let variedPoints = styledPoints;
+      let variedPoints = settings.singleSegmentPerGroup
+        ? densifyGrowingTrail(styledPoints)
+        : styledPoints;
       if (!settings.singleSegmentPerGroup) {
         const roundedPoints = roundPathCorners(styledPoints);
         // roundPathCorners returns the SAME array when no corner was sharp

--- a/extension/website/shared/hooks/useCursorTrails.ts
+++ b/extension/website/shared/hooks/useCursorTrails.ts
@@ -540,23 +540,19 @@ export function useCursorTrails(
         seed,
         settings.chaosIntensity || 1.0,
       );
-      // Round sharp direction-reversals once, so the freehand stroke outline
-      // doesn't pinch into a knot at those corners (most visible when zoomed in
-      // for cinematic capture). Computed here on the fixed path — not per frame
-      // — so already-drawn ink stays put.
-      const roundedPoints = roundPathCorners(styledPoints);
-      // roundPathCorners returns the SAME array when no corner was sharp enough
-      // to touch (the common case). Only when it actually rounded something do
-      // we resample: rounding bunches points near corners, making them unevenly
-      // spaced by distance, and the animator advances the head by INDEX — so
-      // uneven spacing makes the head speed up/slow down (looks like it lags
-      // then catches up). Resampling to even arc-length spacing fixes that.
-      // Skipping both when nothing was rounded keeps the common case allocation
-      // -free and identical to the pre-rounding geometry.
-      const variedPoints =
-        roundedPoints === styledPoints
-          ? styledPoints
-          : resampleUniform(roundedPoints, roundedPoints.length);
+      // A growing live path must remain prefix-stable: appending points cannot
+      // reshape ink that is already on screen. Archive paths are fixed, so they
+      // can still round and resample their complete geometry before playback.
+      let variedPoints = styledPoints;
+      if (!settings.singleSegmentPerGroup) {
+        const roundedPoints = roundPathCorners(styledPoints);
+        // roundPathCorners returns the SAME array when no corner was sharp
+        // enough to touch. Only resample when rounding changed the geometry.
+        variedPoints =
+          roundedPoints === styledPoints
+            ? styledPoints
+            : resampleUniform(roundedPoints, roundedPoints.length);
+      }
 
       // Calculate click progress along the trail
       const clicksWithProgress = trail.clicks.map((click) => {

--- a/extension/website/shared/types.ts
+++ b/extension/website/shared/types.ts
@@ -33,11 +33,9 @@ export interface Trail {
   color: string;
   opacity: number;
   angle?: number;
-  /** Stable identity for this trail across re-derivations: participant + url.
-   * Deliberately excludes any timestamp — a person+page is one trail, so the
-   * live animator tracks it as ONE evolving trail instead of re-snapshotting it
-   * (as overlapping copies) each time the sliding event window drops the trail's
-   * earliest points and shifts its derived start. */
+  /** Stable identity for this trail's geometry across re-derivations. Live
+   * trails include their segment start so a replacement segment does not reuse
+   * the completed draw state of the previous segment. */
   id: string;
   startTime: number;
   endTime: number;


### PR DESCRIPTION
## Summary

- Wait eight seconds after the draw head reaches the tip before a trail begins settling.
- Keep settled history dim while a resumed suffix draws at the live opacity.
- Keep settled trails visible for 60 seconds, then fade them out over 8 seconds.
- Keep click and hold ripples visible with their owning trail and apply the trail's departure fade to them.
- Give each replacement cursor segment its own render identity.
- Preserve previously drawn geometry when a live batch adds points.
- Subdivide sparse live geometry into segments no longer than 20 px and allocate at least 32 ms per rendered segment.
- Cap hold ripple size and expansion duration at 3×.
- Prevent removed trails from being rebuilt from events that remain in the live buffer.

## Root cause

The settle timer started when the last point arrived. If a long trail needed more than eight seconds to finish drawing, it settled as soon as the draw head reached the tip. Later points reused the same dimmed SVG path, so the new portion also appeared faded.

Growing live paths were rounded and resampled from the complete point list after every batch. Appending points could therefore reshape geometry that was already visible. Draw progress also advanced by rendered point index. Sparse input could leave hundreds of pixels between two rendered points, and the 30-second duration cap could override point-level pacing on very long trails. Those cases made large portions appear in one step even when the total duration looked reasonable.

Live paths now keep a stable geometric prefix. Sparse segments are subdivided independently, so appending a point does not alter existing geometry. Geometry-driven duration is not capped, which guarantees the spatial and per-segment pacing floors for long trails. Only long idle time in the captured timestamps remains capped.

The path renderer now uses a dim base path and a separate live suffix. The suffix fades into the base when it settles. Click and hold ripples remain mounted with their owning trail and inherit that trail's visibility transition. Hold expansion is bounded so malformed durations cannot produce an unbounded ripple.

## User impact

Live movement draws progressively instead of appearing as a large completed section. The newest part remains at full opacity until the trail settles. Resumed movement adds a bright suffix without relighting settled history. Finished trails and their ripples fade together instead of disappearing independently.

## Validation

- `vitest run` in `extension/website` (25 files, 115 tests)
- `tsc --noEmit` in `extension/website`
- `vite build` in `extension/website`
- Regression coverage for prefix-stable subdivision, spatial pacing, per-segment pacing, and trails longer than the 30-second timestamp cap
- Deterministic browser fixture: a 4-second trail remained fully opaque until 12 seconds, then settled over 1.2 seconds
- Deterministic browser fixture: resumed history remained dim while the live suffix rendered at full opacity
- Deterministic browser fixture: a 20-minute hold was capped at 3×
- Final Cloudflare preview observed for 128 seconds with stable trail identity matching: no multi-hundred-pixel active-head arrivals; largest sample was 95 px over 134 ms
- Final Cloudflare preview: 956 samples captured while ripple wrappers were fading with trails, with zero ripple-only fade samples while the owning trail remained fully visible
