### PR TITLE
Protect room persistence recovery from stale writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "load-test:full": "bun tools/load-test/src/runner.ts --config full-suite",
     "smoke": "cd smoke-tests && bun run test",
     "smoke:partykit": "cd smoke-tests && bun run test:partykit",
+    "smoke:partykit:bridge": "cd smoke-tests && bun run test:partykit:bridge",
     "smoke:partykit:limits": "cd smoke-tests && bun run test:partykit:limits",
     "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",
     "smoke:partykit:compaction": "cd smoke-tests && bun run test:partykit:compaction",

--- a/partykit/.dev.vars.example
+++ b/partykit/.dev.vars.example
@@ -3,3 +3,4 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_KEY=your-secret-key-here
 ADMIN_TOKEN=your-admin-token-here
+PARTYKIT_BRIDGE_SECRET=your-bridge-secret-here

--- a/partykit/__tests__/bridgeAuth.test.ts
+++ b/partykit/__tests__/bridgeAuth.test.ts
@@ -1,0 +1,48 @@
+// ABOUTME: Verifies authentication for internal room-to-room bridge requests.
+// ABOUTME: Ensures public callers cannot forge bridge mutations.
+import { describe, expect, it } from "bun:test";
+import {
+  BRIDGE_SECRET_HEADER,
+  createBridgeRequest,
+  getBridgeAuthFailure,
+} from "../bridgeAuth";
+
+const SECRET = "test-bridge-secret";
+
+describe("bridge request authentication", () => {
+  it("fails closed when the deployment secret is unavailable", () => {
+    const request = new Request("http://internal/apply", {
+      headers: { [BRIDGE_SECRET_HEADER]: SECRET },
+    });
+
+    expect(getBridgeAuthFailure(request, undefined)?.status).toBe(503);
+    expect(() => createBridgeRequest("/apply", {}, undefined)).toThrow(
+      "PARTYKIT_BRIDGE_SECRET is not configured"
+    );
+  });
+
+  it("rejects missing and incorrect credentials", () => {
+    expect(
+      getBridgeAuthFailure(new Request("http://internal/apply"), SECRET)?.status
+    ).toBe(401);
+    expect(
+      getBridgeAuthFailure(
+        new Request("http://internal/apply", {
+          headers: { [BRIDGE_SECRET_HEADER]: "wrong" },
+        }),
+        SECRET
+      )?.status
+    ).toBe(403);
+  });
+
+  it("attaches the configured credential to outbound requests", () => {
+    const request = createBridgeRequest(
+      "/subscribe",
+      { action: "subscribe" },
+      SECRET
+    );
+
+    expect(request.headers.get(BRIDGE_SECRET_HEADER)).toBe(SECRET);
+    expect(getBridgeAuthFailure(request, SECRET)).toBeNull();
+  });
+});

