### PR TITLE
Fix playhtml client CDN example

### DIFF
--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -5,15 +5,24 @@ sidebar:
   order: 4
 ---
 
-The `playhtml` object is the library entry point. Import it from the package, or use `window.playhtml` after a script tag loads.
+The `playhtml` object is the library entry point. Import it from the package or from a CDN.
+
+**npm with a bundler:**
 
 ```js
-// ES module
 import { playhtml } from "playhtml";
 
-// Script tag (CDN) — available as window.playhtml after the script loads
-// <script type="module" src="https://unpkg.com/playhtml/dist/index.js"></script>
-playhtml.init();
+await playhtml.init();
+```
+
+**CDN without a bundler:**
+
+```html
+<script type="module">
+  import { playhtml } from "https://unpkg.com/playhtml";
+
+  await playhtml.init();
+</script>
 ```
 
 **API groups at a glance:**


### PR DESCRIPTION
## Summary

- replace the broken `playhtml/dist/index.js` reference
- show separate copyable examples for npm and CDN usage

## Why

The API reference linked to a file that is not included in the published package and returns 404.

## Validation

- `bun run build-packages`
- `bun run test:docs` (52 tests)
- `bun run check:docs`
- verified `/docs/reference/playhtml-client/` in a browser with no console warnings or errors

## Release impact

Documentation only. No changeset is required, and the starter templates are unchanged because the public API and package behavior do not change.