### PR TITLE
common: avoid redundant shared-data writes

### DIFF
--- a/.changeset/quiet-bridge-updates.md
+++ b/.changeset/quiet-bridge-updates.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Avoid redundant shared-data writes when incoming object and array values are unchanged, preventing unnecessary collaborative document history growth.

--- a/packages/common/src/__tests__/objectUtils.test.ts
+++ b/packages/common/src/__tests__/objectUtils.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Verifies shared-object comparison and replacement avoid redundant writes.
+// ABOUTME: Prevents bridge fanout from accumulating semantically empty Yjs history.
+import { getYjsValue, syncedStore } from "@syncedstore/core";
+import { describe, expect, test } from "vitest";
+import * as Y from "yjs";
+import { deepReplaceIntoProxy } from "../objectUtils";
+
+describe("deepReplaceIntoProxy", () => {
+  test("does not create an update for reordered but equal data", () => {
+    const doc = new Y.Doc();
+    const store = syncedStore<{ value: Record<string, unknown> }>(
+      { value: {} },
+      doc,
+    );
+    store.value.project = { title: "same", members: ["a", "b"] };
+    store.value.count = 2;
+    const stateVector = Y.encodeStateVector(doc);
+
+    doc.transact(() => {
+      deepReplaceIntoProxy(store.value, {
+        count: 2,
+        project: { members: ["a", "b"], title: "same" },
+      });
+    });
+
+    expect(Y.encodeStateAsUpdate(doc, stateVector)).toHaveLength(2);
+    expect(getYjsValue(store.value)).toBeDefined();
+    doc.destroy();
+  });
+
+  test("writes only the changed primitive into a larger subtree", () => {
+    const doc = new Y.Doc();
+    const store = syncedStore<{ value: Record<string, unknown> }>(
+      { value: {} },
+      doc,
+    );
+    store.value.unchanged = { members: ["a", "b"], count: 2 };
+    store.value.changed = 1;
+    const stateVector = Y.encodeStateVector(doc);
+
+    doc.transact(() => {
+      deepReplaceIntoProxy(store.value, {
+        changed: 2,
+        unchanged: { count: 2, members: ["a", "b"] },
+      });
+    });
+
+    const update = Y.decodeUpdate(Y.encodeStateAsUpdate(doc, stateVector));
+    expect(update.structs).toHaveLength(1);
+    expect(store.value.changed).toBe(2);
+    expect(store.value.unchanged).toEqual({ members: ["a", "b"], count: 2 });
+    doc.destroy();
+  });
+});

--- a/packages/common/src/objectUtils.ts
+++ b/packages/common/src/objectUtils.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Compares and updates plain shared-data structures without redundant writes.
+// ABOUTME: Preserves proxy identity while avoiding unnecessary CRDT history.
 export function isPlainObject(value: any): value is Record<string, any> {
   return (
     value !== null &&
@@ -6,9 +8,33 @@ export function isPlainObject(value: any): value is Record<string, any> {
   );
 }
 
+function valuesEqual(left: any, right: any): boolean {
+  if (Object.is(left, right)) return true;
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return (
+      left.length === right.length &&
+      left.every((value, index) => valuesEqual(value, right[index]))
+    );
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      rightKeys.every(
+        (key) =>
+          Object.prototype.hasOwnProperty.call(left, key) &&
+          valuesEqual(left[key], right[key]),
+      )
+    );
+  }
+  return false;
+}
+
 export function deepReplaceIntoProxy(target: any, src: any) {
   if (src === null || src === undefined) return;
   if (Array.isArray(src)) {
+    if (valuesEqual(target, src)) return;
     target.splice(0, target.length, ...src);
     return;
   }
@@ -24,7 +50,9 @@ export function deepReplaceIntoProxy(target: any, src: any) {
         if (!isPlainObject(target[k])) target[k] = {};
         deepReplaceIntoProxy(target[k], v);
       } else {
-        (target as any)[k] = v as any;
+        if (!Object.is(target[k], v)) {
+          (target as any)[k] = v as any;
+        }
       }
     }
     return;


### PR DESCRIPTION
## Summary

- skip writes when incoming shared-data primitives have not changed
- preserve equal arrays instead of replacing them in SyncedStore proxies
- compare nested plain objects without depending on property insertion order

## Why

Room bridges send complete shared-element subtrees. `deepReplaceIntoProxy` previously rewrote every primitive and array in an incoming subtree, even when only property order differed or one nested value changed. Each rewrite appended Yjs history.

The production showcase room amplified semantically unchanged `student-projects` updates into rapid document growth, repeated autosaves, compactions, and Durable Object memory resets.

## Verification

- `bun run test:common`: 18 tests passed
- `bun run --cwd packages/common build`: passed
- `tsc -p partykit`: passed
- production Worker dry-run bundle: passed
- deployed to staging as `a618c71f-9d42-4c0b-831a-edf85d91cfcf`
- deployed to production as `a34c9773-52bc-4cde-ac91-e481799c0150`
- restored the production showcase document with all 27 projects preserved
- observed zero document growth and no semantic change across a 45-second bridge interval
- observed zero targeted failure signatures and zero runtime errors after recovery on the deployed version

## Documentation

No public documentation or starter-template change is needed. This restores the intended bridge behavior without changing the shared-data API.
