### PR TITLE
Eliminate presence-tick render storm in @playhtml/react

### DIFF
--- a/.changeset/react-presence-render-storm.md
+++ b/.changeset/react-presence-render-storm.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Stop cursor-presence updates from re-rendering every playhtml component on the page. PlayProvider no longer stores live cursor positions in context state (the context value is now memoized and the presence map keeps a stable identity; reactive consumers use the useCursorPresences hook, which is unchanged), and usePlayerIdentity only re-renders its consumers when the identity actually changes rather than on every presence tick. On a room with ~3,000 elements this reduced renders during a one-second drag from ~340,000 to just the elements whose data changed.

--- a/packages/react/src/PlayProvider.tsx
+++ b/packages/react/src/PlayProvider.tsx
@@ -247,19 +247,33 @@ export function PlayProvider({
     name: undefined,
   });
 
-  const [cursorPresences, setCursorPresences] = useState<
-    Map<string, CursorPresenceView>
-  >(new Map());
+  // Live cursor positions are per-frame data. Every playhtml component reads
+  // this context, so putting them in state re-rendered every element on the
+  // page on every presence tick (~3,000 components x ~120 ticks during a
+  // one-second drag on a large room). The Map identity stays stable and is
+  // mutated in place; reactive consumers use the useCursorPresences hook,
+  // which subscribes to the cursor client directly.
+  const cursorPresencesRef = useRef<Map<string, CursorPresenceView>>(new Map());
 
   useEffect(() => {
     if (!hasSynced) return;
     return playhtml.users.onChange((users) => {
       const me = playhtml.users.me;
-      setCursorsState({
+      const next = {
         allColors: Array.from(new Set(users.map((user) => user.color))),
         color: me.color,
         name: me.name,
-      });
+      };
+      // Presence churn fires this on every tick with identical values; only
+      // re-render when the roster actually changed.
+      setCursorsState((prev) =>
+        prev.color === next.color &&
+        prev.name === next.name &&
+        prev.allColors.length === next.allColors.length &&
+        prev.allColors.every((color, i) => color === next.allColors[i])
+          ? prev
+          : next,
+      );
     });
   }, [hasSynced]);
 
@@ -267,33 +281,39 @@ export function PlayProvider({
     const client = playhtml.cursorClient;
     if (!client) return;
 
-    setCursorPresences(client.getCursorPresences());
-    const unsubPresences = client.onCursorPresencesChange((presences) => {
-      setCursorPresences(new Map(presences)); // New Map to trigger re-render
-    });
-    return unsubPresences;
+    const applyPresences = (presences: Map<string, CursorPresenceView>) => {
+      const target = cursorPresencesRef.current;
+      target.clear();
+      for (const [key, value] of presences) target.set(key, value);
+    };
+    applyPresences(client.getCursorPresences());
+    return client.onCursorPresencesChange(applyPresences);
   }, [hasSynced]);
 
