### PR TITLE
playhtml: reduce repeated element work

### DIFF
--- a/.changeset/quiet-elements-scale.md
+++ b/.changeset/quiet-elements-scale.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Avoid reinitializing bound elements during repeated page scans and limit local awareness updates to the element that changed, reducing navigation and presence overhead on pages with many PlayHTML elements.

--- a/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
+++ b/apps/docs/src/content/docs/advanced/dynamic-elements.mdx
@@ -52,6 +52,8 @@ el.remove();
 playhtml.deleteElementData("can-move", "note-42");
 ```
 
+Reuse the same stable `id` when a logical item can return. A fresh `id` creates a separate persisted item on every mount. Call `deleteElementData` when the item is permanently removed.
+
 See [Development & data cleanup](/docs/advanced/development/) for inspecting and resetting stored state from the devtools panel.
 
   </TabItem>

--- a/apps/docs/src/content/docs/reference/playhtml-client.md
+++ b/apps/docs/src/content/docs/reference/playhtml-client.md
@@ -152,7 +152,7 @@ playhtml.setupPlayElement(card);
 
 **Signature:** `setupPlayElements(): void`
 
-Scans the entire document and registers every element that carries a playhtml capability attribute. Called internally at the end of `init()`. Useful if you inject a batch of playhtml elements into the DOM at once and want to activate them all in one pass.
+Scans the entire document and registers elements that carry a playhtml capability attribute. Elements already bound to the same DOM node are skipped. Called internally at the end of `init()`. Use it after injecting a batch of playhtml elements into the DOM.
 
 ```js
 container.innerHTML = serverRenderedHtml;

--- a/packages/playhtml/src/__tests__/element-awareness-client.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-client.test.ts
@@ -208,6 +208,46 @@ describe("ElementAwarenessClient", () => {
     expect(entry.byStableId.size).toBe(1);
   });
 
