### PR TITLE
Host Slow Mode rides on synchronized trains

### DIFF
--- a/.changeset/slow-trains-arrive.md
+++ b/.changeset/slow-trains-arrive.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/extension-types": minor
+---
+
+Add the synchronized Internet Commute train assignment contract so the extension, hosted page, and Worker can share bounded train routes without exposing exact Slow Mode destination URLs.

--- a/bun.lock
+++ b/bun.lock
@@ -154,7 +154,7 @@
         "@types/react": "^18.3.17",
         "miniflare": "^4.20260409.0",
         "vitest": "^2.1.8",
-        "wrangler": "^3.19.0",
+        "wrangler": "^4.81.1",
       },
     },
     "packages/common": {
@@ -413,10 +413,6 @@
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
-    "@esbuild-plugins/node-globals-polyfill": ["@esbuild-plugins/node-globals-polyfill@0.2.3", "", { "peerDependencies": { "esbuild": "*" } }, "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw=="],
-
-    "@esbuild-plugins/node-modules-polyfill": ["@esbuild-plugins/node-modules-polyfill@0.2.2", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "rollup-plugin-node-polyfills": "^0.2.1" }, "peerDependencies": { "esbuild": "*" } }, "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA=="],
-
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
@@ -496,8 +492,6 @@
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7", "shiki": "^3.2.2" } }, "sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ=="],
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7" } }, "sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw=="],
-
-    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@fontsource/atkinson-hyperlegible": ["@fontsource/atkinson-hyperlegible@5.3.0", "", {}, "sha512-Sp8Ve8+rQmENY2Lv02VH7sLpntzTTvnncnJMTbRE7DX6TLxGraN4ykZfzaUWIoCFmaomwkvNiqmlPkrKBuDoSA=="],
 
@@ -1057,8 +1051,6 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
-    "as-table": ["as-table@1.0.55", "", { "dependencies": { "printable-characters": "^1.0.42" } }, "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ=="],
-
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
@@ -1163,13 +1155,9 @@
 
     "collapse-white-space": ["collapse-white-space@2.1.0", "", {}, "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw=="],
 
-    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
-
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
-
-    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -1234,8 +1222,6 @@
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
-
-    "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
 
     "data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
 
@@ -1381,8 +1367,6 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
-    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
-
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "expressive-code": ["expressive-code@0.41.7", "", { "dependencies": { "@expressive-code/core": "^0.41.7", "@expressive-code/plugin-frames": "^0.41.7", "@expressive-code/plugin-shiki": "^0.41.7", "@expressive-code/plugin-text-markers": "^0.41.7" } }, "sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA=="],
@@ -1462,8 +1446,6 @@
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
 
     "get-port-please": ["get-port-please@3.2.0", "", {}, "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A=="],
-
-    "get-source": ["get-source@2.0.12", "", { "dependencies": { "data-uri-to-buffer": "^2.0.0", "source-map": "^0.6.1" } }, "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -1883,8 +1865,6 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
-
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
@@ -1908,8 +1888,6 @@
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
     "multimatch": ["multimatch@6.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.5", "array-differ": "^4.0.0", "array-union": "^3.0.1", "minimatch": "^3.0.4" } }, "sha512-I7tSVxHGPlmPN/enE3mS1aOSo6bWBfls+3HmuEeCUBCE7gWnm3cBXCBkpurzFjVRwC6Kld8lLaZ1Iv5vOcjvcQ=="],
-
-    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "nano-spawn": ["nano-spawn@1.0.3", "", {}, "sha512-jtpsQDetTnvS2Ts1fiRdci5rx0VYws5jGyC+4IYOTnIQ/wwdf6JdomlHBwqC3bJYOvaKu0C2GSZ1A60anrYpaA=="],
 
@@ -2079,8 +2057,6 @@
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
-    "printable-characters": ["printable-characters@1.0.42", "", {}, "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="],
-
     "prismjs": ["prismjs@1.29.0", "", {}, "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
@@ -2221,12 +2197,6 @@
 
     "rollup": ["rollup@4.55.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.2", "@rollup/rollup-android-arm64": "4.55.2", "@rollup/rollup-darwin-arm64": "4.55.2", "@rollup/rollup-darwin-x64": "4.55.2", "@rollup/rollup-freebsd-arm64": "4.55.2", "@rollup/rollup-freebsd-x64": "4.55.2", "@rollup/rollup-linux-arm-gnueabihf": "4.55.2", "@rollup/rollup-linux-arm-musleabihf": "4.55.2", "@rollup/rollup-linux-arm64-gnu": "4.55.2", "@rollup/rollup-linux-arm64-musl": "4.55.2", "@rollup/rollup-linux-loong64-gnu": "4.55.2", "@rollup/rollup-linux-loong64-musl": "4.55.2", "@rollup/rollup-linux-ppc64-gnu": "4.55.2", "@rollup/rollup-linux-ppc64-musl": "4.55.2", "@rollup/rollup-linux-riscv64-gnu": "4.55.2", "@rollup/rollup-linux-riscv64-musl": "4.55.2", "@rollup/rollup-linux-s390x-gnu": "4.55.2", "@rollup/rollup-linux-x64-gnu": "4.55.2", "@rollup/rollup-linux-x64-musl": "4.55.2", "@rollup/rollup-openbsd-x64": "4.55.2", "@rollup/rollup-openharmony-arm64": "4.55.2", "@rollup/rollup-win32-arm64-msvc": "4.55.2", "@rollup/rollup-win32-ia32-msvc": "4.55.2", "@rollup/rollup-win32-x64-gnu": "4.55.2", "@rollup/rollup-win32-x64-msvc": "4.55.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg=="],
 
-    "rollup-plugin-inject": ["rollup-plugin-inject@3.0.2", "", { "dependencies": { "estree-walker": "^0.6.1", "magic-string": "^0.25.3", "rollup-pluginutils": "^2.8.1" } }, "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w=="],
-
-    "rollup-plugin-node-polyfills": ["rollup-plugin-node-polyfills@0.2.1", "", { "dependencies": { "rollup-plugin-inject": "^3.0.0" } }, "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA=="],
-
-    "rollup-pluginutils": ["rollup-pluginutils@2.8.2", "", { "dependencies": { "estree-walker": "^0.6.1" } }, "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ=="],
-
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
@@ -2275,8 +2245,6 @@
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
-
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
@@ -2295,8 +2263,6 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
-    "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
-
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "spawn-sync": ["spawn-sync@1.0.15", "", { "dependencies": { "concat-stream": "^1.4.7", "os-shim": "^0.1.2" } }, "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw=="],
@@ -2311,15 +2277,11 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
-    "stacktracey": ["stacktracey@2.2.0", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg=="],
-
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
-
-    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
     "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
@@ -2685,8 +2647,6 @@
 
     "@playhtml/extension/sass": ["sass@1.101.0", "", { "dependencies": { "chokidar": "^5.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw=="],
 
-    "@playhtml/extension-worker/wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
-
     "@playhtml/react/jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
     "@playhtml/react/react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
@@ -2899,15 +2859,7 @@
 
     "readable-stream/inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "rollup-plugin-inject/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
-
-    "rollup-plugin-inject/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
-
-    "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
-
     "shelljs/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
 
     "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
@@ -3022,20 +2974,6 @@
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@microsoft/api-extractor/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
-
-    "@playhtml/extension-worker/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.3.4", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q=="],
-
-    "@playhtml/extension-worker/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild": ["esbuild@0.17.19", "", { "optionalDependencies": { "@esbuild/android-arm": "0.17.19", "@esbuild/android-arm64": "0.17.19", "@esbuild/android-x64": "0.17.19", "@esbuild/darwin-arm64": "0.17.19", "@esbuild/darwin-x64": "0.17.19", "@esbuild/freebsd-arm64": "0.17.19", "@esbuild/freebsd-x64": "0.17.19", "@esbuild/linux-arm": "0.17.19", "@esbuild/linux-arm64": "0.17.19", "@esbuild/linux-ia32": "0.17.19", "@esbuild/linux-loong64": "0.17.19", "@esbuild/linux-mips64el": "0.17.19", "@esbuild/linux-ppc64": "0.17.19", "@esbuild/linux-riscv64": "0.17.19", "@esbuild/linux-s390x": "0.17.19", "@esbuild/linux-x64": "0.17.19", "@esbuild/netbsd-x64": "0.17.19", "@esbuild/openbsd-x64": "0.17.19", "@esbuild/sunos-x64": "0.17.19", "@esbuild/win32-arm64": "0.17.19", "@esbuild/win32-ia32": "0.17.19", "@esbuild/win32-x64": "0.17.19" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare": ["miniflare@3.20250718.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250718.0", "ws": "8.18.0", "youch": "3.3.4", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ=="],
-
-    "@playhtml/extension-worker/wrangler/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
-
-    "@playhtml/extension-worker/wrangler/unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
-
-    "@playhtml/extension-worker/wrangler/workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
 
     "@playhtml/extension/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -3391,116 +3329,6 @@
 
     "@microsoft/api-extractor/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.17.19", "", { "os": "android", "cpu": "arm64" }, "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.17.19", "", { "os": "android", "cpu": "x64" }, "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.17.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.17.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.17.19", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.17.19", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.17.19", "", { "os": "linux", "cpu": "arm" }, "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.17.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.17.19", "", { "os": "linux", "cpu": "ia32" }, "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.17.19", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.17.19", "", { "os": "linux", "cpu": "s390x" }, "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.17.19", "", { "os": "linux", "cpu": "x64" }, "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.17.19", "", { "os": "none", "cpu": "x64" }, "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.17.19", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.17.19", "", { "os": "sunos", "cpu": "x64" }, "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.17.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.17.19", "", { "os": "win32", "cpu": "ia32" }, "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="],
-
-    "@playhtml/extension-worker/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.17.19", "", { "os": "win32", "cpu": "x64" }, "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
-
-    "@playhtml/extension-worker/wrangler/sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "@playhtml/extension-worker/wrangler/unenv/defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
-    "@playhtml/extension-worker/wrangler/unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "@playhtml/extension-worker/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250718.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g=="],
-
-    "@playhtml/extension-worker/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250718.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q=="],
-
-    "@playhtml/extension-worker/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250718.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg=="],
-
-    "@playhtml/extension-worker/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250718.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog=="],
-
-    "@playhtml/extension-worker/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250718.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg=="],
-
     "@playhtml/extension/sass/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "@playhtml/react/jsdom/cssstyle/@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
@@ -3696,8 +3524,6 @@
     "@aklinker1/rollup-plugin-visualizer/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@astrojs/react/@vitejs/plugin-react/@babel/core/@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@playhtml/extension-worker/wrangler/miniflare/youch/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "@playhtml/react/jsdom/tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Internet Commute now keeps riders, arrivals, and train timing in sync across browsers.
+- Slow Mode now boards the hosted Internet Commute, where up to four riders share a train while exact destinations stay in the extension.
+- Slow Mode can route deliberate far jumps through a short Internet Commute, with chance controls, cooldowns, and an always-available teleport.
+- Authentication pages no longer appear in Internet Commute or trigger Slow Mode.
 - Wikipedia always shows its shared cursors and remembered-link patina.
 - Browsing history now refreshes the current week, month, or year as new activity is recorded.
 

--- a/extension/src/components/InternetPortraitHome.scss
+++ b/extension/src/components/InternetPortraitHome.scss
@@ -287,6 +287,7 @@
 
   &__heading,
   &__chance,
+  &__sharing,
   &__today {
     padding: 11px 13px;
   }
@@ -332,6 +333,39 @@
     input {
       width: 100%;
       accent-color: $accent-teal;
+    }
+  }
+
+  &__sharing {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border-top: 1px solid $border;
+
+    > span {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    strong {
+      font-size: 10px;
+    }
+
+    small {
+      color: $text-muted;
+      font: 8px $font-mono;
+    }
+
+    select {
+      max-width: 110px;
+      border: 1px solid $border;
+      border-radius: 4px;
+      padding: 4px 5px;
+      color: $text;
+      background: $surface;
+      font: 9px $font-mono;
     }
   }
 

--- a/extension/src/components/SlowModeSettings.test.tsx
+++ b/extension/src/components/SlowModeSettings.test.tsx
@@ -18,7 +18,11 @@ describe("SlowModeSettings", () => {
       globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
     vi.mocked(browser.storage.local.get).mockResolvedValue({
-      [SLOW_MODE_SETTINGS_KEY]: { enabled: true, chancePercent: 40 },
+      [SLOW_MODE_SETTINGS_KEY]: {
+        enabled: true,
+        chancePercent: 40,
+        stopVisibility: "domain",
+      },
       [SLOW_MODE_STATE_KEY]: {
         lastCommuteAt: null,
         lastCommuteByDomain: {},
@@ -52,7 +56,11 @@ describe("SlowModeSettings", () => {
     });
 
     expect(browser.storage.local.set).toHaveBeenCalledWith({
-      [SLOW_MODE_SETTINGS_KEY]: { enabled: true, chancePercent: 70 },
+      [SLOW_MODE_SETTINGS_KEY]: {
+        enabled: true,
+        chancePercent: 70,
+        stopVisibility: "domain",
+      },
     });
     await act(async () => root.unmount());
   });

--- a/extension/src/components/SlowModeSettings.tsx
+++ b/extension/src/components/SlowModeSettings.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Renders the popup controls and daily ride summary for Slow Mode.
-// ABOUTME: Persists the global toggle and chance while exposing cooldown status.
+// ABOUTME: Persists interception and stop-sharing choices while exposing cooldown status.
 
 import React, { useEffect, useMemo, useState } from "react";
 import browser from "webextension-polyfill";

--- a/extension/src/components/SlowModeSettings.tsx
+++ b/extension/src/components/SlowModeSettings.tsx
@@ -112,6 +112,27 @@ export function SlowModeSettings() {
         />
       </label>
 
+      <label className="slow-mode-settings__sharing">
+        <span>
+          <strong>share my stop</strong>
+          <small>exact pages always stay private</small>
+        </span>
+        <select
+          value={settings.stopVisibility === "private" ? "private" : "domain"}
+          disabled={!settings.enabled}
+          onChange={(event) =>
+            saveSettings({
+              ...settings,
+              stopVisibility:
+                event.target.value === "private" ? "private" : "domain",
+            })
+          }
+        >
+          <option value="domain">domain only</option>
+          <option value="private">keep private</option>
+        </select>
+      </label>
+
       <div className="slow-mode-settings__today">
         <span className="slow-mode-settings__label">today</span>
         {ridesToday.length === 0 ? (

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -61,12 +61,15 @@ import {
 } from '../features/featureAccess'
 import { FEATURE_IDS } from '../flags'
 import {
+  SLOW_MODE_SETTINGS_KEY,
   SLOW_MODE_STATE_KEY,
   isSlowModeRideOutcome,
+  normalizeSlowModeSettings,
   normalizeSlowModeState,
   updateSlowModeRide,
 } from '../features/slowMode/slowMode'
 import { initSlowModeInterception } from '../features/slowMode/slowModeBackground'
+import { isHostedCommuteUrl } from '../features/slowMode/slowModeHostedBridge'
 
 function replyWithWikipediaHandle(
   request: Promise<string>,
@@ -501,26 +504,68 @@ export default defineBackground(() => {
   // Cross-site messaging coordination
   browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const reply = sendResponse as (response?: any) => void
+    if (message.type === 'GET_SLOW_MODE_HOSTED_RIDE') {
+      if (
+        typeof message.rideId !== 'string' ||
+        !sender.tab?.url ||
+        !isHostedCommuteUrl(sender.tab.url)
+      ) {
+        reply(null)
+        return
+      }
+      browser.storage.local
+        .get([SLOW_MODE_SETTINGS_KEY, SLOW_MODE_STATE_KEY])
+        .then((stored) => {
+          const ride = normalizeSlowModeState(
+            stored[SLOW_MODE_STATE_KEY],
+          ).rides.find((candidate) => candidate.id === message.rideId)
+          if (!ride) return null
+          return {
+            rideId: ride.id,
+            destinationDomain: ride.destinationDomain,
+            stopVisibility: normalizeSlowModeSettings(
+              stored[SLOW_MODE_SETTINGS_KEY],
+            ).stopVisibility,
+          }
+        })
+        .then(reply)
+        .catch(() => reply(null))
+      return true
+    }
+
     if (message.type === 'SLOW_MODE_RIDE_OUTCOME') {
       if (
         typeof message.rideId !== 'string' ||
-        !isSlowModeRideOutcome(message.outcome)
+        !isSlowModeRideOutcome(message.outcome) ||
+        (message.navigate === true &&
+          (!sender.tab?.url || !isHostedCommuteUrl(sender.tab.url)))
       ) {
         reply({ success: false })
         return
       }
       browser.storage.local
         .get(SLOW_MODE_STATE_KEY)
-        .then((stored) =>
-          browser.storage.local.set({
+        .then(async (stored) => {
+          const state = normalizeSlowModeState(stored[SLOW_MODE_STATE_KEY])
+          const ride = state.rides.find(
+            (candidate) => candidate.id === message.rideId,
+          )
+          if (!ride) return false
+          await browser.storage.local.set({
             [SLOW_MODE_STATE_KEY]: updateSlowModeRide(
-              normalizeSlowModeState(stored[SLOW_MODE_STATE_KEY]),
+              state,
               message.rideId,
               message.outcome,
             ),
-          }),
-        )
-        .then(() => reply({ success: true }))
+          })
+          if (message.navigate === true && sender.tab?.id != null) {
+            await browser.tabs.update(sender.tab.id, {
+              url: ride.destinationUrl,
+            })
+          }
+          return true
+        })
+        .then((success) => reply({ success }))
         .catch((error) => {
           console.warn('[Slow Mode] failed to update ride log:', error)
           reply({ success: false })

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -301,6 +301,47 @@ button {
   }
 }
 
+.slow-mode-sharing,
+.commute-route-notice {
+  width: fit-content;
+  max-width: calc(100% - 24px);
+  margin: 0 auto 8px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #5f574a;
+  background: rgba(245, 240, 232, 0.92);
+  font-family: var(--wwo-font-mono);
+  font-size: 10px;
+  text-align: center;
+}
+
+.commute-route-notice {
+  color: #fdfaf4;
+  background: #4a9a8a;
+}
+
+.commute-board-status {
+  min-height: 100vh;
+  display: grid;
+  place-content: center;
+  gap: 14px;
+  text-align: center;
+
+  strong {
+    font-family: var(--wwo-font-mono);
+    font-size: 15px;
+  }
+
+  button {
+    padding: 8px 12px;
+    border: 1px solid #5f574a;
+    border-radius: 999px;
+    color: #3d3833;
+    background: #f5f0e8;
+    cursor: pointer;
+  }
+}
+
 .slow-mode-teleport {
   display: block;
   margin: -4px auto 10px;

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -77,8 +77,10 @@ import { createCommuteInitOptions } from "./commuteIdentity";
 import {
   boardCommuteTrain,
   createCommuteTrainBoardRequest,
+  getCommuteTrainNextAction,
   getCommuteRiderToken,
   getCommuteTrainTimeOffset,
+  rotateCommuteRiderToken,
   toCommuteStop,
 } from "./commuteTrain";
 import "./commute.scss";
@@ -237,7 +239,9 @@ function useCommuteTrain(
     serverTimeOffsetMs: 0,
     status: "loading",
   });
-  const riderToken = useMemo(() => getCommuteRiderToken(ride), [ride]);
+  const [riderToken, setRiderToken] = useState(() =>
+    getCommuteRiderToken(ride),
+  );
   const request = useMemo(
     () => createCommuteTrainBoardRequest(riderToken, ride),
     [ride, riderToken],
@@ -273,8 +277,21 @@ function useCommuteTrain(
             status: "live",
           };
         });
-        if (assignment.joinable) {
-          refreshTimer = window.setTimeout(() => void board(), 3_000);
+        const nextAction = getCommuteTrainNextAction(assignment, ride !== null);
+        if (nextAction.kind === "refresh") {
+          refreshTimer = window.setTimeout(
+            () => void board(),
+            nextAction.delayMs,
+          );
+        } else if (nextAction.kind === "reboard") {
+          refreshTimer = window.setTimeout(() => {
+            setConnection({
+              assignment: null,
+              serverTimeOffsetMs: 0,
+              status: "loading",
+            });
+            setRiderToken(rotateCommuteRiderToken());
+          }, nextAction.delayMs);
         }
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -1821,6 +1838,7 @@ function CommuteBoardingRoot({
 
   return (
     <PlayProvider
+      key={connection.assignment.trainId}
       initOptions={createCommuteInitOptions(
         playerIdentity,
         connection.assignment.trainId,

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -1503,11 +1503,13 @@ function usePrefersReducedMotion(): boolean {
 
 function InternetCommute({
   assignment,
+  bridgeUnavailable,
   extensionCursorColor,
   ride,
   serverTimeOffsetMs,
 }: {
   assignment: CommuteTrainAssignment;
+  bridgeUnavailable: boolean;
   extensionCursorColor: string | null;
   ride: HostedSlowModeRide | null;
   serverTimeOffsetMs: number;
@@ -1614,6 +1616,12 @@ function InternetCommute({
         <p className="commute-subtitle">a slow train through the recent web</p>
 
         <CommuteInstallPrompt />
+
+        {bridgeUnavailable && (
+          <p className="slow-mode-sharing" role="status">
+            Slow Mode connection unavailable · riding the public route
+          </p>
+        )}
 
         {ride && destinationStopIndex >= 0 && (
           <SlowModeProgress
@@ -1783,9 +1791,11 @@ function InternetCommute({
 }
 
 function CommuteBoardingRoot({
+  bridgeUnavailable,
   playerIdentity,
   ride,
 }: {
+  bridgeUnavailable: boolean;
   playerIdentity: PlayerIdentity | null;
   ride: HostedSlowModeRide | null;
 }) {
@@ -1818,6 +1828,7 @@ function CommuteBoardingRoot({
     >
       <InternetCommute
         assignment={connection.assignment}
+        bridgeUnavailable={bridgeUnavailable}
         extensionCursorColor={
           playerIdentity?.playerStyle.colorPalette[0] ?? null
         }
@@ -1830,7 +1841,11 @@ function CommuteBoardingRoot({
 
 function CommuteRoot() {
   const [rootState, setRootState] = useState<
-    | { playerIdentity: PlayerIdentity | null; ride: HostedSlowModeRide | null }
+    | {
+        bridgeUnavailable: boolean;
+        playerIdentity: PlayerIdentity | null;
+        ride: HostedSlowModeRide | null;
+      }
     | undefined
   >(undefined);
 
@@ -1842,13 +1857,20 @@ function CommuteRoot() {
         return null;
       }),
       rideId ? requestHostedSlowModeRide(rideId) : Promise.resolve(null),
-    ]).then(([playerIdentity, ride]) => setRootState({ playerIdentity, ride }));
+    ]).then(([playerIdentity, ride]) =>
+      setRootState({
+        bridgeUnavailable: rideId !== null && ride === null,
+        playerIdentity,
+        ride,
+      }),
+    );
   }, []);
 
   if (!rootState) return null;
 
   return (
     <CommuteBoardingRoot
+      bridgeUnavailable={rootState.bridgeUnavailable}
       playerIdentity={rootState.playerIdentity}
       ride={rootState.ride}
     />

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -9,9 +9,9 @@ import React, {
   useState,
 } from "react";
 import type { PlayerIdentity } from "@playhtml/common";
+import type { CommuteTrainAssignment } from "@playhtml/extension-types";
 import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
-import browser from "webextension-polyfill";
 import trainIceUrl from "../../assets/train-ice.png";
 import {
   PlayProvider,
@@ -31,27 +31,12 @@ import {
   SAMPLE_STOPS,
   type CommuteStop,
 } from "./commuteStops";
-import {
-  COMMUTE_SERVICE_CHANNEL,
-  COMMUTE_SERVICE_DISCOVERY_MS,
-  createCommuteService,
-  estimateServerTimeOffset,
-  getCommuteServiceDomains,
-  getCommuteServiceEndTime,
-  getCommuteServicesFromPresences,
-  getCommuteStops,
-  getUnvisitedCommuteStops,
-  selectCommuteService,
-  type CommuteService,
-  type CommuteServicePresence,
-} from "./commuteService";
+import { estimateServerTimeOffset } from "./commuteService";
 import {
   DEPARTURE_SECONDS,
   getSlowModePlatformPhase,
-  getSlowModeProgress,
   getCommuteTiming,
-  INITIAL_PLATFORM_SECONDS,
-  SLOW_MODE_DURATIONS,
+  TRAIN_DURATIONS,
   type CommutePhase,
   type SlowModePlatformPhase,
 } from "./commuteTiming";
@@ -82,17 +67,20 @@ import {
 } from "./commuteMobile";
 import { ProceduralLandscape } from "./landscape";
 import {
-  SLOW_MODE_STATE_KEY,
-  normalizeSlowModeState,
-  type SlowModeRideOutcome,
-} from "../../features/slowMode/slowMode";
-import {
-  buildSlowModeRoute,
-  parseSlowModeRequest,
-  type SlowModeRequest,
-} from "../../features/slowMode/slowModeRoute";
+  getHostedSlowModeRideId,
+  reportHostedSlowModeOutcome,
+  requestHostedSlowModeRide,
+  type HostedSlowModeRide,
+} from "../../features/slowMode/slowModeHostedBridge";
 import { getPublicPlayerIdentity } from "../../storage/playerIdentity";
 import { createCommuteInitOptions } from "./commuteIdentity";
+import {
+  boardCommuteTrain,
+  createCommuteTrainBoardRequest,
+  getCommuteRiderToken,
+  getCommuteTrainTimeOffset,
+  toCommuteStop,
+} from "./commuteTrain";
 import "./commute.scss";
 
 type CarData = Record<string, never>;
@@ -155,7 +143,6 @@ const DOOR_GEOMETRY = DOORS.map((x) => ({ x }));
 const COMMUTE_REFRESH_MS = 30_000;
 const COMMUTE_ROUTE_TIMEOUT_MS = 5_000;
 const COMMUTE_RIDER_ARRIVAL_EVENT = "commute-rider-arrival";
-const SLOW_MODE_REQUEST = parseSlowModeRequest(window.location.search);
 
 function useRecentRoute(): RecentRoute {
   const [route, setRoute] = useState<RecentRoute>({
@@ -236,211 +223,78 @@ function useRecentRoute(): RecentRoute {
   return route;
 }
 
-interface SlowModeRouteState {
-  startedAt: number;
-  stops: CommuteStop[];
+interface CommuteTrainConnection {
+  assignment: CommuteTrainAssignment | null;
+  serverTimeOffsetMs: number;
+  status: "loading" | "live" | "error";
 }
 
-function useSlowModeRoute(
-  request: SlowModeRequest | null,
-  recentRoute: RecentRoute,
-): SlowModeRouteState | null {
-  const [route, setRoute] = useState<SlowModeRouteState | null>(null);
-  const formingRoute = useRef(false);
-
-  useEffect(() => {
-    if (!request || route || formingRoute.current) return;
-    if (recentRoute.status === "loading") return;
-    formingRoute.current = true;
-
-    browser.storage.local
-      .get(SLOW_MODE_STATE_KEY)
-      .then((stored) => {
-        const state = normalizeSlowModeState(stored[SLOW_MODE_STATE_KEY]);
-        const recentRiderDomains = state.rides
-          .filter((ride) => ride.id !== request.rideId)
-          .map((ride) => ride.destinationDomain);
-        const communalStops =
-          recentRoute.status === "live" ? recentRoute.stops : SAMPLE_STOPS;
-        setRoute({
-          startedAt: Date.now(),
-          stops: buildSlowModeRoute(
-            communalStops,
-            request.destinationUrl,
-            request.stopCount,
-            recentRiderDomains,
-          ),
-        });
-      })
-      .catch(() => {
-        setRoute({
-          startedAt: Date.now(),
-          stops: buildSlowModeRoute(
-            SAMPLE_STOPS,
-            request.destinationUrl,
-            request.stopCount,
-            [],
-          ),
-        });
-      });
-  }, [recentRoute.status, recentRoute.stops, request, route]);
-
-  return route;
-}
-
-interface CommuteServiceState {
-  joinedExistingService: boolean;
-  service: CommuteService | null;
-}
-
-interface CommuteServiceConnection extends CommuteServiceState {
-  nextStops: CommuteStop[];
-}
-
-function useCommuteService(
-  availableStops: CommuteStop[],
-  routeStatus: RecentRoute["status"],
-  serverTimeOffsetMs: number | null,
-  enabled = true,
-): CommuteServiceConnection {
-  const { presences, setMyPresence, myIdentity } = usePresence<
-    typeof COMMUTE_SERVICE_CHANNEL,
-    CommuteServicePresence
-  >(COMMUTE_SERVICE_CHANNEL);
-  const [connection, setConnection] = useState<CommuteServiceState>({
-    joinedExistingService: false,
-    service: null,
+function useCommuteTrain(
+  ride: HostedSlowModeRide | null,
+): CommuteTrainConnection {
+  const [connection, setConnection] = useState<CommuteTrainConnection>({
+    assignment: null,
+    serverTimeOffsetMs: 0,
+    status: "loading",
   });
-  const [visitedDomains, setVisitedDomains] = useState<string[]>([]);
-  const presencesRef = useRef(presences);
-  const nextStops = useMemo(
-    () => getUnvisitedCommuteStops(availableStops, visitedDomains),
-    [availableStops, visitedDomains],
+  const riderToken = useMemo(() => getCommuteRiderToken(ride), [ride]);
+  const request = useMemo(
+    () => createCommuteTrainBoardRequest(riderToken, ride),
+    [ride, riderToken],
   );
 
   useEffect(() => {
-    presencesRef.current = presences;
-  }, [presences]);
+    const controller = new AbortController();
+    let refreshTimer: number | undefined;
+    let lastAssignment: CommuteTrainAssignment | null = null;
 
-  useEffect(() => {
-    if (!enabled || connection.service || !myIdentity) {
-      return;
-    }
-
-    const discoveryTimer = window.setTimeout(() => {
-      const serverNow = Date.now() + (serverTimeOffsetMs ?? 0);
-      const visited = new Set(visitedDomains);
-      const existingService = selectCommuteService(
-        getCommuteServicesFromPresences(presencesRef.current.values()).filter(
-          (service) =>
-            getCommuteServiceDomains(service).every(
-              (domain) => !visited.has(domain),
+    const board = async () => {
+      const requestStartedAt = Date.now();
+      try {
+        const assignment = await boardCommuteTrain(request, controller.signal);
+        const responseReceivedAt = Date.now();
+        lastAssignment = assignment;
+        setConnection((current) => {
+          if (
+            current.assignment?.routeVersion === assignment.routeVersion &&
+            current.assignment.riderCount === assignment.riderCount &&
+            current.assignment.joinable === assignment.joinable &&
+            current.assignment.phase === assignment.phase
+          ) {
+            return current;
+          }
+          return {
+            assignment,
+            serverTimeOffsetMs: getCommuteTrainTimeOffset(
+              assignment,
+              requestStartedAt,
+              responseReceivedAt,
             ),
-        ),
-        serverNow,
-      );
-      if (
-        existingService === null &&
-        (routeStatus === "loading" || serverTimeOffsetMs === null)
-      ) {
-        return;
+            status: "live",
+          };
+        });
+        if (assignment.joinable) {
+          refreshTimer = window.setTimeout(() => void board(), 3_000);
+        }
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.warn("[internet commute] train boarding unavailable:", error);
+        if (lastAssignment) {
+          refreshTimer = window.setTimeout(() => void board(), 3_000);
+        } else {
+          setConnection((current) => ({ ...current, status: "error" }));
+        }
       }
-      if (existingService === null && nextStops.length === 0) {
-        return;
-      }
-
-      const service =
-        existingService ??
-        createCommuteService(serverNow, myIdentity.publicKey, nextStops);
-      const presence: CommuteServicePresence = {
-        service,
-      };
-
-      setConnection({
-        joinedExistingService: existingService !== null,
-        service,
-      });
-      setMyPresence(presence);
-    }, COMMUTE_SERVICE_DISCOVERY_MS);
-
-    return () => window.clearTimeout(discoveryTimer);
-  }, [
-    connection.service,
-    enabled,
-    myIdentity,
-    nextStops,
-    routeStatus,
-    serverTimeOffsetMs,
-    setMyPresence,
-    visitedDomains,
-  ]);
-
-  const canonicalService = useMemo(() => {
-    const visited = new Set(visitedDomains);
-    const candidates = getCommuteServicesFromPresences(
-      presences.values(),
-    ).filter((service) =>
-      getCommuteServiceDomains(service).every((domain) => !visited.has(domain)),
-    );
-    if (connection.service) {
-      candidates.push(connection.service);
-    }
-    return selectCommuteService(
-      candidates,
-      Date.now() + (serverTimeOffsetMs ?? 0),
-    );
-  }, [connection.service, presences, serverTimeOffsetMs, visitedDomains]);
-
-  useEffect(() => {
-    if (
-      !enabled ||
-      !connection.service ||
-      !canonicalService ||
-      canonicalService.id === connection.service.id
-    ) {
-      return;
-    }
-
-    const presence: CommuteServicePresence = {
-      service: canonicalService,
-    };
-    setConnection({
-      joinedExistingService: true,
-      service: canonicalService,
-    });
-    setMyPresence(presence);
-  }, [canonicalService, connection.service, enabled, setMyPresence]);
-
-  useEffect(() => {
-    const service = connection.service;
-    if (!enabled || !service) return;
-
-    const serverNow = Date.now() + (serverTimeOffsetMs ?? 0);
-    const delay = Math.max(0, getCommuteServiceEndTime(service) - serverNow);
-    const completeService = () => {
-      const completedDomains = getCommuteServiceDomains(service);
-      setVisitedDomains((current) => [
-        ...new Set([...current, ...completedDomains]),
-      ]);
-      setConnection((current) =>
-        current.service?.id === service.id
-          ? {
-              joinedExistingService: false,
-              service: null,
-            }
-          : current,
-      );
-      setMyPresence({ service: null });
     };
 
-    const completionTimer = window.setTimeout(completeService, delay);
-    return () => window.clearTimeout(completionTimer);
-  }, [connection.service, enabled, serverTimeOffsetMs, setMyPresence]);
+    void board();
+    return () => {
+      controller.abort();
+      if (refreshTimer !== undefined) window.clearTimeout(refreshTimer);
+    };
+  }, [request]);
 
-  return {
-    ...connection,
-    nextStops,
-  };
+  return connection;
 }
 
 function StopFavicon({
@@ -1096,7 +950,7 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
         () => {
           if (navigateCurrentTab) {
             window.location.assign(props.currentStop.url);
-          } else {
+          } else if (!props.onExitStop) {
             window.open(props.currentStop.url, "_blank", "noopener,noreferrer");
             exitPending.current = false;
           }
@@ -1587,21 +1441,25 @@ function CommuteDebugPanel({
 
 function SlowModeProgress({
   destinationDomain,
+  destinationStopIndex,
   phase,
   stopIndex,
   stops,
   atOrigin,
 }: {
   destinationDomain: string;
+  destinationStopIndex: number;
   phase: CommutePhase;
   stopIndex: number;
   stops: CommuteStop[];
   atOrigin: boolean;
 }) {
-  const { completedIndex, stopsLeft } = getSlowModeProgress(
-    { atOrigin, phase, stopIndex },
-    stops.length,
-  );
+  const completedIndex = atOrigin
+    ? -1
+    : phase === "stopped"
+      ? stopIndex
+      : stopIndex - 1;
+  const stopsLeft = Math.max(0, destinationStopIndex - completedIndex);
 
   return (
     <section className="slow-mode-progress" aria-label="Slow Mode route progress">
@@ -1614,7 +1472,7 @@ function SlowModeProgress({
             />
             <span
               className={`${index <= completedIndex ? "is-complete" : ""} ${
-                index === stops.length - 1 ? "is-destination" : ""
+                index === destinationStopIndex ? "is-destination" : ""
               }`}
               title={stop.domain}
             />
@@ -1644,37 +1502,33 @@ function usePrefersReducedMotion(): boolean {
 }
 
 function InternetCommute({
+  assignment,
   extensionCursorColor,
+  ride,
+  serverTimeOffsetMs,
 }: {
+  assignment: CommuteTrainAssignment;
   extensionCursorColor: string | null;
+  ride: HostedSlowModeRide | null;
+  serverTimeOffsetMs: number;
 }) {
   const riders = useUsers();
   const { cursors } = usePlayContext();
   const cursorColor = (extensionCursorColor ?? cursors.color) || "#3d3833";
   const [debugVisible, setDebugVisible] = useCommuteDebug();
   const recentRoute = useRecentRoute();
-  const slowModeRoute = useSlowModeRoute(SLOW_MODE_REQUEST, recentRoute);
-  const availableStops =
-    recentRoute.status === "live" ? recentRoute.stops : SAMPLE_STOPS;
-  const serviceConnection = useCommuteService(
-    availableStops,
-    recentRoute.status,
-    recentRoute.serverTimeOffsetMs,
-    SLOW_MODE_REQUEST === null,
+  const stops = useMemo(
+    () => assignment.stops.map(toCommuteStop),
+    [assignment.stops],
   );
-  const sharedStops = useMemo(
-    () =>
-      serviceConnection.service
-        ? getCommuteStops(serviceConnection.service)
-        : serviceConnection.nextStops.length > 0
-          ? serviceConnection.nextStops
-          : [SAMPLE_STOPS[0]],
-    [serviceConnection.nextStops, serviceConnection.service],
-  );
-  const stops = slowModeRoute?.stops ?? sharedStops;
-  const waitingForFreshStops =
-    serviceConnection.service === null &&
-    serviceConnection.nextStops.length === 0;
+  const destinationStopIndex = ride
+    ? assignment.stops.findIndex(
+        (stop) =>
+          stop.kind === "domain" && stop.domain === ride.destinationDomain,
+      )
+    : -1;
+  const destinationStopId =
+    destinationStopIndex >= 0 ? stops[destinationStopIndex]?.id : undefined;
   const sceneryStops =
     recentRoute.sceneryStops.length > 0
       ? recentRoute.sceneryStops
@@ -1683,7 +1537,17 @@ function InternetCommute({
   const [clockNow, setClockNow] = useState(() => Date.now());
   const [hasSeat, setHasSeat] = useState(false);
   const [mobileBoarded, setMobileBoarded] = useState(false);
+  const [routeNotice, setRouteNotice] = useState<string | null>(null);
+  const previousStopCount = useRef(assignment.stops.length);
   const reducedMotion = usePrefersReducedMotion();
+
+  useEffect(() => {
+    if (assignment.stops.length <= previousStopCount.current) return;
+    previousStopCount.current = assignment.stops.length;
+    setRouteNotice("route updated · a new stop joined the line");
+    const timer = window.setTimeout(() => setRouteNotice(null), 6_000);
+    return () => window.clearTimeout(timer);
+  }, [assignment.stops.length]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -1692,82 +1556,46 @@ function InternetCommute({
     return () => window.clearInterval(timer);
   }, []);
 
-  const elapsedSeconds = SLOW_MODE_REQUEST
-    ? slowModeRoute
-      ? Math.max(0, Math.floor((clockNow - slowModeRoute.startedAt) / 1000))
-      : 0
-    : serviceConnection.service
-      ? Math.max(
-          0,
-          Math.floor(
-            (clockNow +
-              (recentRoute.serverTimeOffsetMs ?? 0) -
-              serviceConnection.service.startedAt) /
-              1000,
-          ),
-        )
-      : 0;
-  const routeTiming = getCommuteTiming(
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor(
+      (clockNow + serverTimeOffsetMs - assignment.createdAt) / 1_000,
+    ),
+  );
+  const timing = getCommuteTiming(
     elapsedSeconds,
     stops.length,
-    SLOW_MODE_REQUEST ? SLOW_MODE_DURATIONS : undefined,
+    TRAIN_DURATIONS,
   );
-  const timing =
-    SLOW_MODE_REQUEST &&
-    (routeTiming.complete || (slowModeRoute !== null && reducedMotion))
-      ? {
-          ...routeTiming,
-          phase: "stopped" as const,
-          stopIndex: stops.length - 1,
-          atOrigin: false,
-          complete: true,
-          secondsLeft: 0,
-        }
-      : routeTiming;
   const currentStop = stops[timing.stopIndex];
-  const initialPlatformSeconds = SLOW_MODE_REQUEST
-    ? SLOW_MODE_DURATIONS.initialPlatformSeconds
-    : INITIAL_PLATFORM_SECONDS;
   const departingOrigin =
     timing.phase === "riding" &&
-    elapsedSeconds < initialPlatformSeconds + DEPARTURE_SECONDS;
+    elapsedSeconds < TRAIN_DURATIONS.initialPlatformSeconds + DEPARTURE_SECONDS;
   const platformStop =
     timing.departureStopIndex === null
       ? currentStop
       : stops[timing.departureStopIndex];
   const platformAtOrigin = timing.atOrigin || departingOrigin;
   const slowModePlatformPhase =
-    SLOW_MODE_REQUEST && slowModeRoute && timing.atOrigin
+    ride && timing.atOrigin && !timing.complete
       ? getSlowModePlatformPhase(timing.secondsLeft)
       : undefined;
 
   const finishSlowModeRide = useCallback(
-    async (outcome: SlowModeRideOutcome, url: string) => {
-      if (!SLOW_MODE_REQUEST) return;
-      await browser.runtime
-        .sendMessage({
-          type: "SLOW_MODE_RIDE_OUTCOME",
-          rideId: SLOW_MODE_REQUEST.rideId,
-          outcome,
-        })
-        .catch(() => {});
-      window.location.assign(url);
+    (outcome: "arrived" | "teleported" | "left", navigate: boolean) => {
+      if (!ride) return;
+      reportHostedSlowModeOutcome(ride.rideId, outcome, navigate);
     },
-    [],
+    [ride],
   );
 
   return (
     <main
       className="commute-page"
-      data-service-id={serviceConnection.service?.id}
-      data-service-started-at={serviceConnection.service?.startedAt}
+      data-train-id={assignment.trainId}
+      data-train-started-at={assignment.createdAt}
       data-service-elapsed-seconds={elapsedSeconds}
-      data-joined-existing-service={serviceConnection.joinedExistingService}
-      data-joining-service={
-        serviceConnection.joinedExistingService
-          ? serviceConnection.service?.id
-          : undefined
-      }
+      data-route-version={assignment.routeVersion}
       onMouseMove={keepCommuteCursorInCar}
       onTouchMove={keepCommuteCursorInCar}
     >
@@ -1787,11 +1615,10 @@ function InternetCommute({
 
         <CommuteInstallPrompt />
 
-        {SLOW_MODE_REQUEST && slowModeRoute && (
+        {ride && destinationStopIndex >= 0 && (
           <SlowModeProgress
-            destinationDomain={new URL(
-              SLOW_MODE_REQUEST.destinationUrl,
-            ).hostname.replace(/^www\./, "")}
+            destinationDomain={ride.destinationDomain}
+            destinationStopIndex={destinationStopIndex}
             phase={timing.phase}
             stopIndex={timing.stopIndex}
             stops={stops}
@@ -1799,33 +1626,40 @@ function InternetCommute({
           />
         )}
 
+        {ride && (
+          <p className="slow-mode-sharing">
+            {ride.stopVisibility === "private"
+              ? "your destination is private · no stop added"
+              : `your stop is shared as ${ride.destinationDomain}`}
+          </p>
+        )}
+
+        {routeNotice && (
+          <p className="commute-route-notice" role="status">
+            {routeNotice}
+          </p>
+        )}
+
         <Banner
           phase={timing.phase}
           secondsLeft={timing.secondsLeft}
           atOrigin={timing.atOrigin}
           currentStop={
-            SLOW_MODE_REQUEST && timing.atOrigin
-              ? stops[stops.length - 1]
+            ride && timing.atOrigin && destinationStopIndex >= 0
+              ? stops[destinationStopIndex]
               : currentStop
           }
           hasSeat={hasSeat}
-          routeComplete={timing.complete && !SLOW_MODE_REQUEST}
-          waitingForFreshStops={
-            waitingForFreshStops && SLOW_MODE_REQUEST === null
-          }
+          routeComplete={timing.complete}
+          waitingForFreshStops={false}
           slowModePlatformPhase={slowModePlatformPhase}
         />
 
-        {SLOW_MODE_REQUEST && timing.atOrigin && (
+        {ride && timing.atOrigin && (
           <button
             className="slow-mode-teleport"
             type="button"
-            onClick={() =>
-              void finishSlowModeRide(
-                "teleported",
-                SLOW_MODE_REQUEST.destinationUrl,
-              )
-            }
+            onClick={() => finishSlowModeRide("teleported", true)}
           >
             teleport instead →
           </button>
@@ -1834,49 +1668,42 @@ function InternetCommute({
         {debugVisible && (
           <CommuteDebugPanel
             elapsedSeconds={elapsedSeconds}
-            joinedExistingService={serviceConnection.joinedExistingService}
+            joinedExistingService={assignment.riderCount > 1}
             phase={timing.phase}
             riders={riders.length}
             routeStatus={recentRoute.status}
             secondsLeft={timing.secondsLeft}
-            serviceId={serviceConnection.service?.id}
+            serviceId={assignment.trainId}
             stopIndex={timing.stopIndex}
             stops={stops}
             onClose={() => setDebugVisible(false)}
           />
         )}
 
-        {SLOW_MODE_REQUEST && slowModeRoute && reducedMotion ? (
+        {ride && reducedMotion ? (
           <section className="slow-mode-summary">
             <span>your route</span>
-            <h2>{SLOW_MODE_REQUEST.stopCount} stops passed</h2>
+            <h2>{stops.length} stops on this train</h2>
             <ol>
               {stops.map((stop, index) => (
                 <li key={stop.id}>
                   <span>{index + 1}</span>
                   <strong>{stop.domain}</strong>
-                  {index === stops.length - 1 && <small>destination</small>}
+                  {index === destinationStopIndex && <small>your stop</small>}
                 </li>
               ))}
             </ol>
             <button
               type="button"
-              onClick={() =>
-                void finishSlowModeRide(
-                  "arrived",
-                  SLOW_MODE_REQUEST.destinationUrl,
-                )
-              }
+              onClick={() => finishSlowModeRide("teleported", true)}
             >
-              continue to {new URL(SLOW_MODE_REQUEST.destinationUrl).hostname} →
+              continue to {ride.destinationDomain} →
             </button>
           </section>
-        ) : SLOW_MODE_REQUEST && slowModeRoute && timing.atOrigin ? (
+        ) : ride && timing.atOrigin && !timing.complete ? (
           <SlowModePlatformScene
             cursorColor={cursorColor}
-            destinationDomain={new URL(
-              SLOW_MODE_REQUEST.destinationUrl,
-            ).hostname.replace(/^www\./, "")}
+            destinationDomain={ride.destinationDomain}
             secondsLeft={timing.secondsLeft}
           />
         ) : (
@@ -1895,35 +1722,29 @@ function InternetCommute({
               currentStop={currentStop}
               phase={timing.phase}
               atOrigin={timing.atOrigin}
-              serviceReady={
-                SLOW_MODE_REQUEST
-                  ? slowModeRoute !== null
-                  : serviceConnection.service !== null
-              }
+              serviceReady
               mobileBoarded={mobileBoarded}
               onMobileBoardStateChange={setMobileBoarded}
               onSeatStateChange={setHasSeat}
-              navigateCurrentTabOnExit={SLOW_MODE_REQUEST !== null}
+              navigateCurrentTabOnExit={false}
               onExitStop={
-                SLOW_MODE_REQUEST
+                ride
                   ? (stop) => {
-                      const outcome =
-                        stop.url === stops.at(-1)?.url ? "arrived" : "left";
-                      void browser.runtime.sendMessage({
-                        type: "SLOW_MODE_RIDE_OUTCOME",
-                        rideId: SLOW_MODE_REQUEST.rideId,
-                        outcome,
-                      });
+                      if (stop.id === destinationStopId) {
+                        finishSlowModeRide("arrived", true);
+                        return;
+                      }
+                      finishSlowModeRide("left", false);
+                      window.setTimeout(
+                        () => window.location.assign(stop.url),
+                        100,
+                      );
                     }
                   : undefined
               }
               onTeleport={
-                SLOW_MODE_REQUEST
-                  ? () =>
-                      void finishSlowModeRide(
-                        "teleported",
-                        SLOW_MODE_REQUEST.destinationUrl,
-                      )
+                ride
+                  ? () => finishSlowModeRide("teleported", true)
                   : undefined
               }
             />
@@ -1941,7 +1762,7 @@ function InternetCommute({
 
         <div className="commute-counts">
           <strong>
-            {riders.length} {riders.length === 1 ? "person" : "people"} riding
+            {assignment.riderCount}/{assignment.capacity} riders on this train
           </strong>
           <span></span>
           <strong>
@@ -1961,28 +1782,76 @@ function InternetCommute({
   );
 }
 
-function CommuteRoot() {
-  const [playerIdentity, setPlayerIdentity] = useState<
-    PlayerIdentity | null | undefined
-  >(undefined);
+function CommuteBoardingRoot({
+  playerIdentity,
+  ride,
+}: {
+  playerIdentity: PlayerIdentity | null;
+  ride: HostedSlowModeRide | null;
+}) {
+  const connection = useCommuteTrain(ride);
 
-  useEffect(() => {
-    getPublicPlayerIdentity().then(setPlayerIdentity).catch((error: unknown) => {
-      console.warn("[internet commute] cursor identity unavailable:", error);
-      setPlayerIdentity(null);
-    });
-  }, []);
-
-  if (playerIdentity === undefined) return null;
+  if (connection.status === "error") {
+    return (
+      <main className="commute-page commute-board-status">
+        <strong>the next train is delayed</strong>
+        <button type="button" onClick={() => window.location.reload()}>
+          check the platform again
+        </button>
+      </main>
+    );
+  }
+  if (!connection.assignment) {
+    return (
+      <main className="commute-page commute-board-status">
+        <strong>finding your train…</strong>
+      </main>
+    );
+  }
 
   return (
-    <PlayProvider initOptions={createCommuteInitOptions(playerIdentity)}>
+    <PlayProvider
+      initOptions={createCommuteInitOptions(
+        playerIdentity,
+        connection.assignment.trainId,
+      )}
+    >
       <InternetCommute
+        assignment={connection.assignment}
         extensionCursorColor={
           playerIdentity?.playerStyle.colorPalette[0] ?? null
         }
+        ride={ride}
+        serverTimeOffsetMs={connection.serverTimeOffsetMs}
       />
     </PlayProvider>
+  );
+}
+
+function CommuteRoot() {
+  const [rootState, setRootState] = useState<
+    | { playerIdentity: PlayerIdentity | null; ride: HostedSlowModeRide | null }
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const rideId = getHostedSlowModeRideId(window.location.hash);
+    Promise.all([
+      getPublicPlayerIdentity().catch((error: unknown) => {
+        console.warn("[internet commute] cursor identity unavailable:", error);
+        return null;
+      }),
+      rideId ? requestHostedSlowModeRide(rideId) : Promise.resolve(null),
+    ]).then(([playerIdentity, ride]) => setRootState({ playerIdentity, ride }));
+  }, []);
+
+  if (!rootState) return null;
+
+  return (
+    <CommuteBoardingRoot
+      playerIdentity={rootState.playerIdentity}
+      ride={rootState.ride}
+    />
   );
 }
 

--- a/extension/src/entrypoints/commute/commuteIdentity.test.ts
+++ b/extension/src/entrypoints/commute/commuteIdentity.test.ts
@@ -13,10 +13,17 @@ describe("commute identity", () => {
       playerStyle: { colorPalette: ["#c4724e"] },
     };
 
-    expect(createCommuteInitOptions(identity).playerIdentity).toBe(identity);
+    expect(
+      createCommuteInitOptions(identity, "night-line").playerIdentity,
+    ).toBe(identity);
+    expect(createCommuteInitOptions(identity, "night-line").room).toBe(
+      "wwo-internet-commute-train-night-line",
+    );
   });
 
   it("lets the public commute use its browser-local identity", () => {
-    expect(createCommuteInitOptions(null)).not.toHaveProperty("playerIdentity");
+    expect(createCommuteInitOptions(null, "public-line")).not.toHaveProperty(
+      "playerIdentity",
+    );
   });
 });

--- a/extension/src/entrypoints/commute/commuteIdentity.ts
+++ b/extension/src/entrypoints/commute/commuteIdentity.ts
@@ -5,9 +5,10 @@ import type { PlayerIdentity } from "@playhtml/common";
 
 export function createCommuteInitOptions(
   playerIdentity: PlayerIdentity | null,
+  trainId: string,
 ) {
   return {
-    room: "wwo-internet-commute",
+    room: `wwo-internet-commute-train-${trainId}`,
     cursors: {
       enabled: true,
       enableChat: false,

--- a/extension/src/entrypoints/commute/commuteTiming.ts
+++ b/extension/src/entrypoints/commute/commuteTiming.ts
@@ -1,6 +1,15 @@
 // ABOUTME: Computes the Internet Commute's platform, travel, and arrival phases.
 // ABOUTME: Keeps train timing deterministic and independent from React rendering.
 
+import {
+  COMMUTE_TRAIN_ARRIVAL_MS,
+  COMMUTE_TRAIN_DEPARTURE_MS,
+  COMMUTE_TRAIN_PLATFORM_MS,
+  COMMUTE_TRAIN_RETURN_ARRIVAL_MS,
+  COMMUTE_TRAIN_RETURN_TRAVEL_MS,
+  COMMUTE_TRAIN_TRAVEL_MS,
+} from "@playhtml/extension-types";
+
 export const INITIAL_PLATFORM_SECONDS = 10;
 export const TRAVEL_SECONDS = 15;
 export const ARRIVAL_SECONDS = 4;
@@ -38,6 +47,16 @@ export const SLOW_MODE_DURATIONS: CommuteDurations = {
     SLOW_MODE_APPROACH_SECONDS + SLOW_MODE_BOARDING_SECONDS,
   travelSeconds: 12,
   platformSeconds: 8,
+};
+
+export const TRAIN_DURATIONS: CommuteDurations = {
+  initialPlatformSeconds: COMMUTE_TRAIN_DEPARTURE_MS / 1_000,
+  travelSeconds: COMMUTE_TRAIN_TRAVEL_MS / 1_000,
+  arrivalSeconds: COMMUTE_TRAIN_ARRIVAL_MS / 1_000,
+  platformSeconds: COMMUTE_TRAIN_PLATFORM_MS / 1_000,
+  departureSeconds: DEPARTURE_SECONDS,
+  returnTravelSeconds: COMMUTE_TRAIN_RETURN_TRAVEL_MS / 1_000,
+  returnArrivalSeconds: COMMUTE_TRAIN_RETURN_ARRIVAL_MS / 1_000,
 };
 
 export type SlowModePlatformPhase = "waiting" | "arriving" | "boarding";

--- a/extension/src/entrypoints/commute/commuteTrain.test.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.test.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Tests hosted train boarding requests, response parsing, and stop mapping.
+// ABOUTME: Protects the privacy boundary between local Slow Mode rides and public routes.
+
+import { describe, expect, it } from "vitest";
+import type { CommuteTrainAssignment } from "@playhtml/extension-types";
+import {
+  createCommuteTrainBoardRequest,
+  getCommuteRiderToken,
+  getCommuteTrainTimeOffset,
+  parseCommuteTrainAssignment,
+  toCommuteStop,
+} from "./commuteTrain";
+
+const assignment: CommuteTrainAssignment = {
+  trainId: "train-1",
+  createdAt: 1_000,
+  departureAt: 6_000,
+  joinableUntil: 61_000,
+  routeEndsAt: 80_000,
+  routeVersion: 2,
+  riderCount: 2,
+  capacity: 4,
+  joinable: true,
+  phase: "riding",
+  serverNow: 10_100,
+  stops: [
+    {
+      kind: "domain",
+      id: "stop-1",
+      domain: "example.com",
+      url: "https://example.com/",
+      hue: "#4a9a8a",
+      claimantCount: 2,
+    },
+  ],
+};
+
+describe("commute train client", () => {
+  it("uses dispatcher-safe stable tokens", () => {
+    const rideToken = getCommuteRiderToken({
+      rideId: "8cc8e2ef-63cf-4cb6-86c7-6d4999e5641d",
+      destinationDomain: "example.com",
+      stopVisibility: "domain",
+    });
+    expect(rideToken).toBe("slow_8cc8e2ef-63cf-4cb6-86c7-6d4999e5641d");
+    expect(rideToken).toMatch(/^[a-zA-Z0-9_-]{16,128}$/);
+
+    const firstWebToken = getCommuteRiderToken(null);
+    expect(getCommuteRiderToken(null)).toBe(firstWebToken);
+    expect(firstWebToken).toMatch(/^[a-zA-Z0-9_-]{16,128}$/);
+  });
+
+  it("shares only a domain stop when the rider allows it", () => {
+    expect(
+      createCommuteTrainBoardRequest("slow_ride-1", {
+        rideId: "ride-1",
+        destinationDomain: "example.com",
+        stopVisibility: "domain",
+      }),
+    ).toEqual({
+      riderToken: "slow_ride-1",
+      requestedStop: { kind: "domain", domain: "example.com" },
+    });
+  });
+
+  it("does not send a destination for private rides", () => {
+    expect(
+      createCommuteTrainBoardRequest("slow_ride-1", {
+        rideId: "ride-1",
+        destinationDomain: "example.com",
+        stopVisibility: "private",
+      }),
+    ).toEqual({ riderToken: "slow_ride-1", requestedStop: { kind: "none" } });
+  });
+
+  it("parses assignments and maps public domain stops", () => {
+    expect(parseCommuteTrainAssignment(assignment)).toEqual(assignment);
+    expect(toCommuteStop(assignment.stops[0])).toMatchObject({
+      domain: "example.com",
+      url: "https://example.com/",
+      recentDomainVisits: 2,
+    });
+    expect(() => parseCommuteTrainAssignment({ trainId: "incomplete" })).toThrow(
+      "Invalid commute train assignment",
+    );
+    expect(() =>
+      parseCommuteTrainAssignment({
+        ...assignment,
+        stops: [{ ...assignment.stops[0], claimantCount: undefined }],
+      }),
+    ).toThrow("Invalid commute train assignment");
+  });
+
+  it("estimates server time at the request midpoint", () => {
+    expect(getCommuteTrainTimeOffset(assignment, 10_000, 10_100)).toBe(50);
+  });
+});

--- a/extension/src/entrypoints/commute/commuteTrain.test.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 import type { CommuteTrainAssignment } from "@playhtml/extension-types";
 import {
   createCommuteTrainBoardRequest,
+  getCommuteTrainNextAction,
   getCommuteRiderToken,
   getCommuteTrainTimeOffset,
   parseCommuteTrainAssignment,
+  rotateCommuteRiderToken,
   toCommuteStop,
 } from "./commuteTrain";
 
@@ -48,6 +50,39 @@ describe("commute train client", () => {
     const firstWebToken = getCommuteRiderToken(null);
     expect(getCommuteRiderToken(null)).toBe(firstWebToken);
     expect(firstWebToken).toMatch(/^[a-zA-Z0-9_-]{16,128}$/);
+  });
+
+  it("rotates the standard rider token for the next trip", () => {
+    const firstToken = getCommuteRiderToken(null);
+    const nextToken = rotateCommuteRiderToken();
+
+    expect(nextToken).not.toBe(firstToken);
+    expect(getCommuteRiderToken(null)).toBe(nextToken);
+  });
+
+  it("refreshes open trains and reboards standard riders after completion", () => {
+    expect(getCommuteTrainNextAction(assignment, false)).toEqual({
+      kind: "refresh",
+      delayMs: 3_000,
+    });
+    expect(
+      getCommuteTrainNextAction(
+        { ...assignment, joinable: false, serverNow: 75_000 },
+        false,
+      ),
+    ).toEqual({ kind: "reboard", delayMs: 5_000 });
+    expect(
+      getCommuteTrainNextAction(
+        { ...assignment, joinable: false, serverNow: 85_000, phase: "complete" },
+        false,
+      ),
+    ).toEqual({ kind: "reboard", delayMs: 0 });
+    expect(
+      getCommuteTrainNextAction(
+        { ...assignment, joinable: false, serverNow: 85_000, phase: "complete" },
+        true,
+      ),
+    ).toEqual({ kind: "stop" });
   });
 
   it("shares only a domain stop when the rider allows it", () => {

--- a/extension/src/entrypoints/commute/commuteTrain.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.ts
@@ -1,0 +1,130 @@
+// ABOUTME: Boards hosted commute visitors onto authoritative bounded trains.
+// ABOUTME: Maps public train stops into the existing commute scene without exposing private URLs.
+
+import type {
+  CommuteTrainAssignment,
+  CommuteTrainBoardRequest,
+  CommuteTrainStop,
+} from "@playhtml/extension-types";
+import { COMMUTE_TRAIN_BOARD_URL } from "@movement/config";
+import type { HostedSlowModeRide } from "../../features/slowMode/slowModeHostedBridge";
+import type { CommuteStop } from "./commuteStops";
+
+const COMMUTE_RIDER_TOKEN_KEY = "wwo-commute-rider-token";
+
+function isTrainStop(value: unknown): value is CommuteTrainStop {
+  if (!value || typeof value !== "object") return false;
+  const stop = value as Record<string, unknown>;
+  const commonFieldsAreValid =
+    (stop.kind === "communal" || stop.kind === "domain") &&
+    typeof stop.id === "string" &&
+    typeof stop.domain === "string" &&
+    typeof stop.url === "string" &&
+    typeof stop.hue === "string";
+  if (!commonFieldsAreValid) return false;
+  try {
+    const url = new URL(stop.url as string);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  } catch {
+    return false;
+  }
+  return stop.kind === "communal"
+    ? (stop.title === null || typeof stop.title === "string") &&
+        typeof stop.visitedAt === "number"
+    : typeof stop.claimantCount === "number";
+}
+
+export function parseCommuteTrainAssignment(
+  value: unknown,
+): CommuteTrainAssignment {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid commute train assignment");
+  }
+  const assignment = value as Partial<CommuteTrainAssignment>;
+  if (
+    typeof assignment.trainId !== "string" ||
+    typeof assignment.createdAt !== "number" ||
+    typeof assignment.departureAt !== "number" ||
+    typeof assignment.joinableUntil !== "number" ||
+    typeof assignment.routeEndsAt !== "number" ||
+    typeof assignment.routeVersion !== "number" ||
+    typeof assignment.riderCount !== "number" ||
+    typeof assignment.capacity !== "number" ||
+    typeof assignment.joinable !== "boolean" ||
+    (assignment.phase !== "boarding" &&
+      assignment.phase !== "riding" &&
+      assignment.phase !== "complete") ||
+    !Array.isArray(assignment.stops) ||
+    !assignment.stops.every(isTrainStop) ||
+    assignment.stops.length === 0 ||
+    typeof assignment.serverNow !== "number"
+  ) {
+    throw new Error("Invalid commute train assignment");
+  }
+  return assignment as CommuteTrainAssignment;
+}
+
+export function getCommuteRiderToken(
+  ride: HostedSlowModeRide | null,
+): string {
+  if (ride) return `slow_${ride.rideId}`;
+  const stored = window.sessionStorage.getItem(COMMUTE_RIDER_TOKEN_KEY);
+  if (stored) return stored;
+  const token = `web_${crypto.randomUUID()}`;
+  window.sessionStorage.setItem(COMMUTE_RIDER_TOKEN_KEY, token);
+  return token;
+}
+
+export function createCommuteTrainBoardRequest(
+  riderToken: string,
+  ride: HostedSlowModeRide | null,
+): CommuteTrainBoardRequest {
+  return {
+    riderToken,
+    requestedStop:
+      ride && ride.stopVisibility !== "private"
+        ? { kind: "domain", domain: ride.destinationDomain }
+        : { kind: "none" },
+  };
+}
+
+export async function boardCommuteTrain(
+  request: CommuteTrainBoardRequest,
+  signal?: AbortSignal,
+): Promise<CommuteTrainAssignment> {
+  const response = await fetch(COMMUTE_TRAIN_BOARD_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Commute train boarding failed: ${response.status}`);
+  }
+  return parseCommuteTrainAssignment(await response.json());
+}
+
+export function getCommuteTrainTimeOffset(
+  assignment: CommuteTrainAssignment,
+  requestStartedAt: number,
+  responseReceivedAt: number,
+): number {
+  return assignment.serverNow - (requestStartedAt + responseReceivedAt) / 2;
+}
+
+export function toCommuteStop(stop: CommuteTrainStop): CommuteStop {
+  return {
+    id: stop.id,
+    url: stop.url,
+    domain: stop.domain,
+    path: new URL(stop.url).pathname || "/",
+    title: stop.kind === "communal" ? stop.title : stop.domain,
+    faviconUrl: null,
+    recentDomainVisits: stop.kind === "domain" ? stop.claimantCount : 1,
+    visitedBy: stop.kind === "domain" ? "rider" : "commute",
+    visitedAt: stop.kind === "communal" ? stop.visitedAt : null,
+    sampleAge: null,
+    hue: stop.hue,
+    source: "live",
+  };
+}

--- a/extension/src/entrypoints/commute/commuteTrain.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.ts
@@ -11,6 +11,16 @@ import type { HostedSlowModeRide } from "../../features/slowMode/slowModeHostedB
 import type { CommuteStop } from "./commuteStops";
 
 const COMMUTE_RIDER_TOKEN_KEY = "wwo-commute-rider-token";
+const COMMUTE_TRAIN_REFRESH_MS = 3_000;
+
+export type CommuteTrainNextAction =
+  | { kind: "refresh"; delayMs: number }
+  | { kind: "reboard"; delayMs: number }
+  | { kind: "stop" };
+
+function createCommuteRiderToken(): string {
+  return `web_${crypto.randomUUID()}`;
+}
 
 function isTrainStop(value: unknown): value is CommuteTrainStop {
   if (!value || typeof value !== "object") return false;
@@ -70,9 +80,29 @@ export function getCommuteRiderToken(
   if (ride) return `slow_${ride.rideId}`;
   const stored = window.sessionStorage.getItem(COMMUTE_RIDER_TOKEN_KEY);
   if (stored) return stored;
-  const token = `web_${crypto.randomUUID()}`;
+  const token = createCommuteRiderToken();
   window.sessionStorage.setItem(COMMUTE_RIDER_TOKEN_KEY, token);
   return token;
+}
+
+export function rotateCommuteRiderToken(): string {
+  const token = createCommuteRiderToken();
+  window.sessionStorage.setItem(COMMUTE_RIDER_TOKEN_KEY, token);
+  return token;
+}
+
+export function getCommuteTrainNextAction(
+  assignment: CommuteTrainAssignment,
+  isSlowModeRide: boolean,
+): CommuteTrainNextAction {
+  if (assignment.joinable) {
+    return { kind: "refresh", delayMs: COMMUTE_TRAIN_REFRESH_MS };
+  }
+  if (isSlowModeRide) return { kind: "stop" };
+  return {
+    kind: "reboard",
+    delayMs: Math.max(0, assignment.routeEndsAt - assignment.serverNow),
+  };
 }
 
 export function createCommuteTrainBoardRequest(

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -60,7 +60,7 @@ export default defineContentScript({
 
     markExtensionInstalled(document.documentElement);
     const removeSlowModeBridge = initHostedSlowModeContentBridge();
-    ctx.onInvalidated(removeSlowModeBridge);
+    ctx?.onInvalidated(removeSlowModeBridge);
 
     let currentPresenceCount = 0;
 

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -32,6 +32,7 @@ import {
 } from "./content/presencePolicy";
 import { markExtensionInstalled } from "../utils/extensionInstallMarker";
 import { isExtensionPageUrl } from "../utils/extensionPage";
+import { initHostedSlowModeContentBridge } from "../features/slowMode/slowModeHostedContentBridge";
 
 // Scraps are local-only, so normalize any unsupported stored mode before the
 // collector starts.
@@ -58,6 +59,8 @@ export default defineContentScript({
     }
 
     markExtensionInstalled(document.documentElement);
+    const removeSlowModeBridge = initHostedSlowModeContentBridge();
+    ctx.onInvalidated(removeSlowModeBridge);
 
     let currentPresenceCount = 0;
 

--- a/extension/src/features/slowMode/slowMode.test.ts
+++ b/extension/src/features/slowMode/slowMode.test.ts
@@ -133,7 +133,7 @@ describe("Slow Mode consent gates", () => {
   });
 
   it("applies the chance after navigation eligibility", () => {
-    const settings = { enabled: true, chancePercent: 30 };
+    const settings = { enabled: true, chancePercent: 30, stopVisibility: "domain" as const };
     expect(
       evaluateSlowModeNavigation(
         navigation,
@@ -155,7 +155,7 @@ describe("Slow Mode consent gates", () => {
   });
 
   it("enforces global and per-domain cooldowns", () => {
-    const settings = { enabled: true, chancePercent: 100 };
+    const settings = { enabled: true, chancePercent: 100, stopVisibility: "domain" as const };
     const globalState = emptyState();
     globalState.lastCommuteAt = NOW - SLOW_MODE_COOLDOWN_MS + 1;
     expect(
@@ -191,7 +191,7 @@ describe("Slow Mode consent gates", () => {
           ...navigation,
           destinationUrl: "https://news.example.com/article",
         },
-        { enabled: true, chancePercent: 100 },
+        { enabled: true, chancePercent: 100, stopVisibility: "domain" },
         domainState,
         NOW,
         () => 0,
@@ -203,6 +203,7 @@ describe("Slow Mode consent gates", () => {
 describe("Slow Mode state", () => {
   it("records a ride and reports the cooldown", () => {
     const state = recordSlowModeRide(emptyState(), {
+      id: "ride-1234567890",
       destinationUrl: "https://museum.example/exhibit?utm_source=test",
       startedAt: NOW,
       stopCount: 3,
@@ -221,14 +222,12 @@ describe("Slow Mode state", () => {
     );
   });
 
-  it("builds an encoded extension commute URL", () => {
+  it("builds a hosted commute URL containing only the opaque ride ID", () => {
     expect(
       createCommuteUrl(
-        "chrome-extension://abc/commute.html",
-        "https://museum.example/exhibit?q=slow mode",
+        "https://wewere.online/commute/",
+        "ride_1234567890",
       ),
-    ).toBe(
-      "chrome-extension://abc/commute.html?slow=1&destination=https%3A%2F%2Fmuseum.example%2Fexhibit%3Fq%3Dslow+mode",
-    );
+    ).toBe("https://wewere.online/commute/#ride=ride_1234567890");
   });
 });

--- a/extension/src/features/slowMode/slowMode.ts
+++ b/extension/src/features/slowMode/slowMode.ts
@@ -7,15 +7,20 @@ export const SLOW_MODE_SETTINGS_KEY = "slowModeSettings";
 export const SLOW_MODE_STATE_KEY = "slowModeState";
 export const SLOW_MODE_COOLDOWN_MS = 25 * 60 * 1_000;
 export const SLOW_MODE_RIDE_LOG_LIMIT = 30;
+export const HOSTED_COMMUTE_URL = "https://wewere.online/commute/";
+
+export type SlowModeStopVisibility = "page" | "domain" | "private";
 
 export interface SlowModeSettings {
   enabled: boolean;
   chancePercent: number;
+  stopVisibility: SlowModeStopVisibility;
 }
 
 export const DEFAULT_SLOW_MODE_SETTINGS: SlowModeSettings = {
   enabled: false,
   chancePercent: 30,
+  stopVisibility: "domain",
 };
 
 export type SlowModeRideOutcome = "riding" | "arrived" | "teleported" | "left";
@@ -260,12 +265,11 @@ export function evaluateSlowModeNavigation(
 
 export function recordSlowModeRide(
   state: SlowModeState,
-  ride: Omit<SlowModeRide, "id" | "destinationDomain">,
+  ride: Omit<SlowModeRide, "destinationDomain">,
 ): SlowModeState {
   const domain = destinationDomain(ride.destinationUrl);
   const entry: SlowModeRide = {
     ...ride,
-    id: `${ride.startedAt}:${domain}`,
     destinationDomain: domain,
   };
   return {
@@ -297,15 +301,10 @@ export function updateSlowModeRide(
 
 export function createCommuteUrl(
   commutePageUrl: string,
-  destinationUrl: string,
-  rideId?: string,
-  stopCount?: number,
+  rideId: string,
 ): string {
   const url = new URL(commutePageUrl);
-  url.searchParams.set("slow", "1");
-  url.searchParams.set("destination", destinationUrl);
-  if (rideId) url.searchParams.set("ride", rideId);
-  if (stopCount) url.searchParams.set("stops", String(stopCount));
+  url.hash = new URLSearchParams({ ride: rideId }).toString();
   return url.toString();
 }
 
@@ -322,6 +321,12 @@ export function normalizeSlowModeSettings(value: unknown): SlowModeSettings {
       Number.isFinite(stored.chancePercent)
         ? Math.min(100, Math.max(10, Math.round(stored.chancePercent / 10) * 10))
         : DEFAULT_SLOW_MODE_SETTINGS.chancePercent,
+    stopVisibility:
+      stored.stopVisibility === "page" ||
+      stored.stopVisibility === "domain" ||
+      stored.stopVisibility === "private"
+        ? stored.stopVisibility
+        : DEFAULT_SLOW_MODE_SETTINGS.stopVisibility,
   };
 }
 

--- a/extension/src/features/slowMode/slowModeBackground.test.ts
+++ b/extension/src/features/slowMode/slowModeBackground.test.ts
@@ -20,7 +20,11 @@ function emptyState(): SlowModeState {
 describe("Slow Mode browser interception", () => {
   it("redirects a qualifying top-frame navigation and records the ride", async () => {
     const stored: Record<string, unknown> = {
-      [SLOW_MODE_SETTINGS_KEY]: { enabled: true, chancePercent: 100 },
+      [SLOW_MODE_SETTINGS_KEY]: {
+        enabled: true,
+        chancePercent: 100,
+        stopVisibility: "domain",
+      },
       [SLOW_MODE_STATE_KEY]: emptyState(),
     };
     const set = vi.fn(async (items: Record<string, unknown>) => {
@@ -30,10 +34,11 @@ describe("Slow Mode browser interception", () => {
     const handler = createSlowModeNavigationHandler({
       getStorage: async () => stored,
       setStorage: set,
-      getCommutePageUrl: () => "chrome-extension://test/commute.html",
+      getCommutePageUrl: () => "https://wewere.online/commute/",
       updateTab,
       now: () => new Date("2026-08-21T17:00:00-07:00").getTime(),
       random: () => 0,
+      createRideId: () => "ride_1234567890",
     });
 
     handler.rememberTabUrl(7, "https://garden.example/notes");
@@ -47,13 +52,13 @@ describe("Slow Mode browser interception", () => {
 
     expect(updateTab).toHaveBeenCalledOnce();
     const commuteUrl = new URL(updateTab.mock.calls[0][1]);
-    expect(commuteUrl.pathname).toBe("/commute.html");
-    expect(commuteUrl.searchParams.get("destination")).toBe(
-      "https://museum.example/exhibit",
+    expect(commuteUrl.origin).toBe("https://wewere.online");
+    expect(commuteUrl.pathname).toBe("/commute/");
+    expect(commuteUrl.search).toBe("");
+    expect(new URLSearchParams(commuteUrl.hash.slice(1)).get("ride")).toBe(
+      "ride_1234567890",
     );
-    expect(commuteUrl.searchParams.get("ride")).toBe(
-      `${new Date("2026-08-21T17:00:00-07:00").getTime()}:museum.example`,
-    );
+    expect(commuteUrl.href).not.toContain("museum.example");
     const state = stored[SLOW_MODE_STATE_KEY] as SlowModeState;
     expect(state.rides).toHaveLength(1);
     expect(state.rides[0]).toMatchObject({
@@ -67,14 +72,19 @@ describe("Slow Mode browser interception", () => {
     const updateTab = vi.fn().mockResolvedValue(undefined);
     const handler = createSlowModeNavigationHandler({
       getStorage: async () => ({
-        [SLOW_MODE_SETTINGS_KEY]: { enabled: true, chancePercent: 100 },
+        [SLOW_MODE_SETTINGS_KEY]: {
+          enabled: true,
+          chancePercent: 100,
+          stopVisibility: "domain",
+        },
         [SLOW_MODE_STATE_KEY]: emptyState(),
       }),
       setStorage: vi.fn().mockResolvedValue(undefined),
-      getCommutePageUrl: () => "chrome-extension://test/commute.html",
+      getCommutePageUrl: () => "https://wewere.online/commute/",
       updateTab,
       now: () => Date.now(),
       random: () => 0,
+      createRideId: () => "ride_1234567890",
     });
 
     handler.rememberTabUrl(7, "https://garden.example/notes");

--- a/extension/src/features/slowMode/slowModeBackground.ts
+++ b/extension/src/features/slowMode/slowModeBackground.ts
@@ -5,6 +5,7 @@ import browser from "webextension-polyfill";
 import {
   SLOW_MODE_SETTINGS_KEY,
   SLOW_MODE_STATE_KEY,
+  HOSTED_COMMUTE_URL,
   createCommuteUrl,
   evaluateSlowModeNavigation,
   normalizeSlowModeSettings,
@@ -27,6 +28,7 @@ interface SlowModeNavigationDependencies {
   updateTab: (tabId: number, url: string) => Promise<unknown>;
   now: () => number;
   random: () => number;
+  createRideId: () => string;
 }
 
 export function createSlowModeNavigationHandler(
@@ -87,6 +89,7 @@ export function createSlowModeNavigationHandler(
 
         const stopCount = dependencies.random() < 0.5 ? 2 : 3;
         state = recordSlowModeRide(state, {
+          id: dependencies.createRideId(),
           destinationUrl: details.url,
           startedAt: now,
           stopCount,
@@ -96,9 +99,7 @@ export function createSlowModeNavigationHandler(
         await dependencies.setStorage({ [SLOW_MODE_STATE_KEY]: state });
         const commuteUrl = createCommuteUrl(
           dependencies.getCommutePageUrl(),
-          details.url,
           ride.id,
-          stopCount,
         );
         tabUrls.set(details.tabId, commuteUrl);
         await dependencies.updateTab(details.tabId, commuteUrl);
@@ -132,10 +133,11 @@ export function initSlowModeInterception(): void {
         SLOW_MODE_STATE_KEY,
       ]) as Promise<Record<string, unknown>>,
     setStorage: (items) => browser.storage.local.set(items),
-    getCommutePageUrl: () => browser.runtime.getURL("commute.html"),
+    getCommutePageUrl: () => HOSTED_COMMUTE_URL,
     updateTab: (tabId, url) => browser.tabs.update(tabId, { url }),
     now: Date.now,
     random: Math.random,
+    createRideId: () => crypto.randomUUID(),
   });
 
   const tabsApi = browser.tabs as Partial<typeof browser.tabs>;

--- a/extension/src/features/slowMode/slowModeHostedBridge.test.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.test.ts
@@ -24,6 +24,7 @@ describe("hosted Slow Mode bridge", () => {
   it("reads an opaque ride id from the fragment", () => {
     expect(getHostedSlowModeRideId(`#ride=${RIDE_ID}`)).toBe(RIDE_ID);
     expect(getHostedSlowModeRideId("#ride=example.com")).toBeNull();
+    expect(getHostedSlowModeRideId(`#ride=${"-".repeat(36)}`)).toBeNull();
   });
 
   it("validates page requests and outcomes", () => {

--- a/extension/src/features/slowMode/slowModeHostedBridge.test.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.test.ts
@@ -1,0 +1,57 @@
+// ABOUTME: Tests hosted Slow Mode bridge validation and fragment parsing.
+// ABOUTME: Verifies that only opaque ride metadata crosses into the hosted page.
+
+import { describe, expect, it } from "vitest";
+import {
+  SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+  SLOW_MODE_HOSTED_OUTCOME,
+  SLOW_MODE_HOSTED_REQUEST,
+  getHostedSlowModeRideId,
+  isHostedCommuteUrl,
+  isHostedSlowModeOutcome,
+  isHostedSlowModeRequest,
+} from "./slowModeHostedBridge";
+
+const RIDE_ID = "8cc8e2ef-63cf-4cb6-86c7-6d4999e5641d";
+
+describe("hosted Slow Mode bridge", () => {
+  it("accepts only the hosted commute route", () => {
+    expect(isHostedCommuteUrl(`https://wewere.online/commute/#ride=${RIDE_ID}`)).toBe(true);
+    expect(isHostedCommuteUrl("https://wewere.online/commute/extra")).toBe(false);
+    expect(isHostedCommuteUrl("https://example.com/commute/")).toBe(false);
+  });
+
+  it("reads an opaque ride id from the fragment", () => {
+    expect(getHostedSlowModeRideId(`#ride=${RIDE_ID}`)).toBe(RIDE_ID);
+    expect(getHostedSlowModeRideId("#ride=example.com")).toBeNull();
+  });
+
+  it("validates page requests and outcomes", () => {
+    expect(
+      isHostedSlowModeRequest({
+        source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+        type: SLOW_MODE_HOSTED_REQUEST,
+        requestId: "request-1",
+        rideId: RIDE_ID,
+      }),
+    ).toBe(true);
+    expect(
+      isHostedSlowModeOutcome({
+        source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+        type: SLOW_MODE_HOSTED_OUTCOME,
+        rideId: RIDE_ID,
+        outcome: "teleported",
+        navigate: true,
+      }),
+    ).toBe(true);
+    expect(
+      isHostedSlowModeOutcome({
+        source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+        type: SLOW_MODE_HOSTED_OUTCOME,
+        rideId: RIDE_ID,
+        outcome: "riding",
+        navigate: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/extension/src/features/slowMode/slowModeHostedBridge.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.ts
@@ -53,7 +53,12 @@ export function isHostedCommuteUrl(value: string): boolean {
 
 export function getHostedSlowModeRideId(hash: string): string | null {
   const rideId = new URLSearchParams(hash.replace(/^#/, "")).get("ride");
-  return rideId && /^[0-9a-f-]{36}$/i.test(rideId) ? rideId : null;
+  return rideId &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      rideId,
+    )
+    ? rideId
+    : null;
 }
 
 export function isHostedSlowModeRequest(

--- a/extension/src/features/slowMode/slowModeHostedBridge.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.ts
@@ -1,0 +1,140 @@
+// ABOUTME: Defines the page-to-extension bridge for hosted Slow Mode rides.
+// ABOUTME: Keeps exact destination URLs inside the extension while exposing safe ride metadata.
+
+import type {
+  SlowModeRideOutcome,
+  SlowModeStopVisibility,
+} from "./slowMode";
+
+export const SLOW_MODE_HOSTED_BRIDGE_SOURCE = "wwo-slow-mode";
+export const SLOW_MODE_HOSTED_REQUEST = "request-ride";
+export const SLOW_MODE_HOSTED_RESPONSE = "ride-response";
+export const SLOW_MODE_HOSTED_OUTCOME = "ride-outcome";
+
+export interface HostedSlowModeRide {
+  rideId: string;
+  destinationDomain: string;
+  stopVisibility: SlowModeStopVisibility;
+}
+
+interface HostedSlowModeRequestMessage {
+  source: typeof SLOW_MODE_HOSTED_BRIDGE_SOURCE;
+  type: typeof SLOW_MODE_HOSTED_REQUEST;
+  requestId: string;
+  rideId: string;
+}
+
+interface HostedSlowModeResponseMessage {
+  source: typeof SLOW_MODE_HOSTED_BRIDGE_SOURCE;
+  type: typeof SLOW_MODE_HOSTED_RESPONSE;
+  requestId: string;
+  ride: HostedSlowModeRide | null;
+}
+
+interface HostedSlowModeOutcomeMessage {
+  source: typeof SLOW_MODE_HOSTED_BRIDGE_SOURCE;
+  type: typeof SLOW_MODE_HOSTED_OUTCOME;
+  rideId: string;
+  outcome: SlowModeRideOutcome;
+  navigate: boolean;
+}
+
+export function isHostedCommuteUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.origin === "https://wewere.online" &&
+      (url.pathname === "/commute" || url.pathname === "/commute/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getHostedSlowModeRideId(hash: string): string | null {
+  const rideId = new URLSearchParams(hash.replace(/^#/, "")).get("ride");
+  return rideId && /^[0-9a-f-]{36}$/i.test(rideId) ? rideId : null;
+}
+
+export function isHostedSlowModeRequest(
+  value: unknown,
+): value is HostedSlowModeRequestMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<HostedSlowModeRequestMessage>;
+  return (
+    message.source === SLOW_MODE_HOSTED_BRIDGE_SOURCE &&
+    message.type === SLOW_MODE_HOSTED_REQUEST &&
+    typeof message.requestId === "string" &&
+    typeof message.rideId === "string"
+  );
+}
+
+export function isHostedSlowModeOutcome(
+  value: unknown,
+): value is HostedSlowModeOutcomeMessage {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Partial<HostedSlowModeOutcomeMessage>;
+  return (
+    message.source === SLOW_MODE_HOSTED_BRIDGE_SOURCE &&
+    message.type === SLOW_MODE_HOSTED_OUTCOME &&
+    typeof message.rideId === "string" &&
+    (message.outcome === "arrived" ||
+      message.outcome === "teleported" ||
+      message.outcome === "left") &&
+    typeof message.navigate === "boolean"
+  );
+}
+
+export function requestHostedSlowModeRide(
+  rideId: string,
+  timeoutMs = 1_000,
+): Promise<HostedSlowModeRide | null> {
+  const requestId = crypto.randomUUID();
+  return new Promise((resolve) => {
+    const timer = window.setTimeout(() => {
+      window.removeEventListener("message", receiveResponse);
+      resolve(null);
+    }, timeoutMs);
+    const receiveResponse = (event: MessageEvent) => {
+      if (event.source !== window) return;
+      const message = event.data as Partial<HostedSlowModeResponseMessage>;
+      if (
+        message.source !== SLOW_MODE_HOSTED_BRIDGE_SOURCE ||
+        message.type !== SLOW_MODE_HOSTED_RESPONSE ||
+        message.requestId !== requestId
+      ) {
+        return;
+      }
+      window.clearTimeout(timer);
+      window.removeEventListener("message", receiveResponse);
+      resolve(message.ride ?? null);
+    };
+    window.addEventListener("message", receiveResponse);
+    window.postMessage(
+      {
+        source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+        type: SLOW_MODE_HOSTED_REQUEST,
+        requestId,
+        rideId,
+      } satisfies HostedSlowModeRequestMessage,
+      window.location.origin,
+    );
+  });
+}
+
+export function reportHostedSlowModeOutcome(
+  rideId: string,
+  outcome: SlowModeRideOutcome,
+  navigate: boolean,
+): void {
+  window.postMessage(
+    {
+      source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+      type: SLOW_MODE_HOSTED_OUTCOME,
+      rideId,
+      outcome,
+      navigate,
+    } satisfies HostedSlowModeOutcomeMessage,
+    window.location.origin,
+  );
+}

--- a/extension/src/features/slowMode/slowModeHostedContentBridge.ts
+++ b/extension/src/features/slowMode/slowModeHostedContentBridge.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Relays hosted Slow Mode page messages through the extension content script.
+// ABOUTME: Exposes safe ride metadata and keeps destination navigation in the extension.
+
+import browser from "webextension-polyfill";
+import {
+  SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+  SLOW_MODE_HOSTED_RESPONSE,
+  isHostedCommuteUrl,
+  isHostedSlowModeOutcome,
+  isHostedSlowModeRequest,
+  type HostedSlowModeRide,
+} from "./slowModeHostedBridge";
+
+export function initHostedSlowModeContentBridge(): () => void {
+  if (!isHostedCommuteUrl(window.location.href)) return () => {};
+
+  const receivePageMessage = (event: MessageEvent) => {
+    if (event.source !== window) return;
+    if (isHostedSlowModeRequest(event.data)) {
+      browser.runtime
+        .sendMessage({
+          type: "GET_SLOW_MODE_HOSTED_RIDE",
+          rideId: event.data.rideId,
+        })
+        .then((ride: HostedSlowModeRide | null) => {
+          window.postMessage(
+            {
+              source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+              type: SLOW_MODE_HOSTED_RESPONSE,
+              requestId: event.data.requestId,
+              ride,
+            },
+            window.location.origin,
+          );
+        })
+        .catch(() => {});
+      return;
+    }
+    if (isHostedSlowModeOutcome(event.data)) {
+      void browser.runtime.sendMessage({
+        type: "SLOW_MODE_RIDE_OUTCOME",
+        rideId: event.data.rideId,
+        outcome: event.data.outcome,
+        navigate: event.data.navigate,
+      });
+    }
+  };
+
+  window.addEventListener("message", receivePageMessage);
+  return () => window.removeEventListener("message", receivePageMessage);
+}

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -14,6 +14,7 @@ export const WORKER_URL: string =
 
 export const RECENT_EVENTS_URL = `${WORKER_URL}/events/recent`;
 export const COMMUTE_RECENT_URL = `${WORKER_URL}/commute/recent`;
+export const COMMUTE_TRAIN_BOARD_URL = `${WORKER_URL}/commute/trains/board`;
 export const DAILY_COUNTS_URL = `${WORKER_URL}/events/daily-counts`;
 export const PAGE_META_URL = `${WORKER_URL}/page-meta`;
 

--- a/extension/website/vite.config.ts
+++ b/extension/website/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       playhtml: path.resolve(__dirname, "../../packages/playhtml/src/index.ts"),
       "@playhtml/react": path.resolve(__dirname, "../../packages/react/src"),
       "@playhtml/common": path.resolve(__dirname, "../../packages/common/src"),
+      "@playhtml/extension-types": path.resolve(__dirname, "../../packages/extension-types/src"),
       // Bun's hoisting puts react@19 in extension/node_modules and react@18 at
       // the workspace root. Node's upward resolution from extension/website/
       // hits the @19 copy first, even though the website declares @18.3.1.

--- a/extension/worker/package.json
+++ b/extension/worker/package.json
@@ -26,6 +26,6 @@
     "@types/react": "^18.3.17",
     "miniflare": "^4.20260409.0",
     "vitest": "^2.1.8",
-    "wrangler": "^3.19.0"
+    "wrangler": "^4.81.1"
   }
 }

--- a/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
+++ b/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
@@ -1,0 +1,124 @@
+// ABOUTME: Covers bounded oldest-first assignment and append-only train routes.
+// ABOUTME: Verifies rolling joins, domain coalescing, idempotency, and cleanup.
+
+import { describe, expect, it } from 'vitest';
+import type {
+  CommuteTrainBoardRequest,
+  CommuteTrainCommunalStop,
+} from '@playhtml/extension-types';
+import {
+  CommuteTrainDispatcher,
+  EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE,
+} from '../commuteTrainDispatcher';
+
+const NOW = 1_000_000;
+const COMMUNAL_STOPS: CommuteTrainCommunalStop[] = [
+  {
+    kind: 'communal',
+    id: 'communal-1',
+    domain: 'html.energy',
+    url: 'https://html.energy/',
+    title: null,
+    visitedAt: NOW,
+    hue: '#d4b85c',
+  },
+  {
+    kind: 'communal',
+    id: 'communal-2',
+    domain: 'special.fish',
+    url: 'https://special.fish/',
+    title: null,
+    visitedAt: NOW,
+    hue: '#5b8db8',
+  },
+];
+
+function rider(
+  riderToken: string,
+  domain?: string,
+): CommuteTrainBoardRequest {
+  return {
+    riderToken,
+    requestedStop: domain
+      ? { kind: 'domain', domain }
+      : { kind: 'none' },
+  };
+}
+
+function dispatcher() {
+  let id = 0;
+  return new CommuteTrainDispatcher(
+    structuredClone(EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE),
+    () => `generated-${++id}`,
+  );
+}
+
+describe('CommuteTrainDispatcher', () => {
+  it('assigns at most four simultaneous riders to each train', () => {
+    const subject = dispatcher();
+    const assignments = Array.from({ length: 100 }, (_, index) =>
+      subject.board(rider(`rider-${index}`), COMMUNAL_STOPS, NOW),
+    );
+
+    expect(new Set(assignments.map((assignment) => assignment.trainId)).size).toBe(25);
+    expect(Math.max(...assignments.map((assignment) => assignment.riderCount))).toBe(4);
+  });
+
+  it('returns the same assignment for an idempotent rider request', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a', 'example.com'), COMMUNAL_STOPS, NOW);
+    const repeated = subject.board(rider('rider-a', 'other.example'), [], NOW + 10_000);
+
+    expect(repeated.trainId).toBe(first.trainId);
+    expect(repeated.routeVersion).toBe(first.routeVersion);
+    expect(repeated.stops).toEqual(first.stops);
+  });
+
+  it('appends new domains without reordering existing stops', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a', 'a.example'), COMMUNAL_STOPS, NOW);
+    const second = subject.board(rider('rider-b', 'b.example'), [], NOW + 20_000);
+
+    expect(second.trainId).toBe(first.trainId);
+    expect(second.stops.map((stop) => stop.domain)).toEqual([
+      'html.energy',
+      'special.fish',
+      'a.example',
+      'b.example',
+    ]);
+  });
+
+  it('coalesces riders with the same pending domain', () => {
+    const subject = dispatcher();
+    subject.board(rider('rider-a', 'a.example'), COMMUNAL_STOPS, NOW);
+    const assignment = subject.board(
+      rider('rider-b', 'a.example'),
+      [],
+      NOW + 20_000,
+    );
+
+    expect(assignment.stops).toHaveLength(3);
+    expect(assignment.stops[2]).toMatchObject({
+      kind: 'domain',
+      domain: 'a.example',
+      claimantCount: 2,
+    });
+  });
+
+  it('starts a new train after the previous train begins returning home', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+    const later = subject.board(rider('rider-b'), COMMUNAL_STOPS, NOW + 54_000);
+
+    expect(later.trainId).not.toBe(first.trainId);
+  });
+
+  it('deletes completed trains after the retention window', () => {
+    const subject = dispatcher();
+    subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+
+    subject.cleanup(NOW + 124_000);
+
+    expect(subject.snapshot().trains).toEqual([]);
+  });
+});

--- a/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
+++ b/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
@@ -8,7 +8,9 @@ import type {
 } from '@playhtml/extension-types';
 import {
   CommuteTrainDispatcher,
+  CommuteTrainCapacityError,
   EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE,
+  MAX_RETAINED_COMMUTE_TRAINS,
 } from '../commuteTrainDispatcher';
 
 const NOW = 1_000_000;
@@ -120,5 +122,22 @@ describe('CommuteTrainDispatcher', () => {
     subject.cleanup(NOW + 124_000);
 
     expect(subject.snapshot().trains).toEqual([]);
+  });
+
+  it('rejects new trains at the retained-state ceiling', () => {
+    const subject = dispatcher();
+    const admittedRiders = MAX_RETAINED_COMMUTE_TRAINS * 4;
+    const assignments = Array.from({ length: admittedRiders }, (_, index) =>
+      subject.board(rider(`rider-${index}`), COMMUNAL_STOPS, NOW),
+    );
+
+    expect(subject.snapshot().trains).toHaveLength(MAX_RETAINED_COMMUTE_TRAINS);
+    expect(() =>
+      subject.board(rider('rider-over-capacity'), COMMUNAL_STOPS, NOW),
+    ).toThrow(CommuteTrainCapacityError);
+    expect(
+      subject.board(rider('rider-0'), [], NOW + 1).trainId,
+    ).toBe(assignments[0].trainId);
+    expect(subject.snapshot().trains).toHaveLength(MAX_RETAINED_COMMUTE_TRAINS);
   });
 });

--- a/extension/worker/src/__tests__/commuteTrains.test.ts
+++ b/extension/worker/src/__tests__/commuteTrains.test.ts
@@ -1,8 +1,20 @@
 // ABOUTME: Covers the public Internet Commute boarding request boundary.
 // ABOUTME: Rejects malformed rider tokens, destination URLs, and non-domain claims.
 
-import { describe, expect, it } from 'vitest';
-import { parseCommuteTrainBoardRequest } from '../routes/commuteTrains';
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../lib/supabase';
+import {
+  handleCommuteTrainBoard,
+  parseCommuteTrainBoardRequest,
+} from '../routes/commuteTrains';
+
+function rateLimitEnv(
+  limit: RateLimit['limit'],
+): Env {
+  return {
+    COMMUTE_BOARD_RATE_LIMITER: { limit },
+  } as Env;
+}
 
 describe('parseCommuteTrainBoardRequest', () => {
   it('accepts standard and private riders without a shared stop', () => {
@@ -50,5 +62,45 @@ describe('parseCommuteTrainBoardRequest', () => {
         requestedStop: { kind: 'none' },
       }),
     ).toBeNull();
+  });
+});
+
+describe('handleCommuteTrainBoard', () => {
+  it('rejects rate-limited requests before dispatching', async () => {
+    const response = await handleCommuteTrainBoard(
+      new Request('https://wewere.online/api/commute/trains/board', {
+        method: 'POST',
+        headers: { 'CF-Connecting-IP': '198.51.100.10' },
+      }),
+      rateLimitEnv(async ({ key }) => ({ success: key !== '198.51.100.10' })),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('60');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Too many boarding requests',
+    });
+  });
+
+  it('fails closed when the rate-limit binding is unavailable', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const response = await handleCommuteTrainBoard(
+      new Request('https://wewere.online/api/commute/trains/board', {
+        method: 'POST',
+      }),
+      rateLimitEnv(async () => {
+        throw new Error('binding unavailable');
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Boarding is temporarily unavailable',
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      '[commute trains] rate limiter unavailable:',
+      expect.objectContaining({ message: 'binding unavailable' }),
+    );
+    consoleError.mockRestore();
   });
 });

--- a/extension/worker/src/__tests__/commuteTrains.test.ts
+++ b/extension/worker/src/__tests__/commuteTrains.test.ts
@@ -1,0 +1,54 @@
+// ABOUTME: Covers the public Internet Commute boarding request boundary.
+// ABOUTME: Rejects malformed rider tokens, destination URLs, and non-domain claims.
+
+import { describe, expect, it } from 'vitest';
+import { parseCommuteTrainBoardRequest } from '../routes/commuteTrains';
+
+describe('parseCommuteTrainBoardRequest', () => {
+  it('accepts standard and private riders without a shared stop', () => {
+    expect(
+      parseCommuteTrainBoardRequest({
+        riderToken: 'rider_token_1234567890',
+        requestedStop: { kind: 'none' },
+      }),
+    ).toEqual({
+      riderToken: 'rider_token_1234567890',
+      requestedStop: { kind: 'none' },
+    });
+  });
+
+  it('accepts a normalized registrable domain', () => {
+    expect(
+      parseCommuteTrainBoardRequest({
+        riderToken: 'rider_token_1234567890',
+        requestedStop: { kind: 'domain', domain: 'example.co.uk' },
+      }),
+    ).toEqual({
+      riderToken: 'rider_token_1234567890',
+      requestedStop: { kind: 'domain', domain: 'example.co.uk' },
+    });
+  });
+
+  it.each([
+    'https://example.com/private',
+    'www.example.com',
+    'Example.com',
+    'localhost',
+  ])('rejects a non-canonical domain claim: %s', (domain) => {
+    expect(
+      parseCommuteTrainBoardRequest({
+        riderToken: 'rider_token_1234567890',
+        requestedStop: { kind: 'domain', domain },
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects short or missing idempotency tokens', () => {
+    expect(
+      parseCommuteTrainBoardRequest({
+        riderToken: 'short',
+        requestedStop: { kind: 'none' },
+      }),
+    ).toBeNull();
+  });
+});

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -42,6 +42,7 @@ const ENV: Env = {
   RESEND_API_KEY: 'r',
   CODA_API_TOKEN: 'c',
   LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
+  COMMUTE_TRAIN_DISPATCHER: {} as DurableObjectNamespace,
   WWO_ADMIN_DB: {} as D1Database,
 };
 

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -43,6 +43,9 @@ const ENV: Env = {
   CODA_API_TOKEN: 'c',
   LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
   COMMUTE_TRAIN_DISPATCHER: {} as DurableObjectNamespace,
+  COMMUTE_BOARD_RATE_LIMITER: {
+    limit: async () => ({ success: true }),
+  },
   WWO_ADMIN_DB: {} as D1Database,
 };
 

--- a/extension/worker/src/__tests__/subscribe.test.ts
+++ b/extension/worker/src/__tests__/subscribe.test.ts
@@ -27,6 +27,7 @@ const ENV: Env = {
   RESEND_API_KEY: 'r',
   CODA_API_TOKEN: 'c',
   LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
+  COMMUTE_TRAIN_DISPATCHER: {} as DurableObjectNamespace,
   WWO_ADMIN_DB: {} as D1Database,
 };
 

--- a/extension/worker/src/__tests__/subscribe.test.ts
+++ b/extension/worker/src/__tests__/subscribe.test.ts
@@ -28,6 +28,9 @@ const ENV: Env = {
   CODA_API_TOKEN: 'c',
   LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
   COMMUTE_TRAIN_DISPATCHER: {} as DurableObjectNamespace,
+  COMMUTE_BOARD_RATE_LIMITER: {
+    limit: async () => ({ success: true }),
+  },
   WWO_ADMIN_DB: {} as D1Database,
 };
 

--- a/extension/worker/src/commuteTrainDispatcher.ts
+++ b/extension/worker/src/commuteTrainDispatcher.ts
@@ -18,6 +18,14 @@ import {
 } from '@playhtml/extension-types';
 
 const COMPLETED_TRAIN_RETENTION_MS = 60_000;
+export const MAX_RETAINED_COMMUTE_TRAINS = 64;
+
+export class CommuteTrainCapacityError extends Error {
+  constructor() {
+    super('Internet Commute is at train capacity');
+    this.name = 'CommuteTrainCapacityError';
+  }
+}
 
 interface CommuteTrainRider {
   requestedStop: CommuteTrainStopRequest;
@@ -132,18 +140,25 @@ export class CommuteTrainDispatcher {
   }
 
   cleanup(now: number): void {
-    this.state.trains = this.state.trains.filter(
+    const retainedTrains = this.state.trains.filter(
       (train) =>
         getCommuteTrainRouteEndsAt(train.createdAt, train.stops.length) +
           COMPLETED_TRAIN_RETENTION_MS >
         now,
     );
+    this.state.trains = retainedTrains.slice(-MAX_RETAINED_COMMUTE_TRAINS);
   }
 
   needsCommunalStops(riderToken: string, now: number): boolean {
     this.cleanup(now);
     if (this.findRiderTrain(riderToken)) return false;
-    return !this.state.trains.some((train) => isTrainJoinable(train, now));
+    if (this.state.trains.some((train) => isTrainJoinable(train, now))) {
+      return false;
+    }
+    if (this.state.trains.length >= MAX_RETAINED_COMMUTE_TRAINS) {
+      throw new CommuteTrainCapacityError();
+    }
+    return true;
   }
 
   board(
@@ -161,6 +176,9 @@ export class CommuteTrainDispatcher {
       .find((candidate) => isTrainJoinable(candidate, now));
 
     if (!train) {
+      if (this.state.trains.length >= MAX_RETAINED_COMMUTE_TRAINS) {
+        throw new CommuteTrainCapacityError();
+      }
       if (communalStops.length === 0) {
         throw new Error('Internet Commute requires at least one communal stop');
       }

--- a/extension/worker/src/commuteTrainDispatcher.ts
+++ b/extension/worker/src/commuteTrainDispatcher.ts
@@ -1,0 +1,228 @@
+// ABOUTME: Assigns Internet Commute riders to bounded rolling trains.
+// ABOUTME: Owns append-only routes while keeping exact destination URLs out of shared state.
+
+import {
+  COMMUTE_TRAIN_CAPACITY,
+  COMMUTE_TRAIN_DEPARTURE_MS,
+  COMMUTE_TRAIN_JOIN_WINDOW_MS,
+  getCommuteTrainReturnStartsAt,
+  getCommuteTrainRouteEndsAt,
+  getCommuteTrainStopPassedAt,
+  type CommuteTrainAssignment,
+  type CommuteTrainBoardRequest,
+  type CommuteTrainCommunalStop,
+  type CommuteTrainDomainStop,
+  type CommuteTrainPhase,
+  type CommuteTrainStop,
+  type CommuteTrainStopRequest,
+} from '@playhtml/extension-types';
+
+const COMPLETED_TRAIN_RETENTION_MS = 60_000;
+
+interface CommuteTrainRider {
+  requestedStop: CommuteTrainStopRequest;
+}
+
+interface StoredDomainStop extends CommuteTrainDomainStop {
+  claimantTokens: string[];
+}
+
+type StoredTrainStop = CommuteTrainCommunalStop | StoredDomainStop;
+
+interface CommuteTrainRecord {
+  id: string;
+  createdAt: number;
+  departureAt: number;
+  routeVersion: number;
+  riders: Record<string, CommuteTrainRider>;
+  stops: StoredTrainStop[];
+}
+
+export interface CommuteTrainDispatcherState {
+  trains: CommuteTrainRecord[];
+}
+
+export const EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE: CommuteTrainDispatcherState = {
+  trains: [],
+};
+
+function getTrainPhase(train: CommuteTrainRecord, now: number): CommuteTrainPhase {
+  if (now < train.departureAt) return 'boarding';
+  if (now < getCommuteTrainRouteEndsAt(train.createdAt, train.stops.length)) {
+    return 'riding';
+  }
+  return 'complete';
+}
+
+function getJoinableUntil(train: CommuteTrainRecord): number {
+  return Math.min(
+    train.createdAt + COMMUTE_TRAIN_JOIN_WINDOW_MS,
+    getCommuteTrainReturnStartsAt(train.createdAt, train.stops.length),
+  );
+}
+
+function isTrainJoinable(train: CommuteTrainRecord, now: number): boolean {
+  return (
+    Object.keys(train.riders).length < COMMUTE_TRAIN_CAPACITY &&
+    now < getJoinableUntil(train)
+  );
+}
+
+function publicStop(stop: StoredTrainStop): CommuteTrainStop {
+  if (stop.kind === 'communal') return stop;
+  return {
+    kind: 'domain',
+    id: stop.id,
+    domain: stop.domain,
+    url: stop.url,
+    hue: stop.hue,
+    claimantCount: stop.claimantTokens.length,
+  };
+}
+
+function assignmentFor(
+  train: CommuteTrainRecord,
+  now: number,
+): CommuteTrainAssignment {
+  return {
+    trainId: train.id,
+    createdAt: train.createdAt,
+    departureAt: train.departureAt,
+    joinableUntil: getJoinableUntil(train),
+    routeEndsAt: getCommuteTrainRouteEndsAt(
+      train.createdAt,
+      train.stops.length,
+    ),
+    routeVersion: train.routeVersion,
+    riderCount: Object.keys(train.riders).length,
+    capacity: COMMUTE_TRAIN_CAPACITY,
+    joinable: isTrainJoinable(train, now),
+    phase: getTrainPhase(train, now),
+    stops: train.stops.map(publicStop),
+    serverNow: now,
+  };
+}
+
+function findClaimableDomainStop(
+  train: CommuteTrainRecord,
+  domain: string,
+  now: number,
+): StoredDomainStop | null {
+  for (let index = train.stops.length - 1; index >= 0; index -= 1) {
+    const stop = train.stops[index];
+    if (
+      stop.kind === 'domain' &&
+      stop.domain === domain &&
+      now < getCommuteTrainStopPassedAt(train.createdAt, index)
+    ) {
+      return stop;
+    }
+  }
+  return null;
+}
+
+export class CommuteTrainDispatcher {
+  constructor(
+    private readonly state: CommuteTrainDispatcherState,
+    private readonly createId: () => string,
+  ) {}
+
+  snapshot(): CommuteTrainDispatcherState {
+    return this.state;
+  }
+
+  cleanup(now: number): void {
+    this.state.trains = this.state.trains.filter(
+      (train) =>
+        getCommuteTrainRouteEndsAt(train.createdAt, train.stops.length) +
+          COMPLETED_TRAIN_RETENTION_MS >
+        now,
+    );
+  }
+
+  needsCommunalStops(riderToken: string, now: number): boolean {
+    this.cleanup(now);
+    if (this.findRiderTrain(riderToken)) return false;
+    return !this.state.trains.some((train) => isTrainJoinable(train, now));
+  }
+
+  board(
+    request: CommuteTrainBoardRequest,
+    communalStops: CommuteTrainCommunalStop[],
+    now: number,
+  ): CommuteTrainAssignment {
+    this.cleanup(now);
+
+    const existingTrain = this.findRiderTrain(request.riderToken);
+    if (existingTrain) return assignmentFor(existingTrain, now);
+
+    let train = [...this.state.trains]
+      .sort((left, right) => left.createdAt - right.createdAt)
+      .find((candidate) => isTrainJoinable(candidate, now));
+
+    if (!train) {
+      if (communalStops.length === 0) {
+        throw new Error('Internet Commute requires at least one communal stop');
+      }
+      train = {
+        id: this.createId(),
+        createdAt: now,
+        departureAt: now + COMMUTE_TRAIN_DEPARTURE_MS,
+        routeVersion: 0,
+        riders: {},
+        stops: communalStops.map((stop) => ({ ...stop })),
+      };
+      this.state.trains.push(train);
+    }
+
+    train.riders[request.riderToken] = {
+      requestedStop: request.requestedStop,
+    };
+    this.addRequestedStop(train, request.riderToken, request.requestedStop, now);
+    train.routeVersion += 1;
+
+    return assignmentFor(train, now);
+  }
+
+  nextCleanupAt(): number | null {
+    let cleanupAt: number | null = null;
+    for (const train of this.state.trains) {
+      const candidate =
+        getCommuteTrainRouteEndsAt(train.createdAt, train.stops.length) +
+        COMPLETED_TRAIN_RETENTION_MS;
+      if (cleanupAt === null || candidate < cleanupAt) cleanupAt = candidate;
+    }
+    return cleanupAt;
+  }
+
+  private findRiderTrain(riderToken: string): CommuteTrainRecord | null {
+    return (
+      this.state.trains.find((train) => riderToken in train.riders) ?? null
+    );
+  }
+
+  private addRequestedStop(
+    train: CommuteTrainRecord,
+    riderToken: string,
+    request: CommuteTrainStopRequest,
+    now: number,
+  ): void {
+    if (request.kind === 'none') return;
+
+    const existingStop = findClaimableDomainStop(train, request.domain, now);
+    if (existingStop) {
+      existingStop.claimantTokens.push(riderToken);
+      return;
+    }
+
+    train.stops.push({
+      kind: 'domain',
+      id: this.createId(),
+      domain: request.domain,
+      url: `https://${request.domain}/`,
+      hue: '#4a9a8a',
+      claimantCount: 1,
+      claimantTokens: [riderToken],
+    });
+  }
+}

--- a/extension/worker/src/commuteTrainDispatcherObject.ts
+++ b/extension/worker/src/commuteTrainDispatcherObject.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Loads communal routes only when a new bounded train must be created.
 
 import type {
+  CommuteTrainAssignment,
   CommuteTrainBoardRequest,
   CommuteTrainCommunalStop,
 } from '@playhtml/extension-types';
@@ -9,6 +10,7 @@ import type { Env } from './lib/supabase';
 import { getCommuteResponse } from './routes/commute';
 import {
   CommuteTrainDispatcher,
+  CommuteTrainCapacityError,
   EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE,
   type CommuteTrainDispatcherState,
 } from './commuteTrainDispatcher';
@@ -66,13 +68,21 @@ export class CommuteTrainDispatcherObject {
 
     const now = Date.now();
     const dispatcher = await this.ready;
-    const communalStops = dispatcher.needsCommunalStops(
-      parsed.riderToken,
-      now,
-    )
-      ? await this.loadCommunalStops(now)
-      : [];
-    const assignment = dispatcher.board(parsed, communalStops, now);
+    let assignment: CommuteTrainAssignment;
+    try {
+      const communalStops = dispatcher.needsCommunalStops(
+        parsed.riderToken,
+        now,
+      )
+        ? await this.loadCommunalStops(now)
+        : [];
+      assignment = dispatcher.board(parsed, communalStops, now);
+    } catch (error) {
+      if (!(error instanceof CommuteTrainCapacityError)) throw error;
+      await this.state.storage.put(DISPATCHER_STATE_KEY, dispatcher.snapshot());
+      await this.scheduleCleanup(dispatcher);
+      return jsonResponse(429, { error: 'Train dispatcher is at capacity' });
+    }
 
     await this.state.storage.put(DISPATCHER_STATE_KEY, dispatcher.snapshot());
     await this.scheduleCleanup(dispatcher);

--- a/extension/worker/src/commuteTrainDispatcherObject.ts
+++ b/extension/worker/src/commuteTrainDispatcherObject.ts
@@ -1,0 +1,149 @@
+// ABOUTME: Persists the singleton Internet Commute dispatcher in a Durable Object.
+// ABOUTME: Loads communal routes only when a new bounded train must be created.
+
+import type {
+  CommuteTrainBoardRequest,
+  CommuteTrainCommunalStop,
+} from '@playhtml/extension-types';
+import type { Env } from './lib/supabase';
+import { getCommuteResponse } from './routes/commute';
+import {
+  CommuteTrainDispatcher,
+  EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE,
+  type CommuteTrainDispatcherState,
+} from './commuteTrainDispatcher';
+import { parseCommuteTrainBoardRequest } from './routes/commuteTrains';
+
+const DISPATCHER_STATE_KEY = 'dispatcher';
+
+const FALLBACK_COMMUNAL_STOPS: CommuteTrainCommunalStop[] = [
+  {
+    kind: 'communal',
+    id: 'html-energy',
+    domain: 'html.energy',
+    url: 'https://html.energy/',
+    title: null,
+    visitedAt: 0,
+    hue: '#d4b85c',
+  },
+  {
+    kind: 'communal',
+    id: 'special-fish',
+    domain: 'special.fish',
+    url: 'https://special.fish/',
+    title: null,
+    visitedAt: 0,
+    hue: '#5b8db8',
+  },
+];
+
+export class CommuteTrainDispatcherObject {
+  private readonly ready: Promise<CommuteTrainDispatcher>;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    this.ready = state.blockConcurrencyWhile(async () => {
+      const stored = await state.storage.get<CommuteTrainDispatcherState>(
+        DISPATCHER_STATE_KEY,
+      );
+      return new CommuteTrainDispatcher(
+        stored ?? structuredClone(EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE),
+        () => crypto.randomUUID(),
+      );
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== '/board' || request.method !== 'POST') {
+      return jsonResponse(404, { error: 'Not found' });
+    }
+
+    const parsed = await readBoardRequest(request);
+    if (!parsed) return jsonResponse(400, { error: 'Invalid boarding request' });
+
+    const now = Date.now();
+    const dispatcher = await this.ready;
+    const communalStops = dispatcher.needsCommunalStops(
+      parsed.riderToken,
+      now,
+    )
+      ? await this.loadCommunalStops(now)
+      : [];
+    const assignment = dispatcher.board(parsed, communalStops, now);
+
+    await this.state.storage.put(DISPATCHER_STATE_KEY, dispatcher.snapshot());
+    await this.scheduleCleanup(dispatcher);
+    return jsonResponse(200, assignment);
+  }
+
+  async alarm(): Promise<void> {
+    const dispatcher = await this.ready;
+    dispatcher.cleanup(Date.now());
+    await this.state.storage.put(DISPATCHER_STATE_KEY, dispatcher.snapshot());
+    await this.scheduleCleanup(dispatcher);
+  }
+
+  private async loadCommunalStops(
+    now: number,
+  ): Promise<CommuteTrainCommunalStop[]> {
+    let destinations: CommuteTrainCommunalStop[] = [];
+    try {
+      const response = await getCommuteResponse(
+        new Request('https://dispatcher.internal/commute/recent'),
+        this.env,
+        now,
+      );
+      destinations = response.destinations.slice(0, 2).map((destination) => ({
+        kind: 'communal',
+        id: destination.id,
+        domain: destination.domain,
+        url: destination.url,
+        title: destination.title,
+        visitedAt: destination.visitedAt,
+        hue: destination.hue,
+      }));
+    } catch (error) {
+      console.warn('[commute trains] communal route unavailable:', error);
+    }
+
+    const domains = new Set(destinations.map((stop) => stop.domain));
+    for (const fallback of FALLBACK_COMMUNAL_STOPS) {
+      if (destinations.length === 2) break;
+      if (domains.has(fallback.domain)) continue;
+      destinations.push({ ...fallback, visitedAt: now });
+      domains.add(fallback.domain);
+    }
+    return destinations;
+  }
+
+  private async scheduleCleanup(
+    dispatcher: CommuteTrainDispatcher,
+  ): Promise<void> {
+    const cleanupAt = dispatcher.nextCleanupAt();
+    if (cleanupAt === null) {
+      await this.state.storage.deleteAlarm();
+      return;
+    }
+    await this.state.storage.setAlarm(cleanupAt);
+  }
+}
+
+async function readBoardRequest(
+  request: Request,
+): Promise<CommuteTrainBoardRequest | null> {
+  try {
+    return parseCommuteTrainBoardRequest(await request.json());
+  } catch {
+    return null;
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/extension/worker/src/index.ts
+++ b/extension/worker/src/index.ts
@@ -17,6 +17,7 @@ import {
   handleQuarantineRip,
 } from './routes/quarantine';
 import { handleCommute } from './routes/commute';
+import { handleCommuteTrainBoard } from './routes/commuteTrains';
 import {
   handleAccessRequest,
   handleAdminAccessOverview,
@@ -31,6 +32,7 @@ import { isAllowedOrigin, forbiddenResponse } from './lib/originAllowlist';
 import type { Env } from './lib/supabase';
 
 export { LiveEventsHub } from './live/LiveEventsHub';
+export { CommuteTrainDispatcherObject } from './commuteTrainDispatcherObject';
 
 /**
  * Cloudflare Worker entry point
@@ -71,6 +73,11 @@ export default {
       // This response is reduced to public destinations, domain-only scenery,
       // and aggregate counts. Extension-page GETs can omit Origin and Referer.
       return handleCommute(request, env);
+    }
+
+    if (path === '/commute/trains/board' && request.method === 'POST') {
+      if (!isAllowedOrigin(request)) return forbiddenResponse();
+      return handleCommuteTrainBoard(request, env);
     }
 
     if (path === '/events/daily-counts' && request.method === 'GET') {

--- a/extension/worker/src/lib/supabase.ts
+++ b/extension/worker/src/lib/supabase.ts
@@ -43,5 +43,6 @@ export interface Env {
   CODA_API_TOKEN: string;       // Coda API token for extension feedback submissions
   LIVE_EVENTS_HUB: DurableObjectNamespace; // Live cursor-event stream hub
   COMMUTE_TRAIN_DISPATCHER: DurableObjectNamespace; // Synchronized train assignment
+  COMMUTE_BOARD_RATE_LIMITER: RateLimit; // Public train boarding request limiter
   WWO_ADMIN_DB: D1Database;     // Feature policy, beta cohorts, and operator workflows
 }

--- a/extension/worker/src/lib/supabase.ts
+++ b/extension/worker/src/lib/supabase.ts
@@ -42,5 +42,6 @@ export interface Env {
   RESEND_SEGMENT_ID?: string;   // Optional: assign new contacts to this Resend segment
   CODA_API_TOKEN: string;       // Coda API token for extension feedback submissions
   LIVE_EVENTS_HUB: DurableObjectNamespace; // Live cursor-event stream hub
+  COMMUTE_TRAIN_DISPATCHER: DurableObjectNamespace; // Synchronized train assignment
   WWO_ADMIN_DB: D1Database;     // Feature policy, beta cohorts, and operator workflows
 }

--- a/extension/worker/src/routes/commute.ts
+++ b/extension/worker/src/routes/commute.ts
@@ -1,7 +1,10 @@
 // ABOUTME: Serves the privacy-limited recent route used by Internet Commute.
 // ABOUTME: Reduces navigation and recent activity events before returning them to the extension.
 
-import type { CollectionEvent } from '@playhtml/extension-types';
+import type {
+  CollectionEvent,
+  CommuteResponse,
+} from '@playhtml/extension-types';
 import type { Env } from '../lib/supabase';
 import { buildCommuteResponse } from './commutePolicy';
 import { handleRecent } from './recent';
@@ -39,15 +42,7 @@ export async function handleCommute(
   env: Env,
 ): Promise<Response> {
   try {
-    const [navigationEvents, activityEvents] = await Promise.all([
-      fetchRecentEvents(request, env, 'navigation', NAVIGATION_LIMIT),
-      fetchRecentEvents(request, env, 'all', ACTIVITY_LIMIT),
-    ]);
-    const response = buildCommuteResponse(
-      navigationEvents,
-      activityEvents,
-      Date.now(),
-    );
+    const response = await getCommuteResponse(request, env, Date.now());
 
     return new Response(JSON.stringify(response), {
       headers: {
@@ -68,4 +63,16 @@ export async function handleCommute(
       },
     );
   }
+}
+
+export async function getCommuteResponse(
+  request: Request,
+  env: Env,
+  now: number,
+): Promise<CommuteResponse> {
+  const [navigationEvents, activityEvents] = await Promise.all([
+    fetchRecentEvents(request, env, 'navigation', NAVIGATION_LIMIT),
+    fetchRecentEvents(request, env, 'all', ACTIVITY_LIMIT),
+  ]);
+  return buildCommuteResponse(navigationEvents, activityEvents, now);
 }

--- a/extension/worker/src/routes/commuteTrains.ts
+++ b/extension/worker/src/routes/commuteTrains.ts
@@ -7,6 +7,7 @@ import type { Env } from '../lib/supabase';
 
 const RIDER_TOKEN_PATTERN = /^[a-zA-Z0-9_-]{16,128}$/;
 const DISPATCHER_NAME = 'internet-commute-v1';
+const RATE_LIMIT_RETRY_SECONDS = 60;
 
 function record(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -50,6 +51,24 @@ export async function handleCommuteTrainBoard(
   request: Request,
   env: Env,
 ): Promise<Response> {
+  let rateLimitAllowed: boolean;
+  try {
+    const rateLimit = await env.COMMUTE_BOARD_RATE_LIMITER.limit({
+      key: request.headers.get('CF-Connecting-IP') ?? 'unidentified-client',
+    });
+    rateLimitAllowed = rateLimit.success;
+  } catch (error) {
+    console.error('[commute trains] rate limiter unavailable:', error);
+    return jsonResponse(503, { error: 'Boarding is temporarily unavailable' });
+  }
+  if (!rateLimitAllowed) {
+    return jsonResponse(
+      429,
+      { error: 'Too many boarding requests' },
+      { 'Retry-After': String(RATE_LIMIT_RETRY_SECONDS) },
+    );
+  }
+
   let parsed: CommuteTrainBoardRequest | null;
   try {
     parsed = parseCommuteTrainBoardRequest(await request.json());
@@ -75,12 +94,17 @@ export async function handleCommuteTrainBoard(
   });
 }
 
-function jsonResponse(status: number, body: unknown): Response {
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
+      ...headers,
     },
   });
 }

--- a/extension/worker/src/routes/commuteTrains.ts
+++ b/extension/worker/src/routes/commuteTrains.ts
@@ -1,0 +1,86 @@
+// ABOUTME: Validates public train boarding requests and forwards them to the dispatcher.
+// ABOUTME: Exposes assignment responses to allowed WWO website and development origins.
+
+import { getDomain } from 'tldts';
+import type { CommuteTrainBoardRequest } from '@playhtml/extension-types';
+import type { Env } from '../lib/supabase';
+
+const RIDER_TOKEN_PATTERN = /^[a-zA-Z0-9_-]{16,128}$/;
+const DISPATCHER_NAME = 'internet-commute-v1';
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : null;
+}
+
+function parseDomain(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase().replace(/\.$/, '');
+  if (!normalized || normalized !== value) return null;
+  return getDomain(normalized, { allowPrivateDomains: true }) === normalized
+    ? normalized
+    : null;
+}
+
+export function parseCommuteTrainBoardRequest(
+  value: unknown,
+): CommuteTrainBoardRequest | null {
+  const body = record(value);
+  if (!body || typeof body.riderToken !== 'string') return null;
+  if (!RIDER_TOKEN_PATTERN.test(body.riderToken)) return null;
+
+  const requestedStop = record(body.requestedStop);
+  if (!requestedStop || typeof requestedStop.kind !== 'string') return null;
+  if (requestedStop.kind === 'none') {
+    return { riderToken: body.riderToken, requestedStop: { kind: 'none' } };
+  }
+  if (requestedStop.kind === 'domain') {
+    const domain = parseDomain(requestedStop.domain);
+    if (!domain) return null;
+    return {
+      riderToken: body.riderToken,
+      requestedStop: { kind: 'domain', domain },
+    };
+  }
+  return null;
+}
+
+export async function handleCommuteTrainBoard(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  let parsed: CommuteTrainBoardRequest | null;
+  try {
+    parsed = parseCommuteTrainBoardRequest(await request.json());
+  } catch {
+    parsed = null;
+  }
+  if (!parsed) return jsonResponse(400, { error: 'Invalid boarding request' });
+
+  const id = env.COMMUTE_TRAIN_DISPATCHER.idFromName(DISPATCHER_NAME);
+  const response = await env.COMMUTE_TRAIN_DISPATCHER.get(id).fetch(
+    new Request('https://dispatcher.internal/board', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(parsed),
+    }),
+  );
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/extension/worker/wrangler.toml
+++ b/extension/worker/wrangler.toml
@@ -50,6 +50,14 @@ class_name = "LiveEventsHub"
 name = "COMMUTE_TRAIN_DISPATCHER"
 class_name = "CommuteTrainDispatcherObject"
 
+[[ratelimits]]
+name = "COMMUTE_BOARD_RATE_LIMITER"
+namespace_id = "1620187042"
+
+  [ratelimits.simple]
+  limit = 120
+  period = 60
+
 [[d1_databases]]
 binding = "WWO_ADMIN_DB"
 database_name = "wwo-admin"

--- a/extension/worker/wrangler.toml
+++ b/extension/worker/wrangler.toml
@@ -46,6 +46,10 @@ compatibility_date = "2024-01-01"
 name = "LIVE_EVENTS_HUB"
 class_name = "LiveEventsHub"
 
+[[durable_objects.bindings]]
+name = "COMMUTE_TRAIN_DISPATCHER"
+class_name = "CommuteTrainDispatcherObject"
+
 [[d1_databases]]
 binding = "WWO_ADMIN_DB"
 database_name = "wwo-admin"
@@ -55,3 +59,7 @@ migrations_dir = "migrations"
 [[migrations]]
 tag = "v1"
 new_classes = ["LiveEventsHub"]
+
+[[migrations]]
+tag = "v2"
+new_classes = ["CommuteTrainDispatcherObject"]

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "check:extension-worker": "bunx tsc -p extension/worker",
     "check:extension-website": "bunx tsc -p extension/website",
     "check:docs": "bun run --cwd apps/docs build",
-    "smoke:extension-worker": "bun run --cwd extension/worker wrangler deploy --config wrangler.toml --dry-run --outdir .wrangler/smoke",
+    "smoke:extension-worker": "bunx wrangler deploy --config extension/worker/wrangler.toml --dry-run --outdir extension/worker/.wrangler/smoke",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "rewrite-workspace-deps": "bun run scripts/rewrite-workspace-deps.ts",

--- a/packages/extension-types/src/commuteTrain.ts
+++ b/packages/extension-types/src/commuteTrain.ts
@@ -1,0 +1,100 @@
+// ABOUTME: Defines the public boarding contract for synchronized Internet Commute trains.
+// ABOUTME: Keeps exact Slow Mode destination URLs outside Worker and PlayHTML state.
+
+export const COMMUTE_TRAIN_CAPACITY = 4;
+export const COMMUTE_TRAIN_DEPARTURE_MS = 5_000;
+export const COMMUTE_TRAIN_JOIN_WINDOW_MS = 60_000;
+export const COMMUTE_TRAIN_TRAVEL_MS = 12_000;
+export const COMMUTE_TRAIN_ARRIVAL_MS = 4_000;
+export const COMMUTE_TRAIN_PLATFORM_MS = 8_000;
+export const COMMUTE_TRAIN_RETURN_TRAVEL_MS = 6_000;
+export const COMMUTE_TRAIN_RETURN_ARRIVAL_MS = 4_000;
+
+export type CommuteTrainStopRequest =
+  | { kind: "none" }
+  | { kind: "domain"; domain: string };
+
+export interface CommuteTrainBoardRequest {
+  riderToken: string;
+  requestedStop: CommuteTrainStopRequest;
+}
+
+interface CommuteTrainStopBase {
+  id: string;
+  domain: string;
+  url: string;
+  hue: string;
+}
+
+export interface CommuteTrainCommunalStop extends CommuteTrainStopBase {
+  kind: "communal";
+  title: string | null;
+  visitedAt: number;
+}
+
+export interface CommuteTrainDomainStop extends CommuteTrainStopBase {
+  kind: "domain";
+  claimantCount: number;
+}
+
+export type CommuteTrainStop =
+  | CommuteTrainCommunalStop
+  | CommuteTrainDomainStop;
+
+export type CommuteTrainPhase = "boarding" | "riding" | "complete";
+
+export interface CommuteTrainAssignment {
+  trainId: string;
+  createdAt: number;
+  departureAt: number;
+  joinableUntil: number;
+  routeEndsAt: number;
+  routeVersion: number;
+  riderCount: number;
+  capacity: number;
+  joinable: boolean;
+  phase: CommuteTrainPhase;
+  stops: CommuteTrainStop[];
+  serverNow: number;
+}
+
+export function getCommuteTrainStopCycleMs(): number {
+  return (
+    COMMUTE_TRAIN_TRAVEL_MS +
+    COMMUTE_TRAIN_ARRIVAL_MS +
+    COMMUTE_TRAIN_PLATFORM_MS
+  );
+}
+
+export function getCommuteTrainReturnStartsAt(
+  createdAt: number,
+  stopCount: number,
+): number {
+  return (
+    createdAt +
+    COMMUTE_TRAIN_DEPARTURE_MS +
+    stopCount * getCommuteTrainStopCycleMs()
+  );
+}
+
+export function getCommuteTrainRouteEndsAt(
+  createdAt: number,
+  stopCount: number,
+): number {
+  return (
+    getCommuteTrainReturnStartsAt(createdAt, stopCount) +
+    COMMUTE_TRAIN_RETURN_TRAVEL_MS +
+    COMMUTE_TRAIN_RETURN_ARRIVAL_MS
+  );
+}
+
+export function getCommuteTrainStopPassedAt(
+  createdAt: number,
+  stopIndex: number,
+): number {
+  return (
+    createdAt +
+    COMMUTE_TRAIN_DEPARTURE_MS +
+    (stopIndex + 1) * getCommuteTrainStopCycleMs()
+  );
+}

--- a/packages/extension-types/src/index.ts
+++ b/packages/extension-types/src/index.ts
@@ -4,3 +4,4 @@
 export * from "./types";
 export * from "./pageMetadata";
 export * from "./commute";
+export * from "./commuteTrain";


### PR DESCRIPTION
## Summary

- Redirect Slow Mode rides to the hosted Internet Commute while keeping exact destination URLs inside the extension.
- Assign hosted visitors to server-authoritative, four-rider trains with synchronized departure times, routes, phases, and train-specific PlayHTML rooms.
- Let Slow Mode riders share a domain-only stop or keep their destination private, with route progress, teleport controls, and live route-update notices.
- Keep the standard hosted commute available for people without the extension, including separate bounded train groups and the install prompt.

## Why

The extension-local commute and `wewere.online/commute/` could not share presence because PlayHTML room IDs are host-prefixed. Hosting Slow Mode on `wewere.online` gives every rider on a train the same scene and room. The Worker dispatcher prevents unrelated crowds from sharing one global route or room.

Exact destination URLs never enter the hosted page, query string, Worker request, train route, or PlayHTML state. The extension sends only the ride ID, destination domain, and selected stop visibility through a page bridge.

## Train behavior

- Five-second initial boarding period
- Four-rider capacity
- Oldest open train first
- Two communal stops before rider drop-offs
- Same-domain stops coalesce and count claimants
- Riders may miss a stop, leave the train, or hold to teleport
- Joinable trains accept riders in progress and update the route for everyone
- Dispatcher state expires after the route ends

## Testing

- `bun run build-packages`
- `bun run test:extension` (139 files, 893 tests)
- `bunx vitest run src/__tests__/commuteTrainDispatcher.test.ts src/__tests__/commuteTrains.test.ts src/__tests__/index.test.ts` from `extension/worker` (3 files, 15 tests)
- `bun run check:extension`
- `bun run check:extension-worker`
- `bun run check:extension-website`
- Browser verification of domain-only settings, private settings, hosted domain stops, hosted private rides, live route updates, capacity display, and the standard hosted extension prompt

The full extension Worker suite executed all test files without a failure but did not exit because another Worker test leaves an open handle. The commute-specific Worker suite exits cleanly.

## Package and docs notes

- Adds a patch changeset for `@playhtml/extension-types`.
- No public developer docs or starter-template update is needed. The added package types are an internal extension-to-Worker protocol and do not change the public PlayHTML API.

Visual evidence is attached in the PR Evidence comment.
