### PR TITLE
website: read downshift stateChangeTypes at module scope

### DIFF
--- a/extension/website/shared/components/Controls.tsx
+++ b/extension/website/shared/components/Controls.tsx
@@ -27,6 +27,8 @@ import {
   type SavedConfig,
 } from "../utils/savedConfigs";
 
+const { stateChangeTypes: comboboxStateChangeTypes } = useCombobox;
+
 interface ControlsProps {
   visible: boolean;
   settings: any;
@@ -403,7 +405,7 @@ const FilterChipInput: React.FC<{
     initialInputValue: "",
     itemToString: (item) => item ?? "",
     stateReducer: (state, { type, changes }) => {
-      const t = useCombobox.stateChangeTypes;
+      const t = comboboxStateChangeTypes;
       if (type === t.InputClick) {
         return { ...changes, isOpen: true };
       }

--- a/extension/website/shared/components/KeypressesGrid.tsx
+++ b/extension/website/shared/components/KeypressesGrid.tsx
@@ -8,6 +8,8 @@ import { useCombobox } from "downshift";
 import { CollectionEvent, KeyboardEventData, TypingAction } from "../types";
 import { extractDomain } from "../utils/eventUtils";
 
+const { stateChangeTypes: comboboxStateChangeTypes } = useCombobox;
+
 // ── Constants ─────────────────────────────────────────────────────────────────
 const CELL_SIZE = 32;
 /** Base scroll rate in px per real second at speed=1. */
@@ -385,7 +387,7 @@ const DomainFilterInput: React.FC<{
     //    commits the obvious top choice instead of silently dropping the
     //    typed value when nothing is explicitly highlighted.
     stateReducer: (state, { type, changes }) => {
-      const t = useCombobox.stateChangeTypes;
+      const t = comboboxStateChangeTypes;
       if (type === t.InputClick || type === t.InputFocus) {
         return { ...changes, isOpen: true };
       }


### PR DESCRIPTION
## Summary
`extension/website/shared/components/Controls.tsx` and `extension/website/shared/components/KeypressesGrid.tsx` both read `useCombobox.stateChangeTypes` inside their downshift `stateReducer`. This looks like a hook call inside a reducer (it's actually a static property read, so it worked, but it reads as a hook-rules violation and can trip lint tooling). Both files now destructure `stateChangeTypes` from `useCombobox` once at module scope and use that constant in the reducer.

No behavior change: same static enum object, read once at module load instead of on every reducer invocation.

## Testing
- `bun run lint` passes (all packages type-check)
- `bun build-packages` + `bun run test:extension`: 109 files, 649 tests, all passing

No screenshots: pure refactor with no user-visible change (identical values, identical control flow).