+  it("re-keys every local element when the identity changes", () => {
+    let identity = IDENTITY;
+    const socket = new FakeSocket();
+    const transport = new RealtimePresenceTransport({
+      host: "example.com",
+      room: "/page",
+      socketFactory: () => socket as any,
+    });
+    const client = new ElementAwarenessClient({
+      transport,
+      getIdentity: () => identity,
+      getPage: () => "/page",
+      onAwareness: () => {},
+      onAwarenessChange: () => {},
+    });
+    client.setLocalAwareness("can-play", "card-a", { active: false });
+    client.setLocalAwareness("can-play", "card-b", { active: false });
+
+    identity = {
+      publicKey: "pk_replaced",
+      playerStyle: { colorPalette: ["green"] },
+    };
+    client.setLocalAwareness("can-play", "card-a", { active: true });
+    client.setLocalAwareness("can-play", "card-b", { active: true });
+
+    expect(
+      Array.from(
+        client.getAwareness("can-play", "card-a")!.byStableId.keys(),
+      ),
+    ).toEqual(["pk_replaced"]);
+    expect(
+      Array.from(
+        client.getAwareness("can-play", "card-b")!.byStableId.keys(),
+      ),
+    ).toEqual(["pk_replaced"]);
+
+    client.destroy();
+    transport.destroy();
+  });
+
   it("removes a peer's awareness when its channels are removed on disconnect", () => {
     const { socket, emitted } = createClient();
     socket.receive({

--- a/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
@@ -183,6 +183,47 @@ describe("element awareness sync", () => {
     expect(calls[0]).toMatchObject({ myAwareness: { active: true } });
   });
 
+  it("preserves remote awareness during a targeted local update", async () => {
+    const calls: any[] = [];
+    const el = document.createElement("div");
+    el.id = "mixed-presence";
+    el.setAttribute("can-play", "");
+    (el as any).defaultData = {};
+    (el as any).updateElement = () => {};
+    (el as any).updateElementAwareness = (data: any) => calls.push(data);
+    document.body.appendChild(el);
+    await playhtml.setupPlayElementForTag(el, "can-play");
+
+    const socket = getPresenceSocketForRoom(playhtml.roomId);
+    socket.receive({
+      type: "presence-sync",
+      peers: {
+        "conn-remote": {
+          identity: {
+            publicKey: "pk_remote",
+            playerStyle: { colorPalette: ["blue"] },
+          },
+          "element:shard:0": {
+            v: 1,
+            entries: [["can-play", "mixed-presence", { active: "remote" }]],
+          },
+        },
+      },
+    });
+    calls.length = 0;
+
+    elementHandlers.get("can-play")!.get("mixed-presence")!
+      .setMyAwareness({ active: "local" } as any);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].awarenessByStableId.get("pk_remote")).toEqual({
+      active: "remote",
+    });
+    expect(calls[0].awarenessByStableId.get(playhtml.users.me.pid)).toEqual({
+      active: "local",
+    });
+  });
+
   it("keeps existing local awareness when a handler is recreated", async () => {
     const el = document.createElement("div");
     el.id = "seeded-presence";

--- a/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
+++ b/packages/playhtml/src/__tests__/element-awareness-sync.test.ts
@@ -234,4 +234,34 @@ describe("element awareness sync", () => {
     expect(finalShard).toContain("burst-0");
     expect(finalShard).toContain("burst-99");
   });
+
+  it("updates only the element whose local awareness changed", async () => {
+    const updateCounts = new Map<string, number>();
+    for (let i = 0; i < 100; i += 1) {
+      const elementId = `targeted-${i}`;
+      const el = document.createElement("div");
+      el.id = elementId;
+      el.setAttribute("can-play", "");
+      (el as any).defaultData = {};
+      (el as any).myDefaultAwareness = { active: false };
+      (el as any).updateElement = () => {};
+      (el as any).updateElementAwareness = () => {
+        updateCounts.set(elementId, (updateCounts.get(elementId) ?? 0) + 1);
+      };
+      document.body.appendChild(el);
+    }
+    playhtml.setupPlayElements();
+    await flushPresencePublishes();
+    expect(updateCounts.size).toBe(100);
+    expect(Array.from(updateCounts.values()).every((count) => count === 1)).toBe(
+      true,
+    );
+    updateCounts.clear();
+
+    playhtml
+      .getHandle("targeted-50", "can-play")
+      .setMyAwareness({ active: true });
+
+    expect(updateCounts).toEqual(new Map([["targeted-50", 1]]));
+  });
 });

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -356,10 +356,50 @@ describe("playhtml basic setup with SyncedStore", () => {
     await playhtml.setupPlayElementForTag(el, "can-play");
     const renderCountAfterSetup = renderCount;
 
+    const added = document.createElement("div");
+    added.id = "scan-added";
+    added.setAttribute("can-play", "");
+    (added as any).defaultData = { count: 0 };
+    (added as any).updateElement = () => {};
+    document.body.appendChild(added);
+
     playhtml.setupPlayElements();
-    await new Promise((resolve) => queueMicrotask(resolve));
+    await waitForCondition(
+      () => elementHandlers.get("can-play")?.has("scan-added") === true,
+      "Expected the page scan to bind the added element",
+    );
 
     expect(renderCount).toBe(renderCountAfterSetup);
+  });
+
+  it("binds a replacement DOM node with the same ID during a page scan", async () => {
+    const first = document.createElement("div");
+    first.id = "scan-replacement";
+    first.setAttribute("can-play", "");
+    (first as any).defaultData = { count: 0 };
+    (first as any).updateElement = () => {};
+    document.body.appendChild(first);
+    await playhtml.setupPlayElementForTag(first, "can-play");
+    first.remove();
+
+    const replacement = document.createElement("div");
+    replacement.id = "scan-replacement";
+    replacement.setAttribute("can-play", "");
+    (replacement as any).defaultData = { count: 0 };
+    (replacement as any).updateElement = () => {};
+    document.body.appendChild(replacement);
+
+    playhtml.setupPlayElements();
+    await waitForCondition(
+      () =>
+        elementHandlers.get("can-play")?.get("scan-replacement")?.element ===
+        replacement,
+      "Expected the page scan to bind the replacement element",
+    );
+
+    expect(
+      elementHandlers.get("can-play")?.get("scan-replacement")?.element,
+    ).toBe(replacement);
   });
 
   it("deleteElementData cleans up all data and handlers", async () => {

--- a/packages/playhtml/src/__tests__/main.basic.test.ts
+++ b/packages/playhtml/src/__tests__/main.basic.test.ts
@@ -343,6 +343,25 @@ describe("playhtml basic setup with SyncedStore", () => {
     expect(reinitialize).not.toHaveBeenCalled();
   });
 
+  it("does not re-render elements that are already bound during a page scan", async () => {
+    const el = document.createElement("div");
+    el.id = "scan-existing";
+    el.setAttribute("can-play", "");
+    (el as any).defaultData = { count: 0 };
+    let renderCount = 0;
+    (el as any).updateElement = () => {
+      renderCount += 1;
+    };
+    document.body.appendChild(el);
+    await playhtml.setupPlayElementForTag(el, "can-play");
+    const renderCountAfterSetup = renderCount;
+
+    playhtml.setupPlayElements();
+    await new Promise((resolve) => queueMicrotask(resolve));
+
+    expect(renderCount).toBe(renderCountAfterSetup);
+  });
+
   it("deleteElementData cleans up all data and handlers", async () => {
     const el = document.createElement("div");
     el.id = "cleanup-test";

--- a/packages/playhtml/src/element-awareness.ts
+++ b/packages/playhtml/src/element-awareness.ts
@@ -322,6 +322,11 @@ export class ElementAwarenessClient {
     const key = `${tag}:${elementId}`;
     const previous = this.currentAwareness.get(key);
     const nextStableId = this.getIdentity().publicKey;
+    if (nextStableId !== this.localStableId) {
+      this.localStableId = nextStableId;
+      this.emit();
+      return;
+    }
     const byStableId = new Map<string, any>();
     const tagMap = this.localTags.get(tag);
     if (tagMap && elementId in tagMap) {
@@ -333,8 +338,6 @@ export class ElementAwarenessClient {
       }
       byStableId.set(stableId, value);
     }
-    this.localStableId = nextStableId;
-
     if (byStableId.size === 0) {
       this.currentAwareness.delete(key);
       this.onAwarenessChange(key, undefined);

--- a/packages/playhtml/src/element-awareness.ts
+++ b/packages/playhtml/src/element-awareness.ts
@@ -58,6 +58,10 @@ type ElementAwarenessClientOptions = {
   getIdentity: () => PlayerIdentity;
   getPage: () => string | undefined;
   onAwareness: (awareness: ElementAwarenessMap) => void;
+  onAwarenessChange?: (
+    key: string,
+    awareness: ElementAwarenessEntry | undefined,
+  ) => void;
 };
 
 export class ElementAwarenessClient {
@@ -65,7 +69,10 @@ export class ElementAwarenessClient {
   private getIdentity: () => PlayerIdentity;
   private getPage: () => string | undefined;
   private onAwareness: (awareness: ElementAwarenessMap) => void;
+  private onAwarenessChange:
+    ElementAwarenessClientOptions["onAwarenessChange"];
   private localTags = new Map<string, Record<string, unknown>>();
+  private currentAwareness: ElementAwarenessMap = new Map();
   private publishedChannels = new Set<string>();
   // Shard channels whose clear may not have reached the server yet. A dropped
   // clear is otherwise permanent: publishedChannels is updated immediately, so a
@@ -77,12 +84,15 @@ export class ElementAwarenessClient {
   private republishTimer: ReturnType<typeof setTimeout> | null = null;
   private destroyed = false;
   private lastAwarenessFingerprint = "";
+  private localStableId: string;
 
   constructor(options: ElementAwarenessClientOptions) {
     this.transport = options.transport;
     this.getIdentity = options.getIdentity;
     this.getPage = options.getPage;
     this.onAwareness = options.onAwareness;
+    this.onAwarenessChange = options.onAwarenessChange;
+    this.localStableId = this.getIdentity().publicKey;
     // The shared per-socket PeerStore folds messages; we subscribe to just the
     // element + identity namespaces, so frame-rate cursor traffic on the same
     // socket never triggers an element awareness recompute. One shared listener
@@ -108,25 +118,29 @@ export class ElementAwarenessClient {
   setLocalAwareness(tag: string, elementId: string, value: unknown): void {
     if (this.stageLocalAwareness(tag, elementId, value)) {
       this.schedulePublish();
-      this.emit();
+      this.emitLocalAwareness(tag, elementId);
     }
   }
 
   /**
-   * Sets many elements' awareness at once, coalescing into a single publish and
-   * a single local emit. Used to reseed retained handlers after a room change
-   * without triggering one full-shard publish per element.
+   * Sets many elements' awareness at once, coalescing into a single publish
+   * while delivering each changed element once. Used to reseed retained
+   * handlers after a room change without a full-shard publish per element.
    */
   setLocalAwarenessBatch(
     entries: Iterable<[tag: string, elementId: string, value: unknown]>,
   ): void {
-    let changed = false;
+    const changedEntries: Array<[string, string]> = [];
     for (const [tag, elementId, value] of entries) {
-      if (this.stageLocalAwareness(tag, elementId, value)) changed = true;
+      if (this.stageLocalAwareness(tag, elementId, value)) {
+        changedEntries.push([tag, elementId]);
+      }
     }
-    if (!changed) return;
+    if (changedEntries.length === 0) return;
     this.schedulePublish();
-    this.emit();
+    for (const [tag, elementId] of changedEntries) {
+      this.emitLocalAwareness(tag, elementId);
+    }
   }
 
   /** Stages a local write into localTags; returns true if it changed. */
@@ -135,28 +149,36 @@ export class ElementAwarenessClient {
     elementId: string,
     value: unknown,
   ): boolean {
-    const tagMap = this.localTags.get(tag) ?? {};
+    const tagMap = this.localTags.get(tag);
+    if (!tagMap) {
+      this.localTags.set(tag, { [elementId]: value });
+      return true;
+    }
     if (tagMap[elementId] === value) return false;
-    this.localTags.set(tag, { ...tagMap, [elementId]: value });
+    tagMap[elementId] = value;
     return true;
   }
 
   removeLocalAwareness(tag: string, elementId: string): void {
     const tagMap = this.localTags.get(tag);
     if (!tagMap || !(elementId in tagMap)) return;
-    const next = { ...tagMap };
-    delete next[elementId];
-    if (Object.keys(next).length === 0) {
+    delete tagMap[elementId];
+    if (Object.keys(tagMap).length === 0) {
       this.localTags.delete(tag);
-    } else {
-      this.localTags.set(tag, next);
     }
     this.schedulePublish();
-    this.emit();
+    this.emitLocalAwareness(tag, elementId);
   }
 
   getLocalAwareness(tag: string, elementId: string): unknown {
     return this.localTags.get(tag)?.[elementId];
+  }
+
+  getAwareness(
+    tag: string,
+    elementId: string,
+  ): ElementAwarenessEntry | undefined {
+    return this.currentAwareness.get(`${tag}:${elementId}`);
   }
 
   refresh(): void {
@@ -184,6 +206,11 @@ export class ElementAwarenessClient {
     queueMicrotask(() => {
       this.publishScheduled = false;
       if (this.destroyed) return;
+      if (this.onAwarenessChange) {
+        this.lastAwarenessFingerprint = fingerprintAwareness(
+          this.currentAwareness,
+        );
+      }
       this.publishLocalAwareness();
       this.scheduleRepublish();
     });
@@ -282,7 +309,44 @@ export class ElementAwarenessClient {
     const fingerprint = fingerprintAwareness(awareness);
     if (fingerprint === this.lastAwarenessFingerprint) return;
     this.lastAwarenessFingerprint = fingerprint;
+    this.currentAwareness = awareness;
     this.onAwareness(awareness);
+  }
+
+  private emitLocalAwareness(tag: string, elementId: string): void {
+    if (!this.onAwarenessChange) {
+      this.emit();
+      return;
+    }
+
+    const key = `${tag}:${elementId}`;
+    const previous = this.currentAwareness.get(key);
+    const nextStableId = this.getIdentity().publicKey;
+    const byStableId = new Map<string, any>();
+    const tagMap = this.localTags.get(tag);
+    if (tagMap && elementId in tagMap) {
+      byStableId.set(nextStableId, tagMap[elementId]);
+    }
+    for (const [stableId, value] of previous?.byStableId ?? []) {
+      if (stableId === this.localStableId || stableId === nextStableId) {
+        continue;
+      }
+      byStableId.set(stableId, value);
+    }
+    this.localStableId = nextStableId;
+
+    if (byStableId.size === 0) {
+      this.currentAwareness.delete(key);
+      this.onAwarenessChange(key, undefined);
+      return;
+    }
+
+    const awareness = {
+      array: Array.from(byStableId.values()),
+      byStableId,
+    };
+    this.currentAwareness.set(key, awareness);
+    this.onAwarenessChange(key, awareness);
   }
 
   private buildElementAwareness(): ElementAwarenessMap {

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -64,6 +64,7 @@ import {
 } from "./presence-transport";
 import {
   ElementAwarenessClient,
+  type ElementAwarenessEntry,
   type ElementAwarenessMap,
 } from "./element-awareness";
 import { PresenceClient } from "./presence-client";
@@ -1010,6 +1011,7 @@ function buildElementAwarenessClient(): void {
       getIdentity: resolveMyIdentity,
       getPage: getPresencePage,
       onAwareness: applyElementAwareness,
+      onAwarenessChange: applyElementAwarenessEntry,
     });
   } catch (error) {
     elementAwarenessRoom = null;
@@ -1324,7 +1326,7 @@ async function resetCurrentRoomFromServer(): Promise<void> {
   markAllElementsAsLoading();
   await waitForMainProviderSync(SERVER_ROOM_RESET_SYNC_TIMEOUT_MS);
   refreshPageDataChannels(getPageDataDeps());
-  setupElements();
+  reinitializeElements();
   markAllElementsAsReady();
   cursorClient?.refreshContainer?.();
   cursorClient?.refreshCursorStyles?.();
@@ -1487,7 +1489,11 @@ async function runHandleNavigation(): Promise<void> {
     refreshPageDataChannels(getPageDataDeps());
   }
 
-  setupElements();
+  if (mainRoomChanged) {
+    reinitializeElements();
+  } else {
+    setupElements();
+  }
   markAllElementsAsReady();
 
   cursorClient?.refreshContainer?.();
@@ -1886,8 +1892,8 @@ function createPlayElementData<T extends TagType, TData = any>(
     triggerAwarenessUpdate: () => {
       if (elementAwarenessClient) {
         // setLocalAwareness (called by onAwarenessChange, which always runs
-        // immediately before this in setMyAwareness) already emitted the
-        // handler sweep synchronously. Refreshing here would fire
+        // immediately before this in setMyAwareness) already delivered the
+        // element's awareness synchronously. Refreshing here would fire
         // updateElementAwareness a second time for the same local write.
         return;
       }
@@ -2076,6 +2082,26 @@ function applyElementAwareness(elementAwareness: ElementAwarenessMap): void {
   trackedElementAwarenessKeys = new Set(elementAwareness.keys());
 }
 
+function applyElementAwarenessEntry(
+  key: string,
+  awareness: ElementAwarenessEntry | undefined,
+): void {
+  safeInvoke(
+    () =>
+      updateHandlerAwarenessForKey(
+        key,
+        awareness?.array ?? [],
+        awareness?.byStableId ?? new Map(),
+      ),
+    "element awareness handler",
+  );
+  if (awareness) {
+    trackedElementAwarenessKeys.add(key);
+  } else {
+    trackedElementAwarenessKeys.delete(key);
+  }
+}
+
 function updateHandlerAwarenessForKey(
   key: string,
   array: any[],
@@ -2101,6 +2127,14 @@ function updateHandlerAwarenessForKey(
  * on the `playhtml` object on `window`.
  */
 function setupElements(): void {
+  setupElementsFromDocument(false);
+}
+
+function reinitializeElements(): void {
+  setupElementsFromDocument(true);
+}
+
+function setupElementsFromDocument(reinitializeExisting: boolean): void {
   if (!hasSynced) {
     return;
   }
@@ -2127,7 +2161,16 @@ function setupElements(): void {
       console.log(`SET UP ${tag}`);
     }
     void Promise.all(
-      tagElements.map((element) => setupPlayElementForTag(element, tag)),
+      tagElements.map((element) => {
+        const elementId = getIdForElement(element);
+        const existingHandler = elementId
+          ? elementHandlers.get(tag)?.get(elementId)
+          : undefined;
+        if (!reinitializeExisting && existingHandler?.element === element) {
+          return;
+        }
+        return setupPlayElementForTag(element, tag);
+      }),
     );
   }
 
@@ -2643,9 +2686,14 @@ async function setupPlayElementForTag<T extends TagType | string>(
     }
   }
 
-  // redo this now that we have set it in the mapping.
-  // TODO: this is inefficient, it tries to do this in the constructor but fails, should clean up the API
-  elementData.triggerAwarenessUpdate?.();
+  const initialAwareness = elementAwarenessClient?.getAwareness(tag, elementId);
+  if (initialAwareness) {
+    tagElementHandlers
+      .get(elementId)
+      ?.updateAwareness(initialAwareness.array, initialAwareness.byStableId);
+  } else {
+    elementData.triggerAwarenessUpdate?.();
+  }
   // Set up the common classes for affected elements.
   element.classList.add(`__playhtml-element`);
   element.style.setProperty("--jiggle-delay", `${Math.random() * 1}s;}`);


### PR DESCRIPTION
## Summary

- Skip PlayHTML handlers already bound to the same DOM node during repeated document scans while preserving explicit reinitialization for room changes and server resets.
- Deliver local element-awareness changes only to the affected element and fingerprint the full awareness snapshot once per coalesced publish.
- Document stable element IDs and add a patch changeset for the published runtime behavior.

## Why

React route changes repeatedly scan registered elements. The previous scan path set up every matching element again, causing work and renders proportional to the total registered element count even when the DOM nodes had not changed.

Local element-awareness writes also rebuilt and fingerprinted the complete awareness map for every update. This made per-element writes scale with the total element count.

## Measurements

All browser figures are ranges from five Chrome runs on the same machine, Bun version, lockfile, build, and benchmark paths.

| Public path | Before | After |
| --- | ---: | ---: |
| React route scan, 1,000 elements | 29.6-36.0 ms, 1,000 renders | 0.2-0.4 ms, 0 renders |
| Element-awareness initialization, 1,000 elements | 1,285.5-1,328.6 ms | 901.6-912.7 ms |
| 50 local awareness writes, 1,000 elements | 37.3-39.6 ms | 0.1-0.2 ms |

The public ESM path grows by 1,677 raw bytes, 362 gzip bytes, and 374 Brotli bytes using the same build and compression commands.

## Reproduction

- Create 1,000 public React capability elements, initialize PlayHTML, and trigger a route search without replacing the nodes. Record elapsed time and component render callbacks.
- Create 1,000 public `can-play` elements with element awareness, initialize them, then perform 50 local awareness writes. Record initialization and write time.
- Repeat each scenario in five fresh browser runs.

## Verification

- `bun run build-packages`
- PlayHTML tests: 517 passed
- React tests: 54 passed
- Docs tests: 52 passed
- Docs static build
- `bun run check:packages`
- Five-run Chrome route, awareness, and lifecycle measurements

## Scope notes

The lifecycle test also confirmed that unique element IDs in one long-lived room retain CRDT history after live records are deleted. Reclaiming that history requires a separate document-lifecycle decision and is not part of this fix.

The public docs describe repeated scans and stable IDs. The starter templates are unchanged because this does not change API signatures or usage. There is no visual UI change, so screenshots are not applicable.
