### PR TITLE
extension: stop overriding the new tab page, add top nav to popup

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -18,3 +18,5 @@ extension/website/public/changelog/media/ and reference them here:
 - Wikipedia now keeps your article-name consistent across tabs and counts each connected reader once across pages.
 - Wikipedia shows other readers' live text selections in their cursor colors.
 - Wikipedia editing sessions now stay separate from article-reading rooms.
+- Opening a new tab shows your browser's normal new tab page again, and your browsing-history record is still one click away in the extension popup.
+- The popup now has a navigation bar at the top with quick links to your portrait and history pages.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -19,4 +19,5 @@ extension/website/public/changelog/media/ and reference them here:
 - Wikipedia shows other readers' live text selections in their cursor colors.
 - Wikipedia editing sessions now stay separate from article-reading rooms.
 - Opening a new tab shows your browser's normal new tab page again, and your browsing-history record is still one click away in the extension popup.
-- The popup now has a navigation bar at the top with quick links to your portrait and history pages.
+- The popup now has quick links to your portrait and history pages at the top, in a shorter header.
+- The popup leads with your portrait preview, with your collection status below it.

--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -158,7 +158,7 @@ describe("Collections", () => {
     vi.mocked(browser.tabs.query).mockResolvedValue([
       {
         id: 1,
-        url: "safari-web-extension://test/newtab.html",
+        url: "safari-web-extension://test/walking-record.html",
       } as any,
     ]);
 

--- a/extension/src/__tests__/ExtensionPageNav.test.tsx
+++ b/extension/src/__tests__/ExtensionPageNav.test.tsx
@@ -45,17 +45,17 @@ describe("ExtensionPageNav", () => {
     vi.mocked(browser.storage.local.get).mockResolvedValue({
       internalDevFeaturesEnabled: false,
     });
-    const { container, root } = await renderNavigation("time");
+    const { container, root } = await renderNavigation("portrait");
 
     try {
       expect(container.textContent).toContain("portrait");
-      expect(container.textContent).toContain("time");
       expect(container.textContent).toContain("history");
+      expect(container.textContent).not.toContain("time");
       expect(container.textContent).not.toContain("walking record");
       expect(container.textContent).not.toContain("scraps");
       expect(
         container.querySelector('[aria-current="page"]')?.textContent,
-      ).toBe("time");
+      ).toBe("portrait");
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/__tests__/wxt-config.test.ts
+++ b/extension/src/__tests__/wxt-config.test.ts
@@ -57,6 +57,12 @@ describe("WXT manifest", () => {
     });
   });
 
+  it("leaves the browser's own new tab page in place", async () => {
+    const manifest = await manifestFor("chrome");
+
+    expect(manifest.chrome_url_overrides).toBeUndefined();
+  });
+
   it("removes unsupported idle and options tab settings in Safari", async () => {
     const manifest = await manifestFor("safari");
     const generatedManifest = await generatedManifestFor("safari");

--- a/extension/src/announcements/AnnouncementPostcard.test.tsx
+++ b/extension/src/announcements/AnnouncementPostcard.test.tsx
@@ -32,7 +32,7 @@ describe("AnnouncementPostcard", () => {
       body: "Find it in every new tab or from the popup.",
       cta: {
         label: "open history →",
-        extensionPath: "newtab.html",
+        extensionPath: "walking-record.html",
       },
     };
     const onCtaClick = vi.fn();
@@ -61,16 +61,16 @@ describe("AnnouncementPostcard", () => {
       const cta = container.querySelector<HTMLAnchorElement>(
         ".announcement-postcard__cta",
       );
-      expect(cta?.href).toBe("chrome-extension://test/newtab.html");
+      expect(cta?.href).toBe("chrome-extension://test/walking-record.html");
 
       await act(async () => {
         cta?.click();
       });
 
-      expect(browser.runtime.getURL).toHaveBeenCalledWith("newtab.html");
+      expect(browser.runtime.getURL).toHaveBeenCalledWith("walking-record.html");
       expect(onCtaClick).toHaveBeenCalledWith(
         "history",
-        "chrome-extension://test/newtab.html",
+        "chrome-extension://test/walking-record.html",
       );
     } finally {
       cleanup(root, container);

--- a/extension/src/announcements/announcements.ts
+++ b/extension/src/announcements/announcements.ts
@@ -25,7 +25,7 @@ export const ANNOUNCEMENTS: Announcement[] = [
     popupOnly: true,
     cta: {
       label: "open history →",
-      extensionPath: "newtab.html",
+      extensionPath: "walking-record.html",
     },
   },
   {

--- a/extension/src/components/Collections.scss
+++ b/extension/src/components/Collections.scss
@@ -12,21 +12,22 @@
   &__header {
     margin-bottom: 16px;
 
-    .back-row {
-      display: flex;
-      align-items: center;
-      margin-bottom: 8px;
-    }
-
     .back-btn {
+      display: block;
       background: none;
       border: none;
       cursor: pointer;
-      font-size: 18px;
-      margin-right: 8px;
+      font-size: 12px;
+      font-family: $font-body;
+      margin-bottom: 8px;
       padding: 0;
-      color: $text;
+      color: $text-muted;
       line-height: 1;
+      transition: color 0.12s;
+
+      &:hover {
+        color: $accent-teal;
+      }
     }
 
     h1 {

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -680,12 +680,10 @@ export function Collections({ onBack }: CollectionsProps) {
   return (
     <div className="collections">
       <header className="collections__header">
-        <div className="back-row">
-          <button onClick={onBack} className="back-btn">
-            ←
-          </button>
-          <h1>Data Collection Settings</h1>
-        </div>
+        <button onClick={onBack} className="back-btn">
+          ← back
+        </button>
+        <h1>Data Collection Settings</h1>
         <p className="collections__header-desc">
           Control what's collected and whether it's shared
         </p>

--- a/extension/src/components/ExtensionPageNav.tsx
+++ b/extension/src/components/ExtensionPageNav.tsx
@@ -16,8 +16,7 @@ const PAGE_LINKS: Array<{
   path: string;
 }> = [
   { id: "portrait", label: "portrait", path: "portrait.html" },
-  { id: "time", label: "time", path: "stats.html" },
-  { id: "walking-record", label: "history", path: "newtab.html" },
+  { id: "walking-record", label: "history", path: "walking-record.html" },
   { id: "scraps", label: "scraps", path: "scraps.html" },
 ];
 

--- a/extension/src/components/InternetPortraitHome.scss
+++ b/extension/src/components/InternetPortraitHome.scss
@@ -17,7 +17,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 6px;
+    margin-bottom: 4px;
   }
 
   &__wordmark {
@@ -26,16 +26,11 @@
     margin-bottom: 0;
   }
 
-  &__subtitle-row {
+  &__nav-row {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     justify-content: space-between;
     gap: 8px;
-  }
-
-  &__subtitle {
-    font-size: 12px;
-    color: $text-muted;
   }
 
   &__presence {

--- a/extension/src/components/InternetPortraitHome.scss
+++ b/extension/src/components/InternetPortraitHome.scss
@@ -50,12 +50,6 @@
     overflow: auto;
   }
 
-  &__nav-links {
-    display: flex;
-    gap: 12px;
-    justify-content: center;
-  }
-
   &__nav-link {
     background: none;
     border: none;
@@ -92,6 +86,26 @@
     align-items: center;
     justify-content: space-between;
     gap: 8px;
+  }
+
+  &__changelog-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: $font-mono;
+    font-size: 10px;
+    color: $text-faint;
+    cursor: pointer;
+    transition: color 0.12s;
+
+    &:hover {
+      color: $accent-teal;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $accent-teal;
+      outline-offset: 2px;
+    }
   }
 
   &__feedback {

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -14,6 +14,7 @@ import { PostcardStack } from "../announcements/PostcardStack";
 import { FeedbackForm } from "./FeedbackForm";
 import { SiteVisibilityNotice } from "./SiteVisibilityNotice";
 import { ReleasedFeature } from "./ReleasedFeature";
+import { PopupNav, WALKING_RECORD_PAGE } from "./PopupNav";
 
 interface Props {
   playerIdentity: PlayerIdentity | null;
@@ -157,6 +158,23 @@ export function InternetPortraitHome({
         </div>
       </header>
 
+      <PopupNav
+        onNavigate={(path) => {
+          if (path === WALKING_RECORD_PAGE) {
+            onViewBrowsingHistory();
+            return;
+          }
+          if (path === "scraps.html" && onViewScraps) {
+            onViewScraps();
+            return;
+          }
+          void (async () => {
+            await browser.tabs.create({ url: browser.runtime.getURL(path) });
+            window.close();
+          })();
+        }}
+      />
+
       <main className="portrait-home__main">
         {hiddenSiteName && onShowSatchel && (
           <SiteVisibilityNotice
@@ -269,61 +287,6 @@ export function InternetPortraitHome({
               <div className="preview-card__label">Open Portrait Overlay</div>
             </div>
           </div>
-          <div className="portrait-home__nav-links">
-            <button
-              className="portrait-home__nav-link"
-              onClick={async (e) => {
-                e.stopPropagation();
-                const url = browser.runtime.getURL("portrait.html");
-                await browser.tabs.create({ url });
-                window.close();
-              }}
-            >
-              portrait
-            </button>
-            <button
-              className="portrait-home__nav-link"
-              onClick={async (e) => {
-                e.stopPropagation();
-                const url = browser.runtime.getURL("stats.html");
-                await browser.tabs.create({ url });
-                window.close();
-              }}
-            >
-              time
-            </button>
-            <ReleasedFeature feature="SCRAPS">
-              {onViewScraps && (
-                <button
-                  className="portrait-home__nav-link"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onViewScraps();
-                  }}
-                >
-                  scraps
-                </button>
-              )}
-            </ReleasedFeature>
-            <button
-              className="portrait-home__nav-link"
-              onClick={(e) => {
-                e.stopPropagation();
-                onViewBrowsingHistory();
-              }}
-            >
-              history
-            </button>
-            <button
-              className="portrait-home__nav-link"
-              onClick={(e) => {
-                e.stopPropagation();
-                onViewChangelog();
-              }}
-            >
-              changelog
-            </button>
-          </div>
           <ReleasedFeature feature="BAG_SETTINGS">
             {onViewBagSettings && (
               <button
@@ -339,6 +302,13 @@ export function InternetPortraitHome({
 
       <footer className="portrait-home__footer">
         <span>Beta</span>
+        <button
+          type="button"
+          className="portrait-home__changelog-link"
+          onClick={onViewChangelog}
+        >
+          changelog
+        </button>
         <FeedbackForm />
       </footer>
     </div>

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -146,10 +146,23 @@ export function InternetPortraitHome({
             />
           )}
         </div>
-        <div className="portrait-home__subtitle-row">
-          <p className="portrait-home__subtitle">
-            An evolving portrait from your time on the internet
-          </p>
+        <div className="portrait-home__nav-row">
+          <PopupNav
+            onNavigate={(path) => {
+              if (path === WALKING_RECORD_PAGE) {
+                onViewBrowsingHistory();
+                return;
+              }
+              if (path === "scraps.html" && onViewScraps) {
+                onViewScraps();
+                return;
+              }
+              void (async () => {
+                await browser.tabs.create({ url: browser.runtime.getURL(path) });
+                window.close();
+              })();
+            }}
+          />
           {FLAGS.COPRESENCE && presenceCount !== null && presenceCount > 0 && (
             <span className="portrait-home__presence">
               {presenceCount} {presenceCount === 1 ? "person" : "people"} here
@@ -157,23 +170,6 @@ export function InternetPortraitHome({
           )}
         </div>
       </header>
-
-      <PopupNav
-        onNavigate={(path) => {
-          if (path === WALKING_RECORD_PAGE) {
-            onViewBrowsingHistory();
-            return;
-          }
-          if (path === "scraps.html" && onViewScraps) {
-            onViewScraps();
-            return;
-          }
-          void (async () => {
-            await browser.tabs.create({ url: browser.runtime.getURL(path) });
-            window.close();
-          })();
-        }}
-      />
 
       <main className="portrait-home__main">
         {hiddenSiteName && onShowSatchel && (
@@ -216,41 +212,6 @@ export function InternetPortraitHome({
             </button>
           )}
         </ReleasedFeature>
-        <section className="collection-status">
-          <div className="collection-status__header-row">
-            <h3>Your Collection Status</h3>
-            <button
-              onClick={onViewCollections}
-              title="Data settings"
-              className="collection-status__settings-link"
-            >
-              Settings →
-            </button>
-          </div>
-          {error && <p className="collection-status__error">{error}</p>}
-          {collectors && (
-            <div className="collection-status__grid">
-              {collectors.map((c) => (
-                <div key={c.type} className="collector-pill">
-                  <div className="collector-pill__name-row">
-                    <span aria-hidden className="collector-pill__icon">
-                      <CollectorIcon type={c.type} />
-                    </span>
-                    <span className="collector-pill__name">{c.type}</span>
-                  </div>
-                  <span
-                    className={`collector-pill__state collector-pill__state--${
-                      c.enabled ? "on" : "off"
-                    }`}
-                  >
-                    {c.enabled ? "On" : "Off"}
-                  </span>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-
         <section style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           <div
             role="button"
@@ -297,6 +258,41 @@ export function InternetPortraitHome({
               </button>
             )}
           </ReleasedFeature>
+        </section>
+
+        <section className="collection-status">
+          <div className="collection-status__header-row">
+            <h3>Your Collection Status</h3>
+            <button
+              onClick={onViewCollections}
+              title="Data settings"
+              className="collection-status__settings-link"
+            >
+              Settings →
+            </button>
+          </div>
+          {error && <p className="collection-status__error">{error}</p>}
+          {collectors && (
+            <div className="collection-status__grid">
+              {collectors.map((c) => (
+                <div key={c.type} className="collector-pill">
+                  <div className="collector-pill__name-row">
+                    <span aria-hidden className="collector-pill__icon">
+                      <CollectorIcon type={c.type} />
+                    </span>
+                    <span className="collector-pill__name">{c.type}</span>
+                  </div>
+                  <span
+                    className={`collector-pill__state collector-pill__state--${
+                      c.enabled ? "on" : "off"
+                    }`}
+                  >
+                    {c.enabled ? "On" : "Off"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </section>
       </main>
 

--- a/extension/src/components/Inventory.tsx
+++ b/extension/src/components/Inventory.tsx
@@ -112,49 +112,51 @@ export function Inventory({
         flexDirection: "column",
       }}
     >
-      <header
-        style={{
-          marginBottom: "16px",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-          <button
-            onClick={onBack}
-            style={{
-              background: "none",
-              border: "none",
-              fontSize: "18px",
-              cursor: "pointer",
-              padding: "4px",
-            }}
-          >
-            ←
-          </button>
+      <header style={{ marginBottom: "16px" }}>
+        <button
+          onClick={onBack}
+          style={{
+            display: "block",
+            background: "none",
+            border: "none",
+            fontSize: "12px",
+            color: "#6b7280",
+            cursor: "pointer",
+            padding: 0,
+            marginBottom: "8px",
+          }}
+        >
+          ← back
+        </button>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
           <h1 style={{ margin: 0, fontSize: "18px", color: "#1f2937" }}>
             Inventory ({inventory.totalItems})
           </h1>
-        </div>
 
-        {inventory.items.length > 0 && (
-          <button
-            onClick={onClearInventory}
-            style={{
-              background: "#ef4444",
-              color: "white",
-              border: "none",
-              borderRadius: "4px",
-              fontSize: "10px",
-              padding: "4px 6px",
-              cursor: "pointer",
-            }}
-            title="Clear all items"
-          >
-            Clear All
-          </button>
-        )}
+          {inventory.items.length > 0 && (
+            <button
+              onClick={onClearInventory}
+              style={{
+                background: "#ef4444",
+                color: "white",
+                border: "none",
+                borderRadius: "4px",
+                fontSize: "10px",
+                padding: "4px 6px",
+                cursor: "pointer",
+              }}
+              title="Clear all items"
+            >
+              Clear All
+            </button>
+          )}
+        </div>
       </header>
 
       <main style={{ flex: 1, overflow: "auto" }}>

--- a/extension/src/components/PopupNav.scss
+++ b/extension/src/components/PopupNav.scss
@@ -1,16 +1,16 @@
 // ABOUTME: Styles for the popup's page navigation
-// ABOUTME: Segmented bar plus bare-link, compressed-text, and icon-only variants
+// ABOUTME: Bare mono links with an external-tab arrow, sized for the header row
 
 @use "../styles/variables" as *;
 
 .popup-nav {
   display: flex;
   align-items: center;
+  gap: 10px;
 
   &__item {
     display: flex;
     align-items: center;
-    justify-content: center;
     gap: 4px;
     padding: 0;
     background: none;
@@ -20,7 +20,7 @@
     text-transform: lowercase;
     color: $text-muted;
     cursor: pointer;
-    transition: color 0.12s, background 0.12s;
+    transition: color 0.12s;
 
     &:hover {
       color: $accent-teal;
@@ -32,7 +32,7 @@
 
     &:focus-visible {
       outline: 2px solid $accent-teal;
-      outline-offset: -2px;
+      outline-offset: 2px;
     }
   }
 
@@ -40,72 +40,5 @@
     font-size: 9px;
     color: $text-faint;
     transition: color 0.12s;
-  }
-
-  // Full-width segmented bar, hairline dividers between items.
-  &--bar {
-    width: 100%;
-    margin: 10px 0 12px;
-    background: $surface;
-    border: 1px solid $border;
-    border-radius: 8px;
-    overflow: hidden;
-
-    .popup-nav__item {
-      flex: 1;
-      height: 30px;
-
-      & + .popup-nav__item {
-        border-left: 1px solid $border;
-      }
-
-      &:hover {
-        background: rgba($accent-teal, 0.06);
-      }
-    }
-  }
-
-  // Bare links for a tight header row: no chrome, hug content.
-  &--inline {
-    gap: 10px;
-
-    .popup-nav__item:focus-visible {
-      outline-offset: 2px;
-    }
-  }
-
-  // Compressed text: arrows dropped, type tightened to fit three items.
-  &--compact {
-    gap: 8px;
-
-    .popup-nav__item {
-      font-size: 10px;
-      letter-spacing: -0.03em;
-
-      &:focus-visible {
-        outline-offset: 2px;
-      }
-    }
-  }
-
-  // Glyph-only buttons — scales past three items.
-  &--icon {
-    gap: 2px;
-
-    .popup-nav__item {
-      width: 24px;
-      height: 24px;
-      border-radius: 6px;
-      color: $text;
-
-      &:hover {
-        color: $accent-teal;
-        background: rgba($accent-teal, 0.08);
-      }
-
-      &:focus-visible {
-        outline-offset: 0;
-      }
-    }
   }
 }

--- a/extension/src/components/PopupNav.scss
+++ b/extension/src/components/PopupNav.scss
@@ -1,0 +1,56 @@
+// ABOUTME: Styles for the popup's top navigation bar
+// ABOUTME: Equal-width mono links with hairline dividers and an external-tab arrow
+
+@use "../styles/variables" as *;
+
+.popup-nav {
+  display: flex;
+  width: 100%;
+  margin: 10px 0 12px;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 8px;
+  overflow: hidden;
+
+  &__item {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    height: 30px;
+    padding: 0;
+    background: none;
+    border: none;
+    font-family: $font-mono;
+    font-size: 11px;
+    text-transform: lowercase;
+    color: $text-muted;
+    cursor: pointer;
+    transition: color 0.12s, background 0.12s;
+
+    & + & {
+      border-left: 1px solid $border;
+    }
+
+    &:hover {
+      color: $accent-teal;
+      background: rgba($accent-teal, 0.06);
+
+      .popup-nav__arrow {
+        color: inherit;
+      }
+    }
+
+    &:focus-visible {
+      outline: 2px solid $accent-teal;
+      outline-offset: -2px;
+    }
+  }
+
+  &__arrow {
+    font-size: 9px;
+    color: $text-faint;
+    transition: color 0.12s;
+  }
+}

--- a/extension/src/components/PopupNav.scss
+++ b/extension/src/components/PopupNav.scss
@@ -1,24 +1,17 @@
-// ABOUTME: Styles for the popup's top navigation bar
-// ABOUTME: Equal-width mono links with hairline dividers and an external-tab arrow
+// ABOUTME: Styles for the popup's page navigation
+// ABOUTME: Segmented bar plus bare-link, compressed-text, and icon-only variants
 
 @use "../styles/variables" as *;
 
 .popup-nav {
   display: flex;
-  width: 100%;
-  margin: 10px 0 12px;
-  background: $surface;
-  border: 1px solid $border;
-  border-radius: 8px;
-  overflow: hidden;
+  align-items: center;
 
   &__item {
-    flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 4px;
-    height: 30px;
     padding: 0;
     background: none;
     border: none;
@@ -29,13 +22,8 @@
     cursor: pointer;
     transition: color 0.12s, background 0.12s;
 
-    & + & {
-      border-left: 1px solid $border;
-    }
-
     &:hover {
       color: $accent-teal;
-      background: rgba($accent-teal, 0.06);
 
       .popup-nav__arrow {
         color: inherit;
@@ -54,31 +42,69 @@
     transition: color 0.12s;
   }
 
-  // Bare links for a tight header row: no chrome, no dividers, hug content.
-  &--inline {
-    width: auto;
-    margin: 0;
-    gap: 10px;
-    background: none;
-    border: none;
-    border-radius: 0;
-    overflow: visible;
+  // Full-width segmented bar, hairline dividers between items.
+  &--bar {
+    width: 100%;
+    margin: 10px 0 12px;
+    background: $surface;
+    border: 1px solid $border;
+    border-radius: 8px;
+    overflow: hidden;
 
     .popup-nav__item {
-      flex: 0 0 auto;
-      height: auto;
-      gap: 2px;
+      flex: 1;
+      height: 30px;
 
       & + .popup-nav__item {
-        border-left: none;
+        border-left: 1px solid $border;
       }
 
       &:hover {
-        background: none;
+        background: rgba($accent-teal, 0.06);
       }
+    }
+  }
+
+  // Bare links for a tight header row: no chrome, hug content.
+  &--inline {
+    gap: 10px;
+
+    .popup-nav__item:focus-visible {
+      outline-offset: 2px;
+    }
+  }
+
+  // Compressed text: arrows dropped, type tightened to fit three items.
+  &--compact {
+    gap: 8px;
+
+    .popup-nav__item {
+      font-size: 10px;
+      letter-spacing: -0.03em;
 
       &:focus-visible {
         outline-offset: 2px;
+      }
+    }
+  }
+
+  // Glyph-only buttons — scales past three items.
+  &--icon {
+    gap: 2px;
+
+    .popup-nav__item {
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      color: $text;
+
+      &:hover {
+        color: $accent-teal;
+        background: rgba($accent-teal, 0.08);
+      }
+
+      &:focus-visible {
+        outline-offset: 0;
       }
     }
   }

--- a/extension/src/components/PopupNav.scss
+++ b/extension/src/components/PopupNav.scss
@@ -53,4 +53,33 @@
     color: $text-faint;
     transition: color 0.12s;
   }
+
+  // Bare links for a tight header row: no chrome, no dividers, hug content.
+  &--inline {
+    width: auto;
+    margin: 0;
+    gap: 10px;
+    background: none;
+    border: none;
+    border-radius: 0;
+    overflow: visible;
+
+    .popup-nav__item {
+      flex: 0 0 auto;
+      height: auto;
+      gap: 2px;
+
+      & + .popup-nav__item {
+        border-left: none;
+      }
+
+      &:hover {
+        background: none;
+      }
+
+      &:focus-visible {
+        outline-offset: 2px;
+      }
+    }
+  }
 }

--- a/extension/src/components/PopupNav.scss
+++ b/extension/src/components/PopupNav.scss
@@ -16,9 +16,9 @@
     background: none;
     border: none;
     font-family: $font-mono;
-    font-size: 11px;
+    font-size: 12px;
     text-transform: lowercase;
-    color: $text-muted;
+    color: $text;
     cursor: pointer;
     transition: color 0.12s;
 
@@ -37,8 +37,8 @@
   }
 
   &__arrow {
-    font-size: 9px;
-    color: $text-faint;
+    font-size: 10px;
+    color: $text-muted;
     transition: color 0.12s;
   }
 }

--- a/extension/src/components/PopupNav.tsx
+++ b/extension/src/components/PopupNav.tsx
@@ -1,103 +1,54 @@
-// ABOUTME: Top navigation bar for the extension popup home view.
-// ABOUTME: Renders links to the standalone extension pages as a bar, bare links, or icons.
+// ABOUTME: Page navigation for the extension popup header.
+// ABOUTME: Bare mono links that open the standalone extension pages in a new tab.
 
 import React from "react";
-import { isFeatureReleased } from "./ReleasedFeature";
-import { FrameSvg, PathSvg, TornPaperSvg } from "./icons";
+import { ReleasedFeature } from "./ReleasedFeature";
 import "./PopupNav.scss";
 
 export const WALKING_RECORD_PAGE = "walking-record.html";
 
-/**
- * bar     — full-width segmented bar
- * inline  — bare mono links, for a tight header row
- * compact — bare links with the arrows dropped and type tightened, fits 3+
- * icon    — glyph-only buttons, scales past 3 items
- */
-export type PopupNavVariant = "bar" | "inline" | "compact" | "icon";
-
 interface Props {
   onNavigate: (path: string) => void;
-  variant?: PopupNavVariant;
-  /** Preview escape hatch: render gated items regardless of their flag. */
-  forceAllItems?: boolean;
 }
-
-interface NavEntry {
-  label: string;
-  path: string;
-  icon: React.ComponentType<{ size?: number }>;
-  /** Hidden until this feature ships. */
-  gated?: boolean;
-}
-
-const NAV_ENTRIES: NavEntry[] = [
-  { label: "portrait", path: "portrait.html", icon: FrameSvg },
-  { label: "history", path: WALKING_RECORD_PAGE, icon: PathSvg },
-  { label: "scraps", path: "scraps.html", icon: TornPaperSvg, gated: true },
-];
 
 function NavItem({
-  entry,
-  variant,
+  label,
+  path,
   onNavigate,
 }: {
-  entry: NavEntry;
-  variant: PopupNavVariant;
+  label: string;
+  path: string;
   onNavigate: (path: string) => void;
 }) {
-  const { label, path, icon: Icon } = entry;
-  const isIcon = variant === "icon";
-
   return (
     <button
       type="button"
       className="popup-nav__item"
-      title={isIcon ? label : undefined}
-      aria-label={isIcon ? label : undefined}
       onClick={(e) => {
         e.stopPropagation();
         onNavigate(path);
       }}
     >
-      {isIcon ? (
-        <Icon size={16} />
-      ) : (
-        <>
-          {label}
-          {variant !== "compact" && (
-            <span className="popup-nav__arrow" aria-hidden>
-              {"↗"}
-            </span>
-          )}
-        </>
-      )}
+      {label}
+      <span className="popup-nav__arrow" aria-hidden>
+        {"↗"}
+      </span>
     </button>
   );
 }
 
-export function PopupNav({
-  onNavigate,
-  variant = "bar",
-  forceAllItems = false,
-}: Props) {
-  const entries = NAV_ENTRIES.filter(
-    (entry) => !entry.gated || forceAllItems || isFeatureReleased("SCRAPS"),
-  );
-
+export function PopupNav({ onNavigate }: Props) {
   return (
-    <nav
-      className={`popup-nav popup-nav--${variant}`}
-      aria-label="Extension pages"
-    >
-      {entries.map((entry) => (
-        <NavItem
-          key={entry.label}
-          entry={entry}
-          variant={variant}
-          onNavigate={onNavigate}
-        />
-      ))}
+    <nav className="popup-nav" aria-label="Extension pages">
+      <NavItem label="portrait" path="portrait.html" onNavigate={onNavigate} />
+      <NavItem
+        label="history"
+        path={WALKING_RECORD_PAGE}
+        onNavigate={onNavigate}
+      />
+      <ReleasedFeature feature="SCRAPS">
+        <NavItem label="scraps" path="scraps.html" onNavigate={onNavigate} />
+      </ReleasedFeature>
     </nav>
   );
 }

--- a/extension/src/components/PopupNav.tsx
+++ b/extension/src/components/PopupNav.tsx
@@ -9,6 +9,8 @@ export const WALKING_RECORD_PAGE = "walking-record.html";
 
 interface Props {
   onNavigate: (path: string) => void;
+  /** Bare inline links instead of the full-width segmented bar, for tight rows. */
+  inline?: boolean;
 }
 
 function NavItem({
@@ -37,9 +39,12 @@ function NavItem({
   );
 }
 
-export function PopupNav({ onNavigate }: Props) {
+export function PopupNav({ onNavigate, inline = false }: Props) {
   return (
-    <nav className="popup-nav" aria-label="Extension pages">
+    <nav
+      className={`popup-nav${inline ? " popup-nav--inline" : ""}`}
+      aria-label="Extension pages"
+    >
       <NavItem label="portrait" path="portrait.html" onNavigate={onNavigate} />
       <NavItem
         label="history"

--- a/extension/src/components/PopupNav.tsx
+++ b/extension/src/components/PopupNav.tsx
@@ -1,59 +1,103 @@
 // ABOUTME: Top navigation bar for the extension popup home view.
-// ABOUTME: Renders equal-width links that open full extension pages in a new tab.
+// ABOUTME: Renders links to the standalone extension pages as a bar, bare links, or icons.
 
 import React from "react";
-import { ReleasedFeature } from "./ReleasedFeature";
+import { isFeatureReleased } from "./ReleasedFeature";
+import { FrameSvg, PathSvg, TornPaperSvg } from "./icons";
 import "./PopupNav.scss";
 
 export const WALKING_RECORD_PAGE = "walking-record.html";
 
+/**
+ * bar     — full-width segmented bar
+ * inline  — bare mono links, for a tight header row
+ * compact — bare links with the arrows dropped and type tightened, fits 3+
+ * icon    — glyph-only buttons, scales past 3 items
+ */
+export type PopupNavVariant = "bar" | "inline" | "compact" | "icon";
+
 interface Props {
   onNavigate: (path: string) => void;
-  /** Bare inline links instead of the full-width segmented bar, for tight rows. */
-  inline?: boolean;
+  variant?: PopupNavVariant;
+  /** Preview escape hatch: render gated items regardless of their flag. */
+  forceAllItems?: boolean;
 }
 
-function NavItem({
-  label,
-  path,
-  onNavigate,
-}: {
+interface NavEntry {
   label: string;
   path: string;
+  icon: React.ComponentType<{ size?: number }>;
+  /** Hidden until this feature ships. */
+  gated?: boolean;
+}
+
+const NAV_ENTRIES: NavEntry[] = [
+  { label: "portrait", path: "portrait.html", icon: FrameSvg },
+  { label: "history", path: WALKING_RECORD_PAGE, icon: PathSvg },
+  { label: "scraps", path: "scraps.html", icon: TornPaperSvg, gated: true },
+];
+
+function NavItem({
+  entry,
+  variant,
+  onNavigate,
+}: {
+  entry: NavEntry;
+  variant: PopupNavVariant;
   onNavigate: (path: string) => void;
 }) {
+  const { label, path, icon: Icon } = entry;
+  const isIcon = variant === "icon";
+
   return (
     <button
       type="button"
       className="popup-nav__item"
+      title={isIcon ? label : undefined}
+      aria-label={isIcon ? label : undefined}
       onClick={(e) => {
         e.stopPropagation();
         onNavigate(path);
       }}
     >
-      {label}
-      <span className="popup-nav__arrow" aria-hidden>
-        {"↗"}
-      </span>
+      {isIcon ? (
+        <Icon size={16} />
+      ) : (
+        <>
+          {label}
+          {variant !== "compact" && (
+            <span className="popup-nav__arrow" aria-hidden>
+              {"↗"}
+            </span>
+          )}
+        </>
+      )}
     </button>
   );
 }
 
-export function PopupNav({ onNavigate, inline = false }: Props) {
+export function PopupNav({
+  onNavigate,
+  variant = "bar",
+  forceAllItems = false,
+}: Props) {
+  const entries = NAV_ENTRIES.filter(
+    (entry) => !entry.gated || forceAllItems || isFeatureReleased("SCRAPS"),
+  );
+
   return (
     <nav
-      className={`popup-nav${inline ? " popup-nav--inline" : ""}`}
+      className={`popup-nav popup-nav--${variant}`}
       aria-label="Extension pages"
     >
-      <NavItem label="portrait" path="portrait.html" onNavigate={onNavigate} />
-      <NavItem
-        label="history"
-        path={WALKING_RECORD_PAGE}
-        onNavigate={onNavigate}
-      />
-      <ReleasedFeature feature="SCRAPS">
-        <NavItem label="scraps" path="scraps.html" onNavigate={onNavigate} />
-      </ReleasedFeature>
+      {entries.map((entry) => (
+        <NavItem
+          key={entry.label}
+          entry={entry}
+          variant={variant}
+          onNavigate={onNavigate}
+        />
+      ))}
     </nav>
   );
 }

--- a/extension/src/components/PopupNav.tsx
+++ b/extension/src/components/PopupNav.tsx
@@ -1,0 +1,54 @@
+// ABOUTME: Top navigation bar for the extension popup home view.
+// ABOUTME: Renders equal-width links that open full extension pages in a new tab.
+
+import React from "react";
+import { ReleasedFeature } from "./ReleasedFeature";
+import "./PopupNav.scss";
+
+export const WALKING_RECORD_PAGE = "walking-record.html";
+
+interface Props {
+  onNavigate: (path: string) => void;
+}
+
+function NavItem({
+  label,
+  path,
+  onNavigate,
+}: {
+  label: string;
+  path: string;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="popup-nav__item"
+      onClick={(e) => {
+        e.stopPropagation();
+        onNavigate(path);
+      }}
+    >
+      {label}
+      <span className="popup-nav__arrow" aria-hidden>
+        {"↗"}
+      </span>
+    </button>
+  );
+}
+
+export function PopupNav({ onNavigate }: Props) {
+  return (
+    <nav className="popup-nav" aria-label="Extension pages">
+      <NavItem label="portrait" path="portrait.html" onNavigate={onNavigate} />
+      <NavItem
+        label="history"
+        path={WALKING_RECORD_PAGE}
+        onNavigate={onNavigate}
+      />
+      <ReleasedFeature feature="SCRAPS">
+        <NavItem label="scraps" path="scraps.html" onNavigate={onNavigate} />
+      </ReleasedFeature>
+    </nav>
+  );
+}

--- a/extension/src/components/ProfilePage.scss
+++ b/extension/src/components/ProfilePage.scss
@@ -10,20 +10,24 @@
   flex-direction: column;
 
   &__header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
     margin-bottom: 16px;
   }
 
   &__back {
+    display: block;
     background: none;
     border: none;
     cursor: pointer;
-    color: $accent-blue;
+    color: $text-muted;
     font-size: 12px;
     font-family: $font-body;
     padding: 0;
+    margin-bottom: 8px;
+    transition: color 0.12s;
+
+    &:hover {
+      color: $accent-teal;
+    }
   }
 
   &__title {

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -77,7 +77,9 @@ export function ProfilePage({
   return (
     <div className="profile-page">
       <header className="profile-page__header">
-        <button onClick={onBack} className="profile-page__back">← Back</button>
+        <button onClick={onBack} className="profile-page__back">
+          ← back
+        </button>
         <h2 className="profile-page__title">Profile</h2>
       </header>
 

--- a/extension/src/components/SetupPage.tsx
+++ b/extension/src/components/SetupPage.tsx
@@ -477,7 +477,7 @@ export default function SetupPage() {
               </p>
               <button
                 type="button"
-                onClick={() => void openExtensionPage("newtab.html")}
+                onClick={() => void openExtensionPage("walking-record.html")}
                 className="setup-step__text-link"
               >
                 Open history ↗

--- a/extension/src/components/icons.tsx
+++ b/extension/src/components/icons.tsx
@@ -56,43 +56,6 @@ export function ViewportSvg({ size = 14 }: SizeProps) {
   );
 }
 
-/** Picture frame — the portrait page */
-export function FrameSvg({ size = 14 }: SizeProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="4" y="3" width="16" height="18" rx="1.5" stroke="currentColor" />
-      <rect x="7" y="6" width="10" height="12" rx="1" stroke="currentColor" />
-      <path d="M8 16.5 11 12l2 2.5 1.5-2 1.5 4" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-}
-
-/** Footprints along a path — the walking record */
-export function PathSvg({ size = 14 }: SizeProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <ellipse cx="8" cy="18.5" rx="2.3" ry="3" fill="currentColor" transform="rotate(-14 8 18.5)" />
-      <ellipse cx="15.5" cy="14" rx="2.3" ry="3" fill="currentColor" transform="rotate(10 15.5 14)" />
-      <ellipse cx="8.5" cy="9" rx="2.3" ry="3" fill="currentColor" transform="rotate(-14 8.5 9)" />
-      <ellipse cx="16" cy="4.5" rx="2.3" ry="3" fill="currentColor" transform="rotate(10 16 4.5)" />
-    </svg>
-  );
-}
-
-/** Torn-edge paper scrap — collected scraps */
-export function TornPaperSvg({ size = 14 }: SizeProps) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M5 5.5 8 4l3 1.5L14 4l3 1.5L19.5 4v15.5L17 18l-3 1.5L11 18l-3 1.5L5 18z"
-        stroke="currentColor"
-        strokeLinejoin="round"
-      />
-      <path d="M8.5 9h7M8.5 12h4.5" stroke="currentColor" strokeLinecap="round" />
-    </svg>
-  );
-}
-
 /** Returns the collector icon for a given type, or null for unknown types */
 export function CollectorIcon({ type, size = 14 }: { type: string; size?: number }) {
   if (type === "cursor") return <CursorSvg size={size} />;

--- a/extension/src/components/icons.tsx
+++ b/extension/src/components/icons.tsx
@@ -56,6 +56,43 @@ export function ViewportSvg({ size = 14 }: SizeProps) {
   );
 }
 
+/** Picture frame — the portrait page */
+export function FrameSvg({ size = 14 }: SizeProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="4" y="3" width="16" height="18" rx="1.5" stroke="currentColor" />
+      <rect x="7" y="6" width="10" height="12" rx="1" stroke="currentColor" />
+      <path d="M8 16.5 11 12l2 2.5 1.5-2 1.5 4" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/** Footprints along a path — the walking record */
+export function PathSvg({ size = 14 }: SizeProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <ellipse cx="8" cy="18.5" rx="2.3" ry="3" fill="currentColor" transform="rotate(-14 8 18.5)" />
+      <ellipse cx="15.5" cy="14" rx="2.3" ry="3" fill="currentColor" transform="rotate(10 15.5 14)" />
+      <ellipse cx="8.5" cy="9" rx="2.3" ry="3" fill="currentColor" transform="rotate(-14 8.5 9)" />
+      <ellipse cx="16" cy="4.5" rx="2.3" ry="3" fill="currentColor" transform="rotate(10 16 4.5)" />
+    </svg>
+  );
+}
+
+/** Torn-edge paper scrap — collected scraps */
+export function TornPaperSvg({ size = 14 }: SizeProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M5 5.5 8 4l3 1.5L14 4l3 1.5L19.5 4v15.5L17 18l-3 1.5L11 18l-3 1.5L5 18z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+      />
+      <path d="M8.5 9h7M8.5 12h4.5" stroke="currentColor" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 /** Returns the collector icon for a given type, or null for unknown types */
 export function CollectorIcon({ type, size = 14 }: { type: string; size?: number }) {
   if (type === "cursor") return <CursorSvg size={size} />;

--- a/extension/src/entrypoints/popup/popup.test.tsx
+++ b/extension/src/entrypoints/popup/popup.test.tsx
@@ -138,16 +138,16 @@ describe("PlayHTMLPopup", () => {
     try {
       const historyButton = Array.from(
         container.querySelectorAll<HTMLButtonElement>("button"),
-      ).find((button) => button.textContent?.trim() === "history");
+      ).find((button) => button.textContent?.startsWith("history"));
       expect(historyButton).toBeDefined();
 
       await act(async () => {
         historyButton?.click();
       });
 
-      expect(browser.runtime.getURL).toHaveBeenCalledWith("newtab.html");
+      expect(browser.runtime.getURL).toHaveBeenCalledWith("walking-record.html");
       expect(browser.tabs.create).toHaveBeenCalledWith({
-        url: "chrome-extension://test/newtab.html",
+        url: "chrome-extension://test/walking-record.html",
       });
     } finally {
       cleanup(root, container);

--- a/extension/src/entrypoints/popup/popup.test.tsx
+++ b/extension/src/entrypoints/popup/popup.test.tsx
@@ -153,4 +153,37 @@ describe("PlayHTMLPopup", () => {
       cleanup(root, container);
     }
   });
+
+  it("puts the page navigation in the header instead of a subtitle", async () => {
+    const { container, root } = await renderPopup();
+
+    try {
+      const header = container.querySelector(".portrait-home__header");
+      expect(header?.querySelector(".popup-nav")).not.toBeNull();
+      expect(container.querySelector(".portrait-home__subtitle")).toBeNull();
+      expect(container.textContent).not.toContain(
+        "An evolving portrait from your time on the internet",
+      );
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("shows the portrait preview above the collection status", async () => {
+    const { container, root } = await renderPopup();
+
+    try {
+      const main = container.querySelector(".portrait-home__main");
+      const preview = main?.querySelector(".preview-card");
+      const collection = main?.querySelector(".collection-status");
+      expect(preview).not.toBeNull();
+      expect(collection).not.toBeNull();
+      expect(
+        preview!.compareDocumentPosition(collection!) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    } finally {
+      cleanup(root, container);
+    }
+  });
 });

--- a/extension/src/entrypoints/popup/popup.tsx
+++ b/extension/src/entrypoints/popup/popup.tsx
@@ -466,7 +466,7 @@ function PlayHTMLPopup() {
       }}
       commuteIsOpen={commuteIsOpen}
       onViewBrowsingHistory={async () => {
-        const url = browser.runtime.getURL("newtab.html");
+        const url = browser.runtime.getURL("walking-record.html");
         await browser.tabs.create({ url });
         window.close();
       }}

--- a/extension/src/entrypoints/walking-record/index.html
+++ b/extension/src/entrypoints/walking-record/index.html
@@ -1,6 +1,6 @@
 <!--
 ABOUTME: Hosts the standalone walking-record extension page.
-ABOUTME: WXT builds this file as newtab.html for the browser new-tab override.
+ABOUTME: WXT builds this file as walking-record.html, reachable from the popup.
 -->
 <!doctype html>
 <html lang="en">
@@ -12,6 +12,6 @@ ABOUTME: WXT builds this file as newtab.html for the browser new-tab override.
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./newtab.tsx"></script>
+    <script type="module" src="./walking-record.tsx"></script>
   </body>
 </html>

--- a/extension/src/entrypoints/walking-record/walking-record.tsx
+++ b/extension/src/entrypoints/walking-record/walking-record.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Mounts the walking record as both a standalone extension page and the new-tab override.
+// ABOUTME: Mounts the walking record as a standalone extension page reachable from the popup.
 // ABOUTME: Loads navigable calendar week, month, or year records without network requests.
 
 import "@fontsource/atkinson-hyperlegible/latin-400.css";

--- a/extension/src/utils/extensionPage.test.ts
+++ b/extension/src/utils/extensionPage.test.ts
@@ -11,7 +11,7 @@ describe("isExtensionPageUrl", () => {
   it.each([
     "chrome-extension://test/popup.html",
     "moz-extension://test/options.html",
-    "safari-web-extension://test/newtab.html",
+    "safari-web-extension://test/walking-record.html",
   ])("recognizes %s", (url) => {
     expect(isExtensionPageUrl(url)).toBe(true);
   });

--- a/extension/website/components-preview/components-preview.scss
+++ b/extension/website/components-preview/components-preview.scss
@@ -168,6 +168,21 @@ body {
   margin-bottom: 6px;
 }
 
+/* Density experiments: shave the vertical rhythm */
+.popup-frame__row--tight {
+  margin-bottom: 4px;
+}
+
+.popup-frame__navrow--tight {
+  margin-bottom: 0;
+}
+
+/* "wwo" — same Source Serif italic, sized up to hold presence */
+.popup-frame__wordmark--short {
+  font-size: 22px;
+  letter-spacing: 0.01em;
+}
+
 /* A5: subtitle and nav share a line */
 .popup-frame__subtitle-row {
   display: flex;
@@ -224,6 +239,19 @@ body {
 .popup-frame__subtitle {
   font-size: 12px;
   color: #8a8279;
+}
+
+/* Density experiments keep the subtitle on one line so heights are comparable */
+[data-variant="a9"] .popup-frame__subtitle,
+[data-variant="a8"] .popup-frame__subtitle {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Measurement boundary: wordmark top to last header line bottom */
+.popup-frame__header > *:last-child {
+  margin-bottom: 0;
 }
 
 .popup-frame__body {

--- a/extension/website/components-preview/components-preview.scss
+++ b/extension/website/components-preview/components-preview.scss
@@ -126,6 +126,46 @@ body {
 
 .wiki-excerpt a { color: #0645ad; text-decoration: none; }
 
+/* Mock popup frame — approximates the 350px extension popup around PopupNav */
+.popup-frame {
+  width: 350px;
+  padding: 16px;
+  background: #faf7f2;
+  border: 1px solid rgba(90, 78, 65, 0.25);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(90, 78, 65, 0.08);
+}
+
+.popup-frame__header {
+  margin-bottom: 12px;
+}
+
+.popup-frame__wordmark {
+  font-family: 'Source Serif 4', Georgia, serif;
+  font-style: italic;
+  font-weight: 200;
+  font-size: 18px;
+  color: #3d3833;
+  margin-bottom: 6px;
+}
+
+.popup-frame__subtitle {
+  font-size: 12px;
+  color: #8a8279;
+}
+
+.popup-frame__body {
+  height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed rgba(90, 78, 65, 0.25);
+  border-radius: 8px;
+  font-family: 'Martian Mono', monospace;
+  font-size: 10px;
+  color: #b5aea5;
+}
+
 .milestone-preview-cell {
   display: flex;
   justify-content: flex-start;

--- a/extension/website/components-preview/components-preview.scss
+++ b/extension/website/components-preview/components-preview.scss
@@ -129,8 +129,14 @@ body {
 /* Mock popup frames — approximate the 350px extension popup around PopupNav */
 .popup-variants {
   display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.popup-variant-row__frames {
+  display: flex;
   align-items: flex-start;
-  gap: 32px;
+  gap: 24px;
   flex-wrap: wrap;
 }
 
@@ -146,8 +152,39 @@ body {
   font-size: 11px;
   color: #8a8279;
   margin-bottom: 10px;
-  max-width: 350px;
+  max-width: 640px;
   line-height: 1.4;
+}
+
+.popup-frame__count {
+  font-family: 'Martian Mono', monospace;
+  font-size: 9px;
+  color: #b5aea5;
+  margin-bottom: 8px;
+}
+
+/* A4: nav on its own line inside the header block */
+.popup-frame__navrow {
+  margin-bottom: 6px;
+}
+
+/* A5: subtitle and nav share a line */
+.popup-frame__subtitle-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+
+  .popup-frame__subtitle {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .popup-nav {
+    flex-shrink: 0;
+  }
 }
 
 .popup-frame {

--- a/extension/website/components-preview/components-preview.scss
+++ b/extension/website/components-preview/components-preview.scss
@@ -126,7 +126,30 @@ body {
 
 .wiki-excerpt a { color: #0645ad; text-decoration: none; }
 
-/* Mock popup frame — approximates the 350px extension popup around PopupNav */
+/* Mock popup frames — approximate the 350px extension popup around PopupNav */
+.popup-variants {
+  display: flex;
+  align-items: flex-start;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.popup-variant__label {
+  font-family: 'Lora', Georgia, serif;
+  font-weight: 600;
+  font-size: 15px;
+  color: #3d3833;
+  margin-bottom: 2px;
+}
+
+.popup-variant__note {
+  font-size: 11px;
+  color: #8a8279;
+  margin-bottom: 10px;
+  max-width: 350px;
+  line-height: 1.4;
+}
+
 .popup-frame {
   width: 350px;
   padding: 16px;
@@ -136,8 +159,20 @@ body {
   box-shadow: 0 6px 20px rgba(90, 78, 65, 0.08);
 }
 
-.popup-frame__header {
-  margin-bottom: 12px;
+/* Mirrors .portrait-home__header-row in the real popup */
+.popup-frame__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.popup-frame__row-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
 }
 
 .popup-frame__wordmark {
@@ -146,7 +181,7 @@ body {
   font-weight: 200;
   font-size: 18px;
   color: #3d3833;
-  margin-bottom: 6px;
+  white-space: nowrap;
 }
 
 .popup-frame__subtitle {
@@ -155,6 +190,7 @@ body {
 }
 
 .popup-frame__body {
+  margin-top: 12px;
   height: 120px;
   display: flex;
   align-items: center;

--- a/extension/website/components-preview/components-preview.scss
+++ b/extension/website/components-preview/components-preview.scss
@@ -163,43 +163,19 @@ body {
   margin-bottom: 8px;
 }
 
-/* A4: nav on its own line inside the header block */
+/* Nav sits on its own line inside the header block */
 .popup-frame__navrow {
-  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-/* Density experiments: shave the vertical rhythm */
 .popup-frame__row--tight {
   margin-bottom: 4px;
 }
 
 .popup-frame__navrow--tight {
   margin-bottom: 0;
-}
-
-/* "wwo" — same Source Serif italic, sized up to hold presence */
-.popup-frame__wordmark--short {
-  font-size: 22px;
-  letter-spacing: 0.01em;
-}
-
-/* A5: subtitle and nav share a line */
-.popup-frame__subtitle-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
-
-  .popup-frame__subtitle {
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .popup-nav {
-    flex-shrink: 0;
-  }
 }
 
 .popup-frame {
@@ -220,13 +196,6 @@ body {
   margin-bottom: 6px;
 }
 
-.popup-frame__row-right {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-shrink: 0;
-}
-
 .popup-frame__wordmark {
   font-family: 'Source Serif 4', Georgia, serif;
   font-style: italic;
@@ -234,19 +203,6 @@ body {
   font-size: 18px;
   color: #3d3833;
   white-space: nowrap;
-}
-
-.popup-frame__subtitle {
-  font-size: 12px;
-  color: #8a8279;
-}
-
-/* Density experiments keep the subtitle on one line so heights are comparable */
-[data-variant="a9"] .popup-frame__subtitle,
-[data-variant="a8"] .popup-frame__subtitle {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 /* Measurement boundary: wordmark top to last header line bottom */

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -2601,10 +2601,16 @@ function PopupFrame({
   return (
     <div className="popup-frame" data-variant={variantId} data-items={items}>
       <div className="popup-frame__count">{items} items</div>
-      {children}
+      {/* Measured as the header block: wordmark top to last header line bottom. */}
+      <div className="popup-frame__header">{children}</div>
       <div className="popup-frame__body">popup content</div>
     </div>
   );
+}
+
+/** Short wordmark for the ultra-dense experiments. */
+function ShortWordmark() {
+  return <div className="popup-frame__wordmark popup-frame__wordmark--short">wwo</div>;
 }
 
 /** Renders one layout at both item counts so the scaling story is visible. */
@@ -2729,6 +2735,90 @@ function PopupNavSection() {
                 </div>
                 <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
               </div>
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="current"
+          label="current — baseline for height"
+          note="today's header: wordmark + identity, subtitle, then the segmented bar"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <IdentityCard />
+              </div>
+              <PopupSubtitle />
+              <PopupNav onNavigate={noop} variant="bar" forceAllItems={all} />
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="a6"
+          label="A6 — no subtitle, two rows"
+          note="subtitle dropped entirely; row 1 wordmark + identity, row 2 nav links, tight margins"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row popup-frame__row--tight">
+                <div className="popup-frame__wordmark">we were online</div>
+                <IdentityCard />
+              </div>
+              <div className="popup-frame__navrow popup-frame__navrow--tight">
+                <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
+              </div>
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="a7"
+          label="A7 — one line, wwo"
+          note="short wordmark + nav + identity on a single row, no subtitle. Density ceiling."
+          render={(all) => (
+            <div className="popup-frame__row popup-frame__row--tight">
+              <ShortWordmark />
+              <div className="popup-frame__row-right">
+                <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
+                <IdentityCard />
+              </div>
+            </div>
+          )}
+        />
+
+        <VariantRow
+          id="a8"
+          label="A8 — full subtitle kept"
+          note="full subtitle untouched on its own line; nav tucked into the wordmark row"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row popup-frame__row--tight">
+                <div className="popup-frame__wordmark">we were online</div>
+                <div className="popup-frame__row-right">
+                  <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
+                  <IdentityCard />
+                </div>
+              </div>
+              <PopupSubtitle />
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="a9"
+          label="A9 — wwo + nav, subtitle kept (mine)"
+          note="short wordmark buys room for nav on row 1, so the full subtitle survives below"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row popup-frame__row--tight">
+                <ShortWordmark />
+                <div className="popup-frame__row-right">
+                  <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
+                  <IdentityCard />
+                </div>
+              </div>
+              <PopupSubtitle />
             </>
           )}
         />

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -2590,21 +2590,45 @@ function PopupSubtitle() {
 }
 
 function PopupFrame({
-  label,
-  note,
+  variantId,
+  items,
   children,
 }: {
-  label: string;
-  note: string;
+  variantId: string;
+  items: number;
   children: React.ReactNode;
 }) {
   return (
-    <div className="popup-variant">
+    <div className="popup-frame" data-variant={variantId} data-items={items}>
+      <div className="popup-frame__count">{items} items</div>
+      {children}
+      <div className="popup-frame__body">popup content</div>
+    </div>
+  );
+}
+
+/** Renders one layout at both item counts so the scaling story is visible. */
+function VariantRow({
+  id,
+  label,
+  note,
+  render,
+}: {
+  id: string;
+  label: string;
+  note: string;
+  render: (all: boolean) => React.ReactNode;
+}) {
+  return (
+    <div className="popup-variant-row">
       <div className="popup-variant__label">{label}</div>
       <div className="popup-variant__note">{note}</div>
-      <div className="popup-frame">
-        {children}
-        <div className="popup-frame__body">popup content</div>
+      <div className="popup-variant-row__frames">
+        {[false, true].map((all) => (
+          <PopupFrame key={String(all)} variantId={id} items={all ? 3 : 2}>
+            {render(all)}
+          </PopupFrame>
+        ))}
       </div>
     </div>
   );
@@ -2614,46 +2638,100 @@ function PopupNavSection() {
   return (
     <div
       id="section-popup-nav"
-      style={{ padding: "0 40px 40px", maxWidth: "1400px" }}
+      style={{ padding: "0 40px 40px", maxWidth: "1500px" }}
     >
       <div className="popup-variants">
-        <PopupFrame
-          label="variant A — integrated"
-          note="one header row: wordmark, nav as bare links, identity card"
-        >
-          <div className="popup-frame__row">
-            <div className="popup-frame__wordmark">we were online</div>
-            <div className="popup-frame__row-right">
-              <PopupNav onNavigate={noop} inline />
-              <IdentityCard />
-            </div>
-          </div>
-          <PopupSubtitle />
-        </PopupFrame>
+        <VariantRow
+          id="a"
+          label="A — integrated (original)"
+          note="wordmark + bare links with arrows + identity, one row. Overflows at 3."
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <div className="popup-frame__row-right">
+                  <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
+                  <IdentityCard />
+                </div>
+              </div>
+              <PopupSubtitle />
+            </>
+          )}
+        />
 
-        <PopupFrame
-          label="variant B — above"
-          note="segmented nav first, then wordmark + identity, then subtitle"
-        >
-          <PopupNav onNavigate={noop} />
-          <div className="popup-frame__row">
-            <div className="popup-frame__wordmark">we were online</div>
-            <IdentityCard />
-          </div>
-          <PopupSubtitle />
-        </PopupFrame>
+        <VariantRow
+          id="a2"
+          label="A2 — compressed text"
+          note="same row, arrows dropped, 10px type, tightened letter-spacing and gaps"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <div className="popup-frame__row-right">
+                  <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
+                  <IdentityCard />
+                </div>
+              </div>
+              <PopupSubtitle />
+            </>
+          )}
+        />
 
-        <PopupFrame
-          label="current"
-          note="nav below the full header block (what ships today)"
-        >
-          <div className="popup-frame__row">
-            <div className="popup-frame__wordmark">we were online</div>
-            <IdentityCard />
-          </div>
-          <PopupSubtitle />
-          <PopupNav onNavigate={noop} />
-        </PopupFrame>
+        <VariantRow
+          id="a3"
+          label="A3 — icon nav"
+          note="24px glyph buttons with tooltips: framed picture, footprints, torn scrap"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <div className="popup-frame__row-right">
+                  <PopupNav onNavigate={noop} variant="icon" forceAllItems={all} />
+                  <IdentityCard />
+                </div>
+              </div>
+              <PopupSubtitle />
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="a4"
+          label="A4 — two-row header"
+          note="row 1 untouched (wordmark + identity); nav as bare links above the subtitle"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <IdentityCard />
+              </div>
+              <div className="popup-frame__navrow">
+                <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
+              </div>
+              <PopupSubtitle />
+            </>
+          )}
+        />
+
+        <VariantRow
+          id="a5"
+          label="A5 — subtitle row (mine)"
+          note="nav shares the subtitle line, right-aligned; subtitle shortened to make room"
+          render={(all) => (
+            <>
+              <div className="popup-frame__row">
+                <div className="popup-frame__wordmark">we were online</div>
+                <IdentityCard />
+              </div>
+              <div className="popup-frame__subtitle-row">
+                <div className="popup-frame__subtitle">
+                  Your evolving portrait
+                </div>
+                <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
+              </div>
+            </>
+          )}
+        />
       </div>
     </div>
   );

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -2627,6 +2627,18 @@ function PopupNavSection() {
           <PopupHeaderFrame extraItem />
         </div>
       </div>
+
+      <div className="popup-variant-row">
+        <div className="popup-variant__label">actual size</div>
+        <div className="popup-variant__note">
+          The same header at the popup's real 350px width with no zoom. Judge
+          legibility here — screenshots of the frames above are usually scaled
+          up, which makes small type look more present than it is on screen.
+        </div>
+        <div className="popup-variant-row__frames">
+          <PopupHeaderFrame extraItem />
+        </div>
+      </div>
     </div>
   );
 }

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -2575,67 +2575,37 @@ const MOCK_IDENTITY: PlayerIdentity = {
 
 const noop = () => {};
 
-function IdentityCard() {
+/**
+ * The popup header as it ships: wordmark + identity on row 1, nav links on
+ * row 2, no subtitle. `extraItem` stands in for a third gated page (scraps)
+ * so the layout can be checked before that flag ships.
+ */
+function PopupHeaderFrame({ extraItem }: { extraItem: boolean }) {
   return (
-    <PlayerIdentityCard playerIdentity={MOCK_IDENTITY} compact discoveredSites={[]} />
-  );
-}
-
-function PopupSubtitle() {
-  return (
-    <div className="popup-frame__subtitle">
-      An evolving portrait from your time on the internet
-    </div>
-  );
-}
-
-function PopupFrame({
-  variantId,
-  items,
-  children,
-}: {
-  variantId: string;
-  items: number;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="popup-frame" data-variant={variantId} data-items={items}>
-      <div className="popup-frame__count">{items} items</div>
-      {/* Measured as the header block: wordmark top to last header line bottom. */}
-      <div className="popup-frame__header">{children}</div>
-      <div className="popup-frame__body">popup content</div>
-    </div>
-  );
-}
-
-/** Short wordmark for the ultra-dense experiments. */
-function ShortWordmark() {
-  return <div className="popup-frame__wordmark popup-frame__wordmark--short">wwo</div>;
-}
-
-/** Renders one layout at both item counts so the scaling story is visible. */
-function VariantRow({
-  id,
-  label,
-  note,
-  render,
-}: {
-  id: string;
-  label: string;
-  note: string;
-  render: (all: boolean) => React.ReactNode;
-}) {
-  return (
-    <div className="popup-variant-row">
-      <div className="popup-variant__label">{label}</div>
-      <div className="popup-variant__note">{note}</div>
-      <div className="popup-variant-row__frames">
-        {[false, true].map((all) => (
-          <PopupFrame key={String(all)} variantId={id} items={all ? 3 : 2}>
-            {render(all)}
-          </PopupFrame>
-        ))}
+    <div className="popup-frame" data-items={extraItem ? 3 : 2}>
+      <div className="popup-frame__count">{extraItem ? 3 : 2} items</div>
+      <div className="popup-frame__header">
+        <div className="popup-frame__row popup-frame__row--tight">
+          <div className="popup-frame__wordmark">we were online</div>
+          <PlayerIdentityCard
+            playerIdentity={MOCK_IDENTITY}
+            compact
+            discoveredSites={[]}
+          />
+        </div>
+        <div className="popup-frame__navrow popup-frame__navrow--tight">
+          <PopupNav onNavigate={noop} />
+          {extraItem && (
+            <button type="button" className="popup-nav__item" onClick={noop}>
+              scraps
+              <span className="popup-nav__arrow" aria-hidden>
+                {"\u2197"}
+              </span>
+            </button>
+          )}
+        </div>
       </div>
+      <div className="popup-frame__body">popup content</div>
     </div>
   );
 }
@@ -2644,184 +2614,18 @@ function PopupNavSection() {
   return (
     <div
       id="section-popup-nav"
-      style={{ padding: "0 40px 40px", maxWidth: "1500px" }}
+      style={{ padding: "0 40px 40px", maxWidth: "1200px" }}
     >
-      <div className="popup-variants">
-        <VariantRow
-          id="a"
-          label="A — integrated (original)"
-          note="wordmark + bare links with arrows + identity, one row. Overflows at 3."
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <div className="popup-frame__row-right">
-                  <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
-                  <IdentityCard />
-                </div>
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a2"
-          label="A2 — compressed text"
-          note="same row, arrows dropped, 10px type, tightened letter-spacing and gaps"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <div className="popup-frame__row-right">
-                  <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
-                  <IdentityCard />
-                </div>
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a3"
-          label="A3 — icon nav"
-          note="24px glyph buttons with tooltips: framed picture, footprints, torn scrap"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <div className="popup-frame__row-right">
-                  <PopupNav onNavigate={noop} variant="icon" forceAllItems={all} />
-                  <IdentityCard />
-                </div>
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a4"
-          label="A4 — two-row header"
-          note="row 1 untouched (wordmark + identity); nav as bare links above the subtitle"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <IdentityCard />
-              </div>
-              <div className="popup-frame__navrow">
-                <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a5"
-          label="A5 — subtitle row (mine)"
-          note="nav shares the subtitle line, right-aligned; subtitle shortened to make room"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <IdentityCard />
-              </div>
-              <div className="popup-frame__subtitle-row">
-                <div className="popup-frame__subtitle">
-                  Your evolving portrait
-                </div>
-                <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
-              </div>
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="current"
-          label="current — baseline for height"
-          note="today's header: wordmark + identity, subtitle, then the segmented bar"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row">
-                <div className="popup-frame__wordmark">we were online</div>
-                <IdentityCard />
-              </div>
-              <PopupSubtitle />
-              <PopupNav onNavigate={noop} variant="bar" forceAllItems={all} />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a6"
-          label="A6 — no subtitle, two rows"
-          note="subtitle dropped entirely; row 1 wordmark + identity, row 2 nav links, tight margins"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row popup-frame__row--tight">
-                <div className="popup-frame__wordmark">we were online</div>
-                <IdentityCard />
-              </div>
-              <div className="popup-frame__navrow popup-frame__navrow--tight">
-                <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
-              </div>
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a7"
-          label="A7 — one line, wwo"
-          note="short wordmark + nav + identity on a single row, no subtitle. Density ceiling."
-          render={(all) => (
-            <div className="popup-frame__row popup-frame__row--tight">
-              <ShortWordmark />
-              <div className="popup-frame__row-right">
-                <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
-                <IdentityCard />
-              </div>
-            </div>
-          )}
-        />
-
-        <VariantRow
-          id="a8"
-          label="A8 — full subtitle kept"
-          note="full subtitle untouched on its own line; nav tucked into the wordmark row"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row popup-frame__row--tight">
-                <div className="popup-frame__wordmark">we were online</div>
-                <div className="popup-frame__row-right">
-                  <PopupNav onNavigate={noop} variant="compact" forceAllItems={all} />
-                  <IdentityCard />
-                </div>
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
-
-        <VariantRow
-          id="a9"
-          label="A9 — wwo + nav, subtitle kept (mine)"
-          note="short wordmark buys room for nav on row 1, so the full subtitle survives below"
-          render={(all) => (
-            <>
-              <div className="popup-frame__row popup-frame__row--tight">
-                <ShortWordmark />
-                <div className="popup-frame__row-right">
-                  <PopupNav onNavigate={noop} variant="inline" forceAllItems={all} />
-                  <IdentityCard />
-                </div>
-              </div>
-              <PopupSubtitle />
-            </>
-          )}
-        />
+      <div className="popup-variant-row">
+        <div className="popup-variant__label">popup header</div>
+        <div className="popup-variant__note">
+          Row 1 wordmark + identity card, row 2 nav links, no subtitle. Shown
+          with the two shipping pages and with a third gated page added.
+        </div>
+        <div className="popup-variant-row__frames">
+          <PopupHeaderFrame extraItem={false} />
+          <PopupHeaderFrame extraItem />
+        </div>
       </div>
     </div>
   );

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -10,6 +10,7 @@ import {
 } from "@extension/components/MilestoneToast";
 import { MILESTONE_TOAST_CSS } from "@extension/entrypoints/content/milestone-toast-styles";
 import { MILESTONE_COPY } from "@extension/milestones/copy";
+import { PopupNav } from "@extension/components/PopupNav";
 const Agentation = import.meta.env.DEV
   ? lazy(() => import("agentation").then((m) => ({ default: m.Agentation })))
   : null;
@@ -2562,9 +2563,31 @@ function MilestonesSection() {
   );
 }
 
+// ── Popup nav ─────────────────────────────────────────────────────────────────
+
+function PopupNavSection() {
+  return (
+    <div
+      id="section-popup-nav"
+      style={{ padding: "0 40px 40px", maxWidth: "1200px" }}
+    >
+      <div className="popup-frame">
+        <div className="popup-frame__header">
+          <div className="popup-frame__wordmark">we were online</div>
+          <div className="popup-frame__subtitle">
+            An evolving portrait from your time on the internet
+          </div>
+        </div>
+        <PopupNav onNavigate={() => {}} />
+        <div className="popup-frame__body">popup content</div>
+      </div>
+    </div>
+  );
+}
+
 // ── Sidebar navigation ────────────────────────────────────────────────────────
 
-type Section = "portrait-card" | "link-patina" | "milestones";
+type Section = "portrait-card" | "link-patina" | "milestones" | "popup-nav";
 
 const PORTRAIT_NAV = [
   { id: "section-density", label: "density" },
@@ -2590,6 +2613,8 @@ const MILESTONES_NAV = [
   { id: "section-ms-domain", label: "domain visits" },
 ];
 
+const POPUP_NAV_NAV = [{ id: "section-popup-nav", label: "top nav" }];
+
 function SidebarNav({
   activeSection,
   onSectionChange,
@@ -2603,7 +2628,9 @@ function SidebarNav({
       ? PORTRAIT_NAV
       : activeSection === "milestones"
         ? MILESTONES_NAV
-        : LINK_PATINA_NAV;
+        : activeSection === "popup-nav"
+          ? POPUP_NAV_NAV
+          : LINK_PATINA_NAV;
 
   useEffect(() => {
     setActiveId("");
@@ -2624,7 +2651,9 @@ function SidebarNav({
 
   return (
     <nav className="sidebar-nav">
-      {(["portrait-card", "link-patina", "milestones"] as Section[]).map((s) => (
+      {(
+        ["portrait-card", "link-patina", "milestones", "popup-nav"] as Section[]
+      ).map((s) => (
         <a
           key={s}
           href="#"
@@ -2633,7 +2662,7 @@ function SidebarNav({
           }`}
           style={{
             fontWeight: activeSection === s ? 700 : undefined,
-            marginBottom: s !== "milestones" ? "6px" : undefined,
+            marginBottom: s !== "popup-nav" ? "6px" : undefined,
           }}
           onClick={(e) => {
             e.preventDefault();
@@ -2646,7 +2675,9 @@ function SidebarNav({
             ? "portrait card"
             : s === "link-patina"
               ? "link patina"
-              : "milestones"}
+              : s === "milestones"
+                ? "milestones"
+                : "popup nav"}
         </a>
       ))}
       {activeSection !== "portrait-card" && (
@@ -2694,6 +2725,7 @@ function PreviewPage() {
     const hash = window.location.hash.slice(1);
     if (hash === "link-patina") return "link-patina";
     if (hash === "milestones") return "milestones";
+    if (hash === "popup-nav") return "popup-nav";
     return "portrait-card";
   });
 
@@ -2719,14 +2751,18 @@ function PreviewPage() {
                   ? "portrait card — design directions"
                   : activeSection === "milestones"
                     ? "milestones — copy & visuals"
-                    : "link patina — design directions"}
+                    : activeSection === "popup-nav"
+                      ? "popup nav — top navigation bar"
+                      : "link patina — design directions"}
               </div>
               <div className="page-subtitle">
                 {activeSection === "portrait-card"
                   ? "six layout directions · same data across all variants"
                   : activeSection === "milestones"
                     ? "five milestone types · full copy pool for each"
-                    : "three visual treatments · links carry varied visit counts"}
+                    : activeSection === "popup-nav"
+                      ? "the real component inside a mock 350px popup frame"
+                      : "three visual treatments · links carry varied visit counts"}
               </div>
               {activeSection === "portrait-card" && (
                 <div className="mock-note">
@@ -2860,6 +2896,8 @@ function PreviewPage() {
         {activeSection === "link-patina" && <LinkTracesSection />}
 
         {activeSection === "milestones" && <MilestonesSection />}
+
+        {activeSection === "popup-nav" && <PopupNavSection />}
       </div>
     </div>
   );

--- a/extension/website/components-preview/components-preview.tsx
+++ b/extension/website/components-preview/components-preview.tsx
@@ -11,6 +11,8 @@ import {
 import { MILESTONE_TOAST_CSS } from "@extension/entrypoints/content/milestone-toast-styles";
 import { MILESTONE_COPY } from "@extension/milestones/copy";
 import { PopupNav } from "@extension/components/PopupNav";
+import { PlayerIdentityCard } from "@extension/components/PlayerIdentityCard";
+import type { PlayerIdentity } from "@extension/types";
 const Agentation = import.meta.env.DEV
   ? lazy(() => import("agentation").then((m) => ({ default: m.Agentation })))
   : null;
@@ -2565,21 +2567,93 @@ function MilestonesSection() {
 
 // ── Popup nav ─────────────────────────────────────────────────────────────────
 
+const MOCK_IDENTITY: PlayerIdentity = {
+  publicKey: "pk_preview",
+  name: "spencer",
+  playerStyle: { colorPalette: ["#4a9a8a", "#c4724e", "#5b8db8"] },
+};
+
+const noop = () => {};
+
+function IdentityCard() {
+  return (
+    <PlayerIdentityCard playerIdentity={MOCK_IDENTITY} compact discoveredSites={[]} />
+  );
+}
+
+function PopupSubtitle() {
+  return (
+    <div className="popup-frame__subtitle">
+      An evolving portrait from your time on the internet
+    </div>
+  );
+}
+
+function PopupFrame({
+  label,
+  note,
+  children,
+}: {
+  label: string;
+  note: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="popup-variant">
+      <div className="popup-variant__label">{label}</div>
+      <div className="popup-variant__note">{note}</div>
+      <div className="popup-frame">
+        {children}
+        <div className="popup-frame__body">popup content</div>
+      </div>
+    </div>
+  );
+}
+
 function PopupNavSection() {
   return (
     <div
       id="section-popup-nav"
-      style={{ padding: "0 40px 40px", maxWidth: "1200px" }}
+      style={{ padding: "0 40px 40px", maxWidth: "1400px" }}
     >
-      <div className="popup-frame">
-        <div className="popup-frame__header">
-          <div className="popup-frame__wordmark">we were online</div>
-          <div className="popup-frame__subtitle">
-            An evolving portrait from your time on the internet
+      <div className="popup-variants">
+        <PopupFrame
+          label="variant A — integrated"
+          note="one header row: wordmark, nav as bare links, identity card"
+        >
+          <div className="popup-frame__row">
+            <div className="popup-frame__wordmark">we were online</div>
+            <div className="popup-frame__row-right">
+              <PopupNav onNavigate={noop} inline />
+              <IdentityCard />
+            </div>
           </div>
-        </div>
-        <PopupNav onNavigate={() => {}} />
-        <div className="popup-frame__body">popup content</div>
+          <PopupSubtitle />
+        </PopupFrame>
+
+        <PopupFrame
+          label="variant B — above"
+          note="segmented nav first, then wordmark + identity, then subtitle"
+        >
+          <PopupNav onNavigate={noop} />
+          <div className="popup-frame__row">
+            <div className="popup-frame__wordmark">we were online</div>
+            <IdentityCard />
+          </div>
+          <PopupSubtitle />
+        </PopupFrame>
+
+        <PopupFrame
+          label="current"
+          note="nav below the full header block (what ships today)"
+        >
+          <div className="popup-frame__row">
+            <div className="popup-frame__wordmark">we were online</div>
+            <IdentityCard />
+          </div>
+          <PopupSubtitle />
+          <PopupNav onNavigate={noop} />
+        </PopupFrame>
       </div>
     </div>
   );

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
     action: {
       default_title: "we were online",
     },
-    chrome_url_overrides: {
-      newtab: "newtab.html",
-    },
     commands: {
       "open-inventory": {
         suggested_key: {


### PR DESCRIPTION
## Summary

Three related popup/navigation changes prompted by user churn after the new-tab takeover (~100 uninstalls):

1. **Revert the new tab override.** The walking-record history page no longer replaces the browser's new tab page. Removing `chrome_url_overrides` from `wxt.config.ts` was not enough — WXT auto-registers any entrypoint directory named `newtab`, so the entrypoint is renamed to `walking-record/` (served as `walking-record.html`, all references updated). A regression test asserts the built manifest never grows the override back.

2. **Hide the time page.** The `stats.html` per-domain time view is unlinked from the standalone page nav and the popup. The page itself stays live at its URL. Its "where did my time go" ranking overlaps enough with the new history page that it doesn't earn top-level placement.

3. **New popup header with top nav.** The popup header is now two tight rows: wordmark + cursor identity card, then mono nav links (`portrait ↗ history ↗`, scraps appears when its flag ships) directly below. The subtitle is removed; header height drops 115px → 56px. The presence count moved to the right end of the nav row. The old buried link row under the preview card is gone; changelog moved to the footer. Main sections reordered so the portrait preview card leads and collection status follows. Back links on Profile / Collections / Inventory now stack above the title consistently.

Design was explored through ~10 measured variants in `components-preview` (one-row integrated layouts genuinely cannot fit 3 items at 350px with the full wordmark — the chosen two-row layout fits 3+ items with 108px slack). The preview keeps a single living frame of the final header at 2 and 3 items.

## Testing

- `bun run test:extension`: 669 tests passing (2 new: header/nav structure, section order; 1 new: manifest has no `chrome_url_overrides`)
- `bun run check:extension` / `check:extension-website`: clean
- Rebuilt from wiped `dist/` and verified the manifest contains no new-tab override and emits `walking-record.html`

Screenshots incoming as a follow-up comment (real rendered popup).

## Release notes

Two bullets added to `extension/PENDING.md` (new tab restored; popup nav + reorder).

## Non-applicable checklist items

- No changeset: nothing under `packages/` changed (extension-only).
- No `apps/docs/` audit needed: extension surfaces are not covered by the library docs.
- Starter templates untouched: no core API change.

## Note for review

An announcement postcard CTA changed from `newtab.html` to `walking-record.html` — if any shipped announcement state is keyed on that URL, flag it.