### PR TITLE
Detect JavaScript files that shadow TypeScript sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ site-dist
 dist-ssr
 *.local
 
+# TypeScript emit beside source files
+packages/*/src/**/*.js
+packages/*/src/**/*.js.map
+extension/src/**/*.js
+extension/src/**/*.js.map
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/scripts/check-workspace-readiness.mjs
+++ b/scripts/check-workspace-readiness.mjs
@@ -1,6 +1,7 @@
-// ABOUTME: Checks whether a playhtml checkout has generated dependencies and package builds.
-// ABOUTME: Reports the exact command that restores each missing workspace artifact.
+// ABOUTME: Checks whether a playhtml checkout has safe, complete generated workspace artifacts.
+// ABOUTME: Reports missing builds and emitted JavaScript that shadows TypeScript sources.
 
+import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -56,17 +57,78 @@ export function findMissingWorkspaceArtifacts(root) {
   return requiredArtifacts.filter((artifact) => !artifactExists(root, artifact));
 }
 
-export function formatWorkspaceReadinessFailure(missingArtifacts) {
+function listGitFiles(root, args) {
+  return execFileSync("git", ["-C", root, "ls-files", "-z", ...args], {
+    encoding: "utf8",
+  })
+    .split("\0")
+    .filter(Boolean);
+}
+
+export function findShadowingJavaScript(root) {
+  const sourcePathspecs = [
+    ":(glob)packages/*/src/**/*.js",
+    ":(glob)extension/src/**/*.js",
+  ];
+  const trackedTypeScript = new Set(
+    listGitFiles(root, [
+      "--",
+      ":(glob)packages/*/src/**/*.ts",
+      ":(glob)packages/*/src/**/*.tsx",
+      ":(glob)extension/src/**/*.ts",
+      ":(glob)extension/src/**/*.tsx",
+    ]),
+  );
+  const untrackedJavaScript = [
+    ...listGitFiles(root, [
+      "--others",
+      "--exclude-standard",
+      "--",
+      ...sourcePathspecs,
+    ]),
+    ...listGitFiles(root, [
+      "--others",
+      "--ignored",
+      "--exclude-standard",
+      "--",
+      ...sourcePathspecs,
+    ]),
+  ];
+
+  return untrackedJavaScript
+    .filter((path) => {
+      const sourcePath = path.slice(0, -".js".length);
+      return (
+        trackedTypeScript.has(`${sourcePath}.ts`) ||
+        trackedTypeScript.has(`${sourcePath}.tsx`)
+      );
+    })
+    .sort();
+}
+
+export function formatWorkspaceReadinessFailure(
+  missingArtifacts,
+  shadowingJavaScript = [],
+) {
   const details = missingArtifacts.map(
     ({ path, repair }) => `  - Missing ${path}. ${repair}`,
+  );
+  details.push(
+    ...shadowingJavaScript.map(
+      (path) =>
+        `  - ${path} shadows a tracked TypeScript source. Remove the emitted JavaScript file.`,
+    ),
   );
   return ["Workspace is not ready:", ...details].join("\n");
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const missingArtifacts = findMissingWorkspaceArtifacts(workspaceRoot);
-  if (missingArtifacts.length > 0) {
-    console.error(formatWorkspaceReadinessFailure(missingArtifacts));
+  const shadowingJavaScript = findShadowingJavaScript(workspaceRoot);
+  if (missingArtifacts.length > 0 || shadowingJavaScript.length > 0) {
+    console.error(
+      formatWorkspaceReadinessFailure(missingArtifacts, shadowingJavaScript),
+    );
     process.exitCode = 1;
   } else {
     console.log("Workspace is ready.");

--- a/scripts/check-workspace-readiness.test.mjs
+++ b/scripts/check-workspace-readiness.test.mjs
@@ -1,13 +1,15 @@
-// ABOUTME: Tests workspace readiness checks against complete and incomplete checkout fixtures.
-// ABOUTME: Verifies that each missing artifact reports a precise recovery command.
+// ABOUTME: Tests workspace readiness checks against real filesystem and Git fixtures.
+// ABOUTME: Verifies recovery messages for missing artifacts and shadowing JavaScript.
 
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, test } from "node:test";
 import {
   findMissingWorkspaceArtifacts,
+  findShadowingJavaScript,
   formatWorkspaceReadinessFailure,
 } from "./check-workspace-readiness.mjs";
 
@@ -29,6 +31,10 @@ function writeArtifact(fixtureRoot, path) {
   const artifactPath = join(fixtureRoot, path);
   mkdirSync(join(artifactPath, ".."), { recursive: true });
   writeFileSync(artifactPath, "");
+}
+
+function initializeGitFixture(fixtureRoot) {
+  execFileSync("git", ["init", "--quiet", fixtureRoot]);
 }
 
 test("reports every missing workspace artifact with its repair command", () => {
@@ -66,4 +72,37 @@ test("passes when dependencies, WXT metadata, and package builds exist", () => {
   writeArtifact(fixtureRoot, "packages/react/dist/main.d.ts");
 
   assert.deepEqual(findMissingWorkspaceArtifacts(fixtureRoot), []);
+});
+
+test("reports ignored JavaScript that shadows tracked TypeScript sources", () => {
+  const fixtureRoot = createWorkspaceFixture();
+  initializeGitFixture(fixtureRoot);
+  writeFileSync(
+    join(fixtureRoot, ".gitignore"),
+    "packages/*/src/**/*.js\nextension/src/**/*.js\n",
+  );
+  writeArtifact(fixtureRoot, "packages/playhtml/src/index.ts");
+  writeArtifact(fixtureRoot, "extension/src/content.tsx");
+  execFileSync("git", [
+    "-C",
+    fixtureRoot,
+    "add",
+    ".gitignore",
+    "packages/playhtml/src/index.ts",
+    "extension/src/content.tsx",
+  ]);
+  writeArtifact(fixtureRoot, "packages/playhtml/src/index.js");
+  writeArtifact(fixtureRoot, "packages/playhtml/src/orphan.js");
+  writeArtifact(fixtureRoot, "extension/src/content.js");
+
+  const shadowingJavaScript = findShadowingJavaScript(fixtureRoot);
+
+  assert.deepEqual(shadowingJavaScript, [
+    "extension/src/content.js",
+    "packages/playhtml/src/index.js",
+  ]);
+  assert.match(
+    formatWorkspaceReadinessFailure([], shadowingJavaScript),
+    /packages\/playhtml\/src\/index\.js shadows a tracked TypeScript source\. Remove the emitted JavaScript file\./,
+  );
 });


### PR DESCRIPTION
## Summary

- Ignore TypeScript-emitted `.js` and `.js.map` siblings under `packages/*/src` and `extension/src`.
- Make `bun run doctor` detect untracked `.js` files that shadow tracked `.ts` or `.tsx` sources, including files hidden by `.gitignore`.
- Cover ignored shadow files and non-shadowing JavaScript with a real temporary Git repository fixture.

## Root cause

A stray TypeScript emit can place JavaScript beside source files. Module resolution may select that JavaScript instead of the TypeScript source, which caused the package build to read `packages/playhtml/src/index.js` and fail with `"playhtml" is not exported by "src/index.js"`.

The existing doctor checked generated dependencies and build artifacts only. It did not inspect source trees, and ordinary untracked-file checks would stop seeing the emitted files after adding ignore rules.

## Behavior

The source-tree ignore rules are limited to `packages/*/src` and `extension/src`. The doctor queries both ordinary and ignored untracked JavaScript, then reports a file only when Git tracks the matching TypeScript source. Each failure names the emitted file and tells the developer to remove it.

No tracked JavaScript currently exists in these source trees. This is a development guardrail only, so no changeset, public documentation update, starter update, or screenshot is needed.

## Verification

- Reproduced the missing guardrail with an untracked `packages/playhtml/src/index.js`; the previous doctor output did not report it.
- Verified the updated doctor reports the same file after `.gitignore` hides it.
- `bun run setup`
- `bun run test:doctor`
- `bun run doctor`
- `bun run lint`
- `git diff --check`
- Conservative review of `origin/main...HEAD`: no findings.