### PR TITLE
extension-worker: derive feature catalog from code

### DIFF
--- a/extension/worker/src/__tests__/accessControl.test.ts
+++ b/extension/worker/src/__tests__/accessControl.test.ts
@@ -118,6 +118,72 @@ describe('feature access control', () => {
     expect(body.features.QUARANTINE_TAPE.available).toBe(true);
   });
 
+  it('gives internal members code-defined features without seeded policy rows', async () => {
+    await workerEnv.WWO_ADMIN_DB.prepare(
+      'DELETE FROM features WHERE feature_id = ?',
+    ).bind('QUARANTINE_TAPE').run();
+    expect((await addToCohort([PUBLIC_ID], 'internal')).status).toBe(201);
+
+    const response = await handleFeatureAccessCheck(workerEnv, PUBLIC_ID);
+    const body = await response.json() as {
+      features: Record<string, { stage: string; available: boolean }>;
+    };
+
+    expect(body.features.QUARANTINE_TAPE).toEqual({
+      stage: 'internal',
+      available: true,
+    });
+  });
+
+  it('shows code-defined features in the admin overview without policy rows', async () => {
+    await workerEnv.WWO_ADMIN_DB.prepare(
+      'DELETE FROM features WHERE feature_id = ?',
+    ).bind('QUARANTINE_TAPE').run();
+
+    const response = await handleAdminAccessOverview(
+      adminRequest('/admin/access-control'),
+      workerEnv,
+    );
+    const body = await response.json() as {
+      features: Array<{
+        id: string;
+        name: string;
+        description: string;
+        stage: string;
+      }>;
+    };
+
+    expect(body.features).toContainEqual({
+      id: 'QUARANTINE_TAPE',
+      name: 'Quarantine tape',
+      description: 'Mark pages with shared caution tape.',
+      stage: 'internal',
+    });
+  });
+
+  it('creates missing policy rows when a cohort receives a feature grant', async () => {
+    await workerEnv.WWO_ADMIN_DB.prepare(
+      'DELETE FROM features WHERE feature_id = ?',
+    ).bind('QUARANTINE_TAPE').run();
+
+    const cohortUpdate = await handleAdminCohortFeaturesUpdate(
+      adminRequest('/admin/access-control/cohorts/closed-beta', {
+        method: 'PUT',
+        body: JSON.stringify({ featureIds: ['QUARANTINE_TAPE'] }),
+      }),
+      workerEnv,
+      'closed-beta',
+    );
+    expect(cohortUpdate.status).toBe(200);
+    expect((await addToCohort([PUBLIC_ID], 'closed-beta')).status).toBe(201);
+
+    const response = await handleFeatureAccessCheck(workerEnv, PUBLIC_ID);
+    const body = await response.json() as {
+      features: Record<string, { available: boolean }>;
+    };
+    expect(body.features.QUARANTINE_TAPE.available).toBe(true);
+  });
+
   it('limits closed beta members to the cohort feature grants', async () => {
     expect((await addToCohort([PUBLIC_ID], 'closed-beta')).status).toBe(201);
 
@@ -159,6 +225,25 @@ describe('feature access control', () => {
     expect(memberBody.features.BOTTLES.available).toBe(true);
     expect(memberBody.features.COMMUTE.available).toBe(false);
     expect(publicBody.features.EMOTES.available).toBe(true);
+  });
+
+  it('clears every explicit cohort feature grant', async () => {
+    await addToCohort([PUBLIC_ID], 'closed-beta');
+    const cohortUpdate = await handleAdminCohortFeaturesUpdate(
+      adminRequest('/admin/access-control/cohorts/closed-beta', {
+        method: 'PUT',
+        body: JSON.stringify({ featureIds: [] }),
+      }),
+      workerEnv,
+      'closed-beta',
+    );
+    expect(cohortUpdate.status).toBe(200);
+
+    const body = await (await handleFeatureAccessCheck(workerEnv, PUBLIC_ID)).json() as {
+      features: Record<string, { available: boolean }>;
+    };
+    expect(body.features.COMMUTE.available).toBe(false);
+    expect(body.features.SCRAPS.available).toBe(false);
   });
 
   it('rejects the removed Labs stage', async () => {

--- a/extension/worker/src/__tests__/featurePolicy.test.ts
+++ b/extension/worker/src/__tests__/featurePolicy.test.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Verifies code-defined features remain resolvable without seeded production policy rows.
+// ABOUTME: Covers mutable stage overrides and cohort grants without requiring a D1 emulator.
+
+import { describe, expect, it } from 'vitest';
+import {
+  resolveFeaturePolicies,
+  resolveFeatureStage,
+} from '../lib/featurePolicy';
+
+describe('feature policy', () => {
+  it('grants code-defined features to internal members without stored stages', () => {
+    const features = resolveFeaturePolicies({
+      storedStages: new Map(),
+      grantsAllUnreleased: true,
+      grantedFeatureIds: new Set(),
+    });
+
+    expect(features.QUARANTINE_TAPE).toEqual({
+      stage: 'internal',
+      available: true,
+    });
+  });
+
+  it('keeps ungranted code-defined features unavailable to the public', () => {
+    const features = resolveFeaturePolicies({
+      storedStages: new Map(),
+      grantsAllUnreleased: false,
+      grantedFeatureIds: new Set(),
+    });
+
+    expect(features.QUARANTINE_TAPE).toEqual({
+      stage: 'internal',
+      available: false,
+    });
+  });
+
+  it('applies stored stages and explicit cohort grants', () => {
+    const storedStages = new Map<string, string>([
+      ['EMOTES', 'released'],
+      ['QUARANTINE_TAPE', 'invalid'],
+    ]);
+    const features = resolveFeaturePolicies({
+      storedStages,
+      grantsAllUnreleased: false,
+      grantedFeatureIds: new Set(['BOTTLES']),
+    });
+
+    expect(features.EMOTES).toEqual({ stage: 'released', available: true });
+    expect(features.BOTTLES.available).toBe(true);
+    expect(resolveFeatureStage('QUARANTINE_TAPE', storedStages)).toBe('internal');
+  });
+});

--- a/extension/worker/src/lib/featurePolicy.ts
+++ b/extension/worker/src/lib/featurePolicy.ts
@@ -1,0 +1,43 @@
+// ABOUTME: Resolves the effective feature policy from the code catalog and stored rollout controls.
+// ABOUTME: Keeps catalog features visible when production has no matching policy row.
+
+import {
+  FEATURE_CATALOG,
+  FEATURE_IDS,
+  isFeatureStage,
+  type FeatureAccessSnapshot,
+  type FeatureId,
+  type FeatureStage,
+} from '../../../shared/featureCatalog';
+
+export function resolveFeatureStage(
+  featureId: FeatureId,
+  storedStages: ReadonlyMap<string, string>,
+): FeatureStage {
+  const storedStage = storedStages.get(featureId);
+  return storedStage && isFeatureStage(storedStage)
+    ? storedStage
+    : FEATURE_CATALOG[featureId].defaultStage;
+}
+
+export function resolveFeaturePolicies(options: {
+  storedStages: ReadonlyMap<string, string>;
+  grantsAllUnreleased: boolean;
+  grantedFeatureIds: ReadonlySet<string>;
+}): FeatureAccessSnapshot['features'] {
+  return Object.fromEntries(
+    FEATURE_IDS.map((featureId) => {
+      const stage = resolveFeatureStage(featureId, options.storedStages);
+      return [
+        featureId,
+        {
+          stage,
+          available:
+            stage === 'released' ||
+            options.grantsAllUnreleased ||
+            options.grantedFeatureIds.has(featureId),
+        },
+      ];
+    }),
+  ) as FeatureAccessSnapshot['features'];
+}

--- a/extension/worker/src/routes/accessControl.ts
+++ b/extension/worker/src/routes/accessControl.ts
@@ -6,11 +6,11 @@ import {
   FEATURE_IDS,
   isFeatureId,
   isFeatureStage,
-  type FeatureAccessSnapshot,
   type FeatureId,
   type FeatureStage,
 } from '../../../shared/featureCatalog';
 import { getAdminAuthError } from '../lib/adminAuth';
+import { resolveFeaturePolicies, resolveFeatureStage } from '../lib/featurePolicy';
 import { createIpRateLimiter } from '../lib/ipRateLimit';
 import { createResendClient } from '../lib/resend';
 import type { Env } from '../lib/supabase';
@@ -26,9 +26,12 @@ const JSON_HEADERS = {
 
 type FeatureRow = {
   feature_id: string;
-  name: string;
-  description: string;
   stage: string;
+};
+
+type FeatureGrantRow = {
+  feature_id: string | null;
+  grants_all_unreleased: number;
 };
 
 type CohortRow = {
@@ -92,16 +95,18 @@ async function allRows<T>(statement: D1PreparedStatement): Promise<T[]> {
   return result.results;
 }
 
-async function ensureFeatureCatalog(db: D1Database): Promise<void> {
+async function ensureFeaturePolicyRows(
+  db: D1Database,
+  featureIds: FeatureId[],
+): Promise<void> {
+  if (featureIds.length === 0) return;
   await db.batch(
-    FEATURE_IDS.map((featureId) => {
+    featureIds.map((featureId) => {
       const feature = FEATURE_CATALOG[featureId];
       return db.prepare(
         `INSERT INTO features (feature_id, name, description, stage)
          VALUES (?, ?, ?, ?)
-         ON CONFLICT(feature_id) DO UPDATE SET
-           name = excluded.name,
-           description = excluded.description`,
+         ON CONFLICT(feature_id) DO NOTHING`,
       ).bind(
         featureId,
         feature.name,
@@ -128,46 +133,31 @@ export async function handleFeatureAccessCheck(
     return jsonResponse(400, { error: 'Invalid public ID' });
   }
 
-  const rows = await allRows<FeatureRow & { available: number }>(
-    env.WWO_ADMIN_DB.prepare(
-      `SELECT
-         f.feature_id,
-         f.name,
-         f.description,
-         f.stage,
-         CASE
-           WHEN f.stage = 'released' THEN 1
-           WHEN EXISTS (
-             SELECT 1
-             FROM cohort_memberships cm
-             JOIN cohorts c ON c.cohort_id = cm.cohort_id
-             LEFT JOIN cohort_features cf
-               ON cf.cohort_id = c.cohort_id
-              AND cf.feature_id = f.feature_id
-             WHERE cm.public_id = ?
-               AND (c.grants_all_unreleased = 1 OR cf.feature_id IS NOT NULL)
-           ) THEN 1
-           ELSE 0
-         END AS available
-       FROM features f`,
-    ).bind(publicId),
+  const [featureRows, grantRows] = await Promise.all([
+    allRows<FeatureRow>(env.WWO_ADMIN_DB.prepare(
+      'SELECT feature_id, stage FROM features',
+    )),
+    allRows<FeatureGrantRow>(env.WWO_ADMIN_DB.prepare(
+      `SELECT c.grants_all_unreleased, cf.feature_id
+       FROM cohort_memberships cm
+       JOIN cohorts c ON c.cohort_id = cm.cohort_id
+       LEFT JOIN cohort_features cf ON cf.cohort_id = c.cohort_id
+       WHERE cm.public_id = ?`,
+    ).bind(publicId)),
+  ]);
+  const grantsAllUnreleased = grantRows.some((row) => row.grants_all_unreleased === 1);
+  const grantedFeatureIds = new Set(
+    grantRows.flatMap((row) => row.feature_id ? [row.feature_id] : []),
   );
 
-  const features = Object.fromEntries(
-    FEATURE_IDS.map((featureId) => {
-      const row = rows.find((candidate) => candidate.feature_id === featureId);
-      const stage = row && isFeatureStage(row.stage)
-        ? row.stage
-        : FEATURE_CATALOG[featureId].defaultStage;
-      return [
-        featureId,
-        {
-          stage,
-          available: stage === 'released' || row?.available === 1,
-        },
-      ];
-    }),
-  ) as FeatureAccessSnapshot['features'];
+  const storedStages = new Map(
+    featureRows.map((row) => [row.feature_id, row.stage]),
+  );
+  const features = resolveFeaturePolicies({
+    storedStages,
+    grantsAllUnreleased,
+    grantedFeatureIds,
+  });
 
   return jsonResponse(200, { features });
 }
@@ -179,11 +169,10 @@ export async function handleAdminAccessOverview(
   const authError = getAdminAuthError(request, env.ADMIN_KEY);
   if (authError) return authError;
 
-  await ensureFeatureCatalog(env.WWO_ADMIN_DB);
   const [featureRows, cohortRows, cohortFeatureRows, personRows, membershipRows, requestRows] =
     await Promise.all([
       allRows<FeatureRow>(env.WWO_ADMIN_DB.prepare(
-        'SELECT feature_id, name, description, stage FROM features ORDER BY name',
+        'SELECT feature_id, stage FROM features',
       )),
       allRows<CohortRow>(env.WWO_ADMIN_DB.prepare(
         'SELECT cohort_id, name, grants_all_unreleased FROM cohorts ORDER BY name',
@@ -205,15 +194,19 @@ export async function handleAdminAccessOverview(
       )),
     ]);
 
+  const storedStages = new Map(
+    featureRows.map((row) => [row.feature_id, row.stage]),
+  );
   return jsonResponse(200, {
-    features: featureRows
-      .filter((row) => isFeatureId(row.feature_id) && isFeatureStage(row.stage))
-      .map((row) => ({
-        id: row.feature_id,
-        name: row.name,
-        description: row.description,
-        stage: row.stage,
-      })),
+    features: FEATURE_IDS.map((featureId) => {
+      const definition = FEATURE_CATALOG[featureId];
+      return {
+        id: featureId,
+        name: definition.name,
+        description: definition.description,
+        stage: resolveFeatureStage(featureId, storedStages),
+      };
+    }),
     cohorts: cohortRows.map((row) => ({
       id: row.cohort_id,
       name: row.name,
@@ -257,7 +250,7 @@ export async function handleAdminFeatureStageUpdate(
     return jsonResponse(400, { error: 'Invalid feature stage' });
   }
 
-  await ensureFeatureCatalog(env.WWO_ADMIN_DB);
+  await ensureFeaturePolicyRows(env.WWO_ADMIN_DB, [featureId]);
   await env.WWO_ADMIN_DB.prepare(
     'UPDATE features SET stage = ?, updated_at = CURRENT_TIMESTAMP WHERE feature_id = ?',
   ).bind(stage, featureId).run();
@@ -285,6 +278,7 @@ export async function handleAdminCohortFeaturesUpdate(
   }
 
   const featureIds = [...new Set(requestedFeatureIds as FeatureId[])];
+  await ensureFeaturePolicyRows(env.WWO_ADMIN_DB, featureIds);
   await env.WWO_ADMIN_DB.batch([
     env.WWO_ADMIN_DB.prepare('DELETE FROM cohort_features WHERE cohort_id = ?').bind(cohortId),
     ...featureIds.map((featureId) => env.WWO_ADMIN_DB.prepare(


### PR DESCRIPTION
## Summary

- derive feature definitions and default stages from `FEATURE_CATALOG`
- keep mutable stage overrides and cohort grants in D1
- create missing policy rows only when admin writes need them

## Why

A newly deployed feature could remain unavailable to internal testers until a separate D1 seed migration ran. The access endpoint now enumerates the code catalog and applies stored rollout policy when present.

## Verification

- `bun run test:extension-worker` (110 tests)
- `bun run check:extension-worker`
- `bun run smoke:extension-worker`
- `git diff --check`

No screenshot is needed because this changes Worker policy resolution without changing UI. No `extension/PENDING.md` entry is needed because the affected feature remains internal.