### PR TITLE
Keep Wikipedia copresence always available

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -3,6 +3,7 @@
 - Internet Commute now keeps riders, arrivals, and train timing in sync across browsers.
 - Slow Mode can route deliberate far jumps through a short Internet Commute, with chance controls, cooldowns, and an always-available teleport.
 - Authentication pages no longer appear in Internet Commute or trigger Slow Mode.
+- Wikipedia always shows its shared cursors and remembered-link patina.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/src/__tests__/content-wikipedia-launch.test.ts
+++ b/extension/src/__tests__/content-wikipedia-launch.test.ts
@@ -1,0 +1,142 @@
+// ABOUTME: Verifies launched Wikipedia collaboration survives unavailable experiment access.
+// ABOUTME: Exercises the content-script gate through PlayHTML and Wikipedia initialization.
+// @vitest-environment-options {"url":"https://en.wikipedia.org/wiki/Main_Page"}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageGet = vi.hoisted(() => vi.fn());
+const runtimeSendMessage = vi.hoisted(() => vi.fn());
+const playhtml = vi.hoisted(() => ({
+  createPageData: vi.fn(),
+  createPresenceRoom: vi.fn(),
+  cursorClient: {},
+  init: vi.fn().mockResolvedValue(undefined),
+  presence: {},
+}));
+const initWikipedia = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const maybeInjectAnnouncementToast = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        get: storageGet,
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      sendMessage: runtimeSendMessage,
+      onMessage: { addListener: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("playhtml", () => ({ playhtml }));
+
+vi.mock("../custom-sites/wikipedia", () => ({ initWikipedia }));
+
+vi.mock("../announcements/inject-toast", () => ({
+  maybeInjectAnnouncementToast,
+}));
+
+vi.mock("../features/global", () => ({
+  anyGlobalFeatureActive: vi.fn().mockResolvedValue(false),
+  initGlobalFeatures: vi.fn(),
+}));
+
+vi.mock("../collectors/CollectorManager", () => ({
+  CollectorManager: class {
+    registerCollector = vi.fn();
+    init = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn();
+    pauseAll = vi.fn();
+    resumeAll = vi.fn();
+    getCollectorStatuses = vi.fn(() => []);
+  },
+}));
+
+vi.mock("../collectors/CursorCollector", () => ({ CursorCollector: class {} }));
+vi.mock("../collectors/NavigationCollector", () => ({
+  NavigationCollector: class {},
+}));
+vi.mock("../collectors/ViewportCollector", () => ({
+  ViewportCollector: class {},
+}));
+vi.mock("../collectors/KeyboardCollector", () => ({
+  KeyboardCollector: class {},
+}));
+
+describe("Wikipedia launch contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
+    document.documentElement.removeAttribute("data-playhtml");
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+    playhtml.init.mockClear();
+    initWikipedia.mockClear();
+    maybeInjectAnnouncementToast.mockClear();
+
+    storageGet.mockImplementation((keys: string | string[]) => {
+      if (keys === "wwoFeatureAccess") {
+        return Promise.resolve({
+          wwoFeatureAccess: {
+            features: {
+              COPRESENCE: { stage: "internal", available: false },
+            },
+            checkedAt: 1,
+          },
+        });
+      }
+      if (keys === "wwoFeatureOverrides") {
+        return Promise.resolve({ wwoFeatureOverrides: {} });
+      }
+      return Promise.resolve({});
+    });
+
+    runtimeSendMessage.mockImplementation((message: { type?: string }) => {
+      if (message.type === "GET_PUBLIC_PLAYER_IDENTITY") {
+        return Promise.resolve({
+          publicKey: "pk_test",
+          playerStyle: { colorPalette: ["#4a9a8a"] },
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("initializes Wikipedia when COPRESENCE experiment access is unavailable", async () => {
+    expect(window.location.hostname).toBe("en.wikipedia.org");
+
+    const contentScript = (await import("../entrypoints/content")).default as {
+      main: () => void;
+    };
+
+    contentScript.main();
+    await vi.waitFor(() => {
+      expect(storageGet).toHaveBeenCalledWith("wwoFeatureAccess");
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(playhtml.init).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cursors: expect.objectContaining({ enabled: true }),
+          }),
+        );
+        expect(initWikipedia).toHaveBeenCalledOnce();
+        expect(maybeInjectAnnouncementToast).toHaveBeenCalledOnce();
+      },
+      { timeout: 3_000 },
+    );
+  });
+});

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -10,7 +10,10 @@ import {
   shouldEnableCursorsForHostname,
 } from "../custom-sites";
 import { initWikipedia } from "../custom-sites/wikipedia";
-import { shouldStartExtensionPresence } from "../entrypoints/content/presencePolicy";
+import {
+  shouldInitializeCopresence,
+  shouldStartExtensionPresence,
+} from "../entrypoints/content/presencePolicy";
 
 vi.mock("../custom-sites/wikipedia", () => ({
   initWikipedia: vi.fn(() => null),
@@ -27,6 +30,28 @@ const customSiteDeps = {
 afterEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+});
+
+describe("shouldInitializeCopresence", () => {
+  it("initializes Wikipedia when the global feature is disabled", () => {
+    expect(
+      shouldInitializeCopresence({
+        featureEnabled: false,
+        customSiteCursorsEnabled:
+          shouldEnableCursorsForHostname("en.wikipedia.org"),
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps unsupported sites disabled when the global feature is disabled", () => {
+    expect(
+      shouldInitializeCopresence({
+        featureEnabled: false,
+        customSiteCursorsEnabled:
+          shouldEnableCursorsForHostname("www.youtube.com"),
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("shouldStartExtensionPresence", () => {

--- a/extension/src/__tests__/presencePolicy.test.ts
+++ b/extension/src/__tests__/presencePolicy.test.ts
@@ -32,13 +32,21 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("shouldInitializeCopresence", () => {
-  it("initializes Wikipedia when the global feature is disabled", () => {
+describe("launched copresence surfaces", () => {
+  it("keeps Wikipedia launched without experiment access", () => {
+    const wikipediaCursorsEnabled =
+      shouldEnableCursorsForHostname("en.wikipedia.org");
+
     expect(
       shouldInitializeCopresence({
         featureEnabled: false,
-        customSiteCursorsEnabled:
-          shouldEnableCursorsForHostname("en.wikipedia.org"),
+        customSiteCursorsEnabled: wikipediaCursorsEnabled,
+      }),
+    ).toBe(true);
+    expect(
+      shouldStartExtensionPresence({
+        nativePlayhtmlDetected: false,
+        cursorsEnabled: wikipediaCursorsEnabled,
       }),
     ).toBe(true);
   });

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -26,7 +26,10 @@ import {
 import { VERBOSE } from "../config";
 import { getFaviconUrl, getPageTitle } from "../utils/pageMetadata";
 import { isFeatureEnabled } from "../features/featureAccess";
-import { shouldStartExtensionPresence } from "./content/presencePolicy";
+import {
+  shouldInitializeCopresence,
+  shouldStartExtensionPresence,
+} from "./content/presencePolicy";
 import { markExtensionInstalled } from "../utils/extensionInstallMarker";
 import { isExtensionPageUrl } from "../utils/extensionPage";
 
@@ -1105,7 +1108,19 @@ export default defineContentScript({
       }
 
       private async setupPresence() {
-        if (!(await isFeatureEnabled("COPRESENCE"))) return;
+        const { getCustomSiteSettings, initCustomSite } = await import(
+          "../custom-sites"
+        );
+        const customSiteSettings = getCustomSiteSettings();
+        if (
+          !shouldInitializeCopresence({
+            featureEnabled: await isFeatureEnabled("COPRESENCE"),
+            customSiteCursorsEnabled:
+              customSiteSettings?.cursorsEnabled ?? false,
+          })
+        ) {
+          return;
+        }
 
         // On pages that already run playhtml, defer presence/cursors to the
         // page's instance (we only inject our identity). We don't stand up our
@@ -1129,10 +1144,6 @@ export default defineContentScript({
         }
 
         // Initialize PlayHTML only for sites with explicit extension cursor support.
-        const { getCustomSiteSettings, initCustomSite } = await import(
-          "../custom-sites"
-        );
-        const customSiteSettings = getCustomSiteSettings();
         const enableCursors = customSiteSettings?.cursorsEnabled ?? false;
         if (
           !shouldStartExtensionPresence({

--- a/extension/src/entrypoints/content/presencePolicy.ts
+++ b/extension/src/entrypoints/content/presencePolicy.ts
@@ -6,6 +6,18 @@ export type ExtensionPresenceDecision = {
   cursorsEnabled: boolean;
 };
 
+export type CopresenceInitializationDecision = {
+  featureEnabled: boolean;
+  customSiteCursorsEnabled: boolean;
+};
+
+export function shouldInitializeCopresence({
+  featureEnabled,
+  customSiteCursorsEnabled,
+}: CopresenceInitializationDecision): boolean {
+  return featureEnabled || customSiteCursorsEnabled;
+}
+
 export function shouldStartExtensionPresence({
   nativePlayhtmlDetected,
   cursorsEnabled,


### PR DESCRIPTION
## Summary

- let explicitly supported cursor sites initialize independently of the global COPRESENCE experiment gate
- keep unsupported sites and native PlayHTML integration behind the existing gate
- add policy-level and content-script launch-contract regression tests
- add an extension release note

## Why

The cohort feature-access migration classified COPRESENCE as internal. Because that global check ran before Wikipedia site policy, released Wikipedia cursors and link patina silently stopped initializing for public users.

## Verification

- full extension suite: 136 files, 884 tests
- latest-head focused suite: 4 files, 19 tests
- bun run check:extension
- Chrome production build
- Firefox production build
- Safari production build
- GitHub validation and extension performance checks

## Screenshots

Not captured. Spencer explicitly waived installed-surface screenshot verification for this narrow activation-policy fix after automated verification and review were green.