### PR TITLE
Add Safari install links to extension surfaces

### DIFF
--- a/extension/website/shared/downloadLinks.ts
+++ b/extension/website/shared/downloadLinks.ts
@@ -14,4 +14,8 @@ export const DOWNLOAD_LINKS = [
     browser: "Edge",
     url: "https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl",
   },
+  {
+    browser: "Safari",
+    url: "https://apps.apple.com/us/app/we-were-online/id6798847358?mt=12",
+  },
 ] as const;

--- a/extension/website/src/components/__tests__/DownloadGate.test.tsx
+++ b/extension/website/src/components/__tests__/DownloadGate.test.tsx
@@ -7,6 +7,8 @@ import { DownloadGate } from "../DownloadGate";
 
 const EDGE_DOWNLOAD_URL =
   "https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl";
+const SAFARI_DOWNLOAD_URL =
+  "https://apps.apple.com/us/app/we-were-online/id6798847358?mt=12";
 
 vi.mock("../DownloadGate.module.scss", () => ({
   default: {
@@ -35,9 +37,11 @@ describe("DownloadGate", () => {
     expect(html).toContain('>Chrome</a>');
     expect(html).toContain('>Firefox</a>');
     expect(html).toContain('>Edge</a>');
+    expect(html).toContain('>Safari</a>');
     expect(html).not.toContain('install for Chrome');
     expect(html).not.toContain('install for Firefox');
     expect(html).not.toContain('install for Edge');
     expect(html).toContain(`href="${EDGE_DOWNLOAD_URL}"`);
+    expect(html).toContain(`href="${SAFARI_DOWNLOAD_URL}"`);
   });
 });

--- a/extension/worker/src/emails/WelcomeEmail.tsx
+++ b/extension/worker/src/emails/WelcomeEmail.tsx
@@ -7,6 +7,8 @@ const FIREFOX_URL =
   'https://addons.mozilla.org/en-US/firefox/addon/we-were-online/';
 const EDGE_URL =
   'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
+const SAFARI_URL =
+  'https://apps.apple.com/us/app/we-were-online/id6798847358?mt=12';
 const HOMEPAGE_URL = 'https://wewere.online/';
 const PLAYHTML_URL = 'https://playhtml.fun/';
 const DISCORD_INVITE_URL = 'https://discord.gg/SKbsSf4ptU';
@@ -22,6 +24,7 @@ const DOWNLOAD_LINKS = [
   { browser: 'Chrome', textBrowser: 'Chrome (or chromium equivalents)', url: CHROME_URL },
   { browser: 'Firefox', textBrowser: 'Firefox', url: FIREFOX_URL },
   { browser: 'Edge', textBrowser: 'Edge', url: EDGE_URL },
+  { browser: 'Safari', textBrowser: 'Safari', url: SAFARI_URL },
 ];
 
 const DOWNLOAD_BUTTON_STYLE =

--- a/extension/worker/src/emails/__tests__/WelcomeEmail.test.ts
+++ b/extension/worker/src/emails/__tests__/WelcomeEmail.test.ts
@@ -6,6 +6,8 @@ import { WELCOME_EMAIL_TEXT, renderWelcomeEmail } from '../WelcomeEmail';
 
 const EDGE_DOWNLOAD_URL =
   'https://microsoftedge.microsoft.com/addons/detail/we-were-online/kiamoecdnaglmhigmbmdkiodbbphpodl';
+const SAFARI_DOWNLOAD_URL =
+  'https://apps.apple.com/us/app/we-were-online/id6798847358?mt=12';
 
 describe('WelcomeEmail', () => {
   it('includes an Edge install link in the plaintext welcome email', () => {
@@ -17,5 +19,16 @@ describe('WelcomeEmail', () => {
 
     expect(html).toContain('Download on Edge');
     expect(html).toContain(`href="${EDGE_DOWNLOAD_URL}"`);
+  });
+
+  it('includes a Safari install link in the plaintext welcome email', () => {
+    expect(WELCOME_EMAIL_TEXT).toContain(`- Download on Safari: ${SAFARI_DOWNLOAD_URL}`);
+  });
+
+  it('includes a Safari install link in the HTML welcome email', async () => {
+    const html = await renderWelcomeEmail();
+
+    expect(html).toContain('Download on Safari');
+    expect(html).toContain(`href="${SAFARI_DOWNLOAD_URL}"`);
   });
 });


### PR DESCRIPTION
## Summary

- add Safari to the website install options using the existing browser-link list
- add the Safari App Store link to the welcome email HTML and plaintext bodies
- cover the Safari URL in the focused website and email tests

## Rationale

Safari users can now reach the App Store listing from the same install surfaces as Chrome, Firefox, and Edge.

## Verification

- `bunx vitest run src/components/__tests__/DownloadGate.test.tsx --config vite.config.ts` (1 test passed)
- `bunx vitest run src/emails/__tests__/WelcomeEmail.test.ts --config vitest.config.ts` (4 tests passed)
- `bun run build` in `extension/website`
- `bun run check:extension-website`
- `bun run check:extension-worker`
- `bun run build-packages`
- live local website check confirmed both Safari install links use the App Store URL and preserve the existing external-link behavior

The full extension-worker suite reported all 97 tests as passing but did not exit after completion, so the process was terminated manually.

## Screenshots

Visual evidence is attached in the PR Evidence comment.