+  const contextValue = useMemo<PlayContextInfo>(
+    () => ({
+      setupPlayElements: playhtml.setupPlayElements,
+      dispatchPlayEvent: playhtml.dispatchPlayEvent,
+      registerPlayEventListener: playhtml.registerPlayEventListener,
+      removePlayEventListener: playhtml.removePlayEventListener,
+      deleteElementData: playhtml.deleteElementData,
+      hasSynced,
+      isLoading: !hasSynced,
+      isProviderMissing: false,
+      configureCursors,
+      getMyPlayerIdentity,
+      triggerCursorAnimation,
+      registerCursorZone,
+      unregisterCursorZone,
+      cursors: cursorsState,
+      cursorPresences: cursorPresencesRef.current,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hasSynced, cursorsState, registerCursorZone, unregisterCursorZone],
+  );
+
   return (
-    <PlayContext.Provider
-      value={{
-        setupPlayElements: playhtml.setupPlayElements,
-        dispatchPlayEvent: playhtml.dispatchPlayEvent,
-        registerPlayEventListener: playhtml.registerPlayEventListener,
-        removePlayEventListener: playhtml.removePlayEventListener,
-        deleteElementData: playhtml.deleteElementData,
-        hasSynced,
-        isLoading: !hasSynced,
-        isProviderMissing: false,
-        configureCursors,
-        getMyPlayerIdentity,
-        triggerCursorAnimation,
-        registerCursorZone,
-        unregisterCursorZone,
-        cursors: cursorsState,
-        cursorPresences,
-      }}
-    >
+    <PlayContext.Provider value={contextValue}>
       {children}
     </PlayContext.Provider>
   );

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -283,7 +283,13 @@ export function usePlayerIdentity(): {
     }
     const readIdentity = () => {
       const me = playhtml.users.me;
-      setIdentity({ color: me.color, pid: me.pid, name: me.name });
+      // users.onChange fires on every presence tick; only re-render consumers
+      // when the identity itself changed.
+      setIdentity((prev) =>
+        prev.color === me.color && prev.pid === me.pid && prev.name === me.name
+          ? prev
+          : { color: me.color, pid: me.pid, name: me.name },
+      );
     };
     readIdentity();
     return playhtml.users.onChange(readIdentity);

--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -448,6 +448,14 @@ interface ToolboxProps {
   currentPan?: { x: number; y: number };
 }
 
+// Isolated so the per-tick cursor-presence updates re-render only this span.
+// Calling useCursorPresences inside WordControls re-rendered the entire word
+// list (~3,000 components) on every presence tick.
+function OnlineCount() {
+  const onlineCount = useCursorPresences().size;
+  return <>{onlineCount} online</>;
+}
+
 const WordControls = withSharedState<FridgeWordType[]>(
   {
     defaultData: [] as FridgeWordType[],
@@ -473,7 +481,6 @@ const WordControls = withSharedState<FridgeWordType[]>(
     const userColor =
       window.cursors?.color || localStorage.getItem("userColor") || undefined;
     const isMobile = useIsMobile();
-    const onlineCount = useCursorPresences().size;
 
     // Convert screen coordinates to fridge-relative content coordinates,
     // accounting for the zoom/pan transform on .content
@@ -842,7 +849,7 @@ const WordControls = withSharedState<FridgeWordType[]>(
                     display: "inline-block",
                   }}
                 />
-                {onlineCount} online
+                <OnlineCount />
               </span>
               <span
                 title="contributors"


### PR DESCRIPTION
## Summary

Every cursor-presence tick re-rendered **every playhtml component on the page**. On a room with ~3,000 elements (the production fridge), a one-second drag caused ~340,000 React renders; after this fix the same drag renders only the element whose data changed (61 renders).

Three sources, all fixed:

1. **PlayProvider** stored live cursor positions in unmemoized context state, so every presence message produced a new context value and re-rendered every context consumer (every `CanPlayElement`). The context value is now memoized; the presence map keeps a stable identity and is mutated in place. Reactive consumers use the `useCursorPresences` hook, which subscribes to the cursor client directly and is unchanged.
2. **`usePlayerIdentity`** set a fresh state object on every `users.onChange` tick (which fires per presence update) even when the identity was unchanged. It now bails when color/pid/name are identical.
3. **The fridge page**: `WordControls` — the component that renders the entire word list — called `useCursorPresences()` only to display an online count, re-rendering all words per tick. The count is now an isolated `<OnlineCount />` component.

## Rationale

Found while perf-testing the v2 protocol branch against the full production fridge room seeded locally: the storm exists identically on v1 and was masked only by small rooms. Production pays this cost today on any large room with cursors enabled.

## Measurements (fridge room, 2,906 mounted words, 1s drag, ~120 presence ticks)

| | before | after |
|---|---|---|
| PlayProvider renders | ~120 | 1 |
| CanPlayElement renders | ~340,000 | 61 (dragged word only) |
| word-list re-renders | ~120 | 0 |

No visual/UI change (perf only), so no screenshots; the render-count instrumentation methodology is reproducible via the latency probe on the v2 branch (`feat/v2-op-protocol`, `e2e/v2/latency-probe.ts`).

## Notes

- Changeset included (`@playhtml/react` patch).
- `PlayContextInfo` shape is unchanged; `context.cursorPresences` still exists but its Map identity is now stable (nothing in this repo consumed it reactively — the documented path is `useCursorPresences`).
- Tests: `bun run test:react` green (52 + 2), `tsc --noEmit` clean, website vite build passes.