### PR TITLE
Refresh active browsing history records

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -4,6 +4,7 @@
 - Slow Mode can route deliberate far jumps through a short Internet Commute, with chance controls, cooldowns, and an always-available teleport.
 - Authentication pages no longer appear in Internet Commute or trigger Slow Mode.
 - Wikipedia always shows its shared cursors and remembered-link patina.
+- Browsing history now refreshes the current week, month, or year as new activity is recorded.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/src/__tests__/walkingRecordCache.test.ts
+++ b/extension/src/__tests__/walkingRecordCache.test.ts
@@ -47,6 +47,28 @@ describe("walking record cache", () => {
     ).resolves.toEqual({ record, fresh: true });
   });
 
+  it("refreshes snapshots captured before their period ended", async () => {
+    const inProgressRecord = {
+      ...record,
+      range: { startTs: 1_000, endTs: 20_000 },
+    };
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      walking_record_cache: {
+        entries: [
+          {
+            key: "week:1000:#4a9a8a",
+            cachedAt: 10_000,
+            record: inProgressRecord,
+          },
+        ],
+      },
+    });
+
+    await expect(
+      readWalkingRecordCache("week:1000:#4a9a8a", 10_001),
+    ).resolves.toEqual({ record: inProgressRecord, fresh: false });
+  });
+
   it("returns an older matching snapshot while marking it stale", async () => {
     vi.mocked(browser.storage.local.get).mockResolvedValue({
       walking_record_cache: {

--- a/extension/src/__tests__/walkingRecordEntry.test.tsx
+++ b/extension/src/__tests__/walkingRecordEntry.test.tsx
@@ -113,7 +113,7 @@ describe("walking record entrypoint", () => {
     mocks.writeWalkingRecordCache.mockReset();
   });
 
-  it("retries a stale refresh after navigating away and back", async () => {
+  it("retries refreshes after navigation and returning to the page", async () => {
     await act(async () => {
       await import("../entrypoints/walking-record/walking-record");
       await flushEffects();
@@ -136,6 +136,18 @@ describe("walking record entrypoint", () => {
     expect(mocks.loadWalkingRecord.mock.calls.map((call) => call[0])).toEqual([
       "week",
       "month",
+      "week",
+    ]);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      await flushEffects();
+    });
+
+    expect(mocks.loadWalkingRecord.mock.calls.map((call) => call[0])).toEqual([
+      "week",
+      "month",
+      "week",
       "week",
     ]);
   });

--- a/extension/src/entrypoints/walking-record/walking-record.tsx
+++ b/extension/src/entrypoints/walking-record/walking-record.tsx
@@ -71,6 +71,7 @@ function WalkingRecordEntryPage() {
   const [movementLoadingKey, setMovementLoadingKey] = useState<string | null>(
     null,
   );
+  const [refreshSequence, setRefreshSequence] = useState(0);
   const [loadingProgress, setLoadingProgress] =
     useState<WalkingRecordLoadProgress>({
       completed: 0,
@@ -115,14 +116,10 @@ function WalkingRecordEntryPage() {
     if (!baseColor) return;
 
     const existingRecord = records[recordKey];
-    if (existingRecord) {
-      setLoading(false);
-      return;
-    }
-
     let cancelled = false;
     const visiblePreview =
-      previewRecord?.key === recordKey ? previewRecord.record : null;
+      existingRecord ??
+      (previewRecord?.key === recordKey ? previewRecord.record : null);
     let baseRecordShown = Boolean(visiblePreview);
     const cacheKey = walkingRecordCacheKey(period, range, baseColor);
 
@@ -239,7 +236,24 @@ function WalkingRecordEntryPage() {
     range.endTs,
     range.startTs,
     recordKey,
+    refreshSequence,
   ]);
+
+  useEffect(() => {
+    const refreshCurrentPeriod = () => {
+      if (
+        document.visibilityState === "visible" &&
+        range.endTs > Date.now()
+      ) {
+        setRefreshSequence((current) => current + 1);
+      }
+    };
+
+    document.addEventListener("visibilitychange", refreshCurrentPeriod);
+    return () => {
+      document.removeEventListener("visibilitychange", refreshCurrentPeriod);
+    };
+  }, [range.endTs]);
 
   useEffect(() => {
     const summaries = summarizeWalkingRecordPeriods(
@@ -281,7 +295,7 @@ function WalkingRecordEntryPage() {
     return () => {
       cancelled = true;
     };
-  }, [period]);
+  }, [period, refreshSequence]);
 
   const selectPeriod = (nextPeriod: WalkingRecordPeriod) => {
     const nextRange = getWalkingRecordPeriodRange(nextPeriod);

--- a/extension/src/history/walkingRecordCache.ts
+++ b/extension/src/history/walkingRecordCache.ts
@@ -92,6 +92,7 @@ export async function readWalkingRecordCache(
   return {
     record: entry.record,
     fresh:
+      entry.cachedAt >= entry.record.range.endTs &&
       now - entry.cachedAt >= 0 &&
       now - entry.cachedAt <= WALKING_RECORD_CACHE_MAX_AGE_MS,
   };


### PR DESCRIPTION
## Summary

- Keep cached History records as an immediate preview while refreshing the current week, month, or year from IndexedDB.
- Refresh the current record and calendar summary when someone returns to an open History tab.
- Keep completed historical periods eligible for the existing fifteen-minute cache window.

## Why

Safari was collecting events correctly, but History could show an empty or outdated current period for up to fifteen minutes. A History tab also stayed stale after browsing elsewhere and returning to it.

The live Safari event store had 148 events, 8 sessions, and 111 seconds of screen time while the page still showed an empty cached record.

## Verification

- Added a regression that failed when an in-progress period was treated as fresh.
- Added coverage for leaving History and returning to the current period.
- `bun run test:extension` (883 tests)
- `bun run check:extension`
- `bun run --cwd extension build:safari`
- Verified the installed Safari History page against its real local event store.

## Screenshots

See the PR Evidence comment for the live Safari History page after it refreshed from the collected data.
