### PR TITLE
extension: replace beta language with early access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ When building or modifying playhtml elements, follow the `building-playhtml-elem
 | Changed published package behavior | Add a changeset + audit `apps/docs/` |
 | Changed the public core API | Update both starter templates |
 | Changed package deps or exports | Run the tarball install simulation |
-| Changed what extension users see | Add a bullet to `extension/PENDING.md` |
+| Added a meaningful feature, common-workflow change, or broadly relevant fix to the released extension | Add a bullet to `extension/PENDING.md` |
 
 - **Commits:** Short imperative subject; scope paths when helpful (e.g., `react:`, `extension:`). Group mechanical changes separately.
 - **PRs:** Include summary, rationale, screenshots for UI/site/extension changes, reproduction for fixes, and link issues.
@@ -143,7 +143,7 @@ When building or modifying playhtml elements, follow the `building-playhtml-elem
 
 - **Starter templates for core API changes:** Whenever you change the public core API under `packages/` (capability attributes/classes, React component props like `<CanDuplicateElement>`/`<CanToggleElement>`, exported functions, the vanilla `can-play` element API `defaultData`/`onClick`/`updateElement`/`setupPlayElement`, `playhtml.init` options, or CSS hooks like `[data-playhtml-hover]`), update BOTH starter templates in the same PR so they stay copy-pasteable and verify them live in a browser: `templates/react-starter/` (React API — `src/App.tsx`, `src/index.css`) and `templates/html-starter/` (vanilla API — `index.html`, `style.css`, `script.js`). The starters depend on the published `@playhtml/react` / `playhtml` (`"latest"`), so they pick up code changes on release — but their own usage (imports, props, selectors, example markup/CSS) won't update itself. Only use real, existing API methods: there is no `playhtml.setupCustomElement`; vanilla custom elements set `defaultData`/`onClick`/`updateElement` directly on the DOM element, then call `playhtml.setupPlayElement(el)`. The starters are standalone projects: `react-starter` is Vite+TS with no `tsconfig.json` of its own (so `npm run build`'s `tsc` step picks up the monorepo root config and fails — verify with `npx vite build` plus a live browser test instead); `html-starter` is static files loading `playhtml@latest` from unpkg. If a change doesn't touch either starter, say why in the PR summary.
 
-- **Extension release notes:** When a PR changes what regular users see or get in the released extension, add final user-facing release-note copy to `extension/PENDING.md` — one short, plain-language sentence per bullet about what someone can do, what works better, or what problem was fixed. No implementation or maintainer details. Full rules, including how feature flags affect this, are in `extension/CLAUDE.md`.
+- **Extension release notes:** `extension/PENDING.md` is a curated public changelog, not a complete record of extension changes. Add a bullet only for a meaningful change that regular users are likely to notice or care about, such as a feature, a common-workflow change, or a broadly relevant fix. Skip copy polish, narrow bug fixes, minor performance or reliability work without a clear user-visible outcome, and internal maintenance. Write one short, plain-language sentence about what someone can do, what works better, or what problem was fixed. No implementation or maintainer details. Full rules, including how feature flags affect this, are in `extension/CLAUDE.md`.
 
 ## Documentation
 

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -22,14 +22,33 @@ Worker backend (in `worker/`):
 The extension ships independently of the core packages, mirroring the
 changesets release-PR flow but on a separate cadence.
 
-**Day-to-day:** when a PR changes what regular users see or get in the
-released extension — `extension/src/**`, `extension/wxt.config.ts`,
-`extension/public/**`, or anything else that ships in the extension zip — add
-a bullet to `extension/PENDING.md` for each meaningful user-facing change.
-Changes that ship dark — behind an unreleased feature in `FEATURE_CATALOG` —
-do NOT get a bullet; the public
-changelog should never describe a feature users can't reach. Add the bullet in
-the PR that enables the feature for everyone.
+**Day-to-day:** `extension/PENDING.md` is a curated public changelog, not a
+complete record of changes that ship in the extension. Add a bullet only when
+a regular user can understand the outcome and is likely to notice or care
+about it.
+
+A change is usually changelog-worthy when it:
+
+- Adds or removes a feature or capability.
+- Meaningfully changes a common workflow or visible behavior.
+- Fixes a problem that affects a substantial group of users.
+- Requires users to take action or changes what they should expect.
+
+Usually skip a bullet for:
+
+- Copy, label, badge, or wording polish.
+- Narrow bug or compatibility fixes that few users encounter.
+- Small performance or reliability improvements without a noticeable outcome.
+- Refactors, dependencies, tests, build changes, telemetry, and other internal
+  maintenance.
+
+A narrow fix can still deserve a bullet when its impact is significant and can
+be explained plainly. If the release note needs implementation jargon or makes
+the impact sound larger than it is, omit it.
+
+Changes that ship dark, behind an unreleased feature in `FEATURE_CATALOG`, do
+not get a bullet. The public changelog should never describe a feature users
+cannot reach. Add the bullet in the PR that enables the feature for everyone.
 
 Write each bullet as final release-note copy for people who use the extension:
 
@@ -40,8 +59,7 @@ Write each bullet as final release-note copy for people who use the extension:
 - Do not mention filenames, functions, storage engines, schemas, migrations,
   message passing, retries, build systems, deployment, tests, PRs, or other
   implementation and maintainer details.
-- Do not describe internal-only maintenance. If a change has no meaningful
-  user-facing effect, it does not need a bullet.
+- Do not describe internal-only maintenance.
 
 Changes under `extension/website/**` (wewere.online pages and visualizations)
 and `extension/worker/**` deploy on their own and do NOT get PENDING bullets or

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,5 +14,3 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
-
-- Early features now invite you to request access and help shape what comes next.

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,3 +14,5 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
+
+- Early features now invite you to request access and help shape what comes next.

--- a/extension/src/__tests__/ProfilePage.test.tsx
+++ b/extension/src/__tests__/ProfilePage.test.tsx
@@ -121,7 +121,7 @@ describe("ProfilePage", () => {
     }
   });
 
-  it("prefills a locally shared email and submits an explicit beta request", async () => {
+  it("prefills a locally shared email and submits an explicit early access request", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ status: "pending" }), { status: 201 }),
     );
@@ -130,10 +130,12 @@ describe("ProfilePage", () => {
 
     try {
       await act(async () => Promise.resolve());
+      expect(container.textContent).toContain("Request early access");
+      expect(container.textContent).not.toContain("Closed beta");
       const email = container.querySelector<HTMLInputElement>('#beta-email');
       expect(email?.value).toBe("person@example.com");
       const submit = Array.from(container.querySelectorAll("button")).find(
-        (button) => button.textContent === "Request access",
+        (button) => button.textContent === "Request early access",
       );
       await act(async () => submit?.click());
       expect(fetchMock).toHaveBeenCalledWith(

--- a/extension/src/components/DeveloperFeaturesPage.test.tsx
+++ b/extension/src/components/DeveloperFeaturesPage.test.tsx
@@ -64,6 +64,8 @@ describe("DeveloperFeaturesPage", () => {
       expect(container.querySelectorAll('input[type="checkbox"]')).toHaveLength(
         FEATURE_IDS.filter((feature) => FEATURE_CATALOG[feature].defaultStage !== "released").length,
       );
+      expect(container.textContent).toContain("Early access");
+      expect(container.textContent).not.toContain("Closed beta");
       const commuteToggle = container.querySelector<HTMLInputElement>(
         'input[aria-label="Enable Internet Commute"]',
       );

--- a/extension/src/components/DeveloperFeaturesPage.tsx
+++ b/extension/src/components/DeveloperFeaturesPage.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 const STAGE_LABELS: Record<FeatureStage, string> = {
   internal: "Internal",
-  beta: "Closed beta",
+  beta: "Early access",
   released: "Released",
 };
 

--- a/extension/src/components/InternetPortraitHome.tsx
+++ b/extension/src/components/InternetPortraitHome.tsx
@@ -300,7 +300,6 @@ export function InternetPortraitHome({
       </main>
 
       <footer className="portrait-home__footer">
-        <span>Beta</span>
         {onViewDeveloperFeatures && (
           <button
             className="portrait-home__internal-link"

--- a/extension/src/components/ProfilePage.scss
+++ b/extension/src/components/ProfilePage.scss
@@ -1,4 +1,4 @@
-// ABOUTME: Styles the profile identity, cursor, collection, and beta access controls.
+// ABOUTME: Styles the profile identity, cursor, collection, and early access controls.
 // ABOUTME: Keeps optional contact details compact inside the extension popup.
 
 @use "../styles/variables" as *;

--- a/extension/src/components/ProfilePage.tsx
+++ b/extension/src/components/ProfilePage.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Profile settings for identity, cursor color, and beta access requests.
+// ABOUTME: Profile settings for identity, cursor color, and early access requests.
 // ABOUTME: Prefills locally shared contact email only when the person submits a request.
 import React, { FormEvent, useEffect, useRef, useState } from "react";
 import browser from "webextension-polyfill";
@@ -203,8 +203,8 @@ export function ProfilePage({
 
         {!privateExperimentAccess && (
           <section className="profile-section profile-section--beta">
-            <label className="profile-section__label" htmlFor="beta-email">Closed beta</label>
-            <p>Request early access to new experimental features to make the internt feel more shared and alive. Experiments stay off until you choose to enable them.</p>
+            <label className="profile-section__label" htmlFor="beta-email">Request early access</label>
+            <p>Try new experimental features that make the internet feel more shared and alive. Experiments stay off until you choose to enable them.</p>
             {betaRequestStatus === "sent" ? (
               <strong className="profile-section__request-success">Request sent</strong>
             ) : (
@@ -218,7 +218,7 @@ export function ProfilePage({
                   autoComplete="email"
                 />
                 <button type="submit" disabled={requestingBeta}>
-                  {requestingBeta ? "Sending…" : "Request access"}
+                  {requestingBeta ? "Sending…" : "Request early access"}
                 </button>
               </form>
             )}

--- a/extension/src/components/SetupPage.test.tsx
+++ b/extension/src/components/SetupPage.test.tsx
@@ -120,7 +120,7 @@ describe("SetupPage", () => {
         "Email for project updates (optional)",
       );
       expect(container.textContent).toContain(
-        "Get occasional updates about we were online and have the opportunity to beta test new features",
+        "Get occasional updates about we were online and opportunities to help shape new features",
       );
       expect(container.querySelector('input[type="email"]')).not.toBeNull();
 

--- a/extension/src/components/SetupPage.tsx
+++ b/extension/src/components/SetupPage.tsx
@@ -366,8 +366,8 @@ export default function SetupPage() {
                 id="updates-email-help"
                 className="setup-step__field-help"
               >
-                Get occasional updates about we were online and have the
-                opportunity to beta test new features
+                Get occasional updates about we were online and opportunities
+                to help shape new features
               </span>
             </div>
             <button


### PR DESCRIPTION
## Summary

- Remove the Beta badge from the extension home screen.
- Replace closed-beta copy with early-access language.
- Invite people to help shape experimental features without presenting the production extension as beta software.
- Treat `extension/PENDING.md` as a curated public changelog and document when small changes should be omitted.

## Why

Apple rejected the Safari submission because the production binary contains beta references. This keeps the participatory framing while removing beta language from visible extension surfaces.

The release-note guidance now reserves public changelog entries for meaningful changes that regular users are likely to notice or care about. Copy polish, narrow fixes, minor performance work, and internal maintenance do not automatically need entries.

## Validation

- `bun run test:extension` (827 tests)
- `bun run check:extension`
- `bun run --cwd extension build:safari`
- Safari build search contains no visible `Closed beta`, `beta test`, or `>Beta<` strings
- `git diff --check`

## Screenshots

Visual verification is pending before this draft is marked ready for review.