### PR TITLE
Extension: fix Safari onboarding acceptance issues

### DIFF
--- a/extension/src/__tests__/SetupPage.safari.test.tsx
+++ b/extension/src/__tests__/SetupPage.safari.test.tsx
@@ -274,6 +274,12 @@ it("offers bookmarking instead of the new tab checkbox on Safari", async () => {
   expect(container.textContent).toContain(
     "Safari doesn't let extensions change the new tab",
   );
+  const historyLink = [...container.querySelectorAll("a")].find(
+    (element) => element.textContent === "Open History ↗",
+  );
+  expect(historyLink?.getAttribute("href")).toBe(
+    "chrome-extension://test/walking-record.html",
+  );
   expect(container.textContent).not.toContain("make this my new tab");
   expect(container.querySelector('input[type="checkbox"]')).toBeNull();
 

--- a/extension/src/components/SetupPage.test.tsx
+++ b/extension/src/components/SetupPage.test.tsx
@@ -97,6 +97,15 @@ describe("SetupPage", () => {
     window.history.replaceState({}, "", "/");
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null)));
     vi.mocked(browser.storage.local.get).mockResolvedValue({});
+    vi.mocked(browser.tabs.getCurrent).mockResolvedValue({
+      id: 1,
+      index: 0,
+      highlighted: true,
+      active: true,
+      pinned: false,
+      incognito: false,
+    });
+    vi.mocked(browser.tabs.remove).mockResolvedValue(undefined);
     vi.spyOn(window, "close").mockImplementation(() => {});
   });
 
@@ -212,7 +221,7 @@ describe("SetupPage", () => {
     }
   });
 
-  it("keeps setup open when the subscription request fails", async () => {
+  it("completes setup when the optional subscription request fails", async () => {
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 503 }));
     const { container, root } = await renderSetup();
 
@@ -223,14 +232,24 @@ describe("SetupPage", () => {
       await click(container, "Finish setup");
 
       await vi.waitFor(() => {
-        expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-          "couldn’t sign you up for updates",
+        expect(container.querySelector('[role="status"]')?.textContent).toContain(
+          "Setup is complete, but we couldn’t sign you up for updates",
         );
       });
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        onboarding_complete: "true",
+        newtab_takeover_enabled: true,
+      });
       expect(browser.storage.local.set).not.toHaveBeenCalledWith(
-        expect.objectContaining({ onboarding_complete: "true" }),
+        expect.objectContaining({ setup_email: "person@example.com" }),
       );
       expect(browser.tabs.remove).not.toHaveBeenCalled();
+      expect(button(container, "Close setup")).toBeDefined();
+
+      await click(container, "Close setup");
+      await vi.waitFor(() => {
+        expect(browser.tabs.remove).toHaveBeenCalledWith(1);
+      });
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/components/SetupPage.tsx
+++ b/extension/src/components/SetupPage.tsx
@@ -122,6 +122,9 @@ export default function SetupPage() {
   const [newTabTakeover, setNewTabTakeover] = useState(true);
   const [busy, setBusy] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [completionWarning, setCompletionWarning] = useState<string | null>(
+    null,
+  );
   const colorInputRef = useRef<HTMLInputElement>(null);
   const heroRef = useRef<HTMLDivElement>(null);
   const [heroSize, setHeroSize] = useState({ width: 0, height: 0 });
@@ -229,6 +232,13 @@ export default function SetupPage() {
     const trimmedEmail = email.trim();
 
     try {
+      if (completionWarning) {
+        await closeSetupTab();
+        return;
+      }
+
+      let subscriptionSucceeded = false;
+      let subscriptionFailed = false;
       if (trimmedEmail) {
         try {
           const response = await fetch(`${WORKER_URL}/subscribe`, {
@@ -245,19 +255,24 @@ export default function SetupPage() {
               `Subscription failed with status ${response.status}`,
             );
           }
+          subscriptionSucceeded = true;
         } catch {
-          setSaveError(
-            "We couldn’t sign you up for updates. Try again, or clear the field to finish without signing up.",
-          );
-          return;
+          subscriptionFailed = true;
         }
       }
 
       await browser.storage.local.set({
         onboarding_complete: "true",
         [NEWTAB_TAKEOVER_KEY]: isSafari ? false : newTabTakeover,
-        ...(trimmedEmail ? { setup_email: trimmedEmail } : {}),
+        ...(subscriptionSucceeded ? { setup_email: trimmedEmail } : {}),
       });
+
+      if (subscriptionFailed) {
+        setCompletionWarning(
+          "Setup is complete, but we couldn’t sign you up for updates. You can try again later from Settings.",
+        );
+        return;
+      }
       await closeSetupTab();
     } catch {
       setSaveError(setupStorageError(isSafari));
@@ -532,10 +547,20 @@ export default function SetupPage() {
                   places you explored, and a cursor portrait from each day.
                 </p>
                 {isSafari ? (
-                  <p className="setup-step__newtab-note">
-                    Safari doesn't let extensions change the new tab — bookmark
-                    or pin the history page to keep it a click away.
-                  </p>
+                  <>
+                    <p className="setup-step__newtab-note">
+                      Safari doesn't let extensions change the new tab —
+                      bookmark or pin the history page to keep it a click away.
+                    </p>
+                    <a
+                      href={browser.runtime.getURL("walking-record.html")}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="setup-step__text-link"
+                    >
+                      Open History ↗
+                    </a>
+                  </>
                 ) : (
                   <label className="setup-step__newtab-optin">
                     <input
@@ -685,9 +710,18 @@ export default function SetupPage() {
                   className="setup-step__btn-primary"
                   disabled={busy}
                 >
-                  {saveError ? "Try again" : "Finish setup"}
+                  {completionWarning
+                    ? "Close setup"
+                    : saveError
+                      ? "Try again"
+                      : "Finish setup"}
                 </button>
               </div>
+              {completionWarning && (
+                <p className="setup-step__save-error" role="status">
+                  {completionWarning}
+                </p>
+              )}
               {saveError && (
                 <p className="setup-step__save-error" role="alert">
                   {saveError}

--- a/extension/src/entrypoints/stats/stats.test.tsx
+++ b/extension/src/entrypoints/stats/stats.test.tsx
@@ -1,0 +1,73 @@
+// ABOUTME: Verifies the time-spent summary matches the domain rows it renders.
+// ABOUTME: Covers newly visited domains whose measured screen time is still zero.
+
+import { act } from "react";
+import { beforeEach, expect, it, vi } from "vitest";
+import browser from "webextension-polyfill";
+
+vi.mock("../../components/ExtensionPageNav", () => ({
+  ExtensionPageNav: () => null,
+}));
+vi.mock("../../styles/options.scss", () => ({}));
+vi.mock("./stats.scss", () => ({}));
+
+beforeEach(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  document.body.innerHTML = '<div id="root"></div>';
+  vi.mocked(browser.runtime.sendMessage).mockResolvedValue({
+    success: true,
+    domains: [
+      {
+        domain: "one.example",
+        eventCount: 4,
+        firstVisit: 1,
+        lastVisit: Date.now(),
+        totalTimeMs: 30_000,
+        uniquePageCount: 1,
+        eventCounts: {},
+      },
+      {
+        domain: "two.example",
+        eventCount: 3,
+        firstVisit: 1,
+        lastVisit: Date.now(),
+        totalTimeMs: 20_000,
+        uniquePageCount: 1,
+        eventCounts: {},
+      },
+      {
+        domain: "three.example",
+        eventCount: 2,
+        firstVisit: 1,
+        lastVisit: Date.now(),
+        totalTimeMs: 10_000,
+        uniquePageCount: 1,
+        eventCounts: {},
+      },
+      {
+        domain: "new.example",
+        eventCount: 1,
+        firstVisit: 1,
+        lastVisit: Date.now(),
+        totalTimeMs: 0,
+        uniquePageCount: 1,
+        eventCounts: {},
+      },
+    ],
+  });
+});
+
+it("counts zero-second domains shown in the list", async () => {
+  await act(async () => {
+    await import("./stats");
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(document.querySelectorAll(".domain-row")).toHaveLength(4);
+  expect(document.querySelector(".stats-page__subtitle")?.textContent).toBe(
+    "1m tracked across 4 domains",
+  );
+});

--- a/extension/src/entrypoints/stats/stats.tsx
+++ b/extension/src/entrypoints/stats/stats.tsx
@@ -272,7 +272,7 @@ const StatsPage = () => {
           {!loading && totalTimeMs > 0 && (
             <p className="stats-page__subtitle">
               {formatDuration(totalTimeMs)} tracked across{" "}
-              {domains.filter((d) => d.stats?.totalTimeMs).length} domains
+              {domains.length} domains
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary

- let onboarding finish when the optional project-update subscription request fails, while keeping failed email signups out of local storage and showing a non-blocking warning
- add an obvious **Open History** action to Safari's completion screen without removing its bookmark/pin explanation or existing completion content
- count zero-second newly visited domains in the time-spent summary when those domains are displayed in the list

## Rationale

These issues came from the Safari new-user acceptance pass. Optional email delivery should not gate the required onboarding state, Safari users need a direct route to the History page they are told to save, and the time-spent header should describe the rows visibly rendered beneath it.

## Screenshots

See the PR Evidence comment for the built Safari completion page and focused Open History state.

## Verification

- `bun run test:extension` — 138 files / 886 tests passed
- focused SetupPage, Safari, and stats regressions — 10 tests passed
- `bun run check:extension`
- `bun run --cwd extension build:safari`
- built Safari completion state rendered locally and visually inspected
- `git diff --check`

## Release notes

No `extension/PENDING.md` entry: these are narrow onboarding and display-consistency fixes rather than a new broadly relevant capability.