--- a/partykit/__tests__/bridgeLeasePolicy.test.ts
+++ b/partykit/__tests__/bridgeLeasePolicy.test.ts
@@ -1,0 +1,63 @@
+// ABOUTME: Verifies renewal and merging of shared-reference bridge leases.
+// ABOUTME: Keeps active identical references subscribed without losing source metadata.
+import { describe, expect, it } from "bun:test";
+import { mergeSharedReferenceLeases } from "../bridgeLeasePolicy";
+
+describe("mergeSharedReferenceLeases", () => {
+  it("renews an identical reference and preserves its source epoch", () => {
+    const result = mergeSharedReferenceLeases({
+      existing: [
+        {
+          sourceRoomId: "source-room",
+          elementIds: ["shared"],
+          sourceResetEpoch: 42,
+          lastSeen: "2026-08-24T00:00:00.000Z",
+        },
+      ],
+      requested: [{ sourceRoomId: "source-room", elementIds: ["shared"] }],
+      nowIso: "2026-08-25T00:00:00.000Z",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.entries).toEqual([
+      {
+        sourceRoomId: "source-room",
+        elementIds: ["shared"],
+        sourceResetEpoch: 42,
+        lastSeen: "2026-08-25T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("merges new ids without refreshing unrelated source leases", () => {
+    const result = mergeSharedReferenceLeases({
+      existing: [
+        {
+          sourceRoomId: "source-room",
+          elementIds: ["first"],
+          lastSeen: "2026-08-24T00:00:00.000Z",
+        },
+        {
+          sourceRoomId: "other-room",
+          elementIds: ["other"],
+          lastSeen: "2026-08-23T00:00:00.000Z",
+        },
+      ],
+      requested: [{ sourceRoomId: "source-room", elementIds: ["second"] }],
+      nowIso: "2026-08-25T00:00:00.000Z",
+    });
+
+    expect(result.entries).toEqual([
+      {
+        sourceRoomId: "source-room",
+        elementIds: ["first", "second"],
+        lastSeen: "2026-08-25T00:00:00.000Z",
+      },
+      {
+        sourceRoomId: "other-room",
+        elementIds: ["other"],
+        lastSeen: "2026-08-23T00:00:00.000Z",
+      },
+    ]);
+  });
+});

--- a/partykit/__tests__/bridgeLeasePolicy.test.ts
+++ b/partykit/__tests__/bridgeLeasePolicy.test.ts
@@ -4,7 +4,32 @@ import { describe, expect, it } from "bun:test";
 import { mergeSharedReferenceLeases } from "../bridgeLeasePolicy";
 
 describe("mergeSharedReferenceLeases", () => {
-  it("renews an identical reference and preserves its source epoch", () => {
+  it("does not renew a recent identical reference", () => {
+    const result = mergeSharedReferenceLeases({
+      existing: [
+        {
+          sourceRoomId: "source-room",
+          elementIds: ["shared"],
+          sourceResetEpoch: 42,
+          lastSeen: "2026-08-24T23:00:00.000Z",
+        },
+      ],
+      requested: [{ sourceRoomId: "source-room", elementIds: ["shared"] }],
+      nowIso: "2026-08-25T00:00:00.000Z",
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.entries).toEqual([
+      {
+        sourceRoomId: "source-room",
+        elementIds: ["shared"],
+        sourceResetEpoch: 42,
+        lastSeen: "2026-08-24T23:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("renews an identical reference once its lease is old", () => {
     const result = mergeSharedReferenceLeases({
       existing: [
         {
@@ -19,14 +44,7 @@ describe("mergeSharedReferenceLeases", () => {
     });
 
     expect(result.changed).toBe(true);
-    expect(result.entries).toEqual([
-      {
-        sourceRoomId: "source-room",
-        elementIds: ["shared"],
-        sourceResetEpoch: 42,
-        lastSeen: "2026-08-25T00:00:00.000Z",
-      },
-    ]);
+    expect(result.entries[0]?.lastSeen).toBe("2026-08-25T00:00:00.000Z");
   });
 
   it("merges new ids without refreshing unrelated source leases", () => {

--- a/partykit/__tests__/bridgeRequest.test.ts
+++ b/partykit/__tests__/bridgeRequest.test.ts
@@ -1,0 +1,67 @@
+// ABOUTME: Verifies parsing of untrusted PartyServer bridge request bodies.
+// ABOUTME: Rejects malformed collections before bridge handlers inspect them.
+import { describe, expect, it } from "bun:test";
+import {
+  isApplySubtreesImmediateRequest,
+  isExportPermissionsRequest,
+  isSubscribeRequest,
+} from "../request";
+
+describe("bridge request parsing", () => {
+  it("accepts well-formed bridge requests", () => {
+    expect(
+      isSubscribeRequest({
+        action: "subscribe",
+        consumerRoomId: "consumer",
+        elementIds: ["shared"],
+      })
+    ).toBe(true);
+    expect(
+      isExportPermissionsRequest({
+        action: "export-permissions",
+        elementIds: ["shared"],
+      })
+    ).toBe(true);
+    expect(
+      isApplySubtreesImmediateRequest({
+        action: "apply-subtrees-immediate",
+        subtrees: { "can-toggle": { shared: { active: true } } },
+        sender: "source",
+        originKind: "source",
+        resetEpoch: null,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects malformed element-id and subtree collections", () => {
+    expect(
+      isSubscribeRequest({
+        action: "subscribe",
+        consumerRoomId: "consumer",
+        elementIds: ["shared", 12],
+      })
+    ).toBe(false);
+    expect(
+      isExportPermissionsRequest({
+        action: "export-permissions",
+        elementIds: [null],
+      })
+    ).toBe(false);
+    expect(
+      isApplySubtreesImmediateRequest({
+        action: "apply-subtrees-immediate",
+        subtrees: null,
+        sender: "source",
+        originKind: "source",
+      })
+    ).toBe(false);
+    expect(
+      isApplySubtreesImmediateRequest({
+        action: "apply-subtrees-immediate",
+        subtrees: { "can-toggle": [] },
+        sender: "source",
+        originKind: "source",
+      })
+    ).toBe(false);
+  });
+});

--- a/partykit/__tests__/bridgeRequestAuth.test.ts
+++ b/partykit/__tests__/bridgeRequestAuth.test.ts
@@ -63,6 +63,7 @@ async function createHarness() {
     circuitBreaker: {
       value: {
         getLoadDeferredResponse: async () => null,
+        getClientLoadDeferredResponse: async () => null,
         isQuarantined: () => false,
       },
       writable: true,

--- a/partykit/__tests__/bridgeRequestAuth.test.ts
+++ b/partykit/__tests__/bridgeRequestAuth.test.ts
@@ -1,7 +1,12 @@
 // ABOUTME: Exercises authentication and relationship checks through PartyServer bridge routing.
 // ABOUTME: Verifies rejected requests leave live documents and bridge metadata untouched.
 import { describe, expect, it, mock } from "bun:test";
-import { docToJson, jsonToDoc } from "../docUtils";
+import {
+  docToJson,
+  encodeDocToBase64,
+  jsonToDoc,
+  replaceDocFromSnapshot,
+} from "../docUtils";
 import { BRIDGE_SECRET_HEADER } from "../bridgeAuth";
 
 const SECRET = "test-bridge-secret";
@@ -52,6 +57,8 @@ async function createHarness() {
     document: { value: document },
     persistenceMode: { value: { kind: "available" }, writable: true },
     documentLoadCompleted: { value: true, writable: true },
+    documentWriteState: { value: { kind: "idle" }, writable: true },
+    documentWriteTail: { value: Promise.resolve(), writable: true },
     realtimeSyncStarted: { value: true, writable: true },
     isSkippingSave: { value: false, writable: true },
     circuitBreaker: {
@@ -132,6 +139,71 @@ describe("PartyServer bridge request protection", () => {
     expect(response.status).toBe(200);
     expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
       active: true,
+    });
+  });
+
+  it("serializes a bridge apply behind an in-flight document replacement", async () => {
+    const { server, document } = await createHarness();
+    Object.defineProperty(server, "getSharedReferences", {
+      value: async () => [
+        {
+          sourceRoomId: "registered-source",
+          elementIds: ["shared"],
+          sourceResetEpoch: 42,
+        },
+      ],
+    });
+    let releaseReplacement = () => {};
+    const replacementGate = new Promise<void>((resolve) => {
+      releaseReplacement = resolve;
+    });
+    const replacement = jsonToDoc({
+      "can-toggle": { shared: { active: false } },
+      "can-play": { preserved: { value: "replacement" } },
+    });
+    const replacementBase64 = encodeDocToBase64(replacement);
+    replacement.destroy();
+    server.documentWriteTail = replacementGate.then(() => {
+      replaceDocFromSnapshot(document, replacementBase64);
+    });
+    let reachedWriteQueue = () => {};
+    const writeQueued = new Promise<void>((resolve) => {
+      reachedWriteQueue = resolve;
+    });
+    const runDocumentWrite = server.runDocumentWrite.bind(server);
+    Object.defineProperty(server, "runDocumentWrite", {
+      value: (work: () => Promise<unknown>) => {
+        reachedWriteQueue();
+        return runDocumentWrite(work);
+      },
+    });
+
+    const responsePromise = server.onRequest(
+      bridgeRequest(
+        {
+          ...applyAction,
+          sender: "registered-source",
+          originKind: "source",
+          resetEpoch: 42,
+        },
+        SECRET
+      )
+    );
+    await writeQueued;
+
+    expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
+      active: false,
+    });
+
+    releaseReplacement();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
+      active: true,
+    });
+    expect(docToJson(document)?.["can-play"]?.preserved).toEqual({
+      value: "replacement",
     });
   });
 });

--- a/partykit/__tests__/bridgeRequestAuth.test.ts
+++ b/partykit/__tests__/bridgeRequestAuth.test.ts
@@ -163,8 +163,10 @@ describe("PartyServer bridge request protection", () => {
     });
     const replacementBase64 = encodeDocToBase64(replacement);
     replacement.destroy();
+    server.documentWriteState = { kind: "reset", resetEpoch: 43 };
     server.documentWriteTail = replacementGate.then(() => {
       replaceDocFromSnapshot(document, replacementBase64);
+      server.documentWriteState = { kind: "idle" };
     });
     let reachedWriteQueue = () => {};
     const writeQueued = new Promise<void>((resolve) => {
@@ -189,8 +191,12 @@ describe("PartyServer bridge request protection", () => {
         SECRET
       )
     );
-    await writeQueued;
+    const admission = await Promise.race([
+      writeQueued.then(() => "queued" as const),
+      responsePromise.then(() => "responded" as const),
+    ]);
 
+    expect(admission).toBe("queued");
     expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
       active: false,
     });

--- a/partykit/__tests__/bridgeRequestAuth.test.ts
+++ b/partykit/__tests__/bridgeRequestAuth.test.ts
@@ -1,0 +1,137 @@
+// ABOUTME: Exercises authentication and relationship checks through PartyServer bridge routing.
+// ABOUTME: Verifies rejected requests leave live documents and bridge metadata untouched.
+import { describe, expect, it, mock } from "bun:test";
+import { docToJson, jsonToDoc } from "../docUtils";
+import { BRIDGE_SECRET_HEADER } from "../bridgeAuth";
+
+const SECRET = "test-bridge-secret";
+
+mock.module("cloudflare:workers", () => ({
+  DurableObject: class {
+    constructor(
+      readonly ctx: unknown,
+      readonly env: unknown
+    ) {}
+  },
+  env: {
+    SUPABASE_URL: "http://127.0.0.1:54321",
+    SUPABASE_KEY: "test-supabase-key",
+    ADMIN_TOKEN: "test-admin-token",
+    PARTYKIT_BRIDGE_SECRET: SECRET,
+    Main: {},
+  },
+}));
+
+type ApplyAction = {
+  action: "apply-subtrees-immediate";
+  subtrees: Record<string, Record<string, unknown>>;
+  sender: string;
+  originKind: "consumer" | "source";
+  resetEpoch: null;
+};
+
+function bridgeRequest(body: ApplyAction, credential?: string): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (credential !== undefined) {
+    headers.set(BRIDGE_SECRET_HEADER, credential);
+  }
+  return new Request("https://api.playhtml.fun/parties/main/source-room", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function createHarness() {
+  const { PartyServer } = await import("../party");
+  const document = jsonToDoc({
+    "can-toggle": { shared: { active: false } },
+  });
+  const server = Object.create(PartyServer.prototype, {
+    name: { value: "source-room" },
+    document: { value: document },
+    persistenceMode: { value: { kind: "available" }, writable: true },
+    documentLoadCompleted: { value: true, writable: true },
+    realtimeSyncStarted: { value: true, writable: true },
+    isSkippingSave: { value: false, writable: true },
+    circuitBreaker: {
+      value: {
+        getLoadDeferredResponse: async () => null,
+        isQuarantined: () => false,
+      },
+      writable: true,
+    },
+    bridgeHealth: { value: { reset() {} }, writable: true },
+    getSubscribers: { value: async () => [], writable: true },
+    getSharedReferences: { value: async () => [], writable: true },
+    getResetEpoch: { value: async () => 42, writable: true },
+  }) as any;
+  return { server, document };
+}
+
+const applyAction: ApplyAction = {
+  action: "apply-subtrees-immediate",
+  subtrees: { "can-toggle": { shared: { active: true } } },
+  sender: "unrelated-room",
+  originKind: "consumer",
+  resetEpoch: null,
+};
+
+describe("PartyServer bridge request protection", () => {
+  it("rejects an unauthenticated mutation before touching the document", async () => {
+    const { server, document } = await createHarness();
+
+    const response = await server.onRequest(bridgeRequest(applyAction));
+
+    expect(response.status).toBe(401);
+    expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
+      active: false,
+    });
+  });
+
+  it("rejects an authenticated mutation from an unrelated room", async () => {
+    const { server, document } = await createHarness();
+
+    const response = await server.onRequest(
+      bridgeRequest(applyAction, SECRET)
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: "bridge_relationship_not_found",
+    });
+    expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
+      active: false,
+    });
+  });
+
+  it("allows a registered source to update only its subscribed subtree", async () => {
+    const { server, document } = await createHarness();
+    Object.defineProperty(server, "getSharedReferences", {
+      value: async () => [
+        {
+          sourceRoomId: "registered-source",
+          elementIds: ["shared"],
+          sourceResetEpoch: 42,
+        },
+      ],
+    });
+
+    const response = await server.onRequest(
+      bridgeRequest(
+        {
+          ...applyAction,
+          sender: "registered-source",
+          originKind: "source",
+          resetEpoch: 42,
+        },
+        SECRET
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(docToJson(document)?.["can-toggle"]?.shared).toEqual({
+      active: true,
+    });
+  });
+});

--- a/partykit/__tests__/bridgeRequestAuth.test.ts
+++ b/partykit/__tests__/bridgeRequestAuth.test.ts
@@ -57,10 +57,9 @@ async function createHarness() {
     document: { value: document },
     persistenceMode: { value: { kind: "available" }, writable: true },
     documentLoadCompleted: { value: true, writable: true },
-    documentWriteState: { value: { kind: "idle" }, writable: true },
+    documentMaintenanceInProgress: { value: false, writable: true },
     documentWriteTail: { value: Promise.resolve(), writable: true },
     realtimeSyncStarted: { value: true, writable: true },
-    isSkippingSave: { value: false, writable: true },
     circuitBreaker: {
       value: {
         getLoadDeferredResponse: async () => null,
@@ -99,9 +98,7 @@ describe("PartyServer bridge request protection", () => {
   it("rejects an authenticated mutation from an unrelated room", async () => {
     const { server, document } = await createHarness();
 
-    const response = await server.onRequest(
-      bridgeRequest(applyAction, SECRET)
-    );
+    const response = await server.onRequest(bridgeRequest(applyAction, SECRET));
 
     expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({
@@ -163,10 +160,10 @@ describe("PartyServer bridge request protection", () => {
     });
     const replacementBase64 = encodeDocToBase64(replacement);
     replacement.destroy();
-    server.documentWriteState = { kind: "reset", resetEpoch: 43 };
+    server.documentMaintenanceInProgress = true;
     server.documentWriteTail = replacementGate.then(() => {
       replaceDocFromSnapshot(document, replacementBase64);
-      server.documentWriteState = { kind: "idle" };
+      server.documentMaintenanceInProgress = false;
     });
     let reachedWriteQueue = () => {};
     const writeQueued = new Promise<void>((resolve) => {

--- a/partykit/__tests__/bridgeRequestPolicy.test.ts
+++ b/partykit/__tests__/bridgeRequestPolicy.test.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Verifies that bridge apply requests require a registered relationship.
+// ABOUTME: Prevents authenticated but unrelated rooms from replacing shared subtrees.
+import { describe, expect, it } from "bun:test";
+import { getBridgeApplyRelationship } from "../bridgeRequestPolicy";
+
+describe("getBridgeApplyRelationship", () => {
+  const relationships = {
+    subscriberRoomIds: ["consumer-room"],
+    sourceRoomIds: ["source-room"],
+  };
+
+  it("recognizes registered senders in the declared direction", () => {
+    expect(
+      getBridgeApplyRelationship({
+        ...relationships,
+        sender: "consumer-room",
+        originKind: "consumer",
+      })
+    ).toBe("consumer");
+    expect(
+      getBridgeApplyRelationship({
+        ...relationships,
+        sender: "source-room",
+        originKind: "source",
+      })
+    ).toBe("source");
+  });
+
+  it("rejects unknown senders and direction mismatches", () => {
+    expect(
+      getBridgeApplyRelationship({
+        ...relationships,
+        sender: "unknown-room",
+        originKind: "source",
+      })
+    ).toBeNull();
+    expect(
+      getBridgeApplyRelationship({
+        ...relationships,
+        sender: "consumer-room",
+        originKind: "source",
+      })
+    ).toBeNull();
+  });
+});

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2152,13 +2152,7 @@ describe("quarantine data safety", () => {
     const { room, storage } = createRoom();
     await startRoom(room);
 
-    const savedDoc = new Y.Doc();
-    savedDoc.getMap("play").set("version", "saved-before-recovery");
-    const savedBase64 = encodeDoc(savedDoc);
-    Y.applyUpdate(
-      room.document,
-      new Uint8Array(Buffer.from(savedBase64, "base64"))
-    );
+    room.document.getMap("play").set("version", "saved-before-recovery");
 
     const delayedSave = createDeferred();
     const saveStarted = createDeferred();

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2304,6 +2304,63 @@ describe("quarantine data safety", () => {
     );
   });
 
+  test("a restart aborts compaction intent that did not reach the database", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("kept", "persisted");
+    const candidate = room.buildCompactedDocument(room.document);
+    expect(candidate).not.toBeNull();
+    persistedRow.document = candidate.sourceBase64;
+    const crashStorage = new FakeStorage();
+    beforeUpsert = async () => {
+      crashStorage.values = new Map(storage.values);
+      throw new Error("simulated isolate crash before database commit");
+    };
+
+    await expect(
+      room.commitCompactedDocument({ compactedDocument: candidate })
+    ).rejects.toThrow("simulated isolate crash before database commit");
+    beforeUpsert = null;
+
+    const restarted = restartRoom(crashStorage);
+    await startRoom(restarted);
+
+    expect(crashStorage.values.get("pendingDocumentReset")).toBeUndefined();
+    expect(restarted.roomState()).toBe("ready");
+    expect(restarted.document.getMap("play").get("kept")).toBe("persisted");
+    expect(persistedRow.document).toBe(candidate.sourceBase64);
+  });
+
+  test("a restart aborts restore intent that did not reach the database", async () => {
+    const originalDocument = encodeDoc(
+      jsonToDoc({ "can-play": { guestbook: { entries: ["persisted"] } } })
+    );
+    persistedRow.document = originalDocument;
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    const crashStorage = new FakeStorage();
+    beforeUpsert = async () => {
+      crashStorage.values = new Map(storage.values);
+      throw new Error("simulated isolate crash before database commit");
+    };
+
+    await expect(
+      room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+    ).rejects.toThrow("Failed to save snapshot");
+    beforeUpsert = null;
+
+    const restarted = restartRoom(crashStorage);
+    await startRoom(restarted);
+
+    expect(crashStorage.values.get("pendingDocumentReset")).toBeUndefined();
+    expect(restarted.roomState()).toBe("ready");
+    expect(docToJson(restarted.document)?.["can-play"]?.guestbook).toEqual({
+      entries: ["persisted"],
+    });
+    expect(persistedRow.document).toBe(originalDocument);
+  });
+
   test("post-compaction cleanup failure does not reopen the committed write", async () => {
     const { room } = createRoom();
     room.documentLoadCompleted = true;

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -8,7 +8,7 @@ import * as Y from "yjs";
 import { Buffer } from "node:buffer";
 import {
   parseSharedElementsFromUrl,
-  parseSharedReferencesFromUrl
+  parseSharedReferencesFromUrl,
 } from "../sharing";
 import { docToJson, getDocResetEpoch, jsonToDoc } from "../docUtils";
 import { recordsFromPlay } from "../moderation";
@@ -61,6 +61,7 @@ const persistedRow: PersistedRow = { document: null };
 let upsertCalls: Array<{ name: string; document: string }> = [];
 let upsertError: Error | null = null;
 let beforeUpsert: (() => Promise<void>) | null = null;
+let afterUpsert: (() => Promise<void>) | null = null;
 
 // Counts reads of the documents row. The load-backoff contract requires that a
 // deferred room never touches Supabase at all, which this makes observable.
@@ -110,6 +111,7 @@ const supabaseStub = {
           return { error: { message: upsertError.message } };
         }
         persistedRow.document = row.document;
+        await afterUpsert?.();
         return { error: null };
       },
     };
@@ -164,7 +166,7 @@ function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
     persistenceMode: { value: { kind: "available" }, writable: true },
     realtimeSyncStarted: { value: true, writable: true },
     documentLoadCompleted: { value: false, writable: true },
-    documentWriteState: { value: { kind: "idle" }, writable: true },
+    documentMaintenanceInProgress: { value: false, writable: true },
     documentWriteTail: { value: Promise.resolve(), writable: true },
     documentGeneration: { value: 0, writable: true },
     persistenceObserverAttached: { value: false, writable: true },
@@ -307,6 +309,7 @@ beforeEach(() => {
   upsertCalls = [];
   upsertError = null;
   beforeUpsert = null;
+  afterUpsert = null;
   documentReadCount = 0;
   documentReadErrors = [];
   beforeDocumentRead = null;
@@ -315,6 +318,65 @@ beforeEach(() => {
 });
 
 describe("admin mutations use the authoritative live document", () => {
+  test("force-save-live encodes the document after acquiring the write queue", async () => {
+    const { room } = buildReadyAdminRoom({
+      "can-post": { guestbook: [{ message: "before" }] },
+    });
+    const releaseQueue = createDeferred();
+    const queueStarted = createDeferred();
+    const queuedWork = room.runDocumentWrite(async () => {
+      queueStarted.resolve();
+      await releaseQueue.promise;
+    });
+    await queueStarted.promise;
+
+    const responsePromise = room.onRequest(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/force-save-live",
+        { method: "POST" }
+      )
+    );
+    await Promise.resolve();
+    room.document.getMap("play").set("written-while-queued", "preserved");
+    releaseQueue.resolve();
+
+    await queuedWork;
+    const response = await responsePromise;
+    const savedDoc = new Y.Doc();
+    Y.applyUpdate(
+      savedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document!, "base64"))
+    );
+
+    expect(response.status).toBe(200);
+    expect(savedDoc.getMap("play").get("written-while-queued")).toBe(
+      "preserved"
+    );
+  });
+
+  test("force-save-live reports when reset-epoch validation skips the save", async () => {
+    const { room } = buildReadyAdminRoom({ "can-post": { guestbook: [] } });
+    room.document.getMap("__playhtml_meta").set("resetEpoch", 1);
+    room.cachedResetEpoch = 2;
+    const originalWarn = console.warn;
+    console.warn = () => {};
+
+    let response: Response;
+    try {
+      response = await room.onRequest(
+        new Request(
+          "https://example.com/parties/main/example-room/admin/force-save-live",
+          { method: "POST" }
+        )
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(response.status).toBe(409);
+    expect(upsertCalls).toEqual([]);
+  });
+
   test("moderation preserves unrelated live-only data and returns commit metadata", async () => {
     const persistedPlay = {
       "can-play": {
@@ -505,10 +567,10 @@ describe("hydration write guards", () => {
     room.documentLoadCompleted = true;
     expect(room.roomState()).toBe("ready");
 
-    room.isSkippingSave = true;
+    room.documentMaintenanceInProgress = true;
     expect(room.roomState()).toBe("save-paused");
 
-    room.isSkippingSave = false;
+    room.documentMaintenanceInProgress = false;
     room.persistenceMode = {
       kind: "transient",
       reason: "database unavailable",
@@ -571,9 +633,13 @@ describe("hydration write guards", () => {
     expect(room.isPersistenceAvailable()).toBe(true);
     expect(documentReadCount).toBe(3);
     expect(warnings).toHaveLength(2);
-    expect(errors).toEqual([
-      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
-    ]);
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toBe(
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
+    );
+    expect(errors[1]).toContain(
+      "ROOM WORK FAILING: room=example-room operation=load consecutiveFailures=1"
+    );
     expect(logs).toEqual([
       "[PartyServer] Supabase persistence restored for room=example-room; leaving transient mode.",
     ]);
@@ -666,9 +732,11 @@ describe("hydration write guards", () => {
     room.handleMessage(connection, encoding.toUint8Array(encoder));
 
     expect(room.isReadOnly(connection)).toBe(true);
-    expect(room.document.awareness.getStates().get(sourceDoc.clientID)).toEqual({
-      online: true,
-    });
+    expect(room.document.awareness.getStates().get(sourceDoc.clientID)).toEqual(
+      {
+        online: true,
+      }
+    );
     sourceAwareness.destroy();
     room.document.awareness.destroy();
     sourceDoc.destroy();
@@ -720,7 +788,7 @@ describe("hydration write guards", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
     room.documentLoadCompleted = true;
-    room.isSkippingSave = true;
+    room.documentMaintenanceInProgress = true;
 
     const autosaveResult = await room.persistLiveDocument({
       allowCompaction: false,
@@ -810,7 +878,7 @@ describe("hydration write guards", () => {
     const { room, storage } = createRoom();
     room.getResetEpoch = async () => null;
     room.clearEmptyRoomCompactAfter = async () => {};
-    room.ensureAlarmScheduled = async () => {};
+    room.scheduleNextAlarm = async () => {};
     room.waitForEmptyRoomCompaction = async () => {};
     room.document.awareness = new awarenessProtocol.Awareness(room.document);
     const connection = {
@@ -827,8 +895,7 @@ describe("hydration write guards", () => {
         { elementId: "shared", permissions: "read-write" },
       ]),
     });
-    const requestUrl =
-      `https://example.com/parties/main/example-room?${params.toString()}`;
+    const requestUrl = `https://example.com/parties/main/example-room?${params.toString()}`;
 
     expect(parseSharedReferencesFromUrl(requestUrl)).toHaveLength(1);
     expect(parseSharedElementsFromUrl(requestUrl)).toHaveLength(1);
@@ -1376,6 +1443,39 @@ describe("alarm failure backoff", () => {
 });
 
 describe("hardening", () => {
+  test("transient degradation survives a recovery-marker storage failure", async () => {
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const { room, storage } = createRoom();
+    const originalPut = storage.put.bind(storage);
+    storage.put = async (key: string, value: unknown) => {
+      if (key === "persistenceRecoveryPending") {
+        throw new Error("durable storage unavailable");
+      }
+      await originalPut(key, value);
+    };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(startRoom(room)).resolves.toBeUndefined();
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(room.isPersistenceAvailable()).toBe(false);
+    expect(room.documentLoadCompleted).toBe(false);
+    expect(errors.some((message) => message.includes("durable storage"))).toBe(
+      true
+    );
+  });
+
   test("a temporary Supabase failure recovers before transient mode", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     documentReadErrors = [new Error("temporary failure")];
@@ -1433,12 +1533,14 @@ describe("hardening", () => {
       "[PartyServer] Supabase document load attempt 1/3 failed for room=example-room; retrying in 1ms: failure 1",
       "[PartyServer] Supabase document load attempt 2/3 failed for room=example-room; retrying in 2ms: failure 2",
     ]);
-    expect(errors).toEqual([
-      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
-    ]);
-    expect(storage.alarm).toBe(
-      storage.values.get("persistenceRecoveryRetryAfter")
+    expect(errors).toHaveLength(2);
+    expect(errors[0]).toBe(
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
     );
+    expect(errors[1]).toContain(
+      "ROOM WORK FAILING: room=example-room operation=load consecutiveFailures=1"
+    );
+    expect(storage.alarm).toBe(storage.values.get("loadRetryAfter"));
   });
 
   test("a warm transient room does not retry before its recovery deadline", async () => {
@@ -1457,9 +1559,7 @@ describe("hardening", () => {
       console.error = originalError;
     }
 
-    const retryAfter = storage.values.get(
-      "persistenceRecoveryRetryAfter"
-    ) as number;
+    const retryAfter = storage.values.get("loadRetryAfter") as number;
     expect(retryAfter).toBeGreaterThan(Date.now());
 
     await room.onRequest(
@@ -1492,7 +1592,7 @@ describe("hardening", () => {
     }
 
     expect(storage.values.get("persistenceRecoveryPending")).toBe(true);
-    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
 
     const resetMessages: string[] = [];
     const closeCalls: Array<{ code: number; reason: string }> = [];
@@ -1553,7 +1653,8 @@ describe("hardening", () => {
     }
 
     room.document.getMap("play").set("transient-only", "discard me");
-    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
+    room.circuitBreaker.setLoadDeferredUntil(Date.now() - 1);
 
     const resetMessages: string[] = [];
     const closeCalls: Array<{ code: number; reason: string }> = [];
@@ -1580,7 +1681,7 @@ describe("hardening", () => {
     expect(room.document.getMap("play").get("greeting")).toBe("hello");
     expect(room.document.getMap("play").get("transient-only")).toBeUndefined();
     expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
-    expect(storage.values.has("persistenceRecoveryRetryAfter")).toBe(false);
+    expect(storage.values.has("loadRetryAfter")).toBe(false);
     expect(resetMessages).toHaveLength(1);
     expect(closeCalls).toEqual([
       { code: 4000, reason: "Room Persistence Restored" },
@@ -1625,9 +1726,7 @@ describe("hardening", () => {
     expect(storage.alarm).toBeNull();
   });
 
-  // L1: the deadline is written speculatively before an attempt that may never
-  // reach hydration.
-  test("a rolled-back load attempt also rolls back its deadline", async () => {
+  test("an observed load failure advances the ordinary load backoff", async () => {
     const { room, storage } = createRoom();
     storage.values.set("quarantineLoadAttempts", 2);
     storage.values.set("loadRetryAfter", Date.now() - 1000);
@@ -1654,8 +1753,8 @@ describe("hardening", () => {
       (supabaseStub as any).from = originalFrom;
     }
 
-    expect(storage.values.get("loadRetryAfter")).toBeUndefined();
-    expect(storage.values.get("quarantineLoadAttempts")).toBe(2);
+    expect(storage.values.get("loadRetryAfter")).toBeGreaterThan(Date.now());
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(3);
   });
 
   // L2: the flag is applied from the control plane and then resumed from durable
@@ -1826,9 +1925,7 @@ describe("admin quarantine endpoints", () => {
     ];
     room.broadcastCustomMessage = () => {};
 
-    await room.onRequest(
-      adminRequest("quarantine-clear", { method: "POST" })
-    );
+    await room.onRequest(adminRequest("quarantine-clear", { method: "POST" }));
     storage.values.set("loadRetryAfter", Date.now() - 1);
 
     const recovered = await room.onRequest(
@@ -2078,6 +2175,16 @@ describe("external quarantine control plane", () => {
 });
 
 describe("manual quarantine", () => {
+  test("pending recovery cannot suppress quarantine at the load threshold", async () => {
+    const { room, storage } = createRoom();
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("quarantineLoadAttempts", 8);
+
+    await room.circuitBreaker.shouldDeferLoad();
+
+    expect(room.circuitBreaker.isQuarantined()).toBe(true);
+  });
+
   test("an operator can quarantine a healthy room and clear it again", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room, storage } = createRoom();
@@ -2165,7 +2272,7 @@ describe("quarantine data safety", () => {
       }
     };
 
-    const autosave = room.saveDocumentBase64(encodeDoc(room.document));
+    const autosave = room.saveLiveDocument();
     await saveStarted.promise;
     const blockedSaveTail = room.documentWriteTail;
     await room.circuitBreaker.enterQuarantine({
@@ -2187,7 +2294,7 @@ describe("quarantine data safety", () => {
       await originalDelete(key);
     };
 
-    const recovery = room.runDocumentWrite(() => room.loadDocument(true));
+    const recovery = room.runDocumentWrite(() => room.loadDocument());
 
     expect(room.documentWriteTail).not.toBe(blockedSaveTail);
     expect(documentReadCount).toBe(0);
@@ -2236,10 +2343,10 @@ describe("quarantine data safety", () => {
     const restoredDoc = new Y.Doc();
     restoredDoc.getMap("play").set("version", "restored");
 
-    const autosave = room.saveDocumentBase64(encodeDoc(staleDoc));
+    const autosave = room.saveLiveDocument();
     await Promise.resolve();
     const restore = room.restoreFromSnapshot(encodeDoc(restoredDoc), {
-      bumpEpoch: true
+      bumpEpoch: true,
     });
     await Promise.resolve();
 
@@ -2255,7 +2362,7 @@ describe("quarantine data safety", () => {
     expect(upsertCalls).toHaveLength(2);
   });
 
-  test("a stale save queued behind a restore cannot overwrite it", async () => {
+  test("a save queued behind a restore encodes the restored live document", async () => {
     const { room } = createRoom();
     room.documentLoadCompleted = true;
     const restoreWrite = createDeferred();
@@ -2265,21 +2372,24 @@ describe("quarantine data safety", () => {
       await restoreWrite.promise;
     };
 
-    const staleDoc = new Y.Doc();
-    staleDoc.getMap("play").set("version", "stale");
     const restoredDoc = new Y.Doc();
     restoredDoc.getMap("play").set("version", "restored");
 
     const restore = room.restoreFromSnapshot(encodeDoc(restoredDoc), {
-      bumpEpoch: true
+      bumpEpoch: true,
     });
     await restoreWriteStarted.promise;
-    const staleSave = room.saveDocumentBase64(encodeDoc(staleDoc));
+    const queuedSave = room.saveLiveDocument();
     restoreWrite.resolve();
 
-    await restore;
-    await expect(staleSave).rejects.toThrow("Cannot persist stale document");
-    expect(upsertCalls).toHaveLength(1);
+    await Promise.all([restore, queuedSave]);
+    const persistedDoc = new Y.Doc();
+    Y.applyUpdate(
+      persistedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document!, "base64"))
+    );
+    expect(persistedDoc.getMap("play").get("version")).toBe("restored");
+    expect(upsertCalls).toHaveLength(2);
   });
 
   test("a failed autosave schedules and completes a durable retry", async () => {
@@ -2306,12 +2416,65 @@ describe("quarantine data safety", () => {
     storage.alarm = null;
     storage.values.set("documentSaveRetry", {
       ...(retry ?? { attempt: 1, generation: 0 }),
-      retryAt: Date.now() - 1
+      retryAt: Date.now() - 1,
     });
     await room.onAlarm();
 
     expect(storage.values.get("documentSaveRetry")).toBeUndefined();
     expect(persistedRow.document).not.toBeNull();
+  });
+
+  test("a successful autosave does not schedule a retry when the document changes mid-upsert", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("message", "before save");
+    const continueUpsert = createDeferred();
+    const upsertStarted = createDeferred();
+    beforeUpsert = async () => {
+      upsertStarted.resolve();
+      await continueUpsert.promise;
+    };
+
+    const save = room.onSave();
+    await upsertStarted.promise;
+    room.document.getMap("play").set("message", "after save started");
+    continueUpsert.resolve();
+    await save;
+
+    expect(storage.values.get("documentSaveRetry")).toBeUndefined();
+  });
+
+  test("a skipped retry consumes its due alarm instead of spinning", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.document.getMap("__playhtml_meta").set("resetEpoch", 1);
+    storage.values.set("resetEpoch", 2);
+    storage.values.set("documentSaveRetry", {
+      retryAt: Date.now() - 1,
+    });
+
+    await room.onAlarm();
+
+    expect(storage.values.get("documentSaveRetry")).toBeUndefined();
+    expect(upsertCalls).toEqual([]);
+  });
+
+  test("a retry that throws schedules a fresh fixed-delay retry", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.getResetEpoch = async () => {
+      throw new Error("durable storage unavailable");
+    };
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    await expect(room.onAlarm()).rejects.toThrow("durable storage unavailable");
+
+    const retry = storage.values.get("documentSaveRetry") as {
+      retryAt: number;
+    };
+    expect(retry.retryAt).toBeGreaterThan(Date.now());
+    expect(storage.alarm).toBe(retry.retryAt);
   });
 
   test("autosave persists the live document when compaction fails", async () => {
@@ -2353,7 +2516,7 @@ describe("quarantine data safety", () => {
     };
 
     const compaction = room.commitCompactedDocument({
-      compactedDocument: candidate
+      compactedDocument: candidate,
     });
     await validationStarted.promise;
     room.document.getMap("play").set("during-validation", "preserved");
@@ -2374,7 +2537,7 @@ describe("quarantine data safety", () => {
     );
   });
 
-  test("a restart aborts compaction intent that did not reach the database", async () => {
+  test("a restart keeps the previous document when compaction did not commit", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
     room.attachPersistenceObserver();
@@ -2396,13 +2559,12 @@ describe("quarantine data safety", () => {
     const restarted = restartRoom(crashStorage);
     await startRoom(restarted);
 
-    expect(crashStorage.values.get("pendingDocumentReset")).toBeUndefined();
     expect(restarted.roomState()).toBe("ready");
     expect(restarted.document.getMap("play").get("kept")).toBe("persisted");
     expect(persistedRow.document).toBe(candidate.sourceBase64);
   });
 
-  test("a restart aborts restore intent that did not reach the database", async () => {
+  test("a restart keeps the previous document when restore did not commit", async () => {
     const originalDocument = encodeDoc(
       jsonToDoc({ "can-play": { guestbook: { entries: ["persisted"] } } })
     );
@@ -2414,21 +2576,110 @@ describe("quarantine data safety", () => {
       crashStorage.values = new Map(storage.values);
       throw new Error("simulated isolate crash before database commit");
     };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
 
-    await expect(
-      room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
-    ).rejects.toThrow("Failed to save snapshot");
+    try {
+      await expect(
+        room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+      ).rejects.toThrow("Failed to save snapshot");
+    } finally {
+      console.error = originalError;
+    }
     beforeUpsert = null;
+
+    expect(
+      errors.some((message) => message.includes("Database save failed"))
+    ).toBe(true);
+    expect(errors.some((message) => message.includes("Failed for room"))).toBe(
+      true
+    );
 
     const restarted = restartRoom(crashStorage);
     await startRoom(restarted);
 
-    expect(crashStorage.values.get("pendingDocumentReset")).toBeUndefined();
     expect(restarted.roomState()).toBe("ready");
     expect(docToJson(restarted.document)?.["can-play"]?.guestbook).toEqual({
       entries: ["persisted"],
     });
     expect(persistedRow.document).toBe(originalDocument);
+  });
+
+  test("a restart converges after restore commits before the live document changes", async () => {
+    const originalDocument = encodeDoc(
+      jsonToDoc({ "can-play": { guestbook: { entries: ["before"] } } })
+    );
+    const replacementDocument = encodeDoc(
+      jsonToDoc({ "can-play": { guestbook: { entries: ["after"] } } })
+    );
+    persistedRow.document = originalDocument;
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    const crashStorage = new FakeStorage();
+    afterUpsert = async () => {
+      crashStorage.values = new Map(storage.values);
+      throw new Error("simulated isolate crash after database commit");
+    };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(
+        room.restoreFromSnapshot(replacementDocument, { bumpEpoch: true })
+      ).rejects.toThrow("Failed to save snapshot");
+    } finally {
+      console.error = originalError;
+      afterUpsert = null;
+    }
+
+    const restarted = restartRoom(crashStorage);
+    await startRoom(restarted);
+
+    expect(docToJson(restarted.document)?.["can-play"]?.guestbook).toEqual({
+      entries: ["after"],
+    });
+    expect(await restarted.getResetEpoch()).toBe(
+      getDocResetEpoch(restarted.document)
+    );
+    expect(errors.some((message) => message.includes("after database"))).toBe(
+      true
+    );
+  });
+
+  test("a restart converges after compaction commits before the live document changes", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("kept", "after compaction");
+    const candidate = room.buildCompactedDocument(room.document);
+    expect(candidate).not.toBeNull();
+    persistedRow.document = candidate.sourceBase64;
+    const crashStorage = new FakeStorage();
+    afterUpsert = async () => {
+      crashStorage.values = new Map(storage.values);
+      throw new Error("simulated isolate crash after database commit");
+    };
+
+    await expect(
+      room.commitCompactedDocument({ compactedDocument: candidate })
+    ).rejects.toThrow("simulated isolate crash after database commit");
+    afterUpsert = null;
+
+    const restarted = restartRoom(crashStorage);
+    await startRoom(restarted);
+
+    expect(restarted.document.getMap("play").get("kept")).toBe(
+      "after compaction"
+    );
+    expect(await restarted.getResetEpoch()).toBe(
+      getDocResetEpoch(restarted.document)
+    );
   });
 
   test("post-compaction cleanup failure does not reopen the committed write", async () => {
@@ -2448,7 +2699,7 @@ describe("quarantine data safety", () => {
           compactedDocument: candidate,
           afterReplace: async () => {
             throw new Error("cleanup unavailable");
-          }
+          },
         })
       ).resolves.toBe(true);
     } finally {
@@ -2459,142 +2710,20 @@ describe("quarantine data safety", () => {
     expect(persistedRow.document).toBe(candidate.base64);
   });
 
-  test("compaction marker cleanup failure does not reopen the committed write", async () => {
-    const { room, storage } = createRoom();
-    room.documentLoadCompleted = true;
-    room.attachPersistenceObserver();
-    room.document.getMap("play").set("kept", "value");
-    const candidate = room.buildCompactedDocument(room.document);
-    expect(candidate).not.toBeNull();
-    persistedRow.document = candidate.sourceBase64;
-    const originalDelete = storage.delete.bind(storage);
-    storage.delete = async (key: string) => {
-      if (key === "pendingDocumentReset") {
-        throw new Error("marker cleanup unavailable");
-      }
-      await originalDelete(key);
-    };
-    const errors: string[] = [];
-    const originalError = console.error;
-    console.error = (...args: unknown[]) => {
-      errors.push(args.map(String).join(" "));
-    };
-
-    try {
-      await expect(
-        room.commitCompactedDocument({ compactedDocument: candidate })
-      ).resolves.toBe(true);
-    } finally {
-      console.error = originalError;
-    }
-
-    expect(upsertCalls).toHaveLength(1);
-    expect(persistedRow.document).toBe(candidate.base64);
-    expect(room.document.getMap("play").get("kept")).toBe("value");
-    expect(errors.some((message) => message.includes("marker cleanup"))).toBe(
-      true
-    );
-  });
-
-  test("an unavailable room pushes an expired save retry into the future", async () => {
+  test("an unavailable room consumes an expired save retry", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
     room.persistenceMode = {
       kind: "transient",
       reason: "database unavailable",
-      failedAt: Date.now()
+      failedAt: Date.now(),
     };
-    storage.values.set("documentSaveRetry", {
-      attempt: 1,
-      retryAt: Date.now() - 1
-    });
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
 
     await room.onAlarm();
 
-    const retry = storage.values.get("documentSaveRetry") as {
-      attempt: number;
-      retryAt: number;
-    };
-    expect(retry.attempt).toBe(2);
-    expect(retry.retryAt).toBeGreaterThan(Date.now());
-    expect(storage.alarm).toBe(retry.retryAt);
+    expect(storage.values.has("documentSaveRetry")).toBe(false);
     expect(upsertCalls).toEqual([]);
-  });
-
-  test("a reset-epoch storage failure retries in the same warm room", async () => {
-    const { room, storage } = createRoom();
-    room.documentLoadCompleted = true;
-    const originalPut = storage.put.bind(storage);
-    let resetEpochWriteFailed = false;
-    storage.put = async (key: string, value: unknown) => {
-      if (key === "resetEpoch" && !resetEpochWriteFailed) {
-        resetEpochWriteFailed = true;
-        throw new Error("durable storage unavailable");
-      }
-      await originalPut(key, value);
-    };
-
-    await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
-
-    expect(resetEpochWriteFailed).toBe(true);
-    expect(storage.values.get("pendingDocumentReset")).toBeUndefined();
-    expect(room.roomState()).toBe("ready");
-    expect(await room.getResetEpoch()).toBe(getDocResetEpoch(room.document));
-  });
-
-  test("a persistent reset-epoch failure recovers by alarm in the same warm room", async () => {
-    const { room, storage } = createRoom();
-    room.documentLoadCompleted = true;
-    const originalPut = storage.put.bind(storage);
-    let resetEpochFailuresRemaining = 3;
-    storage.put = async (key: string, value: unknown) => {
-      if (key === "resetEpoch" && resetEpochFailuresRemaining > 0) {
-        resetEpochFailuresRemaining -= 1;
-        throw new Error("durable storage unavailable");
-      }
-      await originalPut(key, value);
-    };
-    const errors: string[] = [];
-    const warnings: string[] = [];
-    const originalError = console.error;
-    const originalWarn = console.warn;
-    console.error = (...args: unknown[]) => {
-      errors.push(args.map(String).join(" "));
-    };
-    console.warn = (...args: unknown[]) => {
-      warnings.push(args.map(String).join(" "));
-    };
-
-    try {
-      await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
-
-      const pending = storage.values.get("pendingDocumentReset") as {
-        resetEpoch: number;
-        retryAt: number;
-      };
-      expect(resetEpochFailuresRemaining).toBe(0);
-      expect(room.roomState()).toBe("save-paused");
-      expect(pending.retryAt).toBeNumber();
-      expect(storage.alarm).toBe(pending.retryAt);
-
-      storage.values.set("pendingDocumentReset", {
-        ...pending,
-        retryAt: Date.now() - 1
-      });
-      storage.alarm = null;
-      await room.onAlarm();
-
-      expect(storage.values.get("pendingDocumentReset")).toBeUndefined();
-      expect(room.roomState()).toBe("ready");
-      expect(await room.getResetEpoch()).toBe(getDocResetEpoch(room.document));
-    } finally {
-      console.error = originalError;
-      console.warn = originalWarn;
-    }
-    expect(
-      errors.some((message) => message.includes("Reset epoch remains pending"))
-    ).toBe(true);
-    expect(warnings).toHaveLength(3);
   });
 
   test("force-save-live cannot bypass quarantine protection", async () => {
@@ -2646,9 +2775,7 @@ describe("quarantine data safety", () => {
       failureCount: 0,
     });
 
-    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
-      /Refusing to persist document for quarantined room/
-    );
+    await expect(room.saveLiveDocument()).resolves.toBe(false);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
 
@@ -2656,9 +2783,7 @@ describe("quarantine data safety", () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();
 
-    await expect(room.saveDocumentBase64("overwrite-me")).rejects.toThrow(
-      /Cannot persist document while room state is loading/
-    );
+    await expect(room.saveLiveDocument()).resolves.toBe(false);
     expect(upsertCalls).toEqual([]);
     expect(persistedRow.document).toBe(SMALL_DOCUMENT);
   });
@@ -2669,7 +2794,7 @@ describe("quarantine data safety", () => {
 
     await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
 
-    expect(room.isSkippingSave).toBe(false);
+    expect(room.documentMaintenanceInProgress).toBe(false);
   });
 
   test("snapshot restore releases the save lock when persistence fails", async () => {
@@ -2687,7 +2812,7 @@ describe("quarantine data safety", () => {
       console.error = originalError;
     }
 
-    expect(room.isSkippingSave).toBe(false);
+    expect(room.documentMaintenanceInProgress).toBe(false);
   });
 
   test("a hard reset refuses to run while quarantined", async () => {
@@ -2726,7 +2851,7 @@ describe("quarantine data safety", () => {
     });
     expect(upsertCalls).toHaveLength(1);
     expect(persistedRow.document).not.toBe(COMPACT_LETHAL_DOCUMENT);
-    expect(room.isSkippingSave).toBe(false);
+    expect(room.documentMaintenanceInProgress).toBe(false);
   });
 
   test("a hard reset releases the save lock when persistence fails", async () => {
@@ -2749,7 +2874,7 @@ describe("quarantine data safety", () => {
       console.error = originalError;
     }
 
-    expect(room.isSkippingSave).toBe(false);
+    expect(room.documentMaintenanceInProgress).toBe(false);
   });
 
   test("loading a committed reset repairs a stale server epoch", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2101,6 +2101,43 @@ describe("quarantine data safety", () => {
     expect(persistedRow.document).toBe(candidate.base64);
   });
 
+  test("compaction marker cleanup failure does not reopen the committed write", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("kept", "value");
+    const candidate = room.buildCompactedDocument(room.document);
+    expect(candidate).not.toBeNull();
+    persistedRow.document = candidate.sourceBase64;
+    const originalDelete = storage.delete.bind(storage);
+    storage.delete = async (key: string) => {
+      if (key === "pendingDocumentReset") {
+        throw new Error("marker cleanup unavailable");
+      }
+      await originalDelete(key);
+    };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(
+        room.commitCompactedDocument({ compactedDocument: candidate })
+      ).resolves.toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).toBe(candidate.base64);
+    expect(room.document.getMap("play").get("kept")).toBe("value");
+    expect(errors.some((message) => message.includes("marker cleanup"))).toBe(
+      true
+    );
+  });
+
   test("an unavailable room pushes an expired save retry into the future", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
@@ -2145,6 +2182,61 @@ describe("quarantine data safety", () => {
     expect(storage.values.get("pendingDocumentReset")).toBeUndefined();
     expect(room.roomState()).toBe("ready");
     expect(await room.getResetEpoch()).toBe(getDocResetEpoch(room.document));
+  });
+
+  test("a persistent reset-epoch failure recovers by alarm in the same warm room", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    const originalPut = storage.put.bind(storage);
+    let resetEpochFailuresRemaining = 3;
+    storage.put = async (key: string, value: unknown) => {
+      if (key === "resetEpoch" && resetEpochFailuresRemaining > 0) {
+        resetEpochFailuresRemaining -= 1;
+        throw new Error("durable storage unavailable");
+      }
+      await originalPut(key, value);
+    };
+    const errors: string[] = [];
+    const warnings: string[] = [];
+    const originalError = console.error;
+    const originalWarn = console.warn;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    try {
+      await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
+
+      const pending = storage.values.get("pendingDocumentReset") as {
+        resetEpoch: number;
+        retryAt: number;
+      };
+      expect(resetEpochFailuresRemaining).toBe(0);
+      expect(room.roomState()).toBe("save-paused");
+      expect(pending.retryAt).toBeNumber();
+      expect(storage.alarm).toBe(pending.retryAt);
+
+      storage.values.set("pendingDocumentReset", {
+        ...pending,
+        retryAt: Date.now() - 1
+      });
+      storage.alarm = null;
+      await room.onAlarm();
+
+      expect(storage.values.get("pendingDocumentReset")).toBeUndefined();
+      expect(room.roomState()).toBe("ready");
+      expect(await room.getResetEpoch()).toBe(getDocResetEpoch(room.document));
+    } finally {
+      console.error = originalError;
+      console.warn = originalWarn;
+    }
+    expect(
+      errors.some((message) => message.includes("Reset epoch remains pending"))
+    ).toBe(true);
+    expect(warnings).toHaveLength(3);
   });
 
   test("force-save-live cannot bypass quarantine protection", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -10,7 +10,8 @@ import {
   parseSharedElementsFromUrl,
   parseSharedReferencesFromUrl
 } from "../sharing";
-import { getDocResetEpoch } from "../docUtils";
+import { docToJson, getDocResetEpoch, jsonToDoc } from "../docUtils";
+import { recordsFromPlay } from "../moderation";
 
 // PartyServer imports Cloudflare-only modules and constructs a Supabase client at
 // module scope. Stub both so the real class can be exercised under bun test.
@@ -226,6 +227,54 @@ function encodeDoc(doc: Y.Doc): string {
   return Buffer.from(Y.encodeStateAsUpdate(doc)).toString("base64");
 }
 
+function moderationTarget(
+  play: Record<string, unknown>,
+  key: string
+): { key: string; contentHash: string } {
+  const record = recordsFromPlay(play).find(
+    (candidate) => candidate.key === key
+  );
+  if (!record) throw new Error(`No moderation record found for ${key}`);
+  return { key, contentHash: record.contentHash };
+}
+
+function adminPost(
+  room: any,
+  endpoint: string,
+  body: Record<string, unknown>
+): Promise<Response> {
+  return room.adminHandler.handleRequest(
+    new Request(
+      `https://example.com/parties/main/example-room/admin/${endpoint}`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      }
+    )
+  );
+}
+
+function buildReadyAdminRoom(play: Record<string, unknown>) {
+  const storage = new FakeStorage();
+  const room = buildRoom(storage, "example-room", jsonToDoc(play));
+  const effects = {
+    closedReasons: [] as string[],
+    broadcasts: [] as string[],
+  };
+  room.documentLoadCompleted = true;
+  room.getConnections = () => [
+    {
+      close(_code: number, reason: string) {
+        effects.closedReasons.push(reason);
+      },
+    },
+  ];
+  room.broadcastCustomMessage = (message: string) => {
+    effects.broadcasts.push(message);
+  };
+  return { room, effects };
+}
+
 function docIsEmpty(doc: Y.Doc): boolean {
   return Object.keys(doc.getMap("play").toJSON()).length === 0;
 }
@@ -263,6 +312,188 @@ beforeEach(() => {
   beforeDocumentRead = null;
   kvStore.clear();
   kvFailure = null;
+});
+
+describe("admin mutations use the authoritative live document", () => {
+  test("moderation preserves unrelated live-only data and returns commit metadata", async () => {
+    const persistedPlay = {
+      "can-play": {
+        newWords: [
+          { id: "remove", word: "remove me" },
+          { id: "keep", word: "keep me" },
+        ],
+      },
+    };
+    const livePlay = {
+      ...persistedPlay,
+      "can-move": {
+        "live-only": { x: 12, y: 34 },
+      },
+    };
+    persistedRow.document = encodeDoc(jsonToDoc(persistedPlay));
+    const { room, effects } = buildReadyAdminRoom(livePlay);
+
+    const response = await adminPost(room, "moderation-remove", {
+      targets: [moderationTarget(persistedPlay, "can-play.newWords#0")],
+    });
+    const body = await response.json();
+    const savedPlay = docToJson(room.document);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      removed: 1,
+      skipped: [],
+      closedConnections: 1,
+    });
+    expect(body.documentSize).toBeNumber();
+    expect(body.resetEpoch).toBeNumber();
+    expect(savedPlay?.["can-play"].newWords).toEqual([
+      { id: "keep", word: "keep me" },
+    ]);
+    expect(savedPlay?.["can-move"]["live-only"]).toEqual({ x: 12, y: 34 });
+    expect(upsertCalls).toHaveLength(1);
+    expect(effects.closedReasons).toEqual(["Room Restored by Admin"]);
+    expect(effects.broadcasts).toHaveLength(1);
+  });
+
+  test("moderation rechecks stale hashes against live data without saving or resetting", async () => {
+    const persistedPlay = {
+      "can-post": {
+        guestbook: [{ id: "entry", message: "before review" }],
+      },
+    };
+    const livePlay = {
+      "can-post": {
+        guestbook: [{ id: "entry", message: "edited while reviewing" }],
+      },
+    };
+    persistedRow.document = encodeDoc(jsonToDoc(persistedPlay));
+    const { room, effects } = buildReadyAdminRoom(livePlay);
+
+    const response = await adminPost(room, "moderation-remove", {
+      targets: [moderationTarget(persistedPlay, "can-post.guestbook#0")],
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      removed: 0,
+      skipped: [{ key: "can-post.guestbook#0", reason: "hash-mismatch" }],
+      documentSize: null,
+      resetEpoch: null,
+      closedConnections: 0,
+    });
+    expect(docToJson(room.document)).toEqual(livePlay);
+    expect(upsertCalls).toEqual([]);
+    expect(effects.closedReasons).toEqual([]);
+    expect(effects.broadcasts).toEqual([]);
+  });
+
+  test("orphan cleanup dry-run inspects live data without saving or resetting", async () => {
+    const persistedPlay = {
+      "can-move": { kept: { x: 1, y: 2 } },
+    };
+    const livePlay = {
+      "can-move": {
+        kept: { x: 1, y: 2 },
+        "live-orphan": { x: 3, y: 4 },
+      },
+    };
+    persistedRow.document = encodeDoc(jsonToDoc(persistedPlay));
+    const { room, effects } = buildReadyAdminRoom(livePlay);
+
+    const response = await adminPost(room, "cleanup-orphans", {
+      tag: "can-move",
+      activeIds: ["kept"],
+      dryRun: true,
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      tag: "can-move",
+      total: 2,
+      active: 1,
+      orphaned: 1,
+      orphanedIds: ["live-orphan"],
+      dryRun: true,
+    });
+    expect(docToJson(room.document)).toEqual(livePlay);
+    expect(upsertCalls).toEqual([]);
+    expect(effects.closedReasons).toEqual([]);
+    expect(effects.broadcasts).toEqual([]);
+  });
+
+  test("orphan cleanup skips a no-op without saving or resetting", async () => {
+    const livePlay = {
+      "can-move": { kept: { x: 1, y: 2 } },
+    };
+    persistedRow.document = encodeDoc(jsonToDoc(livePlay));
+    const { room, effects } = buildReadyAdminRoom(livePlay);
+
+    const response = await adminPost(room, "cleanup-orphans", {
+      tag: "can-move",
+      activeIds: ["kept"],
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      tag: "can-move",
+      total: 1,
+      active: 1,
+      removed: 0,
+      orphanedIds: [],
+      documentSize: null,
+      resetEpoch: null,
+      closedConnections: 0,
+    });
+    expect(upsertCalls).toEqual([]);
+    expect(effects.closedReasons).toEqual([]);
+    expect(effects.broadcasts).toEqual([]);
+  });
+
+  test("orphan cleanup preserves live-only data and returns commit counts", async () => {
+    const persistedPlay = {
+      "can-move": {
+        kept: { x: 1, y: 2 },
+        orphan: { x: 3, y: 4 },
+      },
+    };
+    const livePlay = {
+      ...persistedPlay,
+      "can-toggle": { "live-only": { on: true } },
+    };
+    persistedRow.document = encodeDoc(jsonToDoc(persistedPlay));
+    const { room, effects } = buildReadyAdminRoom(livePlay);
+
+    const response = await adminPost(room, "cleanup-orphans", {
+      tag: "can-move",
+      activeIds: ["kept"],
+    });
+    const body = await response.json();
+    const savedPlay = docToJson(room.document);
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: true,
+      tag: "can-move",
+      total: 2,
+      active: 1,
+      removed: 1,
+      orphanedIds: ["orphan"],
+      closedConnections: 1,
+    });
+    expect(body.documentSize).toBeNumber();
+    expect(body.resetEpoch).toBeNumber();
+    expect(savedPlay?.["can-move"]).toEqual({ kept: { x: 1, y: 2 } });
+    expect(savedPlay?.["can-toggle"]["live-only"]).toEqual({ on: true });
+    expect(upsertCalls).toHaveLength(1);
+    expect(effects.closedReasons).toEqual(["Room Restored by Admin"]);
+    expect(effects.broadcasts).toHaveLength(1);
+  });
 });
 
 describe("hydration write guards", () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -8,8 +8,9 @@ import * as Y from "yjs";
 import { Buffer } from "node:buffer";
 import {
   parseSharedElementsFromUrl,
-  parseSharedReferencesFromUrl,
+  parseSharedReferencesFromUrl
 } from "../sharing";
+import { getDocResetEpoch } from "../docUtils";
 
 // PartyServer imports Cloudflare-only modules and constructs a Supabase client at
 // module scope. Stub both so the real class can be exercised under bun test.
@@ -58,15 +59,18 @@ type PersistedRow = { document: string | null };
 const persistedRow: PersistedRow = { document: null };
 let upsertCalls: Array<{ name: string; document: string }> = [];
 let upsertError: Error | null = null;
+let beforeUpsert: (() => Promise<void>) | null = null;
 
 // Counts reads of the documents row. The load-backoff contract requires that a
 // deferred room never touches Supabase at all, which this makes observable.
 let documentReadCount = 0;
 let documentReadErrors: Error[] = [];
+let beforeDocumentRead: (() => Promise<void>) | null = null;
 
 function createDocumentRead() {
   const maybeSingle = async () => {
     documentReadCount += 1;
+    await beforeDocumentRead?.();
     const error = documentReadErrors.shift();
     if (error) {
       return { data: null, error: { message: error.message } };
@@ -100,6 +104,7 @@ const supabaseStub = {
       },
       async upsert(row: { name: string; document: string }) {
         upsertCalls.push(row);
+        await beforeUpsert?.();
         if (upsertError) {
           return { error: { message: upsertError.message } };
         }
@@ -158,7 +163,10 @@ function buildRoom(storage: FakeStorage, name: string, doc?: Y.Doc) {
     persistenceMode: { value: { kind: "available" }, writable: true },
     realtimeSyncStarted: { value: true, writable: true },
     documentLoadCompleted: { value: false, writable: true },
-    isSkippingSave: { value: false, writable: true },
+    documentWriteState: { value: { kind: "idle" }, writable: true },
+    documentWriteTail: { value: Promise.resolve(), writable: true },
+    documentGeneration: { value: 0, writable: true },
+    persistenceObserverAttached: { value: false, writable: true },
     lastKnownDocumentBytes: { value: 0, writable: true },
     hasWarnedDocumentSize: { value: false, writable: true },
     cachedSubscribers: { value: null, writable: true },
@@ -222,6 +230,17 @@ function docIsEmpty(doc: Y.Doc): boolean {
   return Object.keys(doc.getMap("play").toJSON()).length === 0;
 }
 
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve = () => {};
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
 const MB = 1024 * 1024;
 
 const SMALL_DOCUMENT = (() => {
@@ -238,8 +257,10 @@ beforeEach(() => {
   persistedRow.document = null;
   upsertCalls = [];
   upsertError = null;
+  beforeUpsert = null;
   documentReadCount = 0;
   documentReadErrors = [];
+  beforeDocumentRead = null;
   kvStore.clear();
   kvFailure = null;
 });
@@ -1737,6 +1758,239 @@ describe("manual quarantine", () => {
 });
 
 describe("quarantine data safety", () => {
+  test("an in-flight autosave cannot finish after an authoritative restore", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    const delayedAutosave = createDeferred();
+    let upsertIndex = 0;
+    beforeUpsert = async () => {
+      upsertIndex += 1;
+      if (upsertIndex === 1) {
+        await delayedAutosave.promise;
+      }
+    };
+
+    const staleDoc = new Y.Doc();
+    staleDoc.getMap("play").set("version", "stale");
+    Y.applyUpdate(
+      room.document,
+      new Uint8Array(Buffer.from(encodeDoc(staleDoc), "base64"))
+    );
+    const restoredDoc = new Y.Doc();
+    restoredDoc.getMap("play").set("version", "restored");
+
+    const autosave = room.saveDocumentBase64(encodeDoc(staleDoc));
+    await Promise.resolve();
+    const restore = room.restoreFromSnapshot(encodeDoc(restoredDoc), {
+      bumpEpoch: true
+    });
+    await Promise.resolve();
+
+    delayedAutosave.resolve();
+    await Promise.all([autosave, restore]);
+
+    const persistedDoc = new Y.Doc();
+    Y.applyUpdate(
+      persistedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document!, "base64"))
+    );
+    expect(persistedDoc.getMap("play").get("version")).toBe("restored");
+    expect(upsertCalls).toHaveLength(2);
+  });
+
+  test("a stale save queued behind a restore cannot overwrite it", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    const restoreWrite = createDeferred();
+    const restoreWriteStarted = createDeferred();
+    beforeUpsert = async () => {
+      restoreWriteStarted.resolve();
+      await restoreWrite.promise;
+    };
+
+    const staleDoc = new Y.Doc();
+    staleDoc.getMap("play").set("version", "stale");
+    const restoredDoc = new Y.Doc();
+    restoredDoc.getMap("play").set("version", "restored");
+
+    const restore = room.restoreFromSnapshot(encodeDoc(restoredDoc), {
+      bumpEpoch: true
+    });
+    await restoreWriteStarted.promise;
+    const staleSave = room.saveDocumentBase64(encodeDoc(staleDoc));
+    restoreWrite.resolve();
+
+    await restore;
+    await expect(staleSave).rejects.toThrow("Cannot persist stale document");
+    expect(upsertCalls).toHaveLength(1);
+  });
+
+  test("a failed autosave schedules and completes a durable retry", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.document.getMap("play").set("message", "retry me");
+    upsertError = new Error("database unavailable");
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await room.onSave();
+    } finally {
+      console.error = originalError;
+    }
+
+    const retry = storage.values.get("documentSaveRetry") as
+      | { retryAt: number }
+      | undefined;
+    expect(retry?.retryAt).toBeNumber();
+    expect(storage.alarm).toBe(retry?.retryAt ?? null);
+
+    upsertError = null;
+    storage.alarm = null;
+    storage.values.set("documentSaveRetry", {
+      ...(retry ?? { attempt: 1, generation: 0 }),
+      retryAt: Date.now() - 1
+    });
+    await room.onAlarm();
+
+    expect(storage.values.get("documentSaveRetry")).toBeUndefined();
+    expect(persistedRow.document).not.toBeNull();
+  });
+
+  test("autosave persists the live document when compaction fails", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    room.document.getMap("play").set("message", "keep me");
+    room.getPersistedDocumentCompactBytes = () => 1;
+    room.getPersistedDocumentCompactCheckAfter = async () => null;
+    room.maybeCompactAutosaveCandidate = async () => {
+      throw new Error("compaction failed");
+    };
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await room.onSave();
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).not.toBeNull();
+  });
+
+  test("compaction preserves a live update that arrives during validation", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("before", "present");
+    const candidate = room.buildCompactedDocument(room.document);
+    expect(candidate).not.toBeNull();
+    persistedRow.document = candidate.sourceBase64;
+
+    const validationStarted = createDeferred();
+    const continueValidation = createDeferred();
+    beforeDocumentRead = async () => {
+      validationStarted.resolve();
+      await continueValidation.promise;
+    };
+
+    const compaction = room.commitCompactedDocument({
+      compactedDocument: candidate
+    });
+    await validationStarted.promise;
+    room.document.getMap("play").set("during-validation", "preserved");
+    continueValidation.resolve();
+
+    expect(await compaction).toBe(false);
+    expect(room.document.getMap("play").get("during-validation")).toBe(
+      "preserved"
+    );
+
+    const persistedDoc = new Y.Doc();
+    Y.applyUpdate(
+      persistedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document!, "base64"))
+    );
+    expect(persistedDoc.getMap("play").get("during-validation")).toBe(
+      "preserved"
+    );
+  });
+
+  test("post-compaction cleanup failure does not reopen the committed write", async () => {
+    const { room } = createRoom();
+    room.documentLoadCompleted = true;
+    room.attachPersistenceObserver();
+    room.document.getMap("play").set("kept", "value");
+    const candidate = room.buildCompactedDocument(room.document);
+    expect(candidate).not.toBeNull();
+    persistedRow.document = candidate.sourceBase64;
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await expect(
+        room.commitCompactedDocument({
+          compactedDocument: candidate,
+          afterReplace: async () => {
+            throw new Error("cleanup unavailable");
+          }
+        })
+      ).resolves.toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).toBe(candidate.base64);
+  });
+
+  test("an unavailable room pushes an expired save retry into the future", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.persistenceMode = {
+      kind: "transient",
+      reason: "database unavailable",
+      failedAt: Date.now()
+    };
+    storage.values.set("documentSaveRetry", {
+      attempt: 1,
+      retryAt: Date.now() - 1
+    });
+
+    await room.onAlarm();
+
+    const retry = storage.values.get("documentSaveRetry") as {
+      attempt: number;
+      retryAt: number;
+    };
+    expect(retry.attempt).toBe(2);
+    expect(retry.retryAt).toBeGreaterThan(Date.now());
+    expect(storage.alarm).toBe(retry.retryAt);
+    expect(upsertCalls).toEqual([]);
+  });
+
+  test("a reset-epoch storage failure retries in the same warm room", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    const originalPut = storage.put.bind(storage);
+    let resetEpochWriteFailed = false;
+    storage.put = async (key: string, value: unknown) => {
+      if (key === "resetEpoch" && !resetEpochWriteFailed) {
+        resetEpochWriteFailed = true;
+        throw new Error("durable storage unavailable");
+      }
+      await originalPut(key, value);
+    };
+
+    await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
+
+    expect(resetEpochWriteFailed).toBe(true);
+    expect(storage.values.get("pendingDocumentReset")).toBeUndefined();
+    expect(room.roomState()).toBe("ready");
+    expect(await room.getResetEpoch()).toBe(getDocResetEpoch(room.document));
+  });
+
   test("force-save-live cannot bypass quarantine protection", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1090,6 +1090,17 @@ describe("load path", () => {
     expect(closes).toEqual([{ code: 1013, reason: "Room Load Deferred" }]);
   });
 
+  test("a caught provider outage does not reject transient connections", async () => {
+    const { room } = createRoom();
+
+    await room.circuitBreaker.deferObservedLoadFailure();
+
+    expect(
+      await room.circuitBreaker.getClientLoadDeferredResponse()
+    ).toBeNull();
+    expect(await room.circuitBreaker.getLoadDeferredResponse()).not.toBeNull();
+  });
+
   // At the deadline exactly one attempt proceeds. The next deadline is written
   // before hydration, so requests racing the boundary in a fresh isolate see a
   // future deadline instead of all retrying together.

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -633,12 +633,9 @@ describe("hydration write guards", () => {
     expect(room.isPersistenceAvailable()).toBe(true);
     expect(documentReadCount).toBe(3);
     expect(warnings).toHaveLength(2);
-    expect(errors).toHaveLength(2);
+    expect(errors).toHaveLength(1);
     expect(errors[0]).toBe(
       "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
-    );
-    expect(errors[1]).toContain(
-      "ROOM WORK FAILING: room=example-room operation=load consecutiveFailures=1"
     );
     expect(logs).toEqual([
       "[PartyServer] Supabase persistence restored for room=example-room; leaving transient mode.",
@@ -1533,12 +1530,9 @@ describe("hardening", () => {
       "[PartyServer] Supabase document load attempt 1/3 failed for room=example-room; retrying in 1ms: failure 1",
       "[PartyServer] Supabase document load attempt 2/3 failed for room=example-room; retrying in 2ms: failure 2",
     ]);
-    expect(errors).toHaveLength(2);
+    expect(errors).toHaveLength(1);
     expect(errors[0]).toBe(
       "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
-    );
-    expect(errors[1]).toContain(
-      "ROOM WORK FAILING: room=example-room operation=load consecutiveFailures=1"
     );
     expect(storage.alarm).toBe(storage.values.get("loadRetryAfter"));
   });
@@ -1726,9 +1720,10 @@ describe("hardening", () => {
     expect(storage.alarm).toBeNull();
   });
 
-  test("an observed load failure advances the ordinary load backoff", async () => {
+  test("an observed load failure clears vanish evidence before deferring", async () => {
     const { room, storage } = createRoom();
-    storage.values.set("quarantineLoadAttempts", 2);
+    const before = Date.now();
+    storage.values.set("quarantineLoadAttempts", 7);
     storage.values.set("loadRetryAfter", Date.now() - 1000);
     // Supabase is unreachable, so hydration is never attempted.
     const originalFrom = supabaseStub.from;
@@ -1747,14 +1742,23 @@ describe("hardening", () => {
       }),
     });
 
+    const originalError = console.error;
+    console.error = () => {};
     try {
       await startRoom(room);
     } finally {
+      console.error = originalError;
       (supabaseStub as any).from = originalFrom;
     }
 
-    expect(storage.values.get("loadRetryAfter")).toBeGreaterThan(Date.now());
-    expect(storage.values.get("quarantineLoadAttempts")).toBe(3);
+    expect(storage.values.get("loadRetryAfter")).toBeGreaterThanOrEqual(
+      before + 60_000
+    );
+    expect(storage.values.get("loadRetryAfter")).toBeLessThanOrEqual(
+      Date.now() + 60_000
+    );
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+    expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
   // L2: the flag is applied from the control plane and then resumed from durable
@@ -2400,6 +2404,7 @@ describe("quarantine data safety", () => {
     const originalError = console.error;
     console.error = () => {};
 
+    const before = Date.now();
     try {
       await room.onSave();
     } finally {
@@ -2409,15 +2414,13 @@ describe("quarantine data safety", () => {
     const retry = storage.values.get("documentSaveRetry") as
       | { retryAt: number }
       | undefined;
-    expect(retry?.retryAt).toBeNumber();
+    expect(retry?.retryAt).toBeGreaterThanOrEqual(before + 60_000);
+    expect(retry?.retryAt).toBeLessThanOrEqual(Date.now() + 60_000);
     expect(storage.alarm).toBe(retry?.retryAt ?? null);
 
     upsertError = null;
     storage.alarm = null;
-    storage.values.set("documentSaveRetry", {
-      ...(retry ?? { attempt: 1, generation: 0 }),
-      retryAt: Date.now() - 1,
-    });
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
     await room.onAlarm();
 
     expect(storage.values.get("documentSaveRetry")).toBeUndefined();
@@ -2460,7 +2463,7 @@ describe("quarantine data safety", () => {
     expect(upsertCalls).toEqual([]);
   });
 
-  test("a retry that throws schedules a fresh fixed-delay retry", async () => {
+  test("a retry that throws waits one minute before trying again", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
     room.getResetEpoch = async () => {
@@ -2468,12 +2471,14 @@ describe("quarantine data safety", () => {
     };
     storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
 
+    const before = Date.now();
     await expect(room.onAlarm()).rejects.toThrow("durable storage unavailable");
 
     const retry = storage.values.get("documentSaveRetry") as {
       retryAt: number;
     };
-    expect(retry.retryAt).toBeGreaterThan(Date.now());
+    expect(retry.retryAt).toBeGreaterThanOrEqual(before + 60_000);
+    expect(retry.retryAt).toBeLessThanOrEqual(Date.now() + 60_000);
     expect(storage.alarm).toBe(retry.retryAt);
   });
 

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2145,6 +2145,82 @@ describe("manual quarantine", () => {
 });
 
 describe("quarantine data safety", () => {
+  test("recovery waits for an in-flight save before reading its authoritative snapshot", async () => {
+    const initialDoc = new Y.Doc();
+    initialDoc.getMap("play").set("version", "initial");
+    persistedRow.document = encodeDoc(initialDoc);
+    const { room, storage } = createRoom();
+    await startRoom(room);
+
+    const savedDoc = new Y.Doc();
+    savedDoc.getMap("play").set("version", "saved-before-recovery");
+    const savedBase64 = encodeDoc(savedDoc);
+    Y.applyUpdate(
+      room.document,
+      new Uint8Array(Buffer.from(savedBase64, "base64"))
+    );
+
+    const delayedSave = createDeferred();
+    const saveStarted = createDeferred();
+    let upsertIndex = 0;
+    beforeUpsert = async () => {
+      upsertIndex += 1;
+      if (upsertIndex === 1) {
+        saveStarted.resolve();
+        await delayedSave.promise;
+      }
+    };
+
+    const autosave = room.saveDocumentBase64(encodeDoc(room.document));
+    await saveStarted.promise;
+    const blockedSaveTail = room.documentWriteTail;
+    await room.circuitBreaker.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    await room.circuitBreaker.clearQuarantine();
+    documentReadCount = 0;
+    const cleanupStarted = createDeferred();
+    const continueCleanup = createDeferred();
+    const originalDelete = storage.delete.bind(storage);
+    storage.delete = async (key: string) => {
+      if (key === "persistenceRecoveryPending") {
+        cleanupStarted.resolve();
+        await continueCleanup.promise;
+      }
+      await originalDelete(key);
+    };
+
+    const recovery = room.runDocumentWrite(() => room.loadDocument(true));
+
+    expect(room.documentWriteTail).not.toBe(blockedSaveTail);
+    expect(documentReadCount).toBe(0);
+
+    delayedSave.resolve();
+    await autosave;
+    await cleanupStarted.promise;
+
+    expect(room.documentLoadCompleted).toBe(false);
+    expect(room.isPersistenceAvailable()).toBe(false);
+
+    continueCleanup.resolve();
+    await recovery;
+
+    const persistedDoc = new Y.Doc();
+    Y.applyUpdate(
+      persistedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document!, "base64"))
+    );
+    expect(persistedDoc.getMap("play").get("version")).toBe(
+      "saved-before-recovery"
+    );
+    expect(room.document.getMap("play").get("version")).toBe(
+      "saved-before-recovery"
+    );
+  });
+
   test("an in-flight autosave cannot finish after an authoritative restore", async () => {
     const { room } = createRoom();
     room.documentLoadCompleted = true;

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1180,7 +1180,7 @@ describe("hardening", () => {
       new Error("failure 2"),
       new Error("failure 3"),
     ];
-    const { room } = createRoom();
+    const { room, storage } = createRoom();
     const warnings: string[] = [];
     const errors: string[] = [];
     const originalWarn = console.warn;
@@ -1205,6 +1205,41 @@ describe("hardening", () => {
     expect(errors).toEqual([
       "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
     ]);
+    expect(storage.alarm).toBe(
+      storage.values.get("persistenceRecoveryRetryAfter")
+    );
+  });
+
+  test("a warm transient room does not retry before its recovery deadline", async () => {
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const { room, storage } = createRoom();
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.error = originalError;
+    }
+
+    const retryAfter = storage.values.get(
+      "persistenceRecoveryRetryAfter"
+    ) as number;
+    expect(retryAfter).toBeGreaterThan(Date.now());
+
+    await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    expect(documentReadCount).toBe(3);
+    expect(room.isPersistenceAvailable()).toBe(false);
   });
 
   test("successful hydration resets clients that connected during transient mode", async () => {
@@ -1226,6 +1261,7 @@ describe("hardening", () => {
     }
 
     expect(storage.values.get("persistenceRecoveryPending")).toBe(true);
+    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
 
     const resetMessages: string[] = [];
     const closeCalls: Array<{ code: number; reason: string }> = [];
@@ -1266,6 +1302,58 @@ describe("hardening", () => {
     expect(persistedDoc.getMap("__playhtml_meta").get("resetEpoch")).toBe(
       resetEpoch
     );
+  });
+
+  test("a warm transient room retries in place and discards transient document state", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const { room, storage } = createRoom();
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.error = originalError;
+    }
+
+    room.document.getMap("play").set("transient-only", "discard me");
+    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+
+    const resetMessages: string[] = [];
+    const closeCalls: Array<{ code: number; reason: string }> = [];
+    room.getConnections = () => [
+      {
+        close(code: number, reason: string) {
+          closeCalls.push({ code, reason });
+        },
+      },
+    ];
+    room.broadcastCustomMessage = (message: string) => {
+      resetMessages.push(message);
+    };
+
+    const response = await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    expect(response.status).not.toBe(503);
+    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+    expect(room.document.getMap("play").get("transient-only")).toBeUndefined();
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+    expect(storage.values.has("persistenceRecoveryRetryAfter")).toBe(false);
+    expect(resetMessages).toHaveLength(1);
+    expect(closeCalls).toEqual([
+      { code: 4000, reason: "Room Persistence Restored" },
+    ]);
   });
 
   // F5: admin force-reload calls markPersistenceAvailable, which would otherwise
@@ -1461,6 +1549,73 @@ describe("admin quarantine endpoints", () => {
     expect(room.circuitBreaker.getQuarantineState().detail).toBe(
       "no reason given"
     );
+  });
+
+  test("quarantine clear keeps failure evidence until authoritative recovery succeeds", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    storage.values.set("quarantineLoadAttempts", 3);
+    storage.values.set("loadRetryAfter", Date.now() + 60_000);
+    await room.circuitBreaker.enterQuarantine({
+      reason: "repeated-failures",
+      detail: "load work failed three times",
+      failureKind: "load",
+      failureCount: 3,
+    });
+
+    const response = await room.onRequest(
+      adminRequest("quarantine-clear", { method: "POST" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(3);
+    expect(storage.values.get("loadRetryAfter")).toBeNumber();
+    expect(storage.values.get("persistenceRecoveryPending")).toBe(true);
+  });
+
+  test("quarantine recovery replaces live-only state and fences connected clients", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    const { room, storage } = createRoom();
+    await startRoom(room);
+    await room.circuitBreaker.enterQuarantine({
+      reason: "manual",
+      detail: "operator",
+      failureKind: null,
+      failureCount: 0,
+    });
+    room.document.getMap("play").set("live-only", "discard me");
+
+    const closeCalls: Array<{ code: number; reason: string }> = [];
+    room.getConnections = () => [
+      {
+        close(code: number, reason: string) {
+          closeCalls.push({ code, reason });
+        },
+      },
+    ];
+    room.broadcastCustomMessage = () => {};
+
+    await room.onRequest(
+      adminRequest("quarantine-clear", { method: "POST" })
+    );
+    storage.values.set("loadRetryAfter", Date.now() - 1);
+
+    const recovered = await room.onRequest(
+      new Request("https://example.com/parties/main/example-room", {
+        method: "POST",
+        body: JSON.stringify({ nonsense: true }),
+      })
+    );
+
+    expect(recovered.status).not.toBe(503);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+    expect(room.document.getMap("play").get("live-only")).toBeUndefined();
+    expect(closeCalls).toEqual([
+      { code: 4000, reason: "Room Persistence Restored" },
+    ]);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+    expect(storage.values.has("quarantineLoadAttempts")).toBe(false);
+    expect(storage.values.has("loadRetryAfter")).toBe(false);
   });
 
   test("restoring a document clears quarantine and compaction failure state", async () => {
@@ -1717,7 +1872,7 @@ describe("manual quarantine", () => {
     expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
-  test("clearing quarantine also clears the failure history behind it", async () => {
+  test("clearing quarantine preserves load evidence until recovery", async () => {
     const { room, storage } = createRoom();
     storage.values.set("alarmFailureAttempts", 8);
     storage.values.set("quarantineLoadAttempts", 3);
@@ -1733,9 +1888,10 @@ describe("manual quarantine", () => {
     await room.circuitBreaker.clearQuarantine();
 
     expect(storage.values.get("alarmFailureAttempts")).toBeUndefined();
-    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
-    expect(storage.values.get("loadRetryAfter")).toBeUndefined();
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(3);
+    expect(storage.values.get("loadRetryAfter")).toBeNumber();
     expect(storage.values.get("alarmRetryAfter")).toBeUndefined();
+    expect(storage.values.get("persistenceRecoveryPending")).toBe(true);
   });
 
   test("a quarantined room resumes quarantine on restart without hydrating", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1186,6 +1186,67 @@ describe("hardening", () => {
     ]);
   });
 
+  test("successful hydration resets clients that connected during transient mode", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const storage = new FakeStorage();
+    const failedRoom = buildRoom(storage, "example-room");
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await startRoom(failedRoom);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(storage.values.get("persistenceRecoveryPending")).toBe(true);
+
+    const resetMessages: string[] = [];
+    const closeCalls: Array<{ code: number; reason: string }> = [];
+    const connection = {
+      close(code: number, reason: string) {
+        closeCalls.push({ code, reason });
+      },
+    };
+    const recoveredRoom = restartRoom(storage);
+    recoveredRoom.getConnections = () => [connection];
+    recoveredRoom.broadcastCustomMessage = (message: string) => {
+      resetMessages.push(message);
+    };
+
+    await startRoom(recoveredRoom);
+
+    const resetEpoch = await recoveredRoom.getResetEpoch();
+    expect(resetEpoch).toBeNumber();
+    expect(resetMessages).toEqual([
+      JSON.stringify({
+        type: "room-reset",
+        timestamp: resetEpoch,
+        resetEpoch,
+      }),
+    ]);
+    expect(closeCalls).toEqual([
+      { code: 4000, reason: "Room Persistence Restored" },
+    ]);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+    expect(persistedRow.document).not.toBe(SMALL_DOCUMENT);
+
+    const persistedDoc = new Y.Doc();
+    Y.applyUpdate(
+      persistedDoc,
+      new Uint8Array(Buffer.from(persistedRow.document ?? "", "base64"))
+    );
+    expect(persistedDoc.getMap("play").get("greeting")).toBe("hello");
+    expect(persistedDoc.getMap("__playhtml_meta").get("resetEpoch")).toBe(
+      resetEpoch
+    );
+  });
+
   // F5: admin force-reload calls markPersistenceAvailable, which would otherwise
   // silently lift the write park on a quarantined room.
   test("markPersistenceAvailable cannot lift a quarantine write park", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2815,6 +2815,65 @@ describe("quarantine data safety", () => {
     expect(room.documentMaintenanceInProgress).toBe(false);
   });
 
+  test("snapshot restore keeps saves blocked when epoch storage fails after commit", async () => {
+    const { room, storage } = createRoom();
+    room.documentLoadCompleted = true;
+    room.document.getMap("play").set("greeting", "stale live value");
+    const originalPut = storage.put.bind(storage);
+    let epochStorageAvailable = false;
+    storage.put = async (key: string, value: unknown) => {
+      if (key === "resetEpoch" && !epochStorageAvailable) {
+        throw new Error("epoch storage unavailable");
+      }
+      await originalPut(key, value);
+    };
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+
+    try {
+      await expect(
+        room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+      ).rejects.toThrow("epoch storage unavailable");
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(
+      errors.some((line) => line.includes("epoch storage unavailable"))
+    ).toBe(true);
+    expect(upsertCalls).toHaveLength(1);
+    const committedDocument = persistedRow.document;
+    expect(room.documentMaintenanceInProgress).toBe(true);
+
+    await room.onSave();
+
+    expect(upsertCalls).toHaveLength(1);
+    expect(persistedRow.document).toBe(committedDocument);
+
+    upsertError = new Error("retry database unavailable");
+    console.error = () => {};
+    try {
+      await expect(
+        room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true })
+      ).rejects.toThrow("retry database unavailable");
+    } finally {
+      console.error = originalError;
+      upsertError = null;
+    }
+
+    expect(room.documentMaintenanceInProgress).toBe(true);
+    expect(persistedRow.document).toBe(committedDocument);
+
+    epochStorageAvailable = true;
+    await room.restoreFromSnapshot(SMALL_DOCUMENT, { bumpEpoch: true });
+
+    expect(room.documentMaintenanceInProgress).toBe(false);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+  });
+
   test("a hard reset refuses to run while quarantined", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     const { room } = createRoom();

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -251,6 +251,30 @@ describe("alarm entry point", () => {
       { code: 4000, reason: "Room Persistence Restored" },
     ]);
   });
+
+  test("clearing quarantine re-arms recovery without new traffic", async () => {
+    const { server, storage } = createServer();
+    kvStore.set("quarantine:example-room", "operator stop");
+
+    await server.alarm();
+    expect(server.circuitBreaker.isQuarantined()).toBe(true);
+    expect(storage.alarm).toBeNull();
+
+    await server.circuitBreaker.clearQuarantine();
+
+    expect(storage.alarm).toBeNumber();
+    expect(storage.alarm!).toBeLessThanOrEqual(Date.now());
+    expect(server.isPersistenceAvailable()).toBe(false);
+    expect(server.circuitBreaker.isQuarantined()).toBe(false);
+    expect(await server.circuitBreaker.isPersistenceRecoveryDue()).toBe(true);
+
+    documentReadCount = 0;
+    await server.onAlarm();
+
+    expect(documentReadCount).toBe(1);
+    expect(server.isPersistenceAvailable()).toBe(true);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+  });
 });
 
 describe("persistence recovery admission", () => {

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -329,6 +329,26 @@ describe("persistence recovery admission", () => {
     expect((server as any).documentLoadCompleted).toBe(false);
     expect(storage.alarm).toBe(retryAfter);
   });
+
+  test("a restarted provider outage honors its deadline without quarantine evidence", async () => {
+    const { server, storage } = createServer();
+    const retryAfter = Date.now() + 10 * 60_000;
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("loadRetryAfter", retryAfter);
+    storage.alarm = retryAfter;
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+
+    expect(documentReadCount).toBe(0);
+    expect((server as any).documentLoadCompleted).toBe(false);
+    expect(server.circuitBreaker.isQuarantined()).toBe(false);
+    expect(storage.alarm).toBe(retryAfter);
+  });
 });
 
 describe("fetch entry point", () => {

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -123,7 +123,11 @@ class FakeStorage {
  */
 function createServer(
   name = "example-room",
-  connections: Array<{ readyState: number; send(message: unknown): void }> = []
+  connections: Array<{
+    readyState: number;
+    send(message: unknown): void;
+    close?(code: number, reason: string): void;
+  }> = []
 ) {
   const storage = new FakeStorage();
   const ctx = {
@@ -207,6 +211,67 @@ describe("alarm entry point", () => {
 
     expect(documentReadCount).toBe(1);
     expect(server.circuitBreaker.isLoadDeferred()).toBe(false);
+  });
+
+  test("a recovery alarm hydrates a warm transient room without new traffic", async () => {
+    const closeCalls: Array<{ code: number; reason: string }> = [];
+    const { server, storage } = createServer("example-room", [
+      {
+        readyState: 1,
+        send() {},
+        close(code: number, reason: string) {
+          closeCalls.push({ code, reason });
+        },
+      },
+    ]);
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+    documentReadCount = 0;
+    (server as any).persistenceMode = {
+      kind: "transient",
+      reason: "database outage",
+      failedAt: Date.now() - 60_000,
+    };
+    (server as any).documentLoadCompleted = false;
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("persistenceRecoveryAttempts", 1);
+    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(1);
+    expect(server.isPersistenceAvailable()).toBe(true);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+    expect(closeCalls).toEqual([
+      { code: 4000, reason: "Room Persistence Restored" },
+    ]);
+  });
+});
+
+describe("persistence recovery admission", () => {
+  test("a restarted isolate honors the durable recovery deadline", async () => {
+    const { server, storage } = createServer();
+    const retryAfter = Date.now() + 10 * 60_000;
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("persistenceRecoveryAttempts", 1);
+    storage.values.set("persistenceRecoveryRetryAfter", retryAfter);
+    storage.alarm = retryAfter;
+
+    await server.fetch(
+      new Request(
+        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        { method: "GET" }
+      )
+    );
+
+    expect(documentReadCount).toBe(0);
+    expect(server.isPersistenceAvailable()).toBe(false);
+    expect(storage.alarm).toBe(retryAfter);
   });
 });
 

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -254,6 +254,21 @@ describe("alarm entry point", () => {
 });
 
 describe("persistence recovery admission", () => {
+  test("a restarted isolate runs due persistence recovery ahead of load backoff", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("persistenceRecoveryAttempts", 1);
+    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(1);
+    expect(server.isPersistenceAvailable()).toBe(true);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
+  });
+
   test("a restarted isolate honors the durable recovery deadline", async () => {
     const { server, storage } = createServer();
     const retryAfter = Date.now() + 10 * 60_000;

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -171,12 +171,14 @@ describe("alarm entry point", () => {
   test("a deferred room does not read the document when its alarm fires", async () => {
     const { server, storage } = createServer();
     storage.values.set("quarantineLoadAttempts", 2);
-    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+    const retryAfter = Date.now() + 10 * 60_000;
+    storage.values.set("loadRetryAfter", retryAfter);
 
     await server.alarm();
 
     expect(documentReadCount).toBe(0);
     expect(server.circuitBreaker.isLoadDeferred()).toBe(true);
+    expect(storage.alarm).toBe(retryAfter);
   });
 
   test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
@@ -239,8 +241,9 @@ describe("alarm entry point", () => {
     };
     (server as any).documentLoadCompleted = false;
     storage.values.set("persistenceRecoveryPending", true);
-    storage.values.set("persistenceRecoveryAttempts", 1);
-    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
+    storage.values.set("quarantineLoadAttempts", 1);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
+    server.circuitBreaker.setLoadDeferredUntil(Date.now() - 1);
 
     await server.alarm();
 
@@ -266,7 +269,9 @@ describe("alarm entry point", () => {
     expect(storage.alarm!).toBeLessThanOrEqual(Date.now());
     expect(server.isPersistenceAvailable()).toBe(false);
     expect(server.circuitBreaker.isQuarantined()).toBe(false);
-    expect(await server.circuitBreaker.isPersistenceRecoveryDue()).toBe(true);
+    expect(storage.values.get("loadRetryAfter")).toBeLessThanOrEqual(
+      Date.now()
+    );
 
     documentReadCount = 0;
     await server.onAlarm();
@@ -278,13 +283,11 @@ describe("alarm entry point", () => {
 });
 
 describe("persistence recovery admission", () => {
-  test("a restarted isolate runs due persistence recovery ahead of load backoff", async () => {
+  test("a restarted isolate runs due persistence recovery through load backoff", async () => {
     const { server, storage } = createServer();
     storage.values.set("persistenceRecoveryPending", true);
-    storage.values.set("persistenceRecoveryAttempts", 1);
-    storage.values.set("persistenceRecoveryRetryAfter", Date.now() - 1);
     storage.values.set("quarantineLoadAttempts", 2);
-    storage.values.set("loadRetryAfter", Date.now() + 10 * 60_000);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
 
     await server.alarm();
 
@@ -297,8 +300,8 @@ describe("persistence recovery admission", () => {
     const { server, storage } = createServer();
     const retryAfter = Date.now() + 10 * 60_000;
     storage.values.set("persistenceRecoveryPending", true);
-    storage.values.set("persistenceRecoveryAttempts", 1);
-    storage.values.set("persistenceRecoveryRetryAfter", retryAfter);
+    storage.values.set("quarantineLoadAttempts", 1);
+    storage.values.set("loadRetryAfter", retryAfter);
     storage.alarm = retryAfter;
 
     await server.fetch(
@@ -309,7 +312,7 @@ describe("persistence recovery admission", () => {
     );
 
     expect(documentReadCount).toBe(0);
-    expect(server.isPersistenceAvailable()).toBe(false);
+    expect((server as any).documentLoadCompleted).toBe(false);
     expect(storage.alarm).toBe(retryAfter);
   });
 });

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -181,6 +181,20 @@ describe("alarm entry point", () => {
     expect(storage.alarm).toBe(retryAfter);
   });
 
+  test("a deferred room consumes a stale save retry when its alarm fires", async () => {
+    const { server, storage } = createServer();
+    const loadRetryAfter = Date.now() + 10 * 60_000;
+    storage.values.set("quarantineLoadAttempts", 2);
+    storage.values.set("loadRetryAfter", loadRetryAfter);
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    await server.alarm();
+
+    expect(documentReadCount).toBe(0);
+    expect(storage.values.has("documentSaveRetry")).toBe(false);
+    expect(storage.alarm).toBe(loadRetryAfter);
+  });
+
   test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
     const { server } = createServer();
     kvStore.set("quarantine:example-room", "operator stop");

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -31,8 +31,8 @@ function compareKeys(
  * AdminHandler provides endpoints for inspecting and managing PlayHTML rooms.
  *
  * Data Flow:
- * - Admin edits load the database snapshot as source of truth, commit a fresh
- *   snapshot, then reset connected clients onto that snapshot.
+ * - Moderation and cleanup mutate the authoritative live room state, commit a
+ *   fresh snapshot, then reset connected clients onto that snapshot.
  * - Force-save-live is an escape hatch for persisting the live in-memory doc.
  * - Force-reload-live syncs the live doc to match the database state.
  * - All Y.Doc conversions use shared utilities in docUtils.ts for consistency.
@@ -138,34 +138,6 @@ export class AdminHandler {
 
   private checkPersistenceWriteAvailable(): Response | null {
     return this.context.getSharedDataWriteUnavailableResponse();
-  }
-
-  private async loadDatabasePlayData(): Promise<{
-    play: Record<string, any> | null;
-    documentSize: number;
-  }> {
-    const { data, error } = await supabase
-      .from("documents")
-      .select("document")
-      .eq("name", this.context.name)
-      .maybeSingle();
-
-    if (error) {
-      throw new Error(error.message);
-    }
-
-    if (!data?.document) {
-      return { play: null, documentSize: 0 };
-    }
-
-    const yDoc = new Y.Doc();
-    const buffer = new Uint8Array(Buffer.from(data.document, "base64"));
-    Y.applyUpdate(yDoc, buffer);
-
-    return {
-      play: docToJson(yDoc),
-      documentSize: data.document.length,
-    };
   }
 
   private async handleAdminInspect(request: Request): Promise<Response> {
@@ -623,26 +595,34 @@ export class AdminHandler {
         );
       }
 
-      const { play } = await this.loadDatabasePlayData();
-      if (!play) {
+      const mutation = await this.context.mutateAdminPlayData<ReturnType<
+        typeof removeRecordsByTargets
+      > | null>((play) => {
+        if (Object.keys(play).length === 0) {
+          return { kind: "skip", result: null };
+        }
+
+        const result = removeRecordsByTargets(play, targets);
+        if (result.removed === 0) {
+          return { kind: "skip", result };
+        }
+
+        for (const key of Object.keys(play)) {
+          delete play[key];
+        }
+        Object.assign(play, result.play);
+        return { kind: "commit", result };
+      });
+
+      if (!mutation.result) {
         return new Response(
           JSON.stringify({ error: "Room has no play data" }),
           { status: 404, headers: { "content-type": "application/json" } }
         );
       }
 
-      const result = removeRecordsByTargets(play, targets);
-      let resetResult:
-        | {
-            documentSize: number;
-            resetEpoch: number;
-            closedConnections: number;
-          }
-        | null = null;
-
-      if (result.removed > 0) {
-        resetResult = await this.context.commitAdminPlayData(result.play);
-      }
+      const result = mutation.result;
+      const resetResult = mutation.kind === "committed" ? mutation : null;
 
       return new Response(
         JSON.stringify({
@@ -771,10 +751,57 @@ export class AdminHandler {
         );
       }
 
+      type CleanupResult =
+        | { kind: "missing" }
+        | {
+            kind: "found";
+            total: number;
+            orphanedIds: string[];
+            removed: number;
+          };
+
       const activeIdSet = new Set(activeIds);
-      const { play } = await this.loadDatabasePlayData();
-      const tagData = play?.[tag];
-      if (!tagData || typeof tagData !== "object") {
+      const mutation = await this.context.mutateAdminPlayData<CleanupResult>(
+        (play) => {
+          const tagData = play[tag];
+          if (!tagData || typeof tagData !== "object") {
+            return { kind: "skip", result: { kind: "missing" } };
+          }
+
+          const allElementIds = Object.keys(tagData);
+          const orphanedIds = allElementIds.filter(
+            (id) => !activeIdSet.has(id)
+          );
+          const result: CleanupResult = {
+            kind: "found",
+            total: allElementIds.length,
+            orphanedIds,
+            removed: 0,
+          };
+
+          if (dryRun || orphanedIds.length === 0) {
+            return { kind: "skip", result };
+          }
+
+          for (const orphanedId of orphanedIds) {
+            try {
+              delete tagData[orphanedId];
+              result.removed += 1;
+            } catch (error) {
+              console.error(
+                `Failed to remove ${tag}:${orphanedId}:`,
+                error instanceof Error ? error.message : String(error)
+              );
+            }
+          }
+
+          return result.removed > 0
+            ? { kind: "commit", result }
+            : { kind: "skip", result };
+        }
+      );
+
+      if (mutation.result.kind === "missing") {
         return new Response(
           JSON.stringify({
             ok: true,
@@ -793,15 +820,14 @@ export class AdminHandler {
         );
       }
 
-      const allElementIds = Object.keys(tagData);
-      const orphanedIds = allElementIds.filter((id) => !activeIdSet.has(id));
+      const { total, orphanedIds, removed } = mutation.result;
 
       if (dryRun) {
         return new Response(
           JSON.stringify({
             ok: true,
             tag,
-            total: allElementIds.length,
+            total,
             active: activeIds.length,
             orphaned: orphanedIds.length,
             orphanedIds,
@@ -817,33 +843,17 @@ export class AdminHandler {
         );
       }
 
-      let removedCount = 0;
-      for (const orphanedId of orphanedIds) {
-        try {
-          delete tagData[orphanedId];
-          removedCount++;
-        } catch (error) {
-          console.error(
-            `Failed to remove ${tag}:${orphanedId}:`,
-            error instanceof Error ? error.message : String(error)
-          );
-        }
-      }
-
-      const resetResult =
-        removedCount > 0 && play
-          ? await this.context.commitAdminPlayData(play)
-          : null;
+      const resetResult = mutation.kind === "committed" ? mutation : null;
 
       return new Response(
         JSON.stringify({
           ok: true,
           tag,
-          total: allElementIds.length,
+          total,
           active: activeIds.length,
-          removed: removedCount,
+          removed,
           orphanedIds,
-          message: `Removed ${removedCount} orphaned entries`,
+          message: `Removed ${removed} orphaned entries`,
           documentSize: resetResult?.documentSize ?? null,
           resetEpoch: resetResult?.resetEpoch ?? null,
           closedConnections: resetResult?.closedConnections ?? 0,

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -5,7 +5,7 @@ import { env } from "cloudflare:workers";
 import * as Y from "yjs";
 import { supabase } from "./db";
 import { PartyServer } from "./party";
-import { docToJson, encodeDocToBase64 } from "./docUtils";
+import { docToJson } from "./docUtils";
 import { removeRecordsByTargets, type RemoveTarget } from "./moderation";
 import { getAdminAuthError } from "./adminAuth";
 
@@ -448,9 +448,16 @@ export class AdminHandler {
     if (persistenceError) return persistenceError;
 
     try {
-      const liveYDoc = this.context.document;
-      const base64 = encodeDocToBase64(liveYDoc);
-      await this.context.saveDocumentBase64(base64);
+      const saved = await this.context.saveLiveDocument();
+      if (!saved) {
+        return new Response(
+          JSON.stringify({ error: "Live document was not saved" }),
+          {
+            status: 409,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
       return new Response(JSON.stringify({ ok: true }), {
         headers: { "content-type": "application/json" },
       });
@@ -622,7 +629,7 @@ export class AdminHandler {
       }
 
       const result = mutation.result;
-      const resetResult = mutation.kind === "committed" ? mutation : null;
+      const resetResult = mutation.committed;
 
       return new Response(
         JSON.stringify({
@@ -843,7 +850,7 @@ export class AdminHandler {
         );
       }
 
-      const resetResult = mutation.kind === "committed" ? mutation : null;
+      const resetResult = mutation.committed;
 
       return new Response(
         JSON.stringify({

--- a/partykit/admin.ts
+++ b/partykit/admin.ts
@@ -1028,7 +1028,9 @@ export class AdminHandler {
         await this.context.circuitBreaker.clearCompactionFailure();
         compactionFailureCleared = true;
         if (this.context.circuitBreaker.isQuarantined()) {
-          await this.context.circuitBreaker.clearQuarantine();
+          await this.context.circuitBreaker.clearQuarantine({
+            recoveryCompleted: true,
+          });
           quarantineCleared = true;
           this.context.markDocumentHydrated();
         }
@@ -1238,9 +1240,9 @@ export class AdminHandler {
             },
             stillTransient: !this.context.isPersistenceAvailable(),
             message: reset.wasQuarantined
-              ? "Quarantine cleared, along with the failure history that caused it. Normal traffic stays gated until a guarded load restores the persisted document."
+              ? "Quarantine cleared. Normal traffic stays gated until a guarded load restores the persisted document, then its load failure history is cleared."
               : resetSomething
-                ? "Room was not quarantined, but its failure history was reset. Normal traffic stays gated until a guarded load restores the persisted document."
+                ? "Room was not quarantined, but guarded recovery is pending. Normal traffic stays gated until the persisted document is restored."
                 : "Room was not quarantined and had no failure history; nothing changed.",
           },
           null,

--- a/partykit/bridgeAuth.ts
+++ b/partykit/bridgeAuth.ts
@@ -1,0 +1,45 @@
+// ABOUTME: Authenticates PartyServer room-to-room HTTP bridge requests.
+// ABOUTME: Builds bridge requests with the deployment's shared credential.
+
+export const BRIDGE_SECRET_HEADER = "x-playhtml-bridge-secret";
+
+function requireBridgeSecret(configuredSecret: string | undefined): string {
+  if (typeof configuredSecret !== "string" || configuredSecret.length === 0) {
+    throw new Error("PARTYKIT_BRIDGE_SECRET is not configured");
+  }
+  return configuredSecret;
+}
+
+export function getBridgeAuthFailure(
+  request: Request,
+  configuredSecret: string | undefined
+): Response | null {
+  if (typeof configuredSecret !== "string" || configuredSecret.length === 0) {
+    return new Response("Bridge authentication unavailable", { status: 503 });
+  }
+
+  const credential = request.headers.get(BRIDGE_SECRET_HEADER);
+  if (credential === null) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  if (credential !== configuredSecret) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}
+
+export function createBridgeRequest(
+  path: string,
+  body: unknown,
+  configuredSecret: string | undefined
+): Request {
+  const credential = requireBridgeSecret(configuredSecret);
+  return new Request(`http://internal${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      [BRIDGE_SECRET_HEADER]: credential,
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/partykit/bridgeLeasePolicy.ts
+++ b/partykit/bridgeLeasePolicy.ts
@@ -1,6 +1,8 @@
 // ABOUTME: Merges and renews shared-reference leases for active bridge consumers.
 // ABOUTME: Preserves source metadata while extending only requested relationships.
-import type { SharedRefEntry } from "./const";
+import { DEFAULT_SUBSCRIBER_LEASE_MS, type SharedRefEntry } from "./const";
+
+const SHARED_REFERENCE_RENEWAL_MS = DEFAULT_SUBSCRIBER_LEASE_MS / 2;
 
 type SharedReferenceRequest = {
   sourceRoomId: string;
@@ -28,19 +30,37 @@ export function mergeSharedReferenceLeases({
   const requestedBySource = new Map(
     requested.map((entry) => [entry.sourceRoomId, entry.elementIds] as const)
   );
+  let changed = false;
+  const now = Date.parse(nowIso);
   const entries = existing.map((entry) => {
     const requestedIds = requestedBySource.get(entry.sourceRoomId);
     if (requestedIds === undefined) return { ...entry };
 
     requestedBySource.delete(entry.sourceRoomId);
+    const elementIds = Array.from(
+      new Set([...entry.elementIds, ...requestedIds])
+    );
+    const lastSeen = Date.parse(entry.lastSeen ?? "");
+    const membershipChanged = elementIds.length !== entry.elementIds.length;
+    const leaseNeedsRenewal =
+      !Number.isFinite(lastSeen) ||
+      !Number.isFinite(now) ||
+      now - lastSeen >= SHARED_REFERENCE_RENEWAL_MS;
+
+    if (!membershipChanged && !leaseNeedsRenewal) {
+      return { ...entry };
+    }
+
+    changed = true;
     return {
       ...entry,
-      elementIds: Array.from(new Set([...entry.elementIds, ...requestedIds])),
+      elementIds,
       lastSeen: nowIso,
     };
   });
 
   for (const [sourceRoomId, elementIds] of requestedBySource) {
+    changed = true;
     entries.push({
       sourceRoomId,
       elementIds: Array.from(new Set(elementIds)),
@@ -48,5 +68,5 @@ export function mergeSharedReferenceLeases({
     });
   }
 
-  return { entries, changed: true };
+  return { entries, changed };
 }

--- a/partykit/bridgeLeasePolicy.ts
+++ b/partykit/bridgeLeasePolicy.ts
@@ -1,0 +1,52 @@
+// ABOUTME: Merges and renews shared-reference leases for active bridge consumers.
+// ABOUTME: Preserves source metadata while extending only requested relationships.
+import type { SharedRefEntry } from "./const";
+
+type SharedReferenceRequest = {
+  sourceRoomId: string;
+  elementIds: string[];
+};
+
+type MergeSharedReferenceLeasesOptions = {
+  existing: readonly SharedRefEntry[];
+  requested: readonly SharedReferenceRequest[];
+  nowIso: string;
+};
+
+export function mergeSharedReferenceLeases({
+  existing,
+  requested,
+  nowIso,
+}: MergeSharedReferenceLeasesOptions): {
+  entries: SharedRefEntry[];
+  changed: boolean;
+} {
+  if (requested.length === 0) {
+    return { entries: [...existing], changed: false };
+  }
+
+  const requestedBySource = new Map(
+    requested.map((entry) => [entry.sourceRoomId, entry.elementIds] as const)
+  );
+  const entries = existing.map((entry) => {
+    const requestedIds = requestedBySource.get(entry.sourceRoomId);
+    if (requestedIds === undefined) return { ...entry };
+
+    requestedBySource.delete(entry.sourceRoomId);
+    return {
+      ...entry,
+      elementIds: Array.from(new Set([...entry.elementIds, ...requestedIds])),
+      lastSeen: nowIso,
+    };
+  });
+
+  for (const [sourceRoomId, elementIds] of requestedBySource) {
+    entries.push({
+      sourceRoomId,
+      elementIds: Array.from(new Set(elementIds)),
+      lastSeen: nowIso,
+    });
+  }
+
+  return { entries, changed: true };
+}

--- a/partykit/bridgeRequestPolicy.ts
+++ b/partykit/bridgeRequestPolicy.ts
@@ -1,0 +1,25 @@
+// ABOUTME: Resolves the registered direction of incoming room bridge mutations.
+// ABOUTME: Rejects senders that have no matching source or consumer relationship.
+import type { BridgeDirection } from "./bridgeHealth";
+
+type BridgeApplyRelationshipOptions = {
+  sender: string;
+  originKind: BridgeDirection;
+  subscriberRoomIds: readonly string[];
+  sourceRoomIds: readonly string[];
+};
+
+export function getBridgeApplyRelationship({
+  sender,
+  originKind,
+  subscriberRoomIds,
+  sourceRoomIds,
+}: BridgeApplyRelationshipOptions): BridgeDirection | null {
+  if (originKind === "consumer" && subscriberRoomIds.includes(sender)) {
+    return "consumer";
+  }
+  if (originKind === "source" && sourceRoomIds.includes(sender)) {
+    return "source";
+  }
+  return null;
+}

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -19,6 +19,10 @@ export const STORAGE_KEYS = {
   // Records a failed autosave retry deadline. The document itself remains the
   // authoritative live Y.Doc and is re-encoded when the retry runs.
   documentSaveRetry: "documentSaveRetry",
+  // Tracks bounded retry rounds while a warm room is serving awareness-only
+  // traffic during a persistence outage.
+  persistenceRecoveryAttempts: "persistenceRecoveryAttempts",
+  persistenceRecoveryRetryAfter: "persistenceRecoveryRetryAfter",
   // Stores the next time a connected large room should pay the expensive
   // compactability check
   emergencyCompactCheckAfter: "emergencyCompactCheckAfter",

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -13,16 +13,9 @@ export const STORAGE_KEYS = {
   emptyRoomCompactAfter: "emptyRoomCompactAfter",
   // Requires the next successful hydration to reset clients that saw transient state
   persistenceRecoveryPending: "persistenceRecoveryPending",
-  // Records a reset that may have reached Supabase before Durable Object
-  // metadata was committed, so hydration can reconcile it safely.
-  pendingDocumentReset: "pendingDocumentReset",
   // Records a failed autosave retry deadline. The document itself remains the
   // authoritative live Y.Doc and is re-encoded when the retry runs.
   documentSaveRetry: "documentSaveRetry",
-  // Tracks bounded retry rounds while a warm room is serving awareness-only
-  // traffic during a persistence outage.
-  persistenceRecoveryAttempts: "persistenceRecoveryAttempts",
-  persistenceRecoveryRetryAfter: "persistenceRecoveryRetryAfter",
   // Stores the next time a connected large room should pay the expensive
   // compactability check
   emergencyCompactCheckAfter: "emergencyCompactCheckAfter",
@@ -124,7 +117,6 @@ export const DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS = (() => {
   return 250;
 })();
 export const DEFAULT_DOCUMENT_SAVE_RETRY_MS = 1_000;
-export const DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS = 60_000;
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";
 

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -11,6 +11,8 @@ export const STORAGE_KEYS = {
   resetEpoch: "resetEpoch",
   // Stores a timestamp after which an empty room can compact its Y.Doc history
   emptyRoomCompactAfter: "emptyRoomCompactAfter",
+  // Requires the next successful hydration to reset clients that saw transient state
+  persistenceRecoveryPending: "persistenceRecoveryPending",
   // Stores the next time a connected large room should pay the expensive
   // compactability check
   emergencyCompactCheckAfter: "emergencyCompactCheckAfter",

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -116,7 +116,8 @@ export const DEFAULT_SUPABASE_LOAD_ATTEMPTS = (() => {
 export const DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS = (() => {
   return 250;
 })();
-export const DEFAULT_DOCUMENT_SAVE_RETRY_MS = 1_000;
+// Save retries use a single deadline while limiting database traffic during outages.
+export const DEFAULT_DOCUMENT_SAVE_RETRY_MS = 60_000;
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";
 

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -13,6 +13,12 @@ export const STORAGE_KEYS = {
   emptyRoomCompactAfter: "emptyRoomCompactAfter",
   // Requires the next successful hydration to reset clients that saw transient state
   persistenceRecoveryPending: "persistenceRecoveryPending",
+  // Records a reset that may have reached Supabase before Durable Object
+  // metadata was committed, so hydration can reconcile it safely.
+  pendingDocumentReset: "pendingDocumentReset",
+  // Records a failed autosave retry deadline. The document itself remains the
+  // authoritative live Y.Doc and is re-encoded when the retry runs.
+  documentSaveRetry: "documentSaveRetry",
   // Stores the next time a connected large room should pay the expensive
   // compactability check
   emergencyCompactCheckAfter: "emergencyCompactCheckAfter",
@@ -113,6 +119,8 @@ export const DEFAULT_SUPABASE_LOAD_ATTEMPTS = (() => {
 export const DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS = (() => {
   return 250;
 })();
+export const DEFAULT_DOCUMENT_SAVE_RETRY_MS = 1_000;
+export const DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS = 60_000;
 export const ORIGIN_S2C = "__bridge_s2c__";
 export const ORIGIN_C2S = "__bridge_c2s__";
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -159,6 +159,8 @@ type DocumentWriteState =
 
 type PendingDocumentReset = {
   resetEpoch: number;
+  attempt?: number;
+  retryAt?: number;
 };
 
 type DocumentSaveRetry = {
@@ -888,23 +890,81 @@ export class PartyServer extends YServer {
       "resetEpoch" in value &&
       typeof value.resetEpoch === "number"
     ) {
-      return { resetEpoch: value.resetEpoch };
+      return {
+        resetEpoch: value.resetEpoch,
+        attempt:
+          "attempt" in value && typeof value.attempt === "number"
+            ? value.attempt
+            : undefined,
+        retryAt:
+          "retryAt" in value && typeof value.retryAt === "number"
+            ? value.retryAt
+            : undefined
+      };
     }
     return null;
   }
 
-  private async reconcilePendingDocumentReset(): Promise<void> {
+  private async schedulePendingDocumentResetRetry(
+    resetEpoch: number
+  ): Promise<void> {
+    try {
+      const previous = await this.getPendingDocumentReset();
+      const attempt = (previous?.attempt ?? 0) + 1;
+      const delay = Math.min(
+        DEFAULT_DOCUMENT_SAVE_RETRY_MS * 2 ** (attempt - 1),
+        DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS
+      );
+      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
+        resetEpoch,
+        attempt,
+        retryAt: Date.now() + delay
+      } satisfies PendingDocumentReset);
+      await this.scheduleNextAlarm();
+    } catch (error) {
+      console.error(
+        `[PartyServer] Pending document reset retry scheduling failed for room=${this.name}:`,
+        error
+      );
+    }
+  }
+
+  private async reconcilePendingDocumentReset(): Promise<boolean> {
     const pending = await this.getPendingDocumentReset();
-    if (pending === null) return;
+    if (pending === null) return true;
 
     const documentResetEpoch = getDocResetEpoch(this.document);
-    if (documentResetEpoch === pending.resetEpoch) {
+    if (documentResetEpoch !== pending.resetEpoch) {
+      this.documentWriteState = {
+        kind: "recovery-required",
+        resetEpoch: pending.resetEpoch
+      };
+      await this.schedulePendingDocumentResetRetry(pending.resetEpoch);
+      return false;
+    }
+
+    try {
       await this.setResetEpoch(pending.resetEpoch);
+      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+      if (this.getDocumentWriteState().kind === "recovery-required") {
+        this.documentWriteState = { kind: "idle" };
+      }
       console.warn(
         `[PartyServer] Recovered interrupted document reset for room=${this.name}: resetEpoch=${pending.resetEpoch}`
       );
+      return true;
+    } catch (error) {
+      this.documentWriteState = {
+        kind: "recovery-required",
+        resetEpoch: pending.resetEpoch
+      };
+      console.error(
+        `[PartyServer] Pending document reset reconciliation failed for room=${this.name}:`,
+        error
+      );
+      await this.schedulePendingDocumentResetRetry(pending.resetEpoch);
+      return false;
     }
-    await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
   }
 
   private async getPersistedDocumentBase64(): Promise<string | null> {
@@ -986,7 +1046,6 @@ export class PartyServer extends YServer {
     afterReplace
   }: CommitCompactedDocumentOptions): Promise<boolean> {
     this.documentWriteState = { kind: "compaction" };
-    let liveDocumentReplaced = false;
     let databaseCommitted = false;
 
     try {
@@ -1058,15 +1117,26 @@ export class PartyServer extends YServer {
         kind: "recovery-required",
         resetEpoch: compactedDocument.resetEpoch
       };
-      await this.setResetEpochAfterDocumentCommit(
+      const resetEpochCommitted = await this.setResetEpochAfterDocumentCommit(
         compactedDocument.resetEpoch
       );
 
       this.compactionAutosaveSnapshot = compactedDocument.base64;
       replaceDocFromSnapshot(this.document, compactedDocument.base64);
-      liveDocumentReplaced = true;
-      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-      this.documentWriteState = { kind: "idle" };
+      if (resetEpochCommitted) {
+        this.documentWriteState = { kind: "idle" };
+        try {
+          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+        } catch (error) {
+          console.error(
+            `[PartyServer] Compaction marker cleanup failed for room=${this.name}:`,
+            error
+          );
+          await this.schedulePendingDocumentResetRetry(
+            compactedDocument.resetEpoch
+          );
+        }
+      }
       try {
         await afterReplace?.();
       } catch (error) {
@@ -1084,10 +1154,7 @@ export class PartyServer extends YServer {
       }
       throw error;
     } finally {
-      if (
-        liveDocumentReplaced ||
-        this.getDocumentWriteState().kind === "compaction"
-      ) {
+      if (this.getDocumentWriteState().kind === "compaction") {
         this.documentWriteState = { kind: "idle" };
       }
     }
@@ -1113,12 +1180,14 @@ export class PartyServer extends YServer {
     }
   }
 
-  private async setResetEpochAfterDocumentCommit(epoch: number): Promise<void> {
+  private async setResetEpochAfterDocumentCommit(
+    epoch: number
+  ): Promise<boolean> {
     let lastError: unknown;
     for (let attempt = 1; attempt <= RESET_EPOCH_WRITE_ATTEMPTS; attempt += 1) {
       try {
         await this.setResetEpoch(epoch);
-        return;
+        return true;
       } catch (error) {
         lastError = error;
         if (attempt < RESET_EPOCH_WRITE_ATTEMPTS) {
@@ -1129,7 +1198,12 @@ export class PartyServer extends YServer {
         }
       }
     }
-    throw lastError;
+    console.error(
+      `[PartyServer] Reset epoch remains pending for room=${this.name}:`,
+      lastError
+    );
+    await this.schedulePendingDocumentResetRetry(epoch);
+    return false;
   }
 
   private setConnectionAcceptedResetEpoch(
@@ -1352,8 +1426,11 @@ export class PartyServer extends YServer {
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
 
       // Set reset epoch for client detection
-      await this.setResetEpochAfterDocumentCommit(resetEpoch);
-      console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
+      const resetEpochCommitted =
+        await this.setResetEpochAfterDocumentCommit(resetEpoch);
+      if (resetEpochCommitted) {
+        console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
+      }
 
       // Broadcast a "room-reset" message to all connected clients
       this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
@@ -1378,8 +1455,18 @@ export class PartyServer extends YServer {
       replaceDocFromSnapshot(liveYDoc, updatedBase64);
       setDocResetEpoch(liveYDoc, resetEpoch);
       this.markDocumentHydrated();
-      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-      resetCompleted = true;
+      if (resetEpochCommitted) {
+        try {
+          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+          resetCompleted = true;
+        } catch (error) {
+          console.error(
+            `[Restore Snapshot] Marker cleanup failed for room=${roomId}:`,
+            error
+          );
+          await this.schedulePendingDocumentResetRetry(resetEpoch);
+        }
+      }
       console.log(`[Restore Snapshot] Successfully reloaded live server`);
 
       console.log(
@@ -1498,16 +1585,26 @@ export class PartyServer extends YServer {
     const documentSaveRetry = await this.getDocumentSaveRetry();
     const persistenceRecoveryAlarm =
       await this.circuitBreaker.getPersistenceRecoveryRetryAfter();
-    const nextAlarm = [
-      maintenanceAlarm,
-      documentSaveRetry?.retryAt ?? null,
-      persistenceRecoveryAlarm,
-    ].reduce<
-      number | null
-    >((earliest, candidate) => {
-      if (candidate === null) return earliest;
-      return earliest === null ? candidate : Math.min(earliest, candidate);
-    }, null);
+    const pendingDocumentReset = await this.getPendingDocumentReset();
+    const pendingDocumentResetAlarm =
+      pendingDocumentReset === null
+        ? null
+        : (pendingDocumentReset.retryAt ?? now);
+    const nextAlarm =
+      [
+        maintenanceAlarm,
+        documentSaveRetry?.retryAt ?? null,
+        persistenceRecoveryAlarm,
+        pendingDocumentResetAlarm,
+      ].reduce<number | null>(
+        (earliest, candidate) =>
+          candidate === null
+            ? earliest
+            : earliest === null
+              ? candidate
+              : Math.min(earliest, candidate),
+        null
+      );
 
     if (nextAlarm === null) {
       await this.ctx.storage.deleteAlarm?.();
@@ -3226,6 +3323,16 @@ export class PartyServer extends YServer {
     if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
     try {
+      const pendingDocumentReset = await this.getPendingDocumentReset();
+      if (
+        pendingDocumentReset !== null &&
+        (pendingDocumentReset.retryAt ?? 0) <= Date.now()
+      ) {
+        await this.runDocumentWrite(() =>
+          this.reconcilePendingDocumentReset()
+        );
+      }
+
       const documentSaveRetry = await this.getDocumentSaveRetry();
       if (
         documentSaveRetry !== null &&

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -321,6 +321,7 @@ export class PartyServer extends YServer {
           this.documentLoadCompleted = false;
         },
         clearCompactionSchedule: () => this.clearEmptyRoomCompactAfter(),
+        scheduleRoomWork: () => this.scheduleNextAlarm(),
       });
     }
     return this.roomCircuitBreakerInstance;
@@ -723,6 +724,7 @@ export class PartyServer extends YServer {
 
     const recovery = (async () => {
       this.documentLoadCompleted = false;
+      this.circuitBreaker.setLoadDeferredUntil(null);
       try {
         await this.onLoad();
       } catch (error) {
@@ -1340,6 +1342,7 @@ export class PartyServer extends YServer {
       bumpEpoch?: boolean;
       allowQuarantined?: boolean;
       connectionCloseReason?: string;
+      completeHydration?: boolean;
     }
   ): Promise<{
     documentSize: number;
@@ -1357,6 +1360,7 @@ export class PartyServer extends YServer {
       bumpEpoch?: boolean;
       allowQuarantined?: boolean;
       connectionCloseReason?: string;
+      completeHydration?: boolean;
     }
   ): Promise<{
     documentSize: number;
@@ -1456,7 +1460,9 @@ export class PartyServer extends YServer {
       const liveYDoc = this.document;
       replaceDocFromSnapshot(liveYDoc, updatedBase64);
       setDocResetEpoch(liveYDoc, resetEpoch);
-      this.markDocumentHydrated();
+      if (options?.completeHydration !== false) {
+        this.markDocumentHydrated();
+      }
       if (resetEpochCommitted) {
         try {
           await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
@@ -2202,6 +2208,17 @@ export class PartyServer extends YServer {
 
     if (this.circuitBreaker.isLoadDeferred()) return;
 
+    if (persistenceRecoveryPending) {
+      await this.runDocumentWrite(() => this.loadDocument(true));
+      return;
+    }
+
+    await this.loadDocument(false);
+  }
+
+  private async loadDocument(
+    persistenceRecoveryPending: boolean
+  ): Promise<void> {
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
     const loadAttempts = await this.circuitBreaker.beginRiskyOperation("load");
@@ -2287,11 +2304,11 @@ export class PartyServer extends YServer {
       // The persisted snapshot is authoritative. Transient and quarantined
       // rooms may have an in-memory Y.Doc containing state that was never
       // accepted for persistence, so merging here would resurrect it.
-      this.documentLoadCompleted = true;
-      this.markPersistenceAvailable();
-      await this.restoreFromSnapshot(persistedDocument, {
+      await this.restoreFromSnapshotNow(persistedDocument, {
         bumpEpoch: true,
+        allowQuarantined: true,
         connectionCloseReason: "Room Persistence Restored",
+        completeHydration: false,
       });
       await this.ctx.storage.delete(STORAGE_KEYS.persistenceRecoveryPending);
     } else {
@@ -2322,6 +2339,9 @@ export class PartyServer extends YServer {
     this.circuitBreaker.setLoadDeferredUntil(null);
     await this.circuitBreaker.completeRiskyOperation("load");
     await this.circuitBreaker.completePersistenceRecovery();
+    if (persistenceRecoveryPending) {
+      this.markDocumentHydrated();
+    }
   }
 
   // Undoes this start's increment when the load ended before hydration could be

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -574,7 +574,7 @@ export class PartyServer extends YServer {
     );
   }
 
-  private enterTransientPersistenceMode(error: unknown): void {
+  private async enterTransientPersistenceMode(error: unknown): Promise<void> {
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
     const attempts = this.getSupabaseLoadAttempts();
     this.persistenceMode = {
@@ -590,6 +590,7 @@ export class PartyServer extends YServer {
         error,
       })
     );
+    await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
   }
 
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
@@ -1014,7 +1015,11 @@ export class PartyServer extends YServer {
    */
   async restoreFromSnapshot(
     snapshotBase64: string,
-    options?: { bumpEpoch?: boolean; allowQuarantined?: boolean }
+    options?: {
+      bumpEpoch?: boolean;
+      allowQuarantined?: boolean;
+      connectionCloseReason?: string;
+    }
   ): Promise<{
     documentSize: number;
     resetEpoch: number;
@@ -1082,7 +1087,9 @@ export class PartyServer extends YServer {
       );
 
       // FORCE DISCONNECT: Close all connections
-      const closedCount = this.closeConnections("Room Restored by Admin");
+      const closedCount = this.closeConnections(
+        options?.connectionCloseReason ?? "Room Restored by Admin"
+      );
       console.log(
         `[Restore Snapshot] Closed ${closedCount} connections`
       );
@@ -1781,8 +1788,8 @@ export class PartyServer extends YServer {
           );
         },
       }
-    ).catch((error) => {
-      this.enterTransientPersistenceMode(error);
+    ).catch(async (error) => {
+      await this.enterTransientPersistenceMode(error);
       return null;
     });
 
@@ -1836,10 +1843,23 @@ export class PartyServer extends YServer {
       }
     }
 
+    const persistenceRecoveryPending =
+      (await this.ctx.storage.get(
+        STORAGE_KEYS.persistenceRecoveryPending
+      )) === true;
+
     // Hydration completed without killing the isolate, so the failure history
     // and any pending backoff are cleared.
     await this.circuitBreaker.completeRiskyOperation("load");
     this.markDocumentHydrated();
+
+    if (persistenceRecoveryPending) {
+      await this.restoreFromSnapshot(encodeDocToBase64(this.document), {
+        bumpEpoch: true,
+        connectionCloseReason: "Room Persistence Restored",
+      });
+      await this.ctx.storage.delete(STORAGE_KEYS.persistenceRecoveryPending);
+    }
   }
 
   // Undoes this start's increment when the load ended before hydration could be

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -252,6 +252,7 @@ export class PartyServer extends YServer {
   private cachedSharedPerms: Record<string, SharedElementPermissions> | null =
     null;
   private persistenceMode: PersistenceMode = { kind: "available" };
+  private persistenceRecoveryPromise: Promise<void> | null = null;
   private roomCircuitBreakerInstance: RoomCircuitBreaker | null = null;
   // Tracks the two startup phases separately because a deferred room hydrates
   // after the platform's one-time onStart hook has already returned.
@@ -692,6 +693,48 @@ export class PartyServer extends YServer {
       })
     );
     await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
+    await this.circuitBreaker.schedulePersistenceRecovery();
+    await this.scheduleNextAlarm();
+  }
+
+  private async recoverTransientPersistenceIfDue(): Promise<void> {
+    if (
+      this.isPersistenceAvailable() ||
+      this.circuitBreaker.isQuarantined() ||
+      !(await this.circuitBreaker.isPersistenceRecoveryDue())
+    ) {
+      return;
+    }
+
+    if (this.persistenceRecoveryPromise) {
+      await this.persistenceRecoveryPromise;
+      return;
+    }
+
+    const recovery = (async () => {
+      this.documentLoadCompleted = false;
+      try {
+        await this.onLoad();
+      } catch (error) {
+        this.documentLoadCompleted = false;
+        this.persistenceMode = {
+          kind: "transient",
+          reason: getErrorMessage(error),
+          failedAt: Date.now(),
+        };
+        await this.circuitBreaker.schedulePersistenceRecovery();
+        console.error(
+          `[PartyServer] Persistence recovery failed for room=${this.name}: ${getErrorMessage(error)}`
+        );
+      }
+    })();
+
+    this.persistenceRecoveryPromise = recovery;
+    try {
+      await recovery;
+    } finally {
+      this.persistenceRecoveryPromise = null;
+    }
   }
 
   private async readLimitedJson(request: Request): Promise<unknown | Response> {
@@ -1274,7 +1317,6 @@ export class PartyServer extends YServer {
         snapshotDoc.destroy();
       }
       this.documentWriteState = { kind: "reset", resetEpoch };
-
       const documentSize = updatedBase64.length;
 
       await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
@@ -1440,19 +1482,25 @@ export class PartyServer extends YServer {
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
     const maintenanceAlarm = getNextAlarmTime({
+    const maintenanceAlarm = getNextAlarmTime({
       compactAfter: await this.getEmptyRoomCompactAfter(),
       hasBridgeLeases: Boolean(subs.length || refs.length),
       now,
       pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS
     });
     const documentSaveRetry = await this.getDocumentSaveRetry();
-    const nextAlarm =
-      maintenanceAlarm === null
-        ? (documentSaveRetry?.retryAt ?? null)
-        : Math.min(
-            maintenanceAlarm,
-            documentSaveRetry?.retryAt ?? maintenanceAlarm
-          );
+    const persistenceRecoveryAlarm =
+      await this.circuitBreaker.getPersistenceRecoveryRetryAfter();
+    const nextAlarm = [
+      maintenanceAlarm,
+      documentSaveRetry?.retryAt ?? null,
+      persistenceRecoveryAlarm,
+    ].reduce<
+      number | null
+    >((earliest, candidate) => {
+      if (candidate === null) return earliest;
+      return earliest === null ? candidate : Math.min(earliest, candidate);
+    }, null);
 
     if (nextAlarm === null) {
       await this.ctx.storage.deleteAlarm?.();
@@ -1833,6 +1881,8 @@ export class PartyServer extends YServer {
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
 
+    await this.recoverTransientPersistenceIfDue();
+
     const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
     if (loadDeferred) {
       const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
@@ -2040,6 +2090,26 @@ export class PartyServer extends YServer {
       return;
     }
 
+    const persistenceRecoveryPending =
+      (await this.ctx.storage.get(
+        STORAGE_KEYS.persistenceRecoveryPending
+      )) === true;
+    const persistenceRecoveryRetryAfter =
+      await this.circuitBreaker.getPersistenceRecoveryRetryAfter();
+    if (
+      persistenceRecoveryPending &&
+      persistenceRecoveryRetryAfter !== null &&
+      persistenceRecoveryRetryAfter > Date.now()
+    ) {
+      this.persistenceMode = {
+        kind: "transient",
+        reason: "waiting for scheduled persistence recovery",
+        failedAt: Date.now(),
+      };
+      await this.scheduleNextAlarm();
+      return;
+    }
+
     if (this.circuitBreaker.isLoadDeferred()) return;
 
     // Durable BEFORE the risky work: if hydration kills the isolate, this
@@ -2096,7 +2166,15 @@ export class PartyServer extends YServer {
       );
     }
 
-    this.markPersistenceAvailable();
+    let persistedDocument = result.data?.document;
+    if (persistedDocument === undefined) {
+      const emptyDoc = new Y.Doc();
+      try {
+        persistedDocument = encodeDocToBase64(emptyDoc);
+      } finally {
+        emptyDoc.destroy();
+      }
+    }
 
     if (result.data) {
       // Size is reported, never enforced. Hydration is one copy of the document
@@ -2113,43 +2191,47 @@ export class PartyServer extends YServer {
       }
 
       this.markDocumentPersisted(result.data.document);
-      Y.applyUpdate(
-        this.document,
-        new Uint8Array(Buffer.from(result.data.document, "base64"))
-      );
-
-      const documentResetEpoch = getDocResetEpoch(this.document);
-      const storedResetEpoch = await this.getResetEpoch();
-      if (
-        documentResetEpoch !== null &&
-        (storedResetEpoch === null || documentResetEpoch > storedResetEpoch)
-      ) {
-        await this.setResetEpoch(documentResetEpoch);
-        console.warn(
-          `[PartyServer] Loaded document advanced the server reset epoch for room=${this.name}: ` +
-            `documentResetEpoch=${documentResetEpoch}, storedResetEpoch=${storedResetEpoch ?? "none"}`
-        );
-      }
     }
 
-    await this.reconcilePendingDocumentReset();
-
-    const persistenceRecoveryPending =
-      (await this.ctx.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
-      true;
-
-    // Hydration completed without killing the isolate, so the failure history
-    // and any pending backoff are cleared.
-    await this.circuitBreaker.completeRiskyOperation("load");
-    this.markDocumentHydrated();
-
     if (persistenceRecoveryPending) {
-      await this.restoreFromSnapshot(encodeDocToBase64(this.document), {
+      // The persisted snapshot is authoritative. Transient and quarantined
+      // rooms may have an in-memory Y.Doc containing state that was never
+      // accepted for persistence, so merging here would resurrect it.
+      this.documentLoadCompleted = true;
+      this.markPersistenceAvailable();
+      await this.restoreFromSnapshot(persistedDocument, {
         bumpEpoch: true,
         connectionCloseReason: "Room Persistence Restored",
       });
       await this.ctx.storage.delete(STORAGE_KEYS.persistenceRecoveryPending);
+    } else {
+      if (result.data) {
+        Y.applyUpdate(
+          this.document,
+          new Uint8Array(Buffer.from(persistedDocument, "base64"))
+        );
+        const documentResetEpoch = getDocResetEpoch(this.document);
+        const storedResetEpoch = await this.getResetEpoch();
+        if (
+          documentResetEpoch !== null &&
+          (storedResetEpoch === null || documentResetEpoch > storedResetEpoch)
+        ) {
+          await this.setResetEpoch(documentResetEpoch);
+          console.warn(
+            `[PartyServer] Loaded document advanced the server reset epoch for room=${this.name}: ` +
+              `documentResetEpoch=${documentResetEpoch}, storedResetEpoch=${storedResetEpoch ?? "none"}`
+          );
+        }
+      }
+      await this.reconcilePendingDocumentReset();
+      this.markDocumentHydrated();
     }
+
+    // Recovery evidence is cleared only after the authoritative reset and its
+    // durable marker cleanup both succeed.
+    this.circuitBreaker.setLoadDeferredUntil(null);
+    await this.circuitBreaker.completeRiskyOperation("load");
+    await this.circuitBreaker.completePersistenceRecovery();
   }
 
   // Undoes this start's increment when the load ended before hydration could be
@@ -2547,6 +2629,14 @@ export class PartyServer extends YServer {
       }
 
       const url = new URL(request.url);
+      const isLoadControlRoute = [
+        "/admin/quarantine-status",
+        "/admin/quarantine-set",
+        "/admin/quarantine-clear",
+      ].some((path) => url.pathname.includes(path));
+      if (!isLoadControlRoute) {
+        await this.recoverTransientPersistenceIfDue();
+      }
 
       // Route admin requests to admin handler
       // PartyKit paths are like /parties/main/room-id/admin/inspect
@@ -2555,11 +2645,6 @@ export class PartyServer extends YServer {
         // operator can inspect or quarantine the room. Every other admin route
         // is blocked: the live document was never hydrated, so a write derived
         // from it could overwrite the real snapshot with an empty document.
-        const isLoadControlRoute = [
-          "/admin/quarantine-status",
-          "/admin/quarantine-set",
-          "/admin/quarantine-clear",
-        ].some((path) => url.pathname.includes(path));
         if (!isLoadControlRoute) {
           const loadDeferred =
             await this.circuitBreaker.getLoadDeferredResponse();
@@ -3117,6 +3202,7 @@ export class PartyServer extends YServer {
 
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
+    await this.recoverTransientPersistenceIfDue();
     if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
     try {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -655,9 +655,7 @@ export class PartyServer extends YServer {
     );
   }
 
-  private async schedulePersistenceRecovery(
-    loadAttempts: number
-  ): Promise<void> {
+  private async schedulePersistenceRecovery(): Promise<void> {
     try {
       await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
     } catch (error) {
@@ -667,7 +665,7 @@ export class PartyServer extends YServer {
     }
 
     try {
-      await this.circuitBreaker.deferFailedLoad(loadAttempts);
+      await this.circuitBreaker.deferObservedLoadFailure();
       await this.scheduleNextAlarm();
     } catch (error) {
       console.error(
@@ -1914,7 +1912,7 @@ export class PartyServer extends YServer {
   private async loadDocument(): Promise<void> {
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
-    const loadAttempts = await this.circuitBreaker.beginRiskyOperation("load");
+    await this.circuitBreaker.beginRiskyOperation("load");
 
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
@@ -1953,7 +1951,7 @@ export class PartyServer extends YServer {
     });
 
     if (result === null) {
-      await this.schedulePersistenceRecovery(loadAttempts);
+      await this.schedulePersistenceRecovery();
       return;
     }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -343,8 +343,17 @@ export class PartyServer extends YServer {
       return;
     }
 
-    // Load backoff, evaluated before hydration for the same reason.
-    if (await this.circuitBreaker.shouldDeferLoad()) {
+    const persistenceRecoveryPending =
+      (await this.ctx.storage.get(
+        STORAGE_KEYS.persistenceRecoveryPending
+      )) === true;
+
+    // Persistence recovery has its own durable deadline and must reach onLoad
+    // before the ordinary load-failure ledger can defer startup.
+    if (
+      !persistenceRecoveryPending &&
+      (await this.circuitBreaker.shouldDeferLoad())
+    ) {
       return;
     }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -1697,7 +1697,8 @@ export class PartyServer extends YServer {
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
 
-    const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
+    const loadDeferred =
+      await this.circuitBreaker.getClientLoadDeferredResponse();
     if (loadDeferred) {
       const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
       console.warn(
@@ -2430,7 +2431,7 @@ export class PartyServer extends YServer {
         // from it could overwrite the real snapshot with an empty document.
         if (!isLoadControlRoute) {
           const loadDeferred =
-            await this.circuitBreaker.getLoadDeferredResponse();
+            await this.circuitBreaker.getClientLoadDeferredResponse();
           if (loadDeferred) return loadDeferred;
         }
         // Awaited so a rejection lands in this method's catch rather than
@@ -2439,7 +2440,8 @@ export class PartyServer extends YServer {
       }
 
       // The document was never read, so there is nothing to serve.
-      const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
+      const loadDeferred =
+        await this.circuitBreaker.getClientLoadDeferredResponse();
       if (loadDeferred) return loadDeferred;
 
       if (request.method !== "POST") {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -2790,9 +2790,20 @@ export class PartyServer extends YServer {
         if (bridgeAuthFailure) return bridgeAuthFailure;
       }
 
+      const documentWriteKind = this.getDocumentWriteState().kind;
+      const bridgeApplyCanWaitForMaintenance =
+        isApplySubtreesImmediateRequest(body) &&
+        this.documentLoadCompleted &&
+        this.isPersistenceAvailable() &&
+        !this.circuitBreaker.isQuarantined() &&
+        (documentWriteKind === "maintenance" ||
+          documentWriteKind === "compaction" ||
+          documentWriteKind === "reset");
       if (
         !this.canWriteSharedData() &&
-        (isSubscribeRequest(body) || isApplySubtreesImmediateRequest(body))
+        (isSubscribeRequest(body) ||
+          (isApplySubtreesImmediateRequest(body) &&
+            !bridgeApplyCanWaitForMaintenance))
       ) {
         return new Response(
           JSON.stringify({
@@ -2890,16 +2901,6 @@ export class PartyServer extends YServer {
       }
 
       if (isApplySubtreesImmediateRequest(body)) {
-        if (!this.canWriteSharedData()) {
-          console.warn(
-            `[Bridge] Ignoring apply-subtrees for room ${this.name}: document hydration or persistence unavailable.`
-          );
-          const response: ApplySubtreesResponse = { ok: true, applied: false };
-          return new Response(JSON.stringify(response), {
-            headers: { "content-type": "application/json" },
-          });
-        }
-
         // Applies provided subtrees immediately and marks origin to suppress echo
         const { subtrees, sender, originKind } = body;
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -41,7 +41,6 @@ import {
   DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
   DEFAULT_DOCUMENT_SAVE_RETRY_MS,
-  DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
   ORIGIN_S2C,
@@ -111,7 +110,6 @@ export { PresenceServer } from "./presenceServer";
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
 const MESSAGE_LIMIT_STATE_KEY = "__playhtmlMessageLimit";
 const CONNECTION_OPENED_AT_STATE_KEY = "__playhtmlConnectionOpenedAt";
-const RESET_EPOCH_WRITE_ATTEMPTS = 3;
 
 type PartyServerConnectionState = Record<string, unknown> & {
   [ACCEPTED_RESET_EPOCH_STATE_KEY]?: number | null;
@@ -150,21 +148,7 @@ type SaveDocumentOptions = {
   operation?: "shared-data" | "reset" | "quarantine-repair";
 };
 
-type DocumentWriteState =
-  | { kind: "idle" }
-  | { kind: "maintenance" }
-  | { kind: "compaction" }
-  | { kind: "reset"; resetEpoch: number | null }
-  | { kind: "recovery-required"; resetEpoch: number };
-
-type PendingDocumentReset = {
-  resetEpoch: number;
-  attempt?: number;
-  retryAt?: number;
-};
-
 type DocumentSaveRetry = {
-  attempt: number;
   retryAt: number;
 };
 
@@ -172,15 +156,14 @@ type AdminPlayDataMutation<T> =
   | { kind: "commit"; result: T }
   | { kind: "skip"; result: T };
 
-type AdminPlayDataMutationResult<T> =
-  | {
-      kind: "committed";
-      result: T;
-      documentSize: number;
-      resetEpoch: number;
-      closedConnections: number;
-    }
-  | { kind: "skipped"; result: T };
+type AdminPlayDataMutationResult<T> = {
+  result: T;
+  committed: {
+    documentSize: number;
+    resetEpoch: number;
+    closedConnections: number;
+  } | null;
+};
 
 type UsefulCompactedDocumentOptions = {
   sourceBase64?: string;
@@ -223,10 +206,10 @@ function readPositiveNumberEnv(name: string, fallback: number): number {
 
 export class PartyServer extends YServer {
   static options = {
-    hibernate: true
+    hibernate: true,
   };
 
-  private documentWriteState: DocumentWriteState = { kind: "idle" };
+  private documentMaintenanceInProgress = false;
   private documentWriteTail: Promise<void> = Promise.resolve();
   private documentGeneration = 0;
   private persistenceObserverAttached = false;
@@ -236,16 +219,6 @@ export class PartyServer extends YServer {
   private lastKnownDocumentBytes = 0;
   private hasWarnedDocumentSize = false;
 
-  public get isSkippingSave(): boolean {
-    return this.getDocumentWriteState().kind !== "idle";
-  }
-
-  public set isSkippingSave(paused: boolean) {
-    this.documentWriteState = paused
-      ? { kind: "maintenance" }
-      : { kind: "idle" };
-  }
-
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
   private cachedSubscribers: Subscriber[] | null = null;
@@ -253,7 +226,6 @@ export class PartyServer extends YServer {
   private cachedSharedPerms: Record<string, SharedElementPermissions> | null =
     null;
   private persistenceMode: PersistenceMode = { kind: "available" };
-  private persistenceRecoveryPromise: Promise<void> | null = null;
   private roomCircuitBreakerInstance: RoomCircuitBreaker | null = null;
   // Tracks the two startup phases separately because a deferred room hydrates
   // after the platform's one-time onStart hook has already returned.
@@ -307,9 +279,8 @@ export class PartyServer extends YServer {
             await this.startRealtimeSync();
           }
 
-          const remainingFailures = await this.circuitBreaker.getFailureCount(
-            "load"
-          );
+          const remainingFailures =
+            await this.circuitBreaker.getFailureCount("load");
           if (remainingFailures !== 0 || !this.documentLoadCompleted) {
             return false;
           }
@@ -346,17 +317,7 @@ export class PartyServer extends YServer {
       return;
     }
 
-    const persistenceRecoveryPending =
-      (await this.ctx.storage.get(
-        STORAGE_KEYS.persistenceRecoveryPending
-      )) === true;
-
-    // Persistence recovery has its own durable deadline and must reach onLoad
-    // before the ordinary load-failure ledger can defer startup.
-    if (
-      !persistenceRecoveryPending &&
-      (await this.circuitBreaker.shouldDeferLoad())
-    ) {
+    if (await this.circuitBreaker.shouldDeferLoad()) {
       return;
     }
 
@@ -374,7 +335,7 @@ export class PartyServer extends YServer {
     this.attachPersistenceObserver();
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
-    await this.ensureAlarmScheduled();
+    await this.scheduleNextAlarm();
   }
 
   async getSubscribers(): Promise<Subscriber[]> {
@@ -439,26 +400,17 @@ export class PartyServer extends YServer {
     if (
       typeof value === "object" &&
       value !== null &&
-      "attempt" in value &&
-      typeof value.attempt === "number" &&
       "retryAt" in value &&
       typeof value.retryAt === "number"
     ) {
-      return { attempt: value.attempt, retryAt: value.retryAt };
+      return { retryAt: value.retryAt };
     }
     return null;
   }
 
   private async scheduleDocumentSaveRetry(): Promise<void> {
-    const previous = await this.getDocumentSaveRetry();
-    const attempt = (previous?.attempt ?? 0) + 1;
-    const delay = Math.min(
-      DEFAULT_DOCUMENT_SAVE_RETRY_MS * 2 ** (attempt - 1),
-      DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS
-    );
     await this.ctx.storage.put(STORAGE_KEYS.documentSaveRetry, {
-      attempt,
-      retryAt: Date.now() + delay
+      retryAt: Date.now() + DEFAULT_DOCUMENT_SAVE_RETRY_MS,
     } satisfies DocumentSaveRetry);
     await this.scheduleNextAlarm();
   }
@@ -468,7 +420,9 @@ export class PartyServer extends YServer {
   }
 
   private async getEmptyRoomCompactAfter(): Promise<number | null> {
-    const value = await this.ctx.storage.get(STORAGE_KEYS.emptyRoomCompactAfter);
+    const value = await this.ctx.storage.get(
+      STORAGE_KEYS.emptyRoomCompactAfter
+    );
     return typeof value === "number" ? value : null;
   }
 
@@ -607,10 +561,6 @@ export class PartyServer extends YServer {
     return this.persistenceMode.kind === "available";
   }
 
-  private getDocumentWriteState(): DocumentWriteState {
-    return this.documentWriteState ?? { kind: "idle" };
-  }
-
   private runDocumentWrite<T>(work: () => Promise<T>): Promise<T> {
     const previous = this.documentWriteTail ?? Promise.resolve();
     const result = previous.then(work, work);
@@ -634,7 +584,7 @@ export class PartyServer extends YServer {
     if (this.circuitBreaker.isQuarantined()) return "quarantined";
     if (!this.documentLoadCompleted) return "loading";
     if (!this.isPersistenceAvailable()) return "transient";
-    if (this.getDocumentWriteState().kind !== "idle") return "save-paused";
+    if (this.documentMaintenanceInProgress) return "save-paused";
     return "ready";
   }
 
@@ -687,7 +637,7 @@ export class PartyServer extends YServer {
     );
   }
 
-  private async enterTransientPersistenceMode(error: unknown): Promise<void> {
+  private enterTransientPersistenceMode(error: unknown): void {
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
     const attempts = this.getSupabaseLoadAttempts();
     this.persistenceMode = {
@@ -703,49 +653,26 @@ export class PartyServer extends YServer {
         error,
       })
     );
-    await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
-    await this.circuitBreaker.schedulePersistenceRecovery();
-    await this.scheduleNextAlarm();
   }
 
-  private async recoverTransientPersistenceIfDue(): Promise<void> {
-    if (
-      this.isPersistenceAvailable() ||
-      this.circuitBreaker.isQuarantined() ||
-      !(await this.circuitBreaker.isPersistenceRecoveryDue())
-    ) {
-      return;
-    }
-
-    if (this.persistenceRecoveryPromise) {
-      await this.persistenceRecoveryPromise;
-      return;
-    }
-
-    const recovery = (async () => {
-      this.documentLoadCompleted = false;
-      this.circuitBreaker.setLoadDeferredUntil(null);
-      try {
-        await this.onLoad();
-      } catch (error) {
-        this.documentLoadCompleted = false;
-        this.persistenceMode = {
-          kind: "transient",
-          reason: getErrorMessage(error),
-          failedAt: Date.now(),
-        };
-        await this.circuitBreaker.schedulePersistenceRecovery();
-        console.error(
-          `[PartyServer] Persistence recovery failed for room=${this.name}: ${getErrorMessage(error)}`
-        );
-      }
-    })();
-
-    this.persistenceRecoveryPromise = recovery;
+  private async schedulePersistenceRecovery(
+    loadAttempts: number
+  ): Promise<void> {
     try {
-      await recovery;
-    } finally {
-      this.persistenceRecoveryPromise = null;
+      await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
+    } catch (error) {
+      console.error(
+        `[PartyServer] Could not persist recovery intent for room=${this.name}: ${getErrorMessage(error)}`
+      );
+    }
+
+    try {
+      await this.circuitBreaker.deferFailedLoad(loadAttempts);
+      await this.scheduleNextAlarm();
+    } catch (error) {
+      console.error(
+        `[PartyServer] Could not schedule persistence recovery for room=${this.name}: ${getErrorMessage(error)}`
+      );
     }
   }
 
@@ -848,7 +775,7 @@ export class PartyServer extends YServer {
         sourceGeneration: this.documentGeneration ?? 0,
         beforeSize,
         afterSize: base64.length,
-        resetEpoch
+        resetEpoch,
       };
     } finally {
       compactDoc.destroy();
@@ -884,93 +811,6 @@ export class PartyServer extends YServer {
     }
   }
 
-  private async getPendingDocumentReset(): Promise<PendingDocumentReset | null> {
-    const value = await this.ctx.storage.get(STORAGE_KEYS.pendingDocumentReset);
-    if (
-      typeof value === "object" &&
-      value !== null &&
-      "resetEpoch" in value &&
-      typeof value.resetEpoch === "number"
-    ) {
-      return {
-        resetEpoch: value.resetEpoch,
-        attempt:
-          "attempt" in value && typeof value.attempt === "number"
-            ? value.attempt
-            : undefined,
-        retryAt:
-          "retryAt" in value && typeof value.retryAt === "number"
-            ? value.retryAt
-            : undefined
-      };
-    }
-    return null;
-  }
-
-  private async schedulePendingDocumentResetRetry(
-    resetEpoch: number
-  ): Promise<void> {
-    try {
-      const previous = await this.getPendingDocumentReset();
-      const attempt = (previous?.attempt ?? 0) + 1;
-      const delay = Math.min(
-        DEFAULT_DOCUMENT_SAVE_RETRY_MS * 2 ** (attempt - 1),
-        DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS
-      );
-      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
-        resetEpoch,
-        attempt,
-        retryAt: Date.now() + delay
-      } satisfies PendingDocumentReset);
-      await this.scheduleNextAlarm();
-    } catch (error) {
-      console.error(
-        `[PartyServer] Pending document reset retry scheduling failed for room=${this.name}:`,
-        error
-      );
-    }
-  }
-
-  private async reconcilePendingDocumentReset(): Promise<boolean> {
-    const pending = await this.getPendingDocumentReset();
-    if (pending === null) return true;
-
-    const documentResetEpoch = getDocResetEpoch(this.document);
-    if (documentResetEpoch !== pending.resetEpoch) {
-      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-      if (this.getDocumentWriteState().kind === "recovery-required") {
-        this.documentWriteState = { kind: "idle" };
-      }
-      console.warn(
-        `[PartyServer] Aborted uncommitted document reset for room=${this.name}: pendingResetEpoch=${pending.resetEpoch}, documentResetEpoch=${documentResetEpoch ?? "none"}`
-      );
-      return true;
-    }
-
-    try {
-      await this.setResetEpoch(pending.resetEpoch);
-      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-      if (this.getDocumentWriteState().kind === "recovery-required") {
-        this.documentWriteState = { kind: "idle" };
-      }
-      console.warn(
-        `[PartyServer] Recovered interrupted document reset for room=${this.name}: resetEpoch=${pending.resetEpoch}`
-      );
-      return true;
-    } catch (error) {
-      this.documentWriteState = {
-        kind: "recovery-required",
-        resetEpoch: pending.resetEpoch
-      };
-      console.error(
-        `[PartyServer] Pending document reset reconciliation failed for room=${this.name}:`,
-        error
-      );
-      await this.schedulePendingDocumentResetRetry(pending.resetEpoch);
-      return false;
-    }
-  }
-
   private async getPersistedDocumentBase64(): Promise<string | null> {
     const { data, error } = await supabase
       .from("documents")
@@ -985,22 +825,8 @@ export class PartyServer extends YServer {
     return typeof data?.document === "string" ? data.document : null;
   }
 
-  async saveDocumentBase64(
-    documentBase64: string,
-    options: SaveDocumentOptions = {}
-  ): Promise<void> {
-    await this.runDocumentWrite(async () => {
-      this.assertDocumentSaveAllowed(options);
-      if (
-        (options.operation ?? "shared-data") === "shared-data" &&
-        documentBase64 !== encodeDocToBase64(this.document)
-      ) {
-        throw new Error(
-          "Cannot persist stale document: live room state changed before the save acquired the write queue"
-        );
-      }
-      await this.saveDocumentBase64Now(documentBase64, options);
-    });
+  async saveLiveDocument(): Promise<boolean> {
+    return this.persistLiveDocument({ allowCompaction: false });
   }
 
   private async saveDocumentBase64Now(
@@ -1040,18 +866,15 @@ export class PartyServer extends YServer {
         `Cannot persist document while room state is ${state} (operation=${operation})`
       );
     }
-
   }
 
   private async commitCompactedDocument({
     compactedDocument,
     validatePersistedSource = true,
     beforeCommit,
-    afterReplace
+    afterReplace,
   }: CommitCompactedDocumentOptions): Promise<boolean> {
-    this.documentWriteState = { kind: "compaction" };
-    let databaseCommitted = false;
-
+    this.documentMaintenanceInProgress = true;
     try {
       if (
         (this.documentGeneration ?? 0) !== compactedDocument.sourceGeneration
@@ -1059,7 +882,7 @@ export class PartyServer extends YServer {
         console.warn(
           `[PartyServer] Compaction skipped for room=${this.name}: live document changed while the candidate was built`
         );
-        this.documentWriteState = { kind: "idle" };
+        this.documentMaintenanceInProgress = false;
         await this.persistLiveDocumentNow({ allowCompaction: false });
         return false;
       }
@@ -1082,7 +905,7 @@ export class PartyServer extends YServer {
           console.warn(
             `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source; saving live document first`
           );
-          this.documentWriteState = { kind: "idle" };
+          this.documentMaintenanceInProgress = false;
           await this.persistLiveDocumentNow({ allowCompaction: false });
           return false;
         }
@@ -1101,7 +924,7 @@ export class PartyServer extends YServer {
         console.warn(
           `[PartyServer] Compaction skipped for room=${this.name}: live document changed during validation`
         );
-        this.documentWriteState = { kind: "idle" };
+        this.documentMaintenanceInProgress = false;
         await this.persistLiveDocumentNow({ allowCompaction: false });
         return false;
       }
@@ -1110,37 +933,13 @@ export class PartyServer extends YServer {
         return false;
       }
 
-      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
-        resetEpoch: compactedDocument.resetEpoch
-      } satisfies PendingDocumentReset);
       await this.saveDocumentBase64Now(compactedDocument.base64, {
-        operation: "reset"
+        operation: "reset",
       });
-      databaseCommitted = true;
-      this.documentWriteState = {
-        kind: "recovery-required",
-        resetEpoch: compactedDocument.resetEpoch
-      };
-      const resetEpochCommitted = await this.setResetEpochAfterDocumentCommit(
-        compactedDocument.resetEpoch
-      );
+      await this.setResetEpoch(compactedDocument.resetEpoch);
 
       this.compactionAutosaveSnapshot = compactedDocument.base64;
       replaceDocFromSnapshot(this.document, compactedDocument.base64);
-      if (resetEpochCommitted) {
-        this.documentWriteState = { kind: "idle" };
-        try {
-          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-        } catch (error) {
-          console.error(
-            `[PartyServer] Compaction marker cleanup failed for room=${this.name}:`,
-            error
-          );
-          await this.schedulePendingDocumentResetRetry(
-            compactedDocument.resetEpoch
-          );
-        }
-      }
       try {
         await afterReplace?.();
       } catch (error) {
@@ -1152,15 +951,9 @@ export class PartyServer extends YServer {
       return true;
     } catch (error) {
       this.compactionAutosaveSnapshot = null;
-      if (!databaseCommitted) {
-        await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-        this.documentWriteState = { kind: "idle" };
-      }
       throw error;
     } finally {
-      if (this.getDocumentWriteState().kind === "compaction") {
-        this.documentWriteState = { kind: "idle" };
-      }
+      this.documentMaintenanceInProgress = false;
     }
   }
 
@@ -1182,32 +975,6 @@ export class PartyServer extends YServer {
       this.cachedResetEpoch = undefined;
       throw error;
     }
-  }
-
-  private async setResetEpochAfterDocumentCommit(
-    epoch: number
-  ): Promise<boolean> {
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= RESET_EPOCH_WRITE_ATTEMPTS; attempt += 1) {
-      try {
-        await this.setResetEpoch(epoch);
-        return true;
-      } catch (error) {
-        lastError = error;
-        if (attempt < RESET_EPOCH_WRITE_ATTEMPTS) {
-          console.warn(
-            `[PartyServer] Reset epoch write failed for room=${this.name}; retrying in the current room (attempt=${attempt}/${RESET_EPOCH_WRITE_ATTEMPTS})`
-          );
-          await Promise.resolve();
-        }
-      }
-    }
-    console.error(
-      `[PartyServer] Reset epoch remains pending for room=${this.name}:`,
-      lastError
-    );
-    await this.schedulePendingDocumentResetRetry(epoch);
-    return false;
   }
 
   private setConnectionAcceptedResetEpoch(
@@ -1377,9 +1144,7 @@ export class PartyServer extends YServer {
     const roomId = this.name;
     console.log(`[Restore Snapshot] Starting for room: ${roomId}`);
 
-    this.documentWriteState = { kind: "reset", resetEpoch: null };
-    let databaseCommitted = false;
-    let resetCompleted = false;
+    this.documentMaintenanceInProgress = true;
 
     try {
       // Decode snapshot to Y.Doc so we can ensure metadata is present
@@ -1404,18 +1169,13 @@ export class PartyServer extends YServer {
       } finally {
         snapshotDoc.destroy();
       }
-      this.documentWriteState = { kind: "reset", resetEpoch };
       const documentSize = updatedBase64.length;
-
-      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
-        resetEpoch
-      } satisfies PendingDocumentReset);
 
       // Save to database
       console.log(`[Restore Snapshot] Saving snapshot to database...`);
       try {
         await this.saveDocumentBase64Now(updatedBase64, {
-          operation: options?.allowQuarantined ? "quarantine-repair" : "reset"
+          operation: options?.allowQuarantined ? "quarantine-repair" : "reset",
         });
       } catch (saveError) {
         console.error(
@@ -1427,16 +1187,11 @@ export class PartyServer extends YServer {
           `Failed to save snapshot: ${getErrorMessage(saveError)}`
         );
       }
-      databaseCommitted = true;
-      this.documentWriteState = { kind: "recovery-required", resetEpoch };
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
 
       // Set reset epoch for client detection
-      const resetEpochCommitted =
-        await this.setResetEpochAfterDocumentCommit(resetEpoch);
-      if (resetEpochCommitted) {
-        console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
-      }
+      await this.setResetEpoch(resetEpoch);
+      console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
 
       // Broadcast a "room-reset" message to all connected clients
       this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
@@ -1448,9 +1203,7 @@ export class PartyServer extends YServer {
       const closedCount = this.closeConnections(
         options?.connectionCloseReason ?? "Room Restored by Admin"
       );
-      console.log(
-        `[Restore Snapshot] Closed ${closedCount} connections`
-      );
+      console.log(`[Restore Snapshot] Closed ${closedCount} connections`);
 
       // Flush disconnect work before installing the authoritative snapshot.
       await Promise.resolve();
@@ -1462,18 +1215,6 @@ export class PartyServer extends YServer {
       setDocResetEpoch(liveYDoc, resetEpoch);
       if (options?.completeHydration !== false) {
         this.markDocumentHydrated();
-      }
-      if (resetEpochCommitted) {
-        try {
-          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-          resetCompleted = true;
-        } catch (error) {
-          console.error(
-            `[Restore Snapshot] Marker cleanup failed for room=${roomId}:`,
-            error
-          );
-          await this.schedulePendingDocumentResetRetry(resetEpoch);
-        }
       }
       console.log(`[Restore Snapshot] Successfully reloaded live server`);
 
@@ -1499,22 +1240,8 @@ export class PartyServer extends YServer {
 
       throw error;
     } finally {
-      if (resetCompleted || !databaseCommitted) {
-        this.documentWriteState = { kind: "idle" };
-        if (!databaseCommitted) {
-          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
-        }
-        console.log("[Restore Snapshot] Autosave re-enabled");
-      } else {
-        const writeState = this.getDocumentWriteState();
-        const pendingResetEpoch =
-          writeState.kind === "recovery-required"
-            ? writeState.resetEpoch
-            : "unknown";
-        console.error(
-          `[Restore Snapshot] Persistence remains paused for room=${roomId}: resetEpoch=${pendingResetEpoch} requires hydration recovery`
-        );
-      }
+      this.documentMaintenanceInProgress = false;
+      console.log("[Restore Snapshot] Autosave re-enabled");
     }
   }
 
@@ -1547,30 +1274,22 @@ export class PartyServer extends YServer {
         );
       }
 
-      this.documentWriteState = { kind: "maintenance" };
+      this.documentMaintenanceInProgress = true;
       try {
         const playData = docToJson(this.document) ?? {};
         const mutation = mutate(playData);
         if (mutation.kind === "skip") {
-          return { kind: "skipped", result: mutation.result };
+          return { result: mutation.result, committed: null };
         }
         const committed = await this.commitAdminPlayDataNow(playData);
         return {
-          kind: "committed",
           result: mutation.result,
-          ...committed
+          committed,
         };
       } finally {
-        if (this.getDocumentWriteState().kind === "maintenance") {
-          this.documentWriteState = { kind: "idle" };
-        }
+        this.documentMaintenanceInProgress = false;
       }
     });
-  }
-
-  // Ensure an alarm is set for bridge lease pruning or empty-room compaction.
-  private async ensureAlarmScheduled(): Promise<void> {
-    await this.scheduleNextAlarm();
   }
 
   private async scheduleNextAlarm(): Promise<void> {
@@ -1588,31 +1307,24 @@ export class PartyServer extends YServer {
       compactAfter: await this.getEmptyRoomCompactAfter(),
       hasBridgeLeases: Boolean(subs.length || refs.length),
       now,
-      pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS
+      pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS,
     });
     const documentSaveRetry = await this.getDocumentSaveRetry();
-    const persistenceRecoveryAlarm =
-      await this.circuitBreaker.getPersistenceRecoveryRetryAfter();
-    const pendingDocumentReset = await this.getPendingDocumentReset();
-    const pendingDocumentResetAlarm =
-      pendingDocumentReset === null
-        ? null
-        : (pendingDocumentReset.retryAt ?? now);
-    const nextAlarm =
-      [
-        maintenanceAlarm,
-        documentSaveRetry?.retryAt ?? null,
-        persistenceRecoveryAlarm,
-        pendingDocumentResetAlarm,
-      ].reduce<number | null>(
-        (earliest, candidate) =>
-          candidate === null
-            ? earliest
-            : earliest === null
-              ? candidate
-              : Math.min(earliest, candidate),
-        null
-      );
+    const loadRetryAlarm =
+      await this.circuitBreaker.getFailureRetryAfter("load");
+    const nextAlarm = [
+      maintenanceAlarm,
+      documentSaveRetry?.retryAt ?? null,
+      loadRetryAlarm,
+    ].reduce<number | null>(
+      (earliest, candidate) =>
+        candidate === null
+          ? earliest
+          : earliest === null
+            ? candidate
+            : Math.min(earliest, candidate),
+      null
+    );
 
     if (nextAlarm === null) {
       await this.ctx.storage.deleteAlarm?.();
@@ -1689,7 +1401,7 @@ export class PartyServer extends YServer {
     });
     if (changed) {
       await this.setSharedReferences(entries);
-      await this.ensureAlarmScheduled();
+      await this.scheduleNextAlarm();
       return { entries, changed: true };
     }
     return { entries, changed: false };
@@ -1977,8 +1689,6 @@ export class PartyServer extends YServer {
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
 
-    await this.recoverTransientPersistenceIfDue();
-
     const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
     if (loadDeferred) {
       const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
@@ -2032,7 +1742,7 @@ export class PartyServer extends YServer {
     await this.clearEmptyRoomCompactAfter();
 
     // Opportunistically schedule an alarm if bridge leases or compaction need one
-    await this.ensureAlarmScheduled();
+    await this.scheduleNextAlarm();
 
     // Parse shared references from the connecting client (for consumer rooms)
     // Parse from the WebSocket request URL
@@ -2186,39 +1896,12 @@ export class PartyServer extends YServer {
       return;
     }
 
-    const persistenceRecoveryPending =
-      (await this.ctx.storage.get(
-        STORAGE_KEYS.persistenceRecoveryPending
-      )) === true;
-    const persistenceRecoveryRetryAfter =
-      await this.circuitBreaker.getPersistenceRecoveryRetryAfter();
-    if (
-      persistenceRecoveryPending &&
-      persistenceRecoveryRetryAfter !== null &&
-      persistenceRecoveryRetryAfter > Date.now()
-    ) {
-      this.persistenceMode = {
-        kind: "transient",
-        reason: "waiting for scheduled persistence recovery",
-        failedAt: Date.now(),
-      };
-      await this.scheduleNextAlarm();
-      return;
-    }
-
     if (this.circuitBreaker.isLoadDeferred()) return;
 
-    if (persistenceRecoveryPending) {
-      await this.runDocumentWrite(() => this.loadDocument(true));
-      return;
-    }
-
-    await this.loadDocument(false);
+    await this.runDocumentWrite(() => this.loadDocument());
   }
 
-  private async loadDocument(
-    persistenceRecoveryPending: boolean
-  ): Promise<void> {
+  private async loadDocument(): Promise<void> {
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
     const loadAttempts = await this.circuitBreaker.beginRiskyOperation("load");
@@ -2254,16 +1937,13 @@ export class PartyServer extends YServer {
           );
         },
       }
-    ).catch(async (error) => {
-      await this.enterTransientPersistenceMode(error);
+    ).catch((error) => {
+      this.enterTransientPersistenceMode(error);
       return null;
     });
 
     if (result === null) {
-      // Supabase is unreachable, so hydration never ran. Roll the attempt back
-      // rather than zeroing it: a sub-threshold document that OOMs mid-hydration
-      // must still be able to accumulate evidence across an outage.
-      await this.releaseLoadAttempt(loadAttempts);
+      await this.schedulePersistenceRecovery(loadAttempts);
       return;
     }
 
@@ -2300,6 +1980,9 @@ export class PartyServer extends YServer {
       this.markDocumentPersisted(result.data.document);
     }
 
+    const persistenceRecoveryPending =
+      (await this.ctx.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
+      true;
     if (persistenceRecoveryPending) {
       // The persisted snapshot is authoritative. Transient and quarantined
       // rooms may have an in-memory Y.Doc containing state that was never
@@ -2330,25 +2013,16 @@ export class PartyServer extends YServer {
           );
         }
       }
-      await this.reconcilePendingDocumentReset();
       this.markDocumentHydrated();
     }
 
-    // Recovery evidence is cleared only after the authoritative reset and its
-    // durable marker cleanup both succeed.
+    // Recovery evidence is cleared only after the authoritative reset and
+    // recovery intent cleanup both succeed.
     this.circuitBreaker.setLoadDeferredUntil(null);
     await this.circuitBreaker.completeRiskyOperation("load");
-    await this.circuitBreaker.completePersistenceRecovery();
     if (persistenceRecoveryPending) {
       this.markDocumentHydrated();
     }
-  }
-
-  // Undoes this start's increment when the load ended before hydration could be
-  // attempted. Attempts that DID reach hydration stay counted, so the failure
-  // history keeps its evidence even if Supabase is flaky in between.
-  private async releaseLoadAttempt(loadAttempts: number): Promise<void> {
-    await this.circuitBreaker.releaseLoadAttempt(loadAttempts);
   }
 
   override async onSave(): Promise<void> {
@@ -2473,13 +2147,13 @@ export class PartyServer extends YServer {
             `resetEpoch=${compactedDocument.resetEpoch}, ` +
             `activeConnections=${activeConnectionCount}, closed=${closedCount}`
         );
-      }
+      },
     });
     return true;
   }
 
   private async persistLiveDocument({
-    allowCompaction
+    allowCompaction,
   }: PersistLiveDocumentOptions): Promise<boolean> {
     return this.runDocumentWrite(() =>
       this.persistLiveDocumentNow({ allowCompaction })
@@ -2487,7 +2161,7 @@ export class PartyServer extends YServer {
   }
 
   private async persistLiveDocumentNow({
-    allowCompaction
+    allowCompaction,
   }: PersistLiveDocumentOptions): Promise<boolean> {
     const doc = this.document;
 
@@ -2533,7 +2207,6 @@ export class PartyServer extends YServer {
     // or an admin edit), which creates a reset boundary.
     const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
-    const saveGeneration = this.documentGeneration ?? 0;
     const activeConnectionCount = this.getOpenConnectionCount();
 
     this.lastKnownDocumentBytes = documentSize;
@@ -2610,11 +2283,7 @@ export class PartyServer extends YServer {
       await this.scheduleDocumentSaveRetry();
       return false;
     }
-    if ((this.documentGeneration ?? 0) === saveGeneration) {
-      await this.clearDocumentSaveRetry();
-    } else {
-      await this.scheduleDocumentSaveRetry();
-    }
+    await this.clearDocumentSaveRetry();
     if (allowCompaction && activeConnectionCount > 0) {
       const compacted = await this.maybeCompactLargeConnectedRoom({
         documentSize,
@@ -2744,10 +2413,6 @@ export class PartyServer extends YServer {
         "/admin/quarantine-set",
         "/admin/quarantine-clear",
       ].some((path) => url.pathname.includes(path));
-      if (!isLoadControlRoute) {
-        await this.recoverTransientPersistenceIfDue();
-      }
-
       // Route admin requests to admin handler
       // PartyKit paths are like /parties/main/room-id/admin/inspect
       if (url.pathname.includes("/admin")) {
@@ -2790,15 +2455,12 @@ export class PartyServer extends YServer {
         if (bridgeAuthFailure) return bridgeAuthFailure;
       }
 
-      const documentWriteKind = this.getDocumentWriteState().kind;
       const bridgeApplyCanWaitForMaintenance =
         isApplySubtreesImmediateRequest(body) &&
         this.documentLoadCompleted &&
         this.isPersistenceAvailable() &&
         !this.circuitBreaker.isQuarantined() &&
-        (documentWriteKind === "maintenance" ||
-          documentWriteKind === "compaction" ||
-          documentWriteKind === "reset");
+        this.documentMaintenanceInProgress;
       if (
         !this.canWriteSharedData() &&
         (isSubscribeRequest(body) ||
@@ -2860,7 +2522,7 @@ export class PartyServer extends YServer {
           found.lastSeen = nowIso;
         }
         await this.setSubscribers(existing);
-        await this.ensureAlarmScheduled();
+        await this.scheduleNextAlarm();
         // A resubscribe means a fresh client load on the consumer side. Reopen
         // its circuit so a genuine new visitor always gets a clean bridge attempt
         // even if the pair had previously tripped from a stale-epoch storm.
@@ -3247,7 +2909,7 @@ export class PartyServer extends YServer {
 
       const restored = await this.restoreFromSnapshotNow(freshBase64, {
         bumpEpoch: false,
-        connectionCloseReason: "Room Reset by Admin"
+        connectionCloseReason: "Room Reset by Admin",
       });
 
       const sizeReduction = beforeSize - afterSize;
@@ -3263,7 +2925,7 @@ export class PartyServer extends YServer {
         beforeSize,
         afterSize,
         resetEpoch: restored.resetEpoch,
-        closedConnections: restored.closedConnections
+        closedConnections: restored.closedConnections,
       };
     } catch (error: unknown) {
       const errorMessage =
@@ -3337,7 +2999,7 @@ export class PartyServer extends YServer {
         onDeferred: (retryAt) => this.setEmptyRoomCompactAfter(retryAt),
         onDisabled: () => this.clearEmptyRoomCompactAfter(),
         run: () =>
-          this.runDocumentWrite(() => this.compactEmptyRoomDocumentOnce())
+          this.runDocumentWrite(() => this.compactEmptyRoomDocumentOnce()),
       });
     };
 
@@ -3377,29 +3039,27 @@ export class PartyServer extends YServer {
 
   // PartyKit Alarm: invoked when storage alarm rings
   override async onAlarm(): Promise<void> {
-    await this.recoverTransientPersistenceIfDue();
+    const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
+    if (loadDeferred) {
+      await this.scheduleNextAlarm();
+      return;
+    }
     if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
     try {
-      const pendingDocumentReset = await this.getPendingDocumentReset();
-      if (
-        pendingDocumentReset !== null &&
-        (pendingDocumentReset.retryAt ?? 0) <= Date.now()
-      ) {
-        await this.runDocumentWrite(() =>
-          this.reconcilePendingDocumentReset()
-        );
-      }
-
       const documentSaveRetry = await this.getDocumentSaveRetry();
       if (
         documentSaveRetry !== null &&
         documentSaveRetry.retryAt <= Date.now()
       ) {
+        await this.clearDocumentSaveRetry();
         if (this.roomState() === "ready") {
-          await this.persistLiveDocument({ allowCompaction: false });
-        } else {
-          await this.scheduleDocumentSaveRetry();
+          try {
+            await this.persistLiveDocument({ allowCompaction: false });
+          } catch (error) {
+            await this.scheduleDocumentSaveRetry();
+            throw error;
+          }
         }
       }
 

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -935,12 +935,14 @@ export class PartyServer extends YServer {
 
     const documentResetEpoch = getDocResetEpoch(this.document);
     if (documentResetEpoch !== pending.resetEpoch) {
-      this.documentWriteState = {
-        kind: "recovery-required",
-        resetEpoch: pending.resetEpoch
-      };
-      await this.schedulePendingDocumentResetRetry(pending.resetEpoch);
-      return false;
+      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+      if (this.getDocumentWriteState().kind === "recovery-required") {
+        this.documentWriteState = { kind: "idle" };
+      }
+      console.warn(
+        `[PartyServer] Aborted uncommitted document reset for room=${this.name}: pendingResetEpoch=${pending.resetEpoch}, documentResetEpoch=${documentResetEpoch ?? "none"}`
+      );
+      return true;
     }
 
     try {
@@ -2882,17 +2884,114 @@ export class PartyServer extends YServer {
         const { subtrees, sender, originKind } = body;
 
         const yDoc = this.document;
-        const subscribers = await this.getSubscribers();
-        const sharedRefs = await this.getSharedReferences();
-        const relationship = getBridgeApplyRelationship({
-          sender,
-          originKind,
-          subscriberRoomIds: subscribers.map(
-            (subscriber) => subscriber.consumerRoomId
-          ),
-          sourceRoomIds: sharedRefs.map((reference) => reference.sourceRoomId),
+        const senderResetEpoch =
+          typeof body.resetEpoch === "number" ? body.resetEpoch : null;
+        const applyResult = await this.runDocumentWrite(async () => {
+          if (!this.canWriteSharedData()) {
+            return { kind: "unavailable" } as const;
+          }
+
+          const subscribers = await this.getSubscribers();
+          const sharedRefs = await this.getSharedReferences();
+          const relationship = getBridgeApplyRelationship({
+            sender,
+            originKind,
+            subscriberRoomIds: subscribers.map(
+              (subscriber) => subscriber.consumerRoomId
+            ),
+            sourceRoomIds: sharedRefs.map(
+              (reference) => reference.sourceRoomId
+            ),
+          });
+          if (relationship === null) {
+            return { kind: "relationship-not-found" } as const;
+          }
+
+          const currentServerResetEpoch = await this.getResetEpoch();
+          if (this.isEpochStale(senderResetEpoch, currentServerResetEpoch)) {
+            return {
+              kind: "stale-epoch",
+              serverResetEpoch: currentServerResetEpoch,
+            } as const;
+          }
+
+          const receivingFromConsumer = relationship === "consumer";
+          const receivingFromSource = relationship === "source";
+          let subtreesToApply: Record<string, Record<string, any>> = subtrees;
+          if (receivingFromConsumer) {
+            // IMPORTANT: Only apply tags/elementIds that already exist in the source's doc to ensure
+            // the source of truth is derived from the source room and not consumer-added capabilities.
+            const play = yDoc.getMap("play") as Y.Map<any>;
+            const filtered: Record<string, Record<string, any>> = {};
+            Object.entries(subtreesToApply).forEach(([tag, elements]) => {
+              const tagMap = play.get?.(tag) as Y.Map<any> | undefined;
+              if (!(tagMap instanceof Y.Map)) return;
+              const kept: Record<string, any> = {};
+              Object.entries(elements).forEach(([elementId, data]) => {
+                if (tagMap.has(elementId)) kept[elementId] = data;
+              });
+              if (Object.keys(kept).length) filtered[tag] = kept;
+            });
+            // Enforce simple permissions: read-only shared elements on this source room cannot be modified by consumers
+            const perms = await this.getSharedPermissions();
+            const filteredByPerms: Record<string, Record<string, any>> = {};
+            Object.entries(filtered).forEach(([tag, elements]) => {
+              const kept: Record<string, any> = {};
+              Object.entries(elements).forEach(([elementId, data]) => {
+                // Only allow writes to elements explicitly shared as read-write
+                // This handles both read-only elements and ones that aren't even shared
+                if (perms[elementId] !== "read-write") {
+                  return;
+                }
+                kept[elementId] = data;
+              });
+              if (Object.keys(kept).length) filteredByPerms[tag] = kept;
+            });
+            subtreesToApply = filteredByPerms;
+          } else if (receivingFromSource) {
+            // Consumer: apply only the elementIds we are subscribed to for this sender/source
+            const ref = sharedRefs.find((r) => r.sourceRoomId === sender);
+            const allowed = new Set(ref?.elementIds || []);
+            if (allowed.size > 0) {
+              const filteredByRefs: Record<string, Record<string, any>> = {};
+              Object.entries(subtreesToApply).forEach(([tag, elements]) => {
+                const kept: Record<string, any> = {};
+                Object.entries(elements).forEach(([elementId, data]) => {
+                  if (allowed.has(elementId)) kept[elementId] = data;
+                });
+                if (Object.keys(kept).length) filteredByRefs[tag] = kept;
+              });
+              subtreesToApply = filteredByRefs;
+            } else {
+              subtreesToApply = {};
+            }
+          }
+          if (!Object.keys(subtreesToApply).length) {
+            return { kind: "empty" } as const;
+          }
+
+          const ORIGIN = originKind === "consumer" ? ORIGIN_C2S : ORIGIN_S2C;
+          yDoc.transact(
+            () => this.assignPlaySubtrees(yDoc, subtreesToApply),
+            ORIGIN
+          );
+          return {
+            kind: "applied",
+            receivingFromConsumer,
+            subtreesToApply,
+          } as const;
         });
-        if (relationship === null) {
+
+        if (applyResult.kind === "unavailable") {
+          console.warn(
+            `[Bridge] Ignoring apply-subtrees for room ${this.name}: document hydration or persistence unavailable after waiting for document maintenance.`
+          );
+          const response: ApplySubtreesResponse = { ok: true, applied: false };
+          return new Response(JSON.stringify(response), {
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (applyResult.kind === "relationship-not-found") {
           return new Response(
             JSON.stringify({
               error: "bridge_relationship_not_found",
@@ -2904,74 +3003,16 @@ export class PartyServer extends YServer {
             }
           );
         }
-
-        const senderResetEpoch =
-          typeof body.resetEpoch === "number" ? body.resetEpoch : null;
-        const serverResetEpoch = await this.getResetEpoch();
-
-        if (this.isEpochStale(senderResetEpoch, serverResetEpoch)) {
+        if (applyResult.kind === "stale-epoch") {
           console.warn(
-            `[Bridge] Ignoring apply-subtrees from ${sender} (${originKind}) due to stale reset epoch (sender=${senderResetEpoch}, server=${serverResetEpoch})`
+            `[Bridge] Ignoring apply-subtrees from ${sender} (${originKind}) due to stale reset epoch after waiting for document maintenance (sender=${senderResetEpoch}, server=${applyResult.serverResetEpoch})`
           );
           const response: ApplySubtreesResponse = { ok: true, applied: false };
           return new Response(JSON.stringify(response), {
             headers: { "content-type": "application/json" },
           });
         }
-
-        const receivingFromConsumer = relationship === "consumer";
-        const receivingFromSource = relationship === "source";
-
-        let subtreesToApply: Record<string, Record<string, any>> = subtrees;
-        if (receivingFromConsumer) {
-          // IMPORTANT: Only apply tags/elementIds that already exist in the source's doc to ensure
-          // the source of truth is derived from the source room and not consumer-added capabilities.
-          const play = yDoc.getMap("play") as Y.Map<any>;
-          const filtered: Record<string, Record<string, any>> = {};
-          Object.entries(subtreesToApply).forEach(([tag, elements]) => {
-            const tagMap = play.get?.(tag) as Y.Map<any> | undefined;
-            if (!(tagMap instanceof Y.Map)) return;
-            const kept: Record<string, any> = {};
-            Object.entries(elements).forEach(([elementId, data]) => {
-              if (tagMap.has(elementId)) kept[elementId] = data;
-            });
-            if (Object.keys(kept).length) filtered[tag] = kept;
-          });
-          // Enforce simple permissions: read-only shared elements on this source room cannot be modified by consumers
-          const perms = await this.getSharedPermissions();
-          const filteredByPerms: Record<string, Record<string, any>> = {};
-          Object.entries(filtered).forEach(([tag, elements]) => {
-            const kept: Record<string, any> = {};
-            Object.entries(elements).forEach(([elementId, data]) => {
-              // Only allow writes to elements explicitly shared as read-write
-              // This handles both read-only elements and ones that aren't even shared
-              if (perms[elementId] !== "read-write") {
-                return;
-              }
-              kept[elementId] = data;
-            });
-            if (Object.keys(kept).length) filteredByPerms[tag] = kept;
-          });
-          subtreesToApply = filteredByPerms;
-        } else if (receivingFromSource) {
-          // Consumer: apply only the elementIds we are subscribed to for this sender/source
-          const ref = sharedRefs.find((r) => r.sourceRoomId === sender);
-          const allowed = new Set(ref?.elementIds || []);
-          if (allowed.size > 0) {
-            const filteredByRefs: Record<string, Record<string, any>> = {};
-            Object.entries(subtreesToApply).forEach(([tag, elements]) => {
-              const kept: Record<string, any> = {};
-              Object.entries(elements).forEach(([elementId, data]) => {
-                if (allowed.has(elementId)) kept[elementId] = data;
-              });
-              if (Object.keys(kept).length) filteredByRefs[tag] = kept;
-            });
-            subtreesToApply = filteredByRefs;
-          } else {
-            subtreesToApply = {};
-          }
-        }
-        if (!Object.keys(subtreesToApply).length) {
+        if (applyResult.kind === "empty") {
           // Nothing to apply (filtered to empty). Not a failure — report applied
           // so it does not count against the sender's circuit breaker.
           const response: ApplySubtreesResponse = { ok: true, applied: true };
@@ -2979,11 +3020,7 @@ export class PartyServer extends YServer {
             headers: { "content-type": "application/json" },
           });
         }
-        const ORIGIN = originKind === "consumer" ? ORIGIN_C2S : ORIGIN_S2C;
-        yDoc.transact(
-          () => this.assignPlaySubtrees(yDoc, subtreesToApply),
-          ORIGIN
-        );
+        const { receivingFromConsumer, subtreesToApply } = applyResult;
 
         // If this is a SOURCE room receiving from a CONSUMER, immediately fanout to other consumers (excluding sender if provided)
         if (receivingFromConsumer) {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -92,6 +92,9 @@ import {
 import { BridgeHealth } from "./bridgeHealth";
 import { getBridgeApplyTargetResetEpoch } from "./bridgeEpochPolicy";
 import { getPermittedSharedElementIds } from "./bridgePermissionPolicy";
+import { createBridgeRequest, getBridgeAuthFailure } from "./bridgeAuth";
+import { getBridgeApplyRelationship } from "./bridgeRequestPolicy";
+import { mergeSharedReferenceLeases } from "./bridgeLeasePolicy";
 import {
   createPersistenceUnavailableResponse,
   formatPersistenceFailureLog,
@@ -196,11 +199,7 @@ type AutomaticCompactionOptions<T> = {
 // Build a JSON POST request for room-to-room (DO-to-DO) RPC.
 // The URL is synthetic — the target server's onRequest reads the body, not the path.
 function internalRequest(path: string, body: unknown): Request {
-  return new Request(`http://internal${path}`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  return createBridgeRequest(path, body, env.PARTYKIT_BRIDGE_SECRET);
 }
 
 function readPositiveNumberEnv(name: string, fallback: number): number {
@@ -1570,33 +1569,17 @@ export class PartyServer extends YServer {
     changed: boolean;
   }> {
     const existing = await this.getSharedReferences();
-    const bySource = new Map<string, Set<string>>();
-    for (const e of existing)
-      bySource.set(e.sourceRoomId, new Set(e.elementIds));
-    let changed = false;
-    for (const e of newEntries) {
-      const set = bySource.get(e.sourceRoomId) ?? new Set<string>();
-      const before = set.size;
-      for (const id of e.elementIds) set.add(id);
-      if (!bySource.has(e.sourceRoomId) || set.size !== before) changed = true;
-      bySource.set(e.sourceRoomId, set);
-    }
+    const { entries, changed } = mergeSharedReferenceLeases({
+      existing,
+      requested: newEntries,
+      nowIso: new Date().toISOString(),
+    });
     if (changed) {
-      const nowIso = new Date().toISOString();
-      const merged: Array<SharedRefEntry> = Array.from(bySource.entries()).map(
-        ([sourceRoomId, ids]) => {
-          return {
-            sourceRoomId,
-            elementIds: Array.from(ids),
-            lastSeen: nowIso,
-          };
-        }
-      );
-      await this.setSharedReferences(merged);
+      await this.setSharedReferences(entries);
       await this.ensureAlarmScheduled();
-      return { entries: merged, changed: true };
+      return { entries, changed: true };
     }
-    return { entries: existing, changed: false };
+    return { entries, changed: false };
   }
 
   // --- Helper: subscribe to sources and optionally hydrate immediately
@@ -2669,6 +2652,18 @@ export class PartyServer extends YServer {
       }
 
       if (
+        isSubscribeRequest(body) ||
+        isExportPermissionsRequest(body) ||
+        isApplySubtreesImmediateRequest(body)
+      ) {
+        const bridgeAuthFailure = getBridgeAuthFailure(
+          request,
+          env.PARTYKIT_BRIDGE_SECRET
+        );
+        if (bridgeAuthFailure) return bridgeAuthFailure;
+      }
+
+      if (
         !this.canWriteSharedData() &&
         (isSubscribeRequest(body) || isApplySubtreesImmediateRequest(body))
       ) {
@@ -2784,6 +2779,27 @@ export class PartyServer extends YServer {
         const yDoc = this.document;
         const subscribers = await this.getSubscribers();
         const sharedRefs = await this.getSharedReferences();
+        const relationship = getBridgeApplyRelationship({
+          sender,
+          originKind,
+          subscriberRoomIds: subscribers.map(
+            (subscriber) => subscriber.consumerRoomId
+          ),
+          sourceRoomIds: sharedRefs.map((reference) => reference.sourceRoomId),
+        });
+        if (relationship === null) {
+          return new Response(
+            JSON.stringify({
+              error: "bridge_relationship_not_found",
+              message: "The sending room has no registered bridge relationship",
+            }),
+            {
+              status: 403,
+              headers: { "content-type": "application/json" },
+            }
+          );
+        }
+
         const senderResetEpoch =
           typeof body.resetEpoch === "number" ? body.resetEpoch : null;
         const serverResetEpoch = await this.getResetEpoch();
@@ -2798,12 +2814,8 @@ export class PartyServer extends YServer {
           });
         }
 
-        const receivingFromConsumer =
-          originKind === "consumer" &&
-          subscribers.some((s) => s.consumerRoomId === sender);
-        const receivingFromSource =
-          originKind === "source" &&
-          sharedRefs.some((r) => r.sourceRoomId === sender);
+        const receivingFromConsumer = relationship === "consumer";
+        const receivingFromSource = relationship === "source";
 
         let subtreesToApply: Record<string, Record<string, any>> = subtrees;
         if (receivingFromConsumer) {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -1144,7 +1144,9 @@ export class PartyServer extends YServer {
     const roomId = this.name;
     console.log(`[Restore Snapshot] Starting for room: ${roomId}`);
 
+    const savesWerePaused = this.documentMaintenanceInProgress;
     this.documentMaintenanceInProgress = true;
+    let committedSnapshotRequiresReload = savesWerePaused;
 
     try {
       // Decode snapshot to Y.Doc so we can ensure metadata is present
@@ -1188,6 +1190,9 @@ export class PartyServer extends YServer {
         );
       }
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
+      // The persisted snapshot is authoritative now. Keep autosave paused until
+      // the live document catches up so a later save cannot restore stale state.
+      committedSnapshotRequiresReload = true;
 
       // Set reset epoch for client detection
       await this.setResetEpoch(resetEpoch);
@@ -1213,6 +1218,7 @@ export class PartyServer extends YServer {
       const liveYDoc = this.document;
       replaceDocFromSnapshot(liveYDoc, updatedBase64);
       setDocResetEpoch(liveYDoc, resetEpoch);
+      committedSnapshotRequiresReload = false;
       if (options?.completeHydration !== false) {
         this.markDocumentHydrated();
       }
@@ -1240,8 +1246,12 @@ export class PartyServer extends YServer {
 
       throw error;
     } finally {
-      this.documentMaintenanceInProgress = false;
-      console.log("[Restore Snapshot] Autosave re-enabled");
+      this.documentMaintenanceInProgress = committedSnapshotRequiresReload;
+      console.log(
+        committedSnapshotRequiresReload
+          ? "[Restore Snapshot] Autosave remains paused until the committed snapshot is loaded"
+          : "[Restore Snapshot] Autosave re-enabled"
+      );
     }
   }
 
@@ -3041,6 +3051,13 @@ export class PartyServer extends YServer {
   override async onAlarm(): Promise<void> {
     const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
     if (loadDeferred) {
+      const documentSaveRetry = await this.getDocumentSaveRetry();
+      if (
+        documentSaveRetry !== null &&
+        documentSaveRetry.retryAt <= Date.now()
+      ) {
+        await this.clearDocumentSaveRetry();
+      }
       await this.scheduleNextAlarm();
       return;
     }

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -40,6 +40,8 @@ import {
   DEFAULT_SUPABASE_LOAD_ATTEMPTS,
   DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
+  DEFAULT_DOCUMENT_SAVE_RETRY_MS,
+  DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
   ORIGIN_S2C,
@@ -106,6 +108,7 @@ export { PresenceServer } from "./presenceServer";
 const ACCEPTED_RESET_EPOCH_STATE_KEY = "__playhtmlAcceptedResetEpoch";
 const MESSAGE_LIMIT_STATE_KEY = "__playhtmlMessageLimit";
 const CONNECTION_OPENED_AT_STATE_KEY = "__playhtmlConnectionOpenedAt";
+const RESET_EPOCH_WRITE_ATTEMPTS = 3;
 
 type PartyServerConnectionState = Record<string, unknown> & {
   [ACCEPTED_RESET_EPOCH_STATE_KEY]?: number | null;
@@ -116,6 +119,7 @@ type PartyServerConnectionState = Record<string, unknown> & {
 type CompactedDocument = {
   base64: string;
   sourceBase64: string;
+  sourceGeneration: number;
   beforeSize: number;
   afterSize: number;
   resetEpoch: number;
@@ -142,6 +146,36 @@ type RoomState =
 type SaveDocumentOptions = {
   operation?: "shared-data" | "reset" | "quarantine-repair";
 };
+
+type DocumentWriteState =
+  | { kind: "idle" }
+  | { kind: "maintenance" }
+  | { kind: "compaction" }
+  | { kind: "reset"; resetEpoch: number | null }
+  | { kind: "recovery-required"; resetEpoch: number };
+
+type PendingDocumentReset = {
+  resetEpoch: number;
+};
+
+type DocumentSaveRetry = {
+  attempt: number;
+  retryAt: number;
+};
+
+type AdminPlayDataMutation<T> =
+  | { kind: "commit"; result: T }
+  | { kind: "skip"; result: T };
+
+type AdminPlayDataMutationResult<T> =
+  | {
+      kind: "committed";
+      result: T;
+      documentSize: number;
+      resetEpoch: number;
+      closedConnections: number;
+    }
+  | { kind: "skipped"; result: T };
 
 type UsefulCompactedDocumentOptions = {
   sourceBase64?: string;
@@ -188,18 +222,28 @@ function readPositiveNumberEnv(name: string, fallback: number): number {
 
 export class PartyServer extends YServer {
   static options = {
-    hibernate: true,
+    hibernate: true
   };
 
-  // Public flag to pause autosave during administrative resets
-  // This prevents the server from overwriting the clean DB state with
-  // in-memory state while we are performing a reset.
-  public isSkippingSave = false;
+  private documentWriteState: DocumentWriteState = { kind: "idle" };
+  private documentWriteTail: Promise<void> = Promise.resolve();
+  private documentGeneration = 0;
+  private persistenceObserverAttached = false;
   private emptyRoomCompactionPromise: Promise<void> | null = null;
   private compactionAutosaveSnapshot: string | null = null;
   private cachedResetEpoch: number | null | undefined;
   private lastKnownDocumentBytes = 0;
   private hasWarnedDocumentSize = false;
+
+  public get isSkippingSave(): boolean {
+    return this.getDocumentWriteState().kind !== "idle";
+  }
+
+  public set isSkippingSave(paused: boolean) {
+    this.documentWriteState = paused
+      ? { kind: "maintenance" }
+      : { kind: "idle" };
+  }
 
   // In-memory caches for hot-path data that rarely changes.
   // Invalidated on writes via the set* methods.
@@ -315,6 +359,7 @@ export class PartyServer extends YServer {
   }
 
   private async completeRoomStartup(): Promise<void> {
+    this.attachPersistenceObserver();
     await this.attachImmediateBridgeObservers();
     await this.pruneBridgeLeases();
     await this.ensureAlarmScheduled();
@@ -375,6 +420,39 @@ export class PartyServer extends YServer {
 
   markDocumentPersisted(documentBase64: string): void {
     this.lastKnownDocumentBytes = documentBase64.length;
+  }
+
+  private async getDocumentSaveRetry(): Promise<DocumentSaveRetry | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.documentSaveRetry);
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "attempt" in value &&
+      typeof value.attempt === "number" &&
+      "retryAt" in value &&
+      typeof value.retryAt === "number"
+    ) {
+      return { attempt: value.attempt, retryAt: value.retryAt };
+    }
+    return null;
+  }
+
+  private async scheduleDocumentSaveRetry(): Promise<void> {
+    const previous = await this.getDocumentSaveRetry();
+    const attempt = (previous?.attempt ?? 0) + 1;
+    const delay = Math.min(
+      DEFAULT_DOCUMENT_SAVE_RETRY_MS * 2 ** (attempt - 1),
+      DEFAULT_DOCUMENT_SAVE_RETRY_MAX_MS
+    );
+    await this.ctx.storage.put(STORAGE_KEYS.documentSaveRetry, {
+      attempt,
+      retryAt: Date.now() + delay
+    } satisfies DocumentSaveRetry);
+    await this.scheduleNextAlarm();
+  }
+
+  private async clearDocumentSaveRetry(): Promise<void> {
+    await this.ctx.storage.delete(STORAGE_KEYS.documentSaveRetry);
   }
 
   private async getEmptyRoomCompactAfter(): Promise<number | null> {
@@ -517,11 +595,34 @@ export class PartyServer extends YServer {
     return this.persistenceMode.kind === "available";
   }
 
+  private getDocumentWriteState(): DocumentWriteState {
+    return this.documentWriteState ?? { kind: "idle" };
+  }
+
+  private runDocumentWrite<T>(work: () => Promise<T>): Promise<T> {
+    const previous = this.documentWriteTail ?? Promise.resolve();
+    const result = previous.then(work, work);
+    this.documentWriteTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private attachPersistenceObserver(): void {
+    if (this.persistenceObserverAttached) return;
+    this.documentGeneration ??= 0;
+    this.document.on("update", () => {
+      this.documentGeneration += 1;
+    });
+    this.persistenceObserverAttached = true;
+  }
+
   private roomState(): RoomState {
     if (this.circuitBreaker.isQuarantined()) return "quarantined";
     if (!this.documentLoadCompleted) return "loading";
     if (!this.isPersistenceAvailable()) return "transient";
-    if (this.isSkippingSave) return "save-paused";
+    if (this.getDocumentWriteState().kind !== "idle") return "save-paused";
     return "ready";
   }
 
@@ -689,9 +790,10 @@ export class PartyServer extends YServer {
       return {
         base64,
         sourceBase64,
+        sourceGeneration: this.documentGeneration ?? 0,
         beforeSize,
         afterSize: base64.length,
-        resetEpoch,
+        resetEpoch
       };
     } finally {
       compactDoc.destroy();
@@ -727,13 +829,31 @@ export class PartyServer extends YServer {
     }
   }
 
-  private async restoreResetEpoch(resetEpoch: number | null): Promise<void> {
-    if (resetEpoch === null) {
-      await this.clearResetEpoch();
-      return;
+  private async getPendingDocumentReset(): Promise<PendingDocumentReset | null> {
+    const value = await this.ctx.storage.get(STORAGE_KEYS.pendingDocumentReset);
+    if (
+      typeof value === "object" &&
+      value !== null &&
+      "resetEpoch" in value &&
+      typeof value.resetEpoch === "number"
+    ) {
+      return { resetEpoch: value.resetEpoch };
     }
+    return null;
+  }
 
-    await this.setResetEpoch(resetEpoch);
+  private async reconcilePendingDocumentReset(): Promise<void> {
+    const pending = await this.getPendingDocumentReset();
+    if (pending === null) return;
+
+    const documentResetEpoch = getDocResetEpoch(this.document);
+    if (documentResetEpoch === pending.resetEpoch) {
+      await this.setResetEpoch(pending.resetEpoch);
+      console.warn(
+        `[PartyServer] Recovered interrupted document reset for room=${this.name}: resetEpoch=${pending.resetEpoch}`
+      );
+    }
+    await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
   }
 
   private async getPersistedDocumentBase64(): Promise<string | null> {
@@ -754,21 +874,25 @@ export class PartyServer extends YServer {
     documentBase64: string,
     options: SaveDocumentOptions = {}
   ): Promise<void> {
-    const operation = options.operation ?? "shared-data";
-    const state = this.roomState();
+    await this.runDocumentWrite(async () => {
+      this.assertDocumentSaveAllowed(options);
+      if (
+        (options.operation ?? "shared-data") === "shared-data" &&
+        documentBase64 !== encodeDocToBase64(this.document)
+      ) {
+        throw new Error(
+          "Cannot persist stale document: live room state changed before the save acquired the write queue"
+        );
+      }
+      await this.saveDocumentBase64Now(documentBase64, options);
+    });
+  }
 
-    if (operation !== "quarantine-repair") {
-      this.circuitBreaker.assertNotQuarantined("persist document");
-    }
-    const stateAllowsSave =
-      operation === "quarantine-repair" ||
-      state === "ready" ||
-      (operation === "reset" && state === "save-paused");
-    if (!stateAllowsSave) {
-      throw new Error(
-        `Cannot persist document while room state is ${state} (operation=${operation})`
-      );
-    }
+  private async saveDocumentBase64Now(
+    documentBase64: string,
+    options: SaveDocumentOptions = {}
+  ): Promise<void> {
+    this.assertDocumentSaveAllowed(options);
 
     const { error } = await supabase.from("documents").upsert(
       {
@@ -785,20 +909,49 @@ export class PartyServer extends YServer {
     this.markDocumentPersisted(documentBase64);
   }
 
+  private assertDocumentSaveAllowed(options: SaveDocumentOptions): void {
+    const operation = options.operation ?? "shared-data";
+    const state = this.roomState();
+
+    if (operation !== "quarantine-repair") {
+      this.circuitBreaker.assertNotQuarantined("persist document");
+    }
+    const stateAllowsSave =
+      operation === "quarantine-repair" ||
+      state === "ready" ||
+      (operation === "reset" && state === "save-paused");
+    if (!stateAllowsSave) {
+      throw new Error(
+        `Cannot persist document while room state is ${state} (operation=${operation})`
+      );
+    }
+
+  }
+
   private async commitCompactedDocument({
     compactedDocument,
     validatePersistedSource = true,
     beforeCommit,
-    afterReplace,
+    afterReplace
   }: CommitCompactedDocumentOptions): Promise<boolean> {
-    const rollbackResetEpoch = await this.getResetEpoch();
+    this.documentWriteState = { kind: "compaction" };
     let liveDocumentReplaced = false;
-    let autosavePaused = false;
+    let databaseCommitted = false;
 
     try {
+      if (
+        (this.documentGeneration ?? 0) !== compactedDocument.sourceGeneration
+      ) {
+        console.warn(
+          `[PartyServer] Compaction skipped for room=${this.name}: live document changed while the candidate was built`
+        );
+        this.documentWriteState = { kind: "idle" };
+        await this.persistLiveDocumentNow({ allowCompaction: false });
+        return false;
+      }
+
       if (validatePersistedSource) {
-        const persistedDocumentBase64 =
-          await this.getPersistedDocumentBase64();
+        const persistedDocumentBase64 = await this.getPersistedDocumentBase64();
         const sourceContainsPersistedDocument =
           persistedDocumentBase64 !== null &&
           documentContainsSnapshot(
@@ -815,7 +968,8 @@ export class PartyServer extends YServer {
           console.warn(
             `[PartyServer] Compaction skipped for room=${this.name}: persisted document no longer matches compacted source; saving live document first`
           );
-          await this.persistLiveDocument({ allowCompaction: false });
+          this.documentWriteState = { kind: "idle" };
+          await this.persistLiveDocumentNow({ allowCompaction: false });
           return false;
         }
 
@@ -827,32 +981,63 @@ export class PartyServer extends YServer {
         }
       }
 
-      this.isSkippingSave = true;
-      autosavePaused = true;
+      if (
+        (this.documentGeneration ?? 0) !== compactedDocument.sourceGeneration
+      ) {
+        console.warn(
+          `[PartyServer] Compaction skipped for room=${this.name}: live document changed during validation`
+        );
+        this.documentWriteState = { kind: "idle" };
+        await this.persistLiveDocumentNow({ allowCompaction: false });
+        return false;
+      }
 
       if (beforeCommit && !(await beforeCommit())) {
         return false;
       }
 
-      await this.setResetEpoch(compactedDocument.resetEpoch);
-      await this.saveDocumentBase64(compactedDocument.base64, {
-        operation: "reset",
+      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
+        resetEpoch: compactedDocument.resetEpoch
+      } satisfies PendingDocumentReset);
+      await this.saveDocumentBase64Now(compactedDocument.base64, {
+        operation: "reset"
       });
+      databaseCommitted = true;
+      this.documentWriteState = {
+        kind: "recovery-required",
+        resetEpoch: compactedDocument.resetEpoch
+      };
+      await this.setResetEpochAfterDocumentCommit(
+        compactedDocument.resetEpoch
+      );
 
       this.compactionAutosaveSnapshot = compactedDocument.base64;
       replaceDocFromSnapshot(this.document, compactedDocument.base64);
       liveDocumentReplaced = true;
-      await afterReplace?.();
+      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+      this.documentWriteState = { kind: "idle" };
+      try {
+        await afterReplace?.();
+      } catch (error) {
+        console.error(
+          `[PartyServer] Compaction post-commit cleanup failed for room=${this.name}:`,
+          error
+        );
+      }
       return true;
     } catch (error) {
-      if (!liveDocumentReplaced) {
-        await this.restoreResetEpoch(rollbackResetEpoch);
-      }
       this.compactionAutosaveSnapshot = null;
+      if (!databaseCommitted) {
+        await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+        this.documentWriteState = { kind: "idle" };
+      }
       throw error;
     } finally {
-      if (autosavePaused) {
-        this.isSkippingSave = false;
+      if (
+        liveDocumentReplaced ||
+        this.getDocumentWriteState().kind === "compaction"
+      ) {
+        this.documentWriteState = { kind: "idle" };
       }
     }
   }
@@ -877,14 +1062,23 @@ export class PartyServer extends YServer {
     }
   }
 
-  private async clearResetEpoch(): Promise<void> {
-    this.cachedResetEpoch = null;
-    try {
-      await this.ctx.storage.delete(STORAGE_KEYS.resetEpoch);
-    } catch (error) {
-      this.cachedResetEpoch = undefined;
-      throw error;
+  private async setResetEpochAfterDocumentCommit(epoch: number): Promise<void> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= RESET_EPOCH_WRITE_ATTEMPTS; attempt += 1) {
+      try {
+        await this.setResetEpoch(epoch);
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt < RESET_EPOCH_WRITE_ATTEMPTS) {
+          console.warn(
+            `[PartyServer] Reset epoch write failed for room=${this.name}; retrying in the current room (attempt=${attempt}/${RESET_EPOCH_WRITE_ATTEMPTS})`
+          );
+          await Promise.resolve();
+        }
+      }
     }
+    throw lastError;
   }
 
   private setConnectionAcceptedResetEpoch(
@@ -1025,6 +1219,23 @@ export class PartyServer extends YServer {
     resetEpoch: number;
     closedConnections: number;
   }> {
+    return this.runDocumentWrite(() =>
+      this.restoreFromSnapshotNow(snapshotBase64, options)
+    );
+  }
+
+  private async restoreFromSnapshotNow(
+    snapshotBase64: string,
+    options?: {
+      bumpEpoch?: boolean;
+      allowQuarantined?: boolean;
+      connectionCloseReason?: string;
+    }
+  ): Promise<{
+    documentSize: number;
+    resetEpoch: number;
+    closedConnections: number;
+  }> {
     // Restoring an operator-supplied snapshot is the one write a quarantined
     // room legitimately accepts, because it is how an oversized document gets
     // repaired. Callers opt in explicitly so no other path inherits it.
@@ -1035,36 +1246,46 @@ export class PartyServer extends YServer {
     const roomId = this.name;
     console.log(`[Restore Snapshot] Starting for room: ${roomId}`);
 
-    // Lock autosave immediately
-    this.isSkippingSave = true;
+    this.documentWriteState = { kind: "reset", resetEpoch: null };
+    let databaseCommitted = false;
+    let resetCompleted = false;
 
     try {
       // Decode snapshot to Y.Doc so we can ensure metadata is present
       const snapshotDoc = new Y.Doc();
-      Y.applyUpdate(
-        snapshotDoc,
-        new Uint8Array(Buffer.from(snapshotBase64, "base64"))
-      );
+      let resetEpoch: number;
+      let updatedBase64: string;
+      try {
+        Y.applyUpdate(
+          snapshotDoc,
+          new Uint8Array(Buffer.from(snapshotBase64, "base64"))
+        );
 
-      const storedEpoch = await this.getResetEpoch();
-      const resetEpoch = resolveRoomResetEpoch({
-        snapshotEpoch: getDocResetEpoch(snapshotDoc),
-        storedEpoch,
-        bumpEpoch: Boolean(options?.bumpEpoch),
-        now: Date.now(),
-      });
-      setDocResetEpoch(snapshotDoc, resetEpoch);
+        const storedEpoch = await this.getResetEpoch();
+        resetEpoch = resolveRoomResetEpoch({
+          snapshotEpoch: getDocResetEpoch(snapshotDoc),
+          storedEpoch,
+          bumpEpoch: Boolean(options?.bumpEpoch),
+          now: Date.now(),
+        });
+        setDocResetEpoch(snapshotDoc, resetEpoch);
+        updatedBase64 = encodeDocToBase64(snapshotDoc);
+      } finally {
+        snapshotDoc.destroy();
+      }
+      this.documentWriteState = { kind: "reset", resetEpoch };
 
-      const updatedBase64 = encodeDocToBase64(snapshotDoc);
       const documentSize = updatedBase64.length;
+
+      await this.ctx.storage.put(STORAGE_KEYS.pendingDocumentReset, {
+        resetEpoch
+      } satisfies PendingDocumentReset);
 
       // Save to database
       console.log(`[Restore Snapshot] Saving snapshot to database...`);
       try {
-        await this.saveDocumentBase64(updatedBase64, {
-          operation: options?.allowQuarantined
-            ? "quarantine-repair"
-            : "reset",
+        await this.saveDocumentBase64Now(updatedBase64, {
+          operation: options?.allowQuarantined ? "quarantine-repair" : "reset"
         });
       } catch (saveError) {
         console.error(
@@ -1072,12 +1293,16 @@ export class PartyServer extends YServer {
           getErrorMessage(saveError),
           saveError
         );
-        throw new Error(`Failed to save snapshot: ${getErrorMessage(saveError)}`);
+        throw new Error(
+          `Failed to save snapshot: ${getErrorMessage(saveError)}`
+        );
       }
+      databaseCommitted = true;
+      this.documentWriteState = { kind: "recovery-required", resetEpoch };
       console.log(`[Restore Snapshot] Successfully saved snapshot to database`);
 
       // Set reset epoch for client detection
-      await this.setResetEpoch(resetEpoch);
+      await this.setResetEpochAfterDocumentCommit(resetEpoch);
       console.log(`[Restore Snapshot] Set resetEpoch: ${resetEpoch}`);
 
       // Broadcast a "room-reset" message to all connected clients
@@ -1103,6 +1328,8 @@ export class PartyServer extends YServer {
       replaceDocFromSnapshot(liveYDoc, updatedBase64);
       setDocResetEpoch(liveYDoc, resetEpoch);
       this.markDocumentHydrated();
+      await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+      resetCompleted = true;
       console.log(`[Restore Snapshot] Successfully reloaded live server`);
 
       console.log(
@@ -1127,8 +1354,22 @@ export class PartyServer extends YServer {
 
       throw error;
     } finally {
-      this.isSkippingSave = false;
-      console.log("[Restore Snapshot] Autosave re-enabled");
+      if (resetCompleted || !databaseCommitted) {
+        this.documentWriteState = { kind: "idle" };
+        if (!databaseCommitted) {
+          await this.ctx.storage.delete(STORAGE_KEYS.pendingDocumentReset);
+        }
+        console.log("[Restore Snapshot] Autosave re-enabled");
+      } else {
+        const writeState = this.getDocumentWriteState();
+        const pendingResetEpoch =
+          writeState.kind === "recovery-required"
+            ? writeState.resetEpoch
+            : "unknown";
+        console.error(
+          `[Restore Snapshot] Persistence remains paused for room=${roomId}: resetEpoch=${pendingResetEpoch} requires hydration recovery`
+        );
+      }
     }
   }
 
@@ -1137,9 +1378,49 @@ export class PartyServer extends YServer {
     resetEpoch: number;
     closedConnections: number;
   }> {
+    return this.runDocumentWrite(() => this.commitAdminPlayDataNow(playData));
+  }
+
+  private async commitAdminPlayDataNow(playData: Record<string, any>): Promise<{
+    documentSize: number;
+    resetEpoch: number;
+    closedConnections: number;
+  }> {
     const resetEpoch = await this.createResetEpoch();
     const snapshot = createAdminSnapshotFromPlayData(playData, resetEpoch);
-    return this.restoreFromSnapshot(snapshot.base64, { bumpEpoch: false });
+    return this.restoreFromSnapshotNow(snapshot.base64, { bumpEpoch: false });
+  }
+
+  async mutateAdminPlayData<T>(
+    mutate: (playData: Record<string, any>) => AdminPlayDataMutation<T>
+  ): Promise<AdminPlayDataMutationResult<T>> {
+    return this.runDocumentWrite(async () => {
+      const unavailable = this.getSharedDataWriteUnavailableResponse();
+      if (unavailable) {
+        throw new Error(
+          `Cannot mutate admin play data while room state is ${this.roomState()}`
+        );
+      }
+
+      this.documentWriteState = { kind: "maintenance" };
+      try {
+        const playData = docToJson(this.document) ?? {};
+        const mutation = mutate(playData);
+        if (mutation.kind === "skip") {
+          return { kind: "skipped", result: mutation.result };
+        }
+        const committed = await this.commitAdminPlayDataNow(playData);
+        return {
+          kind: "committed",
+          result: mutation.result,
+          ...committed
+        };
+      } finally {
+        if (this.getDocumentWriteState().kind === "maintenance") {
+          this.documentWriteState = { kind: "idle" };
+        }
+      }
+    });
   }
 
   // Ensure an alarm is set for bridge lease pruning or empty-room compaction.
@@ -1158,12 +1439,20 @@ export class PartyServer extends YServer {
     const now = Date.now();
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
-    const nextAlarm = getNextAlarmTime({
+    const maintenanceAlarm = getNextAlarmTime({
       compactAfter: await this.getEmptyRoomCompactAfter(),
       hasBridgeLeases: Boolean(subs.length || refs.length),
       now,
-      pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS,
+      pruneIntervalMs: DEFAULT_PRUNE_INTERVAL_MS
     });
+    const documentSaveRetry = await this.getDocumentSaveRetry();
+    const nextAlarm =
+      maintenanceAlarm === null
+        ? (documentSaveRetry?.retryAt ?? null)
+        : Math.min(
+            maintenanceAlarm,
+            documentSaveRetry?.retryAt ?? maintenanceAlarm
+          );
 
     if (nextAlarm === null) {
       await this.ctx.storage.deleteAlarm?.();
@@ -1843,10 +2132,11 @@ export class PartyServer extends YServer {
       }
     }
 
+    await this.reconcilePendingDocumentReset();
+
     const persistenceRecoveryPending =
-      (await this.ctx.storage.get(
-        STORAGE_KEYS.persistenceRecoveryPending
-      )) === true;
+      (await this.ctx.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
+      true;
 
     // Hydration completed without killing the isolate, so the failure history
     // and any pending backoff are cleared.
@@ -1870,6 +2160,7 @@ export class PartyServer extends YServer {
   }
 
   override async onSave(): Promise<void> {
+    this.attachPersistenceObserver();
     await this.persistLiveDocument({ allowCompaction: true });
   }
 
@@ -1990,13 +2281,21 @@ export class PartyServer extends YServer {
             `resetEpoch=${compactedDocument.resetEpoch}, ` +
             `activeConnections=${activeConnectionCount}, closed=${closedCount}`
         );
-      },
+      }
     });
     return true;
   }
 
   private async persistLiveDocument({
-    allowCompaction,
+    allowCompaction
+  }: PersistLiveDocumentOptions): Promise<boolean> {
+    return this.runDocumentWrite(() =>
+      this.persistLiveDocumentNow({ allowCompaction })
+    );
+  }
+
+  private async persistLiveDocumentNow({
+    allowCompaction
   }: PersistLiveDocumentOptions): Promise<boolean> {
     const doc = this.document;
 
@@ -2042,6 +2341,7 @@ export class PartyServer extends YServer {
     // or an admin edit), which creates a reset boundary.
     const documentBase64 = encodeDocToBase64(doc);
     const documentSize = documentBase64.length;
+    const saveGeneration = this.documentGeneration ?? 0;
     const activeConnectionCount = this.getOpenConnectionCount();
 
     this.lastKnownDocumentBytes = documentSize;
@@ -2103,18 +2403,25 @@ export class PartyServer extends YServer {
           `[PartyServer] AUTOSAVE COMPACTION FAILED for room ${this.name}:`,
           error
         );
-        return false;
+        // Compaction is an optimization. A failed compaction must never turn
+        // into a failed save of otherwise valid live data.
       }
     }
 
     try {
-      await this.saveDocumentBase64(documentBase64);
+      await this.saveDocumentBase64Now(documentBase64);
     } catch (error) {
       console.error(
         `[PartyServer] SUPABASE AUTOSAVE FAILED for room ${this.name}:`,
         error
       );
+      await this.scheduleDocumentSaveRetry();
       return false;
+    }
+    if ((this.documentGeneration ?? 0) === saveGeneration) {
+      await this.clearDocumentSaveRetry();
+    } else {
+      await this.scheduleDocumentSaveRetry();
     }
     if (allowCompaction && activeConnectionCount > 0) {
       const compacted = await this.maybeCompactLargeConnectedRoom({
@@ -2555,6 +2862,15 @@ export class PartyServer extends YServer {
     resetEpoch: number;
     closedConnections: number;
   }> {
+    return this.runDocumentWrite(() => this.performHardResetNow());
+  }
+
+  private async performHardResetNow(): Promise<{
+    beforeSize: number;
+    afterSize: number;
+    resetEpoch: number;
+    closedConnections: number;
+  }> {
     // A hard reset derives its new document from the live doc, which is empty
     // for a quarantined room, and falls back to re-reading the persisted one.
     // Both outcomes are exactly what quarantine exists to prevent.
@@ -2562,9 +2878,6 @@ export class PartyServer extends YServer {
 
     const roomId = this.name;
     console.log(`[Hard Reset] Starting for room: ${roomId}`);
-
-    // Lock autosave immediately
-    this.isSkippingSave = true;
 
     try {
       // Get current live doc state
@@ -2672,43 +2985,10 @@ export class PartyServer extends YServer {
       // Release it before the database write and live-document replacement.
       currentPlayData = null;
 
-      // Save to database
-      console.log(`[Hard Reset] Saving fresh doc to database...`);
-      try {
-        await this.saveDocumentBase64(freshBase64, { operation: "reset" });
-      } catch (saveError) {
-        console.error(
-          `[Hard Reset] Database save failed:`,
-          getErrorMessage(saveError),
-          saveError
-        );
-        throw new Error(
-          `Failed to save reset document: ${getErrorMessage(saveError)}`
-        );
-      }
-      console.log(`[Hard Reset] Successfully saved fresh doc to database`);
-
-      // Set reset epoch for client detection
-      await this.setResetEpoch(resetEpoch);
-      console.log(`[Hard Reset] Set resetEpoch: ${resetEpoch}`);
-
-      // Broadcast a "room-reset" message to all connected clients
-      this.broadcastCustomMessage(this.getRoomResetMessage(resetEpoch));
-      console.log(`[Hard Reset] Broadcasted room-reset signal to all clients`);
-
-      // FORCE DISCONNECT: Close all connections to ensure no lingering clients
-      // push their old state back to the server
-      const closedCount = this.closeConnections("Room Reset by Admin");
-      console.log(`[Hard Reset] Closed ${closedCount} connections`);
-
-      // Flush disconnect work before installing the authoritative snapshot.
-      await Promise.resolve();
-
-      // Reload the live server from the snapshot
-      console.log(`[Hard Reset] Reloading live server from snapshot...`);
-      replaceDocFromSnapshot(liveYDoc, freshBase64);
-      setDocResetEpoch(liveYDoc, resetEpoch);
-      console.log(`[Hard Reset] Successfully reloaded live server`);
+      const restored = await this.restoreFromSnapshotNow(freshBase64, {
+        bumpEpoch: false,
+        connectionCloseReason: "Room Reset by Admin"
+      });
 
       const sizeReduction = beforeSize - afterSize;
       const sizeReductionPercent = ((sizeReduction / beforeSize) * 100).toFixed(
@@ -2722,8 +3002,8 @@ export class PartyServer extends YServer {
       return {
         beforeSize,
         afterSize,
-        resetEpoch,
-        closedConnections: closedCount,
+        resetEpoch: restored.resetEpoch,
+        closedConnections: restored.closedConnections
       };
     } catch (error: unknown) {
       const errorMessage =
@@ -2737,9 +3017,6 @@ export class PartyServer extends YServer {
       );
 
       throw error;
-    } finally {
-      this.isSkippingSave = false;
-      console.log("[Hard Reset] Autosave re-enabled");
     }
   }
 
@@ -2799,7 +3076,8 @@ export class PartyServer extends YServer {
       await this.runAutomaticCompaction({
         onDeferred: (retryAt) => this.setEmptyRoomCompactAfter(retryAt),
         onDisabled: () => this.clearEmptyRoomCompactAfter(),
-        run: () => this.compactEmptyRoomDocumentOnce(),
+        run: () =>
+          this.runDocumentWrite(() => this.compactEmptyRoomDocumentOnce())
       });
     };
 
@@ -2842,6 +3120,18 @@ export class PartyServer extends YServer {
     if (!(await this.circuitBreaker.shouldRunAlarm())) return;
 
     try {
+      const documentSaveRetry = await this.getDocumentSaveRetry();
+      if (
+        documentSaveRetry !== null &&
+        documentSaveRetry.retryAt <= Date.now()
+      ) {
+        if (this.roomState() === "ready") {
+          await this.persistLiveDocument({ allowCompaction: false });
+        } else {
+          await this.scheduleDocumentSaveRetry();
+        }
+      }
+
       const compactAfter = await this.getEmptyRoomCompactAfter();
       if (compactAfter !== null && compactAfter <= Date.now()) {
         if (this.getOpenConnectionCount() === 0) {

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -1481,7 +1481,6 @@ export class PartyServer extends YServer {
     const subs = await this.getSubscribers();
     const refs = await this.getSharedReferences();
     const maintenanceAlarm = getNextAlarmTime({
-    const maintenanceAlarm = getNextAlarmTime({
       compactAfter: await this.getEmptyRoomCompactAfter(),
       hasBridgeLeases: Boolean(subs.length || refs.length),
       now,

--- a/partykit/request.ts
+++ b/partykit/request.ts
@@ -15,15 +15,15 @@ export interface ExportPermissionsRequest {
 
 export interface ApplySubtreesImmediateRequest {
   action: "apply-subtrees-immediate";
-  subtrees: Record<string, Record<string, any>>;
+  subtrees: Record<string, Record<string, unknown>>;
   sender: string;
   originKind: "consumer" | "source";
   resetEpoch?: number | null;
 }
 
-export type PartyKitRequest = 
-  | SubscribeRequest 
-  | ExportPermissionsRequest 
+export type PartyKitRequest =
+  | SubscribeRequest
+  | ExportPermissionsRequest
   | ApplySubtreesImmediateRequest;
 
 export interface SubscribeResponse {
@@ -31,7 +31,7 @@ export interface SubscribeResponse {
   subscribed: true;
   elementIds: string[];
   sourceResetEpoch?: number | null;
-  subtrees?: Record<string, Record<string, any>>;
+  subtrees?: Record<string, Record<string, unknown>>;
 }
 
 export interface ExportPermissionsResponse {
@@ -52,19 +52,52 @@ export interface GenericErrorResponse {
   error: string;
 }
 
-export function isSubscribeRequest(body: any): body is SubscribeRequest {
-  return body?.action === "subscribe" && typeof body?.consumerRoomId === "string";
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
-export function isExportPermissionsRequest(body: any): body is ExportPermissionsRequest {
-  return body?.action === "export-permissions" && Array.isArray(body?.elementIds);
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
-export function isApplySubtreesImmediateRequest(body: any): body is ApplySubtreesImmediateRequest {
+function isOptionalResetEpoch(value: unknown): boolean {
   return (
-    body?.action === "apply-subtrees-immediate" &&
-    typeof body?.subtrees === "object" &&
-    typeof body?.sender === "string" &&
-    (body?.originKind === "consumer" || body?.originKind === "source")
+    value === undefined ||
+    value === null ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+export function isSubscribeRequest(body: unknown): body is SubscribeRequest {
+  return (
+    isRecord(body) &&
+    body.action === "subscribe" &&
+    typeof body.consumerRoomId === "string" &&
+    (body.elementIds === undefined || isStringArray(body.elementIds)) &&
+    isOptionalResetEpoch(body.consumerResetEpoch)
+  );
+}
+
+export function isExportPermissionsRequest(
+  body: unknown
+): body is ExportPermissionsRequest {
+  return (
+    isRecord(body) &&
+    body.action === "export-permissions" &&
+    isStringArray(body.elementIds)
+  );
+}
+
+export function isApplySubtreesImmediateRequest(
+  body: unknown
+): body is ApplySubtreesImmediateRequest {
+  return (
+    isRecord(body) &&
+    body.action === "apply-subtrees-immediate" &&
+    isRecord(body.subtrees) &&
+    Object.values(body.subtrees).every(isRecord) &&
+    typeof body.sender === "string" &&
+    (body.originKind === "consumer" || body.originKind === "source") &&
+    isOptionalResetEpoch(body.resetEpoch)
   );
 }

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -575,6 +575,17 @@ export class RoomCircuitBreaker {
     );
   }
 
+  /** Provider outages stay transient for clients while the alarm waits to retry. */
+  async getClientLoadDeferredResponse(): Promise<Response | null> {
+    if ((await this.getFailureCount("load")) === 0) {
+      const retryAfter = await this.getFailureRetryAfter("load");
+      if (retryAfter !== null && !isRetryDue({ retryAfter, now: Date.now() })) {
+        return null;
+      }
+    }
+    return this.getLoadDeferredResponse();
+  }
+
   private async attemptDeferredReload(): Promise<boolean> {
     if (this.inFlightReload) return this.inFlightReload;
 

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -157,46 +157,9 @@ export class RoomCircuitBreaker {
     return typeof value === "number" ? value : null;
   }
 
-  async getPersistenceRecoveryRetryAfter(): Promise<number | null> {
-    const value = await this.storage.get(
-      STORAGE_KEYS.persistenceRecoveryRetryAfter
-    );
-    return typeof value === "number" ? value : null;
-  }
-
-  async isPersistenceRecoveryDue(): Promise<boolean> {
-    const retryAfter = await this.getPersistenceRecoveryRetryAfter();
-    if (retryAfter === null) return false;
-    return isRetryDue({
-      retryAfter,
-      now: Date.now(),
-    });
-  }
-
   private async requestPersistenceRecovery(): Promise<void> {
     await this.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
-    await this.storage.put(STORAGE_KEYS.persistenceRecoveryRetryAfter, Date.now());
-  }
-
-  async schedulePersistenceRecovery(): Promise<number> {
-    const storedAttempts = await this.storage.get(
-      STORAGE_KEYS.persistenceRecoveryAttempts
-    );
-    const attempts = typeof storedAttempts === "number" ? storedAttempts + 1 : 1;
-    const retryAt = getFailureRetryAt({
-      failureCount: attempts,
-      baseMs: this.getFailureBackoffBaseMs(),
-      maxMs: this.getFailureBackoffMaxMs(),
-      now: Date.now(),
-    });
-    await this.storage.put(STORAGE_KEYS.persistenceRecoveryAttempts, attempts);
-    await this.storage.put(STORAGE_KEYS.persistenceRecoveryRetryAfter, retryAt);
-    return retryAt;
-  }
-
-  async completePersistenceRecovery(): Promise<void> {
-    await this.storage.delete(STORAGE_KEYS.persistenceRecoveryAttempts);
-    await this.storage.delete(STORAGE_KEYS.persistenceRecoveryRetryAfter);
+    await this.storage.put(STORAGE_KEYS.loadRetryAfter, Date.now());
   }
 
   async getCompactionFailureCount(): Promise<number> {
@@ -327,17 +290,6 @@ export class RoomCircuitBreaker {
     await this.storage.delete(this.retryKeyFor(kind));
   }
 
-  async releaseLoadAttempt(loadAttempts: number): Promise<void> {
-    const remaining = loadAttempts - 1;
-    if (remaining <= 0) {
-      await this.completeRiskyOperation("load");
-      return;
-    }
-
-    await this.storage.put(STORAGE_KEYS.quarantineLoadAttempts, remaining);
-    await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
-  }
-
   private async handleRepeatedFailures({
     kind,
     failureCount,
@@ -380,17 +332,20 @@ export class RoomCircuitBreaker {
     return { quarantined: false, retryAt };
   }
 
+  async deferFailedLoad(failureCount: number): Promise<void> {
+    const result = await this.handleRepeatedFailures({
+      kind: "load",
+      failureCount,
+    });
+    this.loadDeferredUntil = result.quarantined ? null : result.retryAt;
+  }
+
   async shouldDeferLoad(): Promise<boolean> {
     const previousFailures = await this.getFailureCount("load");
     if (previousFailures === 0) return false;
 
-    const recoveryPending =
-      (await this.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
-      true;
-
     const failureThreshold = this.getFailureThreshold();
     if (
-      !recoveryPending &&
       shouldQuarantineForFailures({
         failureCount: previousFailures,
         failureThreshold,
@@ -611,12 +566,7 @@ export class RoomCircuitBreaker {
       try {
         const previousFailures = await this.getFailureCount("load");
         const failureThreshold = this.getFailureThreshold();
-        const recoveryPending =
-          (await this.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
-          true;
-
         if (
-          !recoveryPending &&
           shouldQuarantineForFailures({
             failureCount: previousFailures,
             failureThreshold,
@@ -716,7 +666,6 @@ export class RoomCircuitBreaker {
       await this.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
       await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
       await this.storage.delete(STORAGE_KEYS.persistenceRecoveryPending);
-      await this.completePersistenceRecovery();
     }
     await this.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
     await this.storage.delete(STORAGE_KEYS.alarmRetryAfter);

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -358,7 +358,13 @@ export class RoomCircuitBreaker {
 
   async shouldDeferLoad(): Promise<boolean> {
     const previousFailures = await this.getFailureCount("load");
-    if (previousFailures === 0) return false;
+    if (previousFailures === 0) {
+      const retryAfter = await this.getFailureRetryAfter("load");
+      if (retryAfter !== null && !isRetryDue({ retryAfter, now: Date.now() })) {
+        this.loadDeferredUntil = retryAfter;
+      }
+      return false;
+    }
 
     const failureThreshold = this.getFailureThreshold();
     if (

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -340,6 +340,22 @@ export class RoomCircuitBreaker {
     this.loadDeferredUntil = result.quarantined ? null : result.retryAt;
   }
 
+  /**
+   * A returned load error proves the isolate survived, so it is not evidence
+   * of the vanished work this circuit breaker quarantines.
+   */
+  async deferObservedLoadFailure(): Promise<void> {
+    await this.completeRiskyOperation("load");
+    const retryAt = getFailureRetryAt({
+      failureCount: 1,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.storage.put(STORAGE_KEYS.loadRetryAfter, retryAt);
+    this.loadDeferredUntil = retryAt;
+  }
+
   async shouldDeferLoad(): Promise<boolean> {
     const previousFailures = await this.getFailureCount("load");
     if (previousFailures === 0) return false;

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -46,6 +46,7 @@ type RoomCircuitBreakerOptions = {
   reloadRoom: () => Promise<boolean>;
   prepareGuardedReload: () => void;
   clearCompactionSchedule: () => Promise<void>;
+  scheduleRoomWork: () => Promise<void>;
 };
 
 export type EnterQuarantineOptions = {
@@ -719,6 +720,7 @@ export class RoomCircuitBreaker {
     }
     await this.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
     await this.storage.delete(STORAGE_KEYS.alarmRetryAfter);
+    await this.options.scheduleRoomWork();
     console.log(
       `[PartyServer] Quarantine cleared for room=${this.roomName}: ` +
         `wasQuarantined=${summary.wasQuarantined}, ` +

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -156,6 +156,48 @@ export class RoomCircuitBreaker {
     return typeof value === "number" ? value : null;
   }
 
+  async getPersistenceRecoveryRetryAfter(): Promise<number | null> {
+    const value = await this.storage.get(
+      STORAGE_KEYS.persistenceRecoveryRetryAfter
+    );
+    return typeof value === "number" ? value : null;
+  }
+
+  async isPersistenceRecoveryDue(): Promise<boolean> {
+    const retryAfter = await this.getPersistenceRecoveryRetryAfter();
+    if (retryAfter === null) return false;
+    return isRetryDue({
+      retryAfter,
+      now: Date.now(),
+    });
+  }
+
+  private async requestPersistenceRecovery(): Promise<void> {
+    await this.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
+    await this.storage.put(STORAGE_KEYS.persistenceRecoveryRetryAfter, Date.now());
+  }
+
+  async schedulePersistenceRecovery(): Promise<number> {
+    const storedAttempts = await this.storage.get(
+      STORAGE_KEYS.persistenceRecoveryAttempts
+    );
+    const attempts = typeof storedAttempts === "number" ? storedAttempts + 1 : 1;
+    const retryAt = getFailureRetryAt({
+      failureCount: attempts,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+    await this.storage.put(STORAGE_KEYS.persistenceRecoveryAttempts, attempts);
+    await this.storage.put(STORAGE_KEYS.persistenceRecoveryRetryAfter, retryAt);
+    return retryAt;
+  }
+
+  async completePersistenceRecovery(): Promise<void> {
+    await this.storage.delete(STORAGE_KEYS.persistenceRecoveryAttempts);
+    await this.storage.delete(STORAGE_KEYS.persistenceRecoveryRetryAfter);
+  }
+
   async getCompactionFailureCount(): Promise<number> {
     const value = await this.storage.get(STORAGE_KEYS.compactionAttempts);
     return typeof value === "number" ? value : 0;
@@ -341,8 +383,13 @@ export class RoomCircuitBreaker {
     const previousFailures = await this.getFailureCount("load");
     if (previousFailures === 0) return false;
 
+    const recoveryPending =
+      (await this.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
+      true;
+
     const failureThreshold = this.getFailureThreshold();
     if (
+      !recoveryPending &&
       shouldQuarantineForFailures({
         failureCount: previousFailures,
         failureThreshold,
@@ -563,8 +610,12 @@ export class RoomCircuitBreaker {
       try {
         const previousFailures = await this.getFailureCount("load");
         const failureThreshold = this.getFailureThreshold();
+        const recoveryPending =
+          (await this.storage.get(STORAGE_KEYS.persistenceRecoveryPending)) ===
+          true;
 
         if (
+          !recoveryPending &&
           shouldQuarantineForFailures({
             failureCount: previousFailures,
             failureThreshold,
@@ -638,7 +689,9 @@ export class RoomCircuitBreaker {
     );
   }
 
-  async clearQuarantine(): Promise<QuarantineResetSummary> {
+  async clearQuarantine(options?: {
+    recoveryCompleted?: boolean;
+  }): Promise<QuarantineResetSummary> {
     const summary = {
       wasQuarantined: this.quarantine !== null,
       loadFailures: await this.getFailureCount("load"),
@@ -646,7 +699,8 @@ export class RoomCircuitBreaker {
       wasLoadDeferred: this.loadDeferredUntil !== null,
     };
     const needsGuardedReload =
-      summary.wasQuarantined || summary.wasLoadDeferred;
+      !options?.recoveryCompleted &&
+      (summary.wasQuarantined || summary.wasLoadDeferred);
 
     await this.writeExternalQuarantineFlag(null);
 
@@ -655,14 +709,20 @@ export class RoomCircuitBreaker {
     this.options.prepareGuardedReload();
     this.loadDeferredUntil = needsGuardedReload ? Date.now() : null;
     await this.storage.delete(STORAGE_KEYS.quarantine);
-    await this.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+    if (needsGuardedReload) {
+      await this.requestPersistenceRecovery();
+    } else {
+      await this.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+      await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
+      await this.storage.delete(STORAGE_KEYS.persistenceRecoveryPending);
+      await this.completePersistenceRecovery();
+    }
     await this.storage.delete(STORAGE_KEYS.alarmFailureAttempts);
-    await this.storage.delete(STORAGE_KEYS.loadRetryAfter);
     await this.storage.delete(STORAGE_KEYS.alarmRetryAfter);
     console.log(
       `[PartyServer] Quarantine cleared for room=${this.roomName}: ` +
         `wasQuarantined=${summary.wasQuarantined}, ` +
-        `loadFailuresReset=${summary.loadFailures}, ` +
+        `loadFailures=${summary.loadFailures}, ` +
         `alarmFailuresReset=${summary.alarmFailures}, ` +
         `wasLoadDeferred=${summary.wasLoadDeferred}, ` +
         `recoveryPending=${needsGuardedReload}.`

--- a/partykit/worker-configuration.d.ts
+++ b/partykit/worker-configuration.d.ts
@@ -12,6 +12,7 @@ declare namespace Cloudflare {
     SUPABASE_URL: string;
     SUPABASE_KEY: string;
     ADMIN_TOKEN: string;
+    PARTYKIT_BRIDGE_SECRET: string;
     Main: DurableObjectNamespace<import("./partykit/party").PartyServer>;
     Presence: DurableObjectNamespace<import("./partykit/party").PresenceServer>;
   }
@@ -20,6 +21,7 @@ declare namespace Cloudflare {
     SUPABASE_URL: string;
     SUPABASE_KEY: string;
     ADMIN_TOKEN: string;
+    PARTYKIT_BRIDGE_SECRET: string;
     Main: DurableObjectNamespace<import("./partykit/party").PartyServer>;
     Presence: DurableObjectNamespace<import("./partykit/party").PresenceServer>;
   }

--- a/partykit/wrangler.jsonc
+++ b/partykit/wrangler.jsonc
@@ -19,7 +19,12 @@
     }
   },
   "secrets": {
-    "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
+    "required": [
+      "SUPABASE_URL",
+      "SUPABASE_KEY",
+      "ADMIN_TOKEN",
+      "PARTYKIT_BRIDGE_SECRET"
+    ]
   },
   // Operator control plane for room quarantine. Read before hydration, so a room
   // that crashes on start can still be taken out of service.
@@ -70,7 +75,12 @@
         }
       },
       "secrets": {
-        "required": ["SUPABASE_URL", "SUPABASE_KEY", "ADMIN_TOKEN"]
+        "required": [
+          "SUPABASE_URL",
+          "SUPABASE_KEY",
+          "ADMIN_TOKEN",
+          "PARTYKIT_BRIDGE_SECRET"
+        ]
       },
       "kv_namespaces": [
         {

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -53,7 +53,8 @@ SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:stale-compaction
 # Verifies connected-room high-watermark compaction.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:emergency
 
-# Verifies local realtime sync and awareness when Supabase startup load fails.
+# Verifies awareness continues while shared-data and admin writes stay blocked
+# when Supabase startup load fails.
 SUPABASE_URL=http://127.0.0.1:9 SUPABASE_KEY=bad ADMIN_TOKEN=dev \
   bunx wrangler dev --config partykit/wrangler.jsonc --port 1999 \
   --var SUPABASE_LOAD_TIMEOUT_MS:100

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -34,6 +34,9 @@ They are manual because they take several minutes, wait for real Durable Object
 alarms, and need staging secrets.
 
 ```bash
+# Verifies authenticated source-to-consumer and consumer-to-source bridge sync.
+bun smoke:partykit:bridge
+
 # Verifies bridge observers reattach after Durable Object hibernation.
 bun smoke:partykit:hibernation
 

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -7,6 +7,7 @@
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:partykit": "bun run test:partykit:hibernation && bun run test:partykit:compaction",
+    "test:partykit:bridge": "node partykit/bridge-integration-smoke.mjs",
     "test:partykit:limits": "node partykit/server-limits-smoke.mjs",
     "test:partykit:hibernation": "node partykit/hibernation-bridge-smoke.mjs",
     "test:partykit:compaction": "node partykit/empty-room-compaction-smoke.mjs",

--- a/smoke-tests/partykit/bridge-integration-smoke.mjs
+++ b/smoke-tests/partykit/bridge-integration-smoke.mjs
@@ -1,0 +1,116 @@
+// ABOUTME: Exercises authenticated shared-element bridge traffic on a deployed Worker.
+// ABOUTME: Verifies both sync directions and rejects forged public bridge requests.
+import {
+  Y,
+  connectRoom,
+  createStore,
+  deriveRoomId,
+  getHost,
+  getPartyHttpUrl,
+  sleep,
+  waitForSync,
+} from "./shared.mjs";
+
+const host = getHost();
+const domain =
+  process.env.PARTYKIT_SMOKE_DOMAIN ?? "codex-bridge-integration.test";
+const stamp = Date.now();
+const elementId = "shared";
+const sourcePath = `/source-${stamp}`;
+const consumerPath = `/consumer-${stamp}`;
+const sourceRoom = deriveRoomId(domain, sourcePath);
+const consumerRoom = deriveRoomId(domain, consumerPath);
+
+function setSharedPosition(store, x) {
+  if (!store.play.canMove) {
+    store.play.canMove = {};
+  }
+  store.play.canMove[elementId] = { x, y: 1 };
+}
+
+function readSharedPosition(store) {
+  return store.play.canMove?.[elementId] ?? null;
+}
+
+async function waitForPosition(store, expectedX, label, timeoutMs = 20_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const position = readSharedPosition(store);
+    if (position?.x === expectedX) {
+      console.log(`${label}: observed x=${expectedX}`);
+      return;
+    }
+    await sleep(100);
+  }
+
+  throw new Error(
+    `${label} did not observe x=${expectedX}; last=${JSON.stringify(
+      readSharedPosition(store),
+    )}`,
+  );
+}
+
+async function expectRejectedBridgeRequest(headers, expectedStatus, label) {
+  const response = await fetch(getPartyHttpUrl(host, sourceRoom), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      action: "subscribe",
+      consumerRoomId: "forged-consumer",
+      elementIds: [elementId],
+    }),
+  });
+
+  if (response.status !== expectedStatus) {
+    throw new Error(
+      `${label} returned ${response.status}; expected ${expectedStatus}`,
+    );
+  }
+  console.log(`${label}: rejected with ${response.status}`);
+}
+
+const sourceDoc = new Y.Doc();
+const consumerDoc = new Y.Doc();
+const sourceStore = createStore(sourceDoc);
+const consumerStore = createStore(consumerDoc);
+const sourceProvider = connectRoom(host, sourceRoom, sourceDoc, {
+  sharedElements: JSON.stringify([{ elementId, permissions: "read-write" }]),
+});
+let consumerProvider;
+
+try {
+  await waitForSync(sourceProvider, "source");
+  setSharedPosition(sourceStore, 1);
+
+  consumerProvider = connectRoom(host, consumerRoom, consumerDoc, {
+    sharedReferences: JSON.stringify([{ domain, path: sourcePath, elementId }]),
+  });
+  await waitForSync(consumerProvider, "consumer");
+  await waitForPosition(consumerStore, 1, "source-to-consumer hydration");
+
+  await expectRejectedBridgeRequest({}, 401, "missing bridge credential");
+  await expectRejectedBridgeRequest(
+    { "x-playhtml-bridge-secret": "invalid-staging-smoke-secret" },
+    403,
+    "wrong bridge credential",
+  );
+
+  setSharedPosition(consumerStore, 2);
+  await waitForPosition(sourceStore, 2, "consumer-to-source update");
+
+  setSharedPosition(sourceStore, 3);
+  await waitForPosition(consumerStore, 3, "source-to-consumer update");
+} finally {
+  consumerProvider?.destroy();
+  sourceProvider.destroy();
+  consumerDoc.destroy();
+  sourceDoc.destroy();
+}
+
+console.log(`host=${host}`);
+console.log(`sourceRoom=${sourceRoom}`);
+console.log(`consumerRoom=${consumerRoom}`);
+console.log("bridge integration smoke passed");

--- a/smoke-tests/partykit/stale-compaction-source-smoke.mjs
+++ b/smoke-tests/partykit/stale-compaction-source-smoke.mjs
@@ -21,18 +21,22 @@ const supabaseKey = process.env.SUPABASE_KEY;
 const room = `codex-stale-compaction-source-${Date.now()}`;
 const compactDelayMs = getNumberEnv(
   "PARTYKIT_EMPTY_ROOM_COMPACT_DELAY_MS",
-  5 * 60 * 1000
+  5 * 60 * 1000,
 );
 const settleMs = getNumberEnv("PARTYKIT_STALE_COMPACTION_SETTLE_MS", 20_000);
+const autosaveSettleMs = getNumberEnv(
+  "PARTYKIT_STALE_SOURCE_AUTOSAVE_SETTLE_MS",
+  3_000,
+);
 
 if (!adminToken) {
   throw new Error(
-    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file."
+    "ADMIN_TOKEN is required. Set ADMIN_TOKEN or SMOKE_ENV_FILE to a .dev.vars/.env file.",
   );
 }
 if (!supabaseUrl || !supabaseKey) {
   throw new Error(
-    "SUPABASE_URL and SUPABASE_KEY are required for direct documents-row setup."
+    "SUPABASE_URL and SUPABASE_KEY are required for direct documents-row setup.",
   );
 }
 
@@ -107,11 +111,11 @@ async function writePersistedDocument(base64Document) {
         Prefer: "return=minimal",
       },
       body: JSON.stringify({ document: base64Document }),
-    }
+    },
   );
   if (!response.ok) {
     throw new Error(
-      `direct documents update failed ${response.status}: ${await response.text()}`
+      `direct documents update failed ${response.status}: ${await response.text()}`,
     );
   }
 }
@@ -135,6 +139,17 @@ try {
   await adminJson("force-save-live", { method: "POST" });
   console.log("saved stale live source as the initial row");
 
+  await sleep(autosaveSettleMs);
+  const settledSource = await adminJson("live-compare");
+  const settledDirectLabel = getAttendanceLabel(
+    settledSource.methods.direct.data,
+  );
+  if (settledDirectLabel !== "stale-live-source") {
+    throw new Error(
+      `expected pending autosave to settle on stale-live-source, got ${settledDirectLabel}`,
+    );
+  }
+
   await writePersistedDocument(buildPersistedGoodDocument());
   console.log("replaced persisted row with newer database data");
 
@@ -152,24 +167,24 @@ try {
   const before = await inspectRoom();
   provider.destroy();
   console.log(
-    `waiting ${compactDelayMs / 1000}s for empty-room compaction alarm`
+    `waiting ${compactDelayMs / 1000}s for empty-room compaction alarm`,
   );
   await sleep(compactDelayMs + settleMs);
 
   const after = await inspectRoom();
   const afterLabel = getAttendanceLabel(after.ydoc.play);
   console.log(
-    `after compaction window: db=${afterLabel}, resetEpoch=${after.resetEpoch}`
+    `after compaction window: db=${afterLabel}, resetEpoch=${after.resetEpoch}`,
   );
 
   if (afterLabel !== "persisted-good") {
     throw new Error(
-      `expected persisted data to survive compaction, got ${afterLabel}`
+      `expected persisted data to survive compaction, got ${afterLabel}`,
     );
   }
   if (after.resetEpoch !== before.resetEpoch) {
     throw new Error(
-      `expected resetEpoch to remain ${before.resetEpoch}, got ${after.resetEpoch}`
+      `expected resetEpoch to remain ${before.resetEpoch}, got ${after.resetEpoch}`,
     );
   }
 

--- a/smoke-tests/partykit/supabase-transient-smoke.mjs
+++ b/smoke-tests/partykit/supabase-transient-smoke.mjs
@@ -1,12 +1,6 @@
 // ABOUTME: Smoke tests PartyKit startup when Supabase persistence is unavailable.
-// ABOUTME: Verifies realtime document sync and awareness continue in transient mode.
-import {
-  Y,
-  connectRoom,
-  getHost,
-  sleep,
-  waitForSync,
-} from "./shared.mjs";
+// ABOUTME: Verifies awareness continues while shared-data writes remain blocked.
+import { Y, connectRoom, getHost, sleep, waitForSync } from "./shared.mjs";
 
 function waitForCondition(label, predicate, timeoutMs = 20_000) {
   return new Promise((resolve, reject) => {
@@ -34,9 +28,10 @@ function waitForCondition(label, predicate, timeoutMs = 20_000) {
 
 const host = getHost();
 const room = `transient-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-const protocol = host.startsWith("localhost:") || host.startsWith("127.0.0.1:")
-  ? "http"
-  : "https";
+const protocol =
+  host.startsWith("localhost:") || host.startsWith("127.0.0.1:")
+    ? "http"
+    : "https";
 
 const docA = new Y.Doc();
 const docB = new Y.Doc();
@@ -56,27 +51,31 @@ try {
   });
 
   await waitForCondition("awareness propagation", () => {
-    return Array.from(providerB.awareness.getStates().values()).some((state) => {
-      return state?.transientSmoke?.client === "A";
-    });
+    return Array.from(providerB.awareness.getStates().values()).some(
+      (state) => {
+        return state?.transientSmoke?.client === "A";
+      },
+    );
   });
   console.log("awareness propagated while persistence was unavailable");
 
   docA.getMap("transient-smoke").set("message", "live while transient");
-
-  await waitForCondition("document propagation", () => {
-    return (
-      docB.getMap("transient-smoke").get("message") === "live while transient"
+  await sleep(500);
+  if (docB.getMap("transient-smoke").has("message")) {
+    throw new Error(
+      "expected transient shared-data write to remain blocked from peers",
     );
-  });
-  console.log("document update propagated while persistence was unavailable");
+  }
+  console.log(
+    "shared-data writes stayed blocked while persistence was unavailable",
+  );
 
   const adminResponse = await fetch(
     `${protocol}://${host}/parties/main/${encodeURIComponent(room)}/admin/force-save-live`,
     {
       method: "POST",
       headers: { Authorization: "Bearer dev" },
-    }
+    },
   );
   const adminBody = await adminResponse.json();
   if (
@@ -84,7 +83,7 @@ try {
     adminBody.error !== "persistence_unavailable"
   ) {
     throw new Error(
-      `expected transient admin write to return 503, got ${adminResponse.status}: ${JSON.stringify(adminBody)}`
+      `expected transient admin write to return 503, got ${adminResponse.status}: ${JSON.stringify(adminBody)}`,
     );
   }
   console.log("admin writes are blocked while persistence is unavailable");


### PR DESCRIPTION
## Summary

- serialize document saves, restores, compaction, transient recovery, and bridge applies behind one room write boundary
- keep shared-data writes paused until authoritative persistence recovery completes, then reset connected clients onto the recovered snapshot
- authenticate cross-room bridge requests and preserve queued bridge updates across maintenance
- add regression coverage and real bridge, transient, stale-source, destroy/reconnect, and compaction smoke tests

## Why

A stale or concurrent write could race an authoritative restore or compaction and overwrite recovered room data. The room now admits persistence-changing operations through one state machine and durable recovery path, including restart and alarm recovery cases.

## Verification

Local:
- bun test partykit/__tests__/*.test.ts: 274 pass, 0 fail, 1397 expectations
- bun run check:partykit
- Prettier and git diff --check

Real staging matrix:
- authenticated bridge hydration and bidirectional updates; missing token 401, wrong token 403
- server request/rate limits and sustained normal traffic
- 8-client keyed-write soak: 1,600 upserts, 8 converged records, bounded Yjs history
- 20-client presence soak at 60 Hz for 20 seconds
- live bridge hibernation and provider destroy/reconnect after 90 seconds
- empty-room compaction after the full 5-minute alarm, stale-client reset rejection, fresh reconnect, and second-window no-op
- stale live compaction source versus newer persisted snapshot after the full 5-minute alarm
- local Supabase-unavailable transient mode: awareness remains live; shared-data and admin writes remain blocked
- connected-room emergency compaction with a temporary staging threshold: active client reset/disconnect, state preserved, fresh reconnect
- restored standard staging deployment and reran the authenticated bridge integration smoke

Final standard staging version: 20322937-9f07-49cf-92cc-edbf285c1dd3. The only active staging quarantine is the pre-existing drill fixture drill-oom-mega; no matrix room was quarantined. Production was not changed.

No changeset, public docs, starter-template update, or screenshot is needed because this changes the internal PartyKit persistence runtime and smoke tooling, not a published package API or user-facing UI.