### PR TITLE
Commute link on wewere.online + install CTAs on the commute

### DIFF
--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
@@ -91,7 +91,7 @@ describe("CommuteInstallPrompt", () => {
     document.body.appendChild(container);
     const root = createRoot(container);
     act(() => {
-      root.render(<CommuteStationPoster />);
+      root.render(<CommuteStationPoster stationVisible />);
     });
     await act(async () => {
       vi.advanceTimersByTime(800);
@@ -134,6 +134,41 @@ describe("CommuteInstallPrompt", () => {
     expect(document.querySelector(".commute-poster-dialog")).toBeNull();
 
     act(() => poster?.click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(document.querySelector(".commute-poster-dialog")).toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("removes the poster trigger while the station is offscreen but keeps an open overlay", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<CommuteStationPoster stationVisible={false} />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(container.querySelector(".station-install-poster")).toBeNull();
+
+    act(() => {
+      root.render(<CommuteStationPoster stationVisible />);
+    });
+    const poster = container.querySelector<HTMLButtonElement>(
+      ".station-install-poster",
+    );
+    act(() => poster?.click());
+    expect(document.querySelector(".commute-poster-dialog")).not.toBeNull();
+
+    act(() => {
+      root.render(<CommuteStationPoster stationVisible={false} />);
+    });
+    expect(container.querySelector(".station-install-poster")).toBeNull();
+    expect(document.querySelector(".commute-poster-dialog")).not.toBeNull();
+
     act(() => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
     });

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.test.tsx
@@ -9,6 +9,7 @@ import {
   markExtensionInstalled,
 } from "../../utils/extensionInstallMarker";
 import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
+import { CommuteStationPoster } from "./CommuteStationPoster";
 
 async function renderPrompt(): Promise<{
   container: HTMLDivElement;
@@ -48,7 +49,9 @@ describe("CommuteInstallPrompt", () => {
     });
 
     expect(container.textContent).toContain("internet transit pass");
+    expect(container.textContent).toContain("join the ride");
     expect(container.textContent).toContain("get the extension");
+    expect(container.textContent).not.toContain("add your stops");
     const link = container.querySelector("a");
     expect(link?.href).toBe("https://wewere.online/");
     expect(link?.target).toBe("_blank");
@@ -80,6 +83,61 @@ describe("CommuteInstallPrompt", () => {
     });
 
     expect(container.querySelector(".commute-install-cta")).toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("opens and dismisses the station poster overlay", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(<CommuteStationPoster />);
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    const poster = container.querySelector<HTMLButtonElement>(
+      ".station-install-poster",
+    );
+    expect(poster?.getAttribute("aria-label")).toBe(
+      "Open the internet transit pass poster",
+    );
+    act(() => poster?.click());
+
+    const dialog = document.querySelector<HTMLElement>(
+      ".commute-poster-dialog",
+    );
+    expect(dialog?.textContent).toContain("internet transit pass");
+    expect(dialog?.textContent).toContain("join the ride");
+    expect(dialog?.textContent).toContain(
+      "this line runs on the stops of riders like you — install we were online and the places you visit become stations on everyone's commute.",
+    );
+    expect(dialog?.querySelector("a")?.href).toBe("https://wewere.online/");
+
+    act(() =>
+      dialog
+        ?.querySelector<HTMLButtonElement>(
+          ".commute-poster-dialog__close",
+        )
+        ?.click(),
+    );
+    expect(document.querySelector(".commute-poster-dialog")).toBeNull();
+
+    act(() => poster?.click());
+    const backdrop = document.querySelector<HTMLElement>(
+      ".commute-poster-backdrop",
+    );
+    act(() => {
+      backdrop?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+    expect(document.querySelector(".commute-poster-dialog")).toBeNull();
+
+    act(() => poster?.click());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    expect(document.querySelector(".commute-poster-dialog")).toBeNull();
     act(() => root.unmount());
   });
 });

--- a/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
+++ b/extension/src/entrypoints/commute/CommuteInstallPrompt.tsx
@@ -1,62 +1,7 @@
 // ABOUTME: Links the public commute to the extension homepage when installation is absent.
 // ABOUTME: Waits for the content-script marker so installed riders do not see the prompt.
 
-import { useEffect, useState } from "react";
-import {
-  EXTENSION_INSTALL_ATTRIBUTE,
-  isExtensionInstalled,
-} from "../../utils/extensionInstallMarker";
-
-const EXTENSION_DETECTION_MS = 800;
-
-type InstallState = "checking" | "installed" | "missing";
-
-function isPublicWebPage(): boolean {
-  return (
-    window.location.protocol === "http:" ||
-    window.location.protocol === "https:"
-  );
-}
-
-function useExtensionInstallState(): InstallState {
-  const [state, setState] = useState<InstallState>(() => {
-    if (!isPublicWebPage()) return "installed";
-    return isExtensionInstalled(document.documentElement)
-      ? "installed"
-      : "checking";
-  });
-
-  useEffect(() => {
-    if (!isPublicWebPage()) return;
-
-    const root = document.documentElement;
-    if (isExtensionInstalled(root)) {
-      setState("installed");
-      return;
-    }
-
-    const observer = new MutationObserver(() => {
-      if (isExtensionInstalled(root)) {
-        setState("installed");
-      }
-    });
-    observer.observe(root, {
-      attributes: true,
-      attributeFilter: [EXTENSION_INSTALL_ATTRIBUTE],
-    });
-
-    const timer = window.setTimeout(() => {
-      setState((current) => (current === "checking" ? "missing" : current));
-    }, EXTENSION_DETECTION_MS);
-
-    return () => {
-      observer.disconnect();
-      window.clearTimeout(timer);
-    };
-  }, []);
-
-  return state;
-}
+import { useExtensionInstallState } from "./commuteInstallState";
 
 export function CommuteInstallPrompt() {
   const installState = useExtensionInstallState();
@@ -75,7 +20,7 @@ export function CommuteInstallPrompt() {
         <span className="commute-install-cta__label">
           internet transit pass
         </span>
-        <strong>add your stops</strong>
+        <strong>join the ride</strong>
         <span>get the extension →</span>
       </span>
     </a>

--- a/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
@@ -4,6 +4,11 @@
 import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKER_URL } from "@movement/config";
+import {
+  EXTENSION_INSTALL_ATTRIBUTE,
+  markExtensionInstalled,
+} from "../../utils/extensionInstallMarker";
 import {
   CommuteMobileControls,
   keepCommuteCursorInCar,
@@ -19,6 +24,14 @@ function renderControls(
   return { container, root };
 }
 
+function enterEmail(input: HTMLInputElement, email: string): void {
+  Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set?.call(input, email);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
 describe("CommuteMobileControls", () => {
   beforeEach(() => {
     (
@@ -32,12 +45,15 @@ describe("CommuteMobileControls", () => {
       "matchMedia",
       vi.fn(() => ({ matches: true })),
     );
+    document.documentElement.removeAttribute(EXTENSION_INSTALL_ATTRIBUTE);
+    localStorage.clear();
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it("boards from a user gesture and requests landscape fullscreen", async () => {
@@ -179,5 +195,164 @@ describe("CommuteMobileControls", () => {
     document.removeEventListener("mousemove", documentMove);
     expect(documentMove).not.toHaveBeenCalled();
     act(() => root.unmount());
+  });
+
+  it("keeps a collapsible transit-pass tab on public mobile rides", async () => {
+    vi.useFakeTimers();
+    const { container, root } = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+
+    await act(async () => vi.advanceTimersByTime(800));
+    const tab = container.querySelector<HTMLButtonElement>(
+      ".commute-mobile-transit-pass__tab",
+    );
+    expect(tab?.textContent).toContain("internet transit pass");
+    expect(tab?.textContent).toContain("join the ride");
+
+    act(() => tab?.click());
+    expect(container.textContent).toContain(
+      "the extension is desktop-only — we'll email you the install link for your computer",
+    );
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-transit-pass__close")
+        ?.click(),
+    );
+    expect(
+      container.querySelector(".commute-mobile-transit-pass__panel"),
+    ).toBeNull();
+    expect(
+      container.querySelector(".commute-mobile-transit-pass__tab"),
+    ).not.toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("emails the install link and remembers a first-time subscription", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ ok: true, alreadySubscribed: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { container, root } = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+
+    await act(async () => vi.advanceTimersByTime(800));
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-transit-pass__tab")!
+        .click(),
+    );
+    const input = container.querySelector<HTMLInputElement>("input")!;
+    await act(async () => {
+      enterEmail(input, "  rider@example.com  ");
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>("form")!
+        .dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true }),
+        );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(`${WORKER_URL}/subscribe`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "rider@example.com", source: "website" }),
+    });
+    expect(container.textContent).toContain(
+      "sent to rider@example.com! excited to make internet feel more alive together :)",
+    );
+    expect(localStorage.getItem("wewere.subscribed")).toBe("1");
+    act(() => root.unmount());
+  });
+
+  it("shows the saved success note instead of the form", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem("wewere.subscribed", "1");
+    const { container, root } = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+
+    await act(async () => vi.advanceTimersByTime(800));
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(
+          ".commute-mobile-transit-pass__tab",
+        )!
+        .click(),
+    );
+
+    expect(container.textContent).toContain(
+      "install link sent — check your email :)",
+    );
+    expect(container.querySelector("form")).toBeNull();
+    act(() => root.unmount());
+  });
+
+  it("shows the rate-limit message and stays hidden when installed", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () => Promise.resolve({ ok: false }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { container, root } = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+    await act(async () => vi.advanceTimersByTime(800));
+    act(() =>
+      container
+        .querySelector<HTMLButtonElement>(".commute-mobile-transit-pass__tab")!
+        .click(),
+    );
+    const input = container.querySelector<HTMLInputElement>("input")!;
+    await act(async () => {
+      enterEmail(input, "rider@example.com");
+    });
+    await act(async () => {
+      container
+        .querySelector<HTMLFormElement>("form")!
+        .dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true }),
+        );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain(
+      "slow down — try again in a minute",
+    );
+    act(() => root.unmount());
+
+    markExtensionInstalled(document.documentElement);
+    const installed = renderControls({
+      action: null,
+      boarded: true,
+      onBoard: vi.fn(),
+      onMove: vi.fn(),
+    });
+    await act(async () => vi.advanceTimersByTime(800));
+    expect(
+      installed.container.querySelector(".commute-mobile-transit-pass"),
+    ).toBeNull();
+    act(() => installed.root.unmount());
   });
 });

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 import type { CommutePoint } from "./commuteMobile";
+import { CommuteMobileTransitPass } from "./CommuteMobileTransitPass";
 
 interface LandscapeOrientation extends ScreenOrientation {
   lock?: (orientation: "landscape") => Promise<void>;
@@ -207,6 +208,7 @@ export function CommuteMobileControls({
               {action.label}
             </button>
           )}
+          <CommuteMobileTransitPass />
         </>
       )}
     </div>

--- a/extension/src/entrypoints/commute/CommuteMobileTransitPass.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileTransitPass.tsx
@@ -1,0 +1,197 @@
+// ABOUTME: Offers public mobile commute riders an emailed desktop install link.
+// ABOUTME: Keeps a collapsible transit-pass tab available throughout the ride.
+
+import { type FormEvent, useEffect, useState } from "react";
+import { WORKER_URL } from "@movement/config";
+import { useExtensionInstallState } from "./commuteInstallState";
+
+const SUBSCRIBED_KEY = "wewere.subscribed";
+
+type FormState =
+  | { status: "idle" }
+  | { status: "submitting" }
+  | { status: "success"; firstTime: boolean; email: string }
+  | { status: "error"; message: string };
+
+interface SubscribeResponse {
+  ok: boolean;
+  alreadySubscribed?: boolean;
+  error?: string;
+}
+
+function isLocallySubscribed(): boolean {
+  try {
+    return localStorage.getItem(SUBSCRIBED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markSubscribed(): void {
+  try {
+    localStorage.setItem(SUBSCRIBED_KEY, "1");
+  } catch {
+    // localStorage may be blocked without preventing the email request.
+  }
+}
+
+export function CommuteMobileTransitPass() {
+  const installState = useExtensionInstallState();
+  const [expanded, setExpanded] = useState(false);
+  const [email, setEmail] = useState("");
+  const [state, setState] = useState<FormState>(() =>
+    isLocallySubscribed()
+      ? { status: "success", firstTime: false, email: "" }
+      : { status: "idle" },
+  );
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === SUBSCRIBED_KEY && event.newValue === "1") {
+        setState({ status: "success", firstTime: false, email: "" });
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  if (installState !== "missing") return null;
+
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed) {
+      setState({ status: "error", message: "please enter an email address" });
+      return;
+    }
+
+    setState({ status: "submitting" });
+
+    try {
+      const response = await fetch(`${WORKER_URL}/subscribe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmed, source: "website" }),
+      });
+      const data = (await response.json()) as SubscribeResponse;
+
+      if (!response.ok || !data.ok) {
+        setState({
+          status: "error",
+          message:
+            data.error ||
+            (response.status === 429
+              ? "slow down — try again in a minute"
+              : "something went wrong. try again?"),
+        });
+        return;
+      }
+
+      markSubscribed();
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: SUBSCRIBED_KEY,
+          newValue: "1",
+        }),
+      );
+      setState({
+        status: "success",
+        firstTime: !data.alreadySubscribed,
+        email: trimmed,
+      });
+    } catch {
+      setState({ status: "error", message: "connection error. try again?" });
+    }
+  };
+
+  const submitting = state.status === "submitting";
+  const errorMessage = state.status === "error" ? state.message : null;
+
+  return (
+    <div className="commute-mobile-transit-pass">
+      {expanded && (
+        <section
+          className="commute-mobile-transit-pass__panel"
+          aria-label="Internet transit pass"
+        >
+          <button
+            className="commute-mobile-transit-pass__close"
+            type="button"
+            aria-label="Collapse the internet transit pass"
+            onClick={() => setExpanded(false)}
+          >
+            ×
+          </button>
+          <span className="commute-mobile-transit-pass__label">
+            internet transit pass
+          </span>
+          <strong>join the ride</strong>
+          <p>
+            the extension is desktop-only — we'll email you the install link for
+            your computer
+          </p>
+          {state.status === "success" ? (
+            <p className="commute-mobile-transit-pass__success" role="status">
+              {state.firstTime && state.email ? (
+                <>
+                  sent to <b>{state.email}</b>! excited to make internet feel
+                  more alive together :)
+                </>
+              ) : (
+                <>install link sent — check your email :)</>
+              )}
+            </p>
+          ) : (
+            <form onSubmit={submit}>
+              <span className="commute-mobile-transit-pass__form-row">
+                <input
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  required
+                  placeholder="your email"
+                  value={email}
+                  disabled={submitting}
+                  aria-invalid={errorMessage ? "true" : undefined}
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+                <button type="submit" disabled={submitting}>
+                  {submitting ? "sending…" : "send"}
+                </button>
+              </span>
+              {errorMessage && (
+                <span
+                  className="commute-mobile-transit-pass__error"
+                  role="alert"
+                >
+                  {errorMessage}
+                </span>
+              )}
+            </form>
+          )}
+        </section>
+      )}
+
+      <button
+        className="commute-mobile-transit-pass__tab"
+        type="button"
+        aria-expanded={expanded}
+        aria-label="Open the internet transit pass"
+        onClick={() => setExpanded(true)}
+      >
+        <span
+          className="commute-mobile-transit-pass__perforation"
+          aria-hidden
+        />
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <rect x="3" y="7" width="18" height="11" rx="2" />
+          <path d="M3 12h18M8 7v11" strokeDasharray="2 2" />
+        </svg>
+        <span>
+          <small>internet transit pass</small>
+          <strong>join the ride</strong>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/extension/src/entrypoints/commute/CommuteStationPoster.tsx
+++ b/extension/src/entrypoints/commute/CommuteStationPoster.tsx
@@ -1,0 +1,89 @@
+// ABOUTME: Adds an install poster to commute station platforms on public web pages.
+// ABOUTME: Opens an accessible transit-pass overlay with the extension link.
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useExtensionInstallState } from "./commuteInstallState";
+
+export function CommuteStationPoster() {
+  const installState = useExtensionInstallState();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [open]);
+
+  if (installState !== "missing") return null;
+
+  return (
+    <>
+      <button
+        className="station-install-poster"
+        type="button"
+        aria-label="Open the internet transit pass poster"
+        onClick={() => setOpen(true)}
+      >
+        <span className="station-install-poster__stripe" aria-hidden />
+        <span className="station-install-poster__copy">
+          <span>internet transit pass</span>
+          <strong>join the ride</strong>
+          <i aria-hidden />
+        </span>
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            className="commute-poster-backdrop"
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) setOpen(false);
+            }}
+          >
+            <section
+              className="commute-poster-dialog"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="commute-poster-title"
+            >
+              <span className="commute-poster-dialog__stripe" aria-hidden />
+              <span
+                className="commute-poster-dialog__tape commute-poster-dialog__tape--left"
+                aria-hidden
+              />
+              <span
+                className="commute-poster-dialog__tape commute-poster-dialog__tape--right"
+                aria-hidden
+              />
+              <button
+                className="commute-poster-dialog__close"
+                type="button"
+                aria-label="Close the internet transit pass poster"
+                onClick={() => setOpen(false)}
+              >
+                ×
+              </button>
+              <span className="commute-poster-dialog__label">
+                internet transit pass
+              </span>
+              <h2 id="commute-poster-title">join the ride</h2>
+              <p>
+                this line runs on the stops of riders like you — install we were
+                online and the places you visit become stations on everyone's
+                commute.
+              </p>
+              <a href="https://wewere.online/" target="_blank" rel="noreferrer">
+                get the extension →
+              </a>
+            </section>
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/extension/src/entrypoints/commute/CommuteStationPoster.tsx
+++ b/extension/src/entrypoints/commute/CommuteStationPoster.tsx
@@ -5,7 +5,11 @@ import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useExtensionInstallState } from "./commuteInstallState";
 
-export function CommuteStationPoster() {
+export function CommuteStationPoster({
+  stationVisible,
+}: {
+  stationVisible: boolean;
+}) {
   const installState = useExtensionInstallState();
   const [open, setOpen] = useState(false);
 
@@ -23,19 +27,21 @@ export function CommuteStationPoster() {
 
   return (
     <>
-      <button
-        className="station-install-poster"
-        type="button"
-        aria-label="Open the internet transit pass poster"
-        onClick={() => setOpen(true)}
-      >
-        <span className="station-install-poster__stripe" aria-hidden />
-        <span className="station-install-poster__copy">
-          <span>internet transit pass</span>
-          <strong>join the ride</strong>
-          <i aria-hidden />
-        </span>
-      </button>
+      {stationVisible && (
+        <button
+          className="station-install-poster"
+          type="button"
+          aria-label="Open the internet transit pass poster"
+          onClick={() => setOpen(true)}
+        >
+          <span className="station-install-poster__stripe" aria-hidden />
+          <span className="station-install-poster__copy">
+            <span>internet transit pass</span>
+            <strong>join the ride</strong>
+            <i aria-hidden />
+          </span>
+        </button>
+      )}
 
       {open &&
         createPortal(

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -1,6 +1,7 @@
 // ABOUTME: Styles the extension's bird's-eye Internet Commute carriage.
 // ABOUTME: Translates the authored prototype and its ink-wash moving landscape.
 
+@use "sass:color";
 @use "../../styles/variables" as *;
 
 $car-shell: #e7e0d4;
@@ -113,18 +114,18 @@ button {
 
 .commute-install-cta {
   position: fixed;
-  right: 14px;
-  bottom: 14px;
+  bottom: 20px;
+  left: 50%;
   z-index: 30;
-  min-width: 198px;
-  min-height: 64px;
-  padding: 9px 11px 8px 8px;
+  min-width: 358px;
+  min-height: 100px;
+  padding: 16px 26px 15px 16px;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 18px;
   overflow: hidden;
   border: 1px dashed rgba($text, 0.32);
-  border-radius: 10px 6px 6px 10px;
+  border-radius: 12px 8px 8px 12px;
   background:
     repeating-linear-gradient(
       90deg,
@@ -133,9 +134,10 @@ button {
     ),
     rgba($surface, 0.96);
   box-shadow:
-    inset 0 3px $accent-teal,
-    0 2px 8px rgba($text, 0.14);
+    inset 0 4px $accent-teal,
+    0 3px 14px rgba($text, 0.16);
   text-decoration: none;
+  transform: translateX(-50%);
   transition:
     border-color 0.15s,
     box-shadow 0.15s,
@@ -145,39 +147,39 @@ button {
   &:focus-visible {
     border-color: rgba($accent-teal, 0.72);
     box-shadow:
-      inset 0 3px $accent-teal,
+      inset 0 4px $accent-teal,
       0 3px 12px rgba($text, 0.18);
     outline: none;
-    transform: translateY(-1px);
+    transform: translate(-50%, -1px);
   }
 
   &::before,
   &::after {
     content: "";
     position: absolute;
-    left: 61px;
-    width: 9px;
-    height: 9px;
+    left: 96px;
+    width: 11px;
+    height: 11px;
     border: 1px dashed rgba($text, 0.28);
     border-radius: 50%;
     background: $bg;
   }
 
   &::before {
-    top: -5px;
+    top: -6px;
   }
 
   &::after {
-    bottom: -5px;
+    bottom: -6px;
   }
 }
 
 .commute-install-cta__icon {
-  width: 44px;
-  height: 44px;
+  width: 66px;
+  height: 66px;
   flex: 0 0 auto;
   border: 1px solid rgba($text, 0.18);
-  border-radius: 6px;
+  border-radius: 8px;
   background-color: $bg;
   background-image: url("../../../public/icon/128.png");
   background-position: center;
@@ -188,23 +190,23 @@ button {
 .commute-install-cta__copy {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 3px;
   border-left: 1px dashed rgba($text, 0.25);
-  padding-left: 5px;
+  padding-left: 14px;
 
   strong {
-    font-size: 12px;
+    font-size: 21px;
   }
 
   span {
     color: $text-muted;
     font-family: $font-mono;
-    font-size: 8px;
+    font-size: 12px;
   }
 
   .commute-install-cta__label {
     color: $accent-rust;
-    font-size: 7px;
+    font-size: 11px;
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -513,7 +515,8 @@ button {
 .commute-mobile-wordmark,
 .commute-mobile-fullscreen,
 .commute-mobile-joystick,
-.commute-mobile-action {
+.commute-mobile-action,
+.commute-mobile-transit-pass {
   display: none;
 }
 
@@ -571,6 +574,7 @@ button {
   display: flex;
   animation: landscape-scroll 20s linear infinite;
   will-change: transform;
+  pointer-events: none;
 
   svg {
     width: 2200px;
@@ -766,6 +770,181 @@ button {
   );
 }
 
+.station-install-poster {
+  width: 56px;
+  height: 42px;
+  position: absolute;
+  top: 8px;
+  left: 216px;
+  z-index: 1;
+  padding: 0;
+  overflow: hidden;
+  color: $text;
+  border: 1.5px solid rgba($text, 0.35);
+  background: $bg;
+  box-shadow: 0 1px 4px rgba(90, 78, 65, 0.18);
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible {
+    border-color: $accent-teal;
+    outline: none;
+  }
+}
+
+.station-install-poster__stripe {
+  height: 6px;
+  display: block;
+  background: repeating-linear-gradient(
+    90deg,
+    $accent-gold 0 10px,
+    #c9a94a 10px 20px
+  );
+}
+
+.station-install-poster__copy {
+  padding: 3px 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  text-align: left;
+
+  span {
+    color: $accent-rust;
+    font-family: $font-mono;
+    font-size: 4px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  strong {
+    font-family: $font-heading;
+    font-size: 8px;
+    font-style: italic;
+    font-weight: 400;
+    line-height: 1.1;
+  }
+
+  i {
+    width: 22px;
+    height: 5px;
+    border-radius: 1px;
+    background: $text;
+  }
+}
+
+.commute-poster-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba($text, 0.36);
+}
+
+.commute-poster-dialog {
+  width: min(300px, calc(100vw - 48px));
+  position: relative;
+  padding: 27px 20px 18px;
+  color: $text;
+  border: 2px solid rgba($text, 0.35);
+  border-radius: 4px;
+  background: $bg;
+  box-shadow: 0 5px 18px rgba($text, 0.18);
+  transform: rotate(-0.8deg);
+
+  h2 {
+    margin: 7px 0 8px;
+    font-family: $font-heading;
+    font-size: 27px;
+    font-style: italic;
+    font-weight: 400;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 0;
+    color: $text-muted;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  > a {
+    margin-top: 12px;
+    padding: 8px 16px;
+    display: inline-block;
+    color: $bg;
+    border-radius: 4px;
+    background: $text;
+    font-size: 13px;
+    text-decoration: none;
+
+    &:hover,
+    &:focus-visible {
+      background: $accent-teal;
+      outline: none;
+    }
+  }
+}
+
+.commute-poster-dialog__stripe {
+  height: 9px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  background: repeating-linear-gradient(
+    90deg,
+    $accent-gold 0 20px,
+    #c9a94a 20px 40px
+  );
+}
+
+.commute-poster-dialog__label {
+  color: $accent-rust;
+  font-family: $font-mono;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.commute-poster-dialog__close {
+  width: 26px;
+  height: 26px;
+  position: absolute;
+  top: 15px;
+  right: 12px;
+  display: grid;
+  place-items: center;
+  color: $text-muted;
+  border: 1px solid rgba($text, 0.2);
+  border-radius: 50%;
+  background: rgba($bg, 0.9);
+  cursor: pointer;
+}
+
+.commute-poster-dialog__tape {
+  width: 32px;
+  height: 11px;
+  position: absolute;
+  top: -8px;
+  background: rgba($accent-gold, 0.55);
+
+  &--left {
+    left: 26px;
+    transform: rotate(-4deg);
+  }
+
+  &--right {
+    right: 26px;
+    transform: rotate(3deg);
+  }
+}
+
 .landscape-window--lower {
   .station-platform {
     background-image: repeating-linear-gradient(
@@ -777,7 +956,8 @@ button {
 
   .station-platform__stripe,
   .station-platform__pillar,
-  .station-sign {
+  .station-sign,
+  .station-install-poster {
     display: none;
   }
 
@@ -1984,6 +2164,192 @@ button {
     &--exit {
       background: $accent-rust;
     }
+  }
+
+  .commute-mobile-transit-pass {
+    position: fixed;
+    inset: 0;
+    z-index: 42;
+    display: block;
+    pointer-events: none;
+  }
+
+  .commute-mobile-transit-pass__tab {
+    min-width: 196px;
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    padding: 8px 16px calc(10px + env(safe-area-inset-bottom)) 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: $text;
+    border: 1px dashed rgba($text, 0.32);
+    border-bottom: 0;
+    border-radius: 10px 10px 0 0;
+    background: rgba($surface, 0.96);
+    box-shadow:
+      inset 0 3px $accent-teal,
+      0 -2px 8px rgba($text, 0.14);
+    transform: translateX(-50%);
+    cursor: pointer;
+    pointer-events: auto;
+
+    svg {
+      flex: 0 0 auto;
+      stroke: $accent-rust;
+      stroke-width: 1.6;
+    }
+
+    > span:last-child {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0;
+    }
+
+    small {
+      color: $accent-rust;
+      font-family: $font-mono;
+      font-size: 7px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    strong {
+      font-size: 12px;
+    }
+  }
+
+  .commute-mobile-transit-pass__perforation {
+    width: 9px;
+    height: 9px;
+    position: absolute;
+    top: -5px;
+    left: 50%;
+    border: 1px dashed rgba($text, 0.28);
+    border-radius: 50%;
+    background: $bg;
+    transform: translateX(-50%);
+  }
+
+  .commute-mobile-transit-pass__panel {
+    width: min(340px, calc(100vw - 32px));
+    position: absolute;
+    bottom: calc(66px + env(safe-area-inset-bottom));
+    left: 50%;
+    box-sizing: border-box;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: $text;
+    border: 1px dashed rgba($text, 0.35);
+    border-radius: 10px 6px 6px 10px;
+    background:
+      repeating-linear-gradient(
+        90deg,
+        rgba($accent-gold, 0.04) 0 1px,
+        transparent 1px 5px
+      ),
+      rgba($bg, 0.98);
+    box-shadow:
+      inset 0 3px $accent-teal,
+      0 6px 20px rgba($text, 0.2);
+    transform: translateX(-50%);
+    pointer-events: auto;
+    user-select: text;
+
+    > strong {
+      font-size: 16px;
+    }
+
+    > p {
+      margin: 0;
+      padding-right: 22px;
+      color: $text-muted;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    form {
+      display: grid;
+      gap: 5px;
+    }
+  }
+
+  .commute-mobile-transit-pass__close {
+    width: 22px;
+    height: 22px;
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    padding: 0;
+    display: grid;
+    place-items: center;
+    color: $text-muted;
+    border: 1px solid rgba($text, 0.2);
+    border-radius: 50%;
+    background: transparent;
+    font-size: 15px;
+    cursor: pointer;
+  }
+
+  .commute-mobile-transit-pass__label {
+    color: $accent-rust;
+    font-family: $font-mono;
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .commute-mobile-transit-pass__form-row {
+    display: flex;
+    gap: 8px;
+
+    input,
+    button {
+      min-height: 38px;
+      box-sizing: border-box;
+      border: 1.5px solid rgba($text, 0.35);
+      border-radius: 4px;
+      font: inherit;
+    }
+
+    input {
+      min-width: 0;
+      flex: 1;
+      padding: 9px 12px;
+      color: $text;
+      background: rgba($bg, 0.85);
+      font-size: 15px;
+    }
+
+    button {
+      padding: 9px 16px;
+      color: $bg;
+      border-color: $text;
+      background: $text;
+      font-size: 15px;
+      cursor: pointer;
+    }
+  }
+
+  .commute-mobile-transit-pass__success,
+  .commute-mobile-transit-pass__error {
+    font-family: $font-mono;
+    font-size: 8px;
+    line-height: 1.5;
+  }
+
+  .commute-mobile-transit-pass__success {
+    color: $accent-teal !important;
+  }
+
+  .commute-mobile-transit-pass__error {
+    color: $accent-rust;
   }
 
   .commute-toast {

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -61,6 +61,7 @@ import {
   type CommuteMobileAction,
 } from "./CommuteMobileControls";
 import { CommuteStage } from "./CommuteStage";
+import { CommuteStationPoster } from "./CommuteStationPoster";
 import { useCommuteDebug } from "./commuteDebug";
 import {
   COMMUTE_CLICK_WALK_SPEED,
@@ -595,10 +596,12 @@ function Platform({
   currentStop,
   visible,
   atOrigin,
+  showInstallPoster,
 }: {
   currentStop: CommuteStop;
   visible: boolean;
   atOrigin: boolean;
+  showInstallPoster: boolean;
 }) {
   return (
     <div
@@ -608,13 +611,13 @@ function Platform({
           "--station-hue": atOrigin ? "#4a9a8a" : currentStop.hue,
         } as React.CSSProperties
       }
-      aria-hidden
     >
-      <span className="station-platform__stripe" />
-      <span className="station-platform__pillar station-platform__pillar--left" />
-      <span className="station-platform__pillar station-platform__pillar--right" />
-      <span className="station-platform__edge" />
-      <span className="station-sign">
+      <span className="station-platform__stripe" aria-hidden />
+      <span className="station-platform__pillar station-platform__pillar--left" aria-hidden />
+      <span className="station-platform__pillar station-platform__pillar--right" aria-hidden />
+      <span className="station-platform__edge" aria-hidden />
+      {showInstallPoster && <CommuteStationPoster />}
+      <span className="station-sign" aria-hidden>
         {!atOrigin && <StopFavicon stop={currentStop} />}
         <span className="station-sign__destination">
           <strong>
@@ -679,6 +682,7 @@ function LandscapeWindow({
         currentStop={platformStop}
         visible={stationVisible}
         atOrigin={platformAtOrigin}
+        showInstallPoster={edge === "upper"}
       />
     </div>
   );

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -616,7 +616,7 @@ function Platform({
       <span className="station-platform__pillar station-platform__pillar--left" aria-hidden />
       <span className="station-platform__pillar station-platform__pillar--right" aria-hidden />
       <span className="station-platform__edge" aria-hidden />
-      {showInstallPoster && <CommuteStationPoster />}
+      {showInstallPoster && <CommuteStationPoster stationVisible={visible} />}
       <span className="station-sign" aria-hidden>
         {!atOrigin && <StopFavicon stop={currentStop} />}
         <span className="station-sign__destination">

--- a/extension/src/entrypoints/commute/commuteInstallState.ts
+++ b/extension/src/entrypoints/commute/commuteInstallState.ts
@@ -1,0 +1,59 @@
+// ABOUTME: Detects whether the browser extension is present on public commute pages.
+// ABOUTME: Delays missing-state promotions so the content-script marker can arrive.
+
+import { useEffect, useState } from "react";
+import {
+  EXTENSION_INSTALL_ATTRIBUTE,
+  isExtensionInstalled,
+} from "../../utils/extensionInstallMarker";
+
+const EXTENSION_DETECTION_MS = 800;
+
+export type InstallState = "checking" | "installed" | "missing";
+
+export function isPublicWebPage(): boolean {
+  return (
+    window.location.protocol === "http:" ||
+    window.location.protocol === "https:"
+  );
+}
+
+export function useExtensionInstallState(): InstallState {
+  const [state, setState] = useState<InstallState>(() => {
+    if (!isPublicWebPage()) return "installed";
+    return isExtensionInstalled(document.documentElement)
+      ? "installed"
+      : "checking";
+  });
+
+  useEffect(() => {
+    if (!isPublicWebPage()) return;
+
+    const root = document.documentElement;
+    if (isExtensionInstalled(root)) {
+      setState("installed");
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (isExtensionInstalled(root)) {
+        setState("installed");
+      }
+    });
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: [EXTENSION_INSTALL_ATTRIBUTE],
+    });
+
+    const timer = window.setTimeout(() => {
+      setState((current) => (current === "checking" ? "missing" : current));
+    }, EXTENSION_DETECTION_MS);
+
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return state;
+}

--- a/extension/src/entrypoints/commute/landscape.tsx
+++ b/extension/src/entrypoints/commute/landscape.tsx
@@ -134,10 +134,7 @@ function makeRidge(
   return points;
 }
 
-function makeRidgeTrees(
-  random: () => number,
-  ridge: Point[],
-): TreeMark[] {
+function makeRidgeTrees(random: () => number, ridge: Point[]): TreeMark[] {
   const trees: TreeMark[] = [];
 
   for (let index = 0; index < ridge.length - 1; index += 1) {
@@ -223,13 +220,7 @@ export function createLandscapePlan(seed: string): LandscapePlan {
   const ridgeTrees = makeRidgeTrees(random, mountainRidge);
 
   const foregroundTrees = Array.from({ length: 13 }, (_, index) =>
-    makeTree(
-      random,
-      45 + index * 170 + between(random, -55, 55),
-      118,
-      23,
-      52,
-    ),
+    makeTree(random, 45 + index * 170 + between(random, -55, 55), 118, 23, 52),
   );
 
   return {
@@ -249,7 +240,9 @@ function SmallTree({ tree }: { tree: TreeMark }) {
   const tipX = tree.x + tree.lean;
   return (
     <g className="landscape-tree landscape-tree--small">
-      <path d={`M ${tree.x} ${tree.y} Q ${tree.x} ${crownY + 5} ${tipX} ${crownY}`} />
+      <path
+        d={`M ${tree.x} ${tree.y} Q ${tree.x} ${crownY + 5} ${tipX} ${crownY}`}
+      />
       <path
         className="landscape-tree__leaf"
         d={`M ${tipX} ${crownY - 4} q -5 7 0 11 q 5 -4 0 -11 Z`}
@@ -298,7 +291,10 @@ function LandscapeSvg({
         ))}
       {layer === "mountain" && (
         <>
-          <path className="landscape-mountain landscape-mountain--near" d={plan.mountain} />
+          <path
+            className="landscape-mountain landscape-mountain--near"
+            d={plan.mountain}
+          />
           {plan.contours.map((contour, index) => (
             <path key={index} className="landscape-contour" d={contour} />
           ))}
@@ -354,8 +350,16 @@ export function ProceduralLandscape({
     <div className={`landscape landscape--${edge} landscape--${phase}`}>
       {edge === "upper" ? (
         <>
-          <MovingLayer plan={plan} layer="clouds" className="landscape-track--clouds" />
-          <MovingLayer plan={plan} layer="mountain" className="landscape-track--mountain" />
+          <MovingLayer
+            plan={plan}
+            layer="clouds"
+            className="landscape-track--clouds"
+          />
+          <MovingLayer
+            plan={plan}
+            layer="mountain"
+            className="landscape-track--mountain"
+          />
           <MovingLayer
             plan={plan}
             layer="foreground"
@@ -364,7 +368,11 @@ export function ProceduralLandscape({
         </>
       ) : (
         <>
-          <MovingLayer plan={plan} layer="water" className="landscape-track--water" />
+          <MovingLayer
+            plan={plan}
+            layer="water"
+            className="landscape-track--water"
+          />
           <MovingLayer
             plan={plan}
             layer="foreground"

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    poolOptions: {
+      forks: { execArgv: ["--no-experimental-webstorage"] },
+      threads: { execArgv: ["--no-experimental-webstorage"] },
+    },
     exclude: ["node_modules/**", "dist/**", ".output/**"],
     setupFiles: [setupFile],
     include: [

--- a/extension/website/index.html
+++ b/extension/website/index.html
@@ -48,7 +48,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,600;0,700;1,600;1,700&family=Atkinson+Hyperlegible:wght@400;700&family=Source+Serif+4:ital,wght@1,200&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,600;0,700;1,600;1,700&family=Atkinson+Hyperlegible:wght@400;700&family=Martian+Mono:wght@400;600&family=Source+Serif+4:ital,wght@1,200&display=swap"
       rel="stylesheet"
     />
     <script

--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -23,6 +23,7 @@ import { PresenceIndicator } from "./components/PresenceIndicator";
 import { Bench } from "./components/Bench";
 import { CoffeeMachine } from "./components/CoffeeMachine";
 import { DownloadGate } from "./components/DownloadGate";
+import { TrainCrossing } from "./components/TrainCrossing";
 import {
   CHANGELOG_URL,
   isNavigationPathActive,
@@ -463,6 +464,8 @@ export default function App() {
           <br />
           <DownloadGate />
         </section>
+
+        <TrainCrossing />
 
         <section className={styles.section}>
           <h2 className={styles.sectionHeading}>leave a mark</h2>

--- a/extension/website/src/components/TrainCrossing.module.scss
+++ b/extension/website/src/components/TrainCrossing.module.scss
@@ -72,13 +72,14 @@ $font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
 
 $accent-gold: #d4b85c;
 
+// The train photo is cropped mid-carriage on its left edge, so the rear must
+// always sit past the viewport's left edge to read as a longer train.
 .train {
   position: absolute;
-  left: clamp(24px, 14vw, 130px);
+  left: -36px;
   bottom: 26px;
   display: block;
-  width: clamp(360px, 46vw, 470px);
-  max-width: calc(100vw - 48px);
+  width: clamp(480px, 58vw, 620px);
   transform: translateX(calc(-100% - 14vw));
   transition: transform 3.2s cubic-bezier(0.22, 0.75, 0.35, 1);
 }
@@ -98,7 +99,7 @@ $accent-gold: #d4b85c;
 .serviceLabel {
   position: absolute;
   top: -32px;
-  left: 50%;
+  left: calc(50% + 18px);
   padding: 3px 14px;
   color: color.adjust($accent-gold, $lightness: -14%);
   background: rgba($bg, 0.9);
@@ -167,10 +168,9 @@ $accent-gold: #d4b85c;
   }
 
   .train {
-    left: 12px;
+    left: -24px;
     bottom: 26px;
-    width: min(88vw, 360px);
-    max-width: none;
+    width: min(96vw, 420px);
   }
 
   .signal {

--- a/extension/website/src/components/TrainCrossing.module.scss
+++ b/extension/website/src/components/TrainCrossing.module.scss
@@ -1,0 +1,197 @@
+// ABOUTME: Styles the homepage Internet Commute crossing and train arrival.
+// ABOUTME: Keeps the track, signal, and train illustration responsive without overflow.
+
+@use "sass:color";
+@use "../styles/variables" as *;
+
+$accent-teal: #4a9a8a;
+$accent-blue: #5b8db8;
+$font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+
+.crossing {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 24px 0 56px;
+  overflow: hidden;
+  color: $text;
+  background: rgba($bg, 0.72);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid $accent-teal;
+    outline-offset: -4px;
+  }
+
+  &:hover .signalSign {
+    border-bottom-color: $accent-blue;
+  }
+
+  &:hover .caption {
+    color: $accent-teal;
+  }
+}
+
+.scene {
+  position: relative;
+  display: block;
+  height: 150px;
+}
+
+.railTop,
+.railBottom,
+.ties {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: block;
+}
+
+.railTop {
+  bottom: 28px;
+  height: 3px;
+  background: rgba($text, 0.28);
+}
+
+.railBottom {
+  bottom: 20px;
+  height: 3px;
+  background: rgba($text, 0.2);
+}
+
+.ties {
+  bottom: 12px;
+  height: 6px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba($text, 0.14) 0 18px,
+    transparent 18px 44px
+  );
+}
+
+$accent-gold: #d4b85c;
+
+.train {
+  position: absolute;
+  left: clamp(24px, 14vw, 130px);
+  bottom: 26px;
+  display: block;
+  width: clamp(360px, 46vw, 470px);
+  max-width: calc(100vw - 48px);
+  transform: translateX(calc(-100% - 14vw));
+  transition: transform 3.2s cubic-bezier(0.22, 0.75, 0.35, 1);
+}
+
+.trainArrived {
+  transform: translateX(0);
+}
+
+.trainIllustration {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: sepia(0.18) contrast(0.9);
+  opacity: 0.9;
+}
+
+.serviceLabel {
+  position: absolute;
+  top: -32px;
+  left: 50%;
+  padding: 3px 14px;
+  color: color.adjust($accent-gold, $lightness: -14%);
+  background: rgba($bg, 0.9);
+  border: 1px solid rgba($accent-gold, 0.5);
+  border-radius: 3px;
+  font-family: $font-mono;
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  transform: translateX(-50%);
+}
+
+.signal {
+  position: absolute;
+  right: clamp(24px, 10vw, 96px);
+  bottom: 42px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.signalSign {
+  display: block;
+  padding: 6px 14px;
+  color: $text;
+  background: rgba($bg, 0.96);
+  border: 1px solid rgba($text, 0.2);
+  border-bottom: 3px solid $accent-teal;
+  border-radius: 4px;
+  font-family: $font-mono;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  transition: border-color 0.15s;
+}
+
+.signalPost {
+  display: block;
+  width: 2px;
+  height: 26px;
+  background: rgba($text, 0.3);
+}
+
+.caption {
+  display: block;
+  max-width: calc(100% - 40px);
+  margin: 6px auto 0;
+  color: $text-muted;
+  font-family: $font-body;
+  font-size: 0.75rem;
+  font-style: italic;
+  line-height: 1.45;
+  text-align: center;
+  transition: color 0.15s;
+}
+
+@media (max-width: 800px) {
+  .crossing {
+    padding-top: 16px;
+    padding-bottom: 44px;
+  }
+
+  .scene {
+    height: 176px;
+  }
+
+  .train {
+    left: 12px;
+    bottom: 26px;
+    width: min(88vw, 360px);
+    max-width: none;
+  }
+
+  .signal {
+    top: 4px;
+    right: 12px;
+    bottom: auto;
+  }
+
+  .signalSign {
+    padding: 5px 10px;
+    font-size: 0.625rem;
+  }
+
+  .caption {
+    max-width: calc(100% - 32px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .train {
+    transform: translateX(0);
+    transition: none;
+  }
+}

--- a/extension/website/src/components/TrainCrossing.tsx
+++ b/extension/website/src/components/TrainCrossing.tsx
@@ -48,7 +48,7 @@ export function TrainCrossing() {
           className={`${styles.train} ${hasArrived ? styles.trainArrived : ""}`}
         >
           <span className={styles.serviceLabel}>
-            local · try the internet commute
+            try the internet commute
           </span>
           <img
             className={styles.trainIllustration}
@@ -65,8 +65,7 @@ export function TrainCrossing() {
         </span>
       </span>
       <span className={styles.caption}>
-        a slow train through the recent web — click to board with whoever's
-        riding
+        a slow train through the recent web
       </span>
     </a>
   );

--- a/extension/website/src/components/TrainCrossing.tsx
+++ b/extension/website/src/components/TrainCrossing.tsx
@@ -1,0 +1,73 @@
+// ABOUTME: Full-width homepage link inviting visitors to board the Internet Commute.
+// ABOUTME: Reveals an illustrated train once as the crossing enters the viewport.
+
+import { useEffect, useRef, useState } from "react";
+import trainIceUrl from "@extension/assets/train-ice.png";
+import styles from "./TrainCrossing.module.scss";
+
+export function TrainCrossing() {
+  const crossingRef = useRef<HTMLAnchorElement>(null);
+  const [hasArrived, setHasArrived] = useState(() =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  useEffect(() => {
+    if (hasArrived) return;
+    const crossing = crossingRef.current;
+    if (!crossing) return;
+    if (!("IntersectionObserver" in window)) {
+      setHasArrived(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setHasArrived(true);
+        observer.disconnect();
+      },
+      { threshold: 0.2 },
+    );
+    observer.observe(crossing);
+    return () => observer.disconnect();
+  }, [hasArrived]);
+
+  return (
+    <a
+      ref={crossingRef}
+      className={styles.crossing}
+      href="/commute"
+      aria-label="Board the internet commute"
+    >
+      <span className={styles.scene} aria-hidden="true">
+        <span className={styles.railTop} />
+        <span className={styles.railBottom} />
+        <span className={styles.ties} />
+
+        <span
+          className={`${styles.train} ${hasArrived ? styles.trainArrived : ""}`}
+        >
+          <span className={styles.serviceLabel}>
+            local · try the internet commute
+          </span>
+          <img
+            className={styles.trainIllustration}
+            src={trainIceUrl}
+            alt=""
+          />
+        </span>
+
+        <span className={styles.signal}>
+          <span className={styles.signalSign}>
+            next stop: somewhere new →
+          </span>
+          <span className={styles.signalPost} />
+        </span>
+      </span>
+      <span className={styles.caption}>
+        a slow train through the recent web — click to board with whoever's
+        riding
+      </span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

Connects wewere.online to the Internet Commute and makes the extension-install path on the commute page much more visible, including a mobile email-link flow.

**Homepage (wewere.online)**
- New train crossing band between the essay and the guestbook: the slow-mode train (real `train-ice` asset, sepia treatment, `local · try the internet commute` service label) rolls across a track when scrolled into view and links to /commute. Animates once via IntersectionObserver; `prefers-reduced-motion` shows it settled.

**Commute page** (all gated on the extension-missing marker; installed riders see none of this)
- The corner install ticket is promoted to a larger bottom-center banner with the `internet transit pass / join the ride / get the extension →` copy system.
- A small poster hangs on the platform wall at each station; clicking opens a readable overlay with the full pitch (dismissible via ×, backdrop, Escape).
- Install detection extracted to `commuteInstallState.ts` and shared across surfaces.

**Mobile (touch, public web)**
- Persistent bottom-center "transit pass" tab during the ride, clear of the joystick; expands to an email form that posts to the worker `/subscribe` (source `website`), mirroring the site DownloadGate's success/error copy and `wewere.subscribed` localStorage key. Desktop banner is hidden on touch layouts.

A blimp ad staged in the scenery was prototyped and pulled before merge — livery design still being iterated (designs live on the shared canvas).

## Verification
- `bun run test:extension`: 136 files / 875 tests pass
- `bun run check:extension`, `bun run check:extension-website`: clean
- Verified in-browser on the dev server; screenshots below.

## Notes
- No changesets: nothing under `packages/` changed.
- No `extension/PENDING.md` bullet: the commute surfaces here only render when the extension is NOT installed, and `extension/website/**` changes deploy separately and don't get bullets.
- `extension/vitest.config.ts` gains `--no-experimental-webstorage` worker args so jsdom localStorage tests run cleanly on newer Node.
- Docs audit: no `apps/docs/` changes needed — nothing here touches the playhtml library surface.