### PR TITLE
Improve mobile Internet Commute controls and rider counts

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -4,6 +4,7 @@
 - Slow Mode can route deliberate far jumps through a short Internet Commute, with chance controls, cooldowns, and an always-available teleport.
 - Authentication pages no longer appear in Internet Commute or trigger Slow Mode.
 - Wikipedia always shows its shared cursors and remembered-link patina.
+- Internet Commute now gives mobile riders more room and lets them use seats and doors directly.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,11 +1,7 @@
 # Unreleased
 
-- Internet Commute now keeps riders, arrivals, and train timing in sync across browsers.
-- Slow Mode can route deliberate far jumps through a short Internet Commute, with chance controls, cooldowns, and an always-available teleport.
-- Authentication pages no longer appear in Internet Commute or trigger Slow Mode.
 - Wikipedia always shows its shared cursors and remembered-link patina.
 - Browsing history now refreshes the current week, month, or year as new activity is recorded.
-- Internet Commute now gives mobile riders more room and lets them use seats and doors directly.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.test.tsx
@@ -1,4 +1,4 @@
-// ABOUTME: Verifies mobile commute boarding, joystick, action, and fullscreen controls.
+// ABOUTME: Verifies mobile commute boarding, joystick, and fullscreen controls.
 // ABOUTME: Covers the screen-space input shell independently from train geometry.
 
 import React, { act } from "react";
@@ -59,7 +59,6 @@ describe("CommuteMobileControls", () => {
   it("boards from a user gesture and requests landscape fullscreen", async () => {
     const onBoard = vi.fn();
     const { container, root } = renderControls({
-      action: null,
       boarded: false,
       onBoard,
       onMove: vi.fn(),
@@ -84,7 +83,6 @@ describe("CommuteMobileControls", () => {
     );
     const onBoard = vi.fn();
     const { container, root } = renderControls({
-      action: null,
       boarded: false,
       onBoard,
       onMove: vi.fn(),
@@ -105,7 +103,6 @@ describe("CommuteMobileControls", () => {
   it("publishes normalized joystick movement and resets on release", () => {
     const onMove = vi.fn();
     const { container, root } = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove,
@@ -149,25 +146,14 @@ describe("CommuteMobileControls", () => {
     act(() => root.unmount());
   });
 
-  it("shows and invokes the contextual train action", () => {
-    const onSelect = vi.fn();
+  it("keeps the train unobstructed by contextual action buttons", () => {
     const { container, root } = renderControls({
-      action: {
-        label: "sit down",
-        tone: "sit",
-        onSelect,
-      },
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),
     });
 
-    act(() => {
-      container
-        .querySelector<HTMLButtonElement>(".commute-mobile-action")!
-        .click();
-    });
-    expect(onSelect).toHaveBeenCalledOnce();
+    expect(container.querySelector(".commute-mobile-action")).toBeNull();
     act(() => root.unmount());
   });
 
@@ -200,7 +186,6 @@ describe("CommuteMobileControls", () => {
   it("keeps a collapsible transit-pass tab on public mobile rides", async () => {
     vi.useFakeTimers();
     const { container, root } = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),
@@ -240,7 +225,6 @@ describe("CommuteMobileControls", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
     const { container, root } = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),
@@ -282,7 +266,6 @@ describe("CommuteMobileControls", () => {
     vi.useFakeTimers();
     localStorage.setItem("wewere.subscribed", "1");
     const { container, root } = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),
@@ -313,7 +296,6 @@ describe("CommuteMobileControls", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
     const { container, root } = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),
@@ -344,7 +326,6 @@ describe("CommuteMobileControls", () => {
 
     markExtensionInstalled(document.documentElement);
     const installed = renderControls({
-      action: null,
       boarded: true,
       onBoard: vi.fn(),
       onMove: vi.fn(),

--- a/extension/src/entrypoints/commute/CommuteMobileControls.tsx
+++ b/extension/src/entrypoints/commute/CommuteMobileControls.tsx
@@ -16,14 +16,7 @@ interface LandscapeOrientation extends ScreenOrientation {
   lock?: (orientation: "landscape") => Promise<void>;
 }
 
-export type CommuteMobileAction = {
-  label: string;
-  tone: "sit" | "stand" | "exit";
-  onSelect: () => void;
-};
-
 interface CommuteMobileControlsProps {
-  action: CommuteMobileAction | null;
   boarded: boolean;
   onBoard: () => void;
   onMove: (vector: CommutePoint) => void;
@@ -65,7 +58,6 @@ async function toggleFullscreen(): Promise<void> {
 }
 
 export function CommuteMobileControls({
-  action,
   boarded,
   onBoard,
   onMove,
@@ -199,15 +191,6 @@ export function CommuteMobileControls({
             />
           </div>
 
-          {action && (
-            <button
-              className={`commute-mobile-action commute-mobile-action--${action.tone}`}
-              type="button"
-              onClick={action.onSelect}
-            >
-              {action.label}
-            </button>
-          )}
           <CommuteMobileTransitPass />
         </>
       )}

--- a/extension/src/entrypoints/commute/commute.scss
+++ b/extension/src/entrypoints/commute/commute.scss
@@ -515,7 +515,6 @@ button {
 .commute-mobile-wordmark,
 .commute-mobile-fullscreen,
 .commute-mobile-joystick,
-.commute-mobile-action,
 .commute-mobile-transit-pass {
   display: none;
 }
@@ -1971,17 +1970,13 @@ button {
     border-radius: 0;
   }
 
-  .train-seat {
-    pointer-events: none;
-  }
-
   .commute-counts {
     width: auto;
     min-width: 280px;
     margin: 0;
     position: fixed;
-    right: calc(20px + env(safe-area-inset-right));
-    bottom: calc(24px + env(safe-area-inset-bottom));
+    right: calc(12px + env(safe-area-inset-right));
+    bottom: calc(10px + env(safe-area-inset-bottom));
     z-index: 30;
     padding: 6px 14px;
     display: flex;
@@ -2102,11 +2097,11 @@ button {
   }
 
   .commute-mobile-joystick {
-    width: 112px;
-    height: 112px;
+    width: 88px;
+    height: 88px;
     position: fixed;
-    bottom: calc(18px + env(safe-area-inset-bottom));
-    left: calc(20px + env(safe-area-inset-left));
+    bottom: calc(10px + env(safe-area-inset-bottom));
+    left: calc(12px + env(safe-area-inset-left));
     z-index: 30;
     display: block;
     border: 1.5px solid rgba($text, 0.35);
@@ -2116,8 +2111,8 @@ button {
     touch-action: none;
 
     span {
-      width: 48px;
-      height: 48px;
+      width: 40px;
+      height: 40px;
       position: absolute;
       top: 50%;
       left: 50%;
@@ -2130,37 +2125,6 @@ button {
         calc(-50% + var(--joystick-y))
       );
       pointer-events: none;
-    }
-  }
-
-  .commute-mobile-action {
-    min-height: 44px;
-    position: fixed;
-    bottom: calc(58px + env(safe-area-inset-bottom));
-    left: calc(148px + env(safe-area-inset-left));
-    z-index: 30;
-    padding: 9px 20px;
-    display: block;
-    color: $bg;
-    border: 2px solid rgba($text, 0.25);
-    border-radius: 999px;
-    background: $accent-teal;
-    box-shadow: 0 2px 10px rgba($text, 0.3);
-    font-size: 13px;
-    font-weight: 700;
-    white-space: nowrap;
-    cursor: pointer;
-
-    &:active {
-      transform: scale(0.96);
-    }
-
-    &--stand {
-      background: $accent-plum;
-    }
-
-    &--exit {
-      background: $accent-rust;
     }
   }
 

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -59,7 +59,6 @@ import { CommuteInstallPrompt } from "./CommuteInstallPrompt";
 import {
   CommuteMobileControls,
   keepCommuteCursorInCar,
-  type CommuteMobileAction,
 } from "./CommuteMobileControls";
 import { CommuteStage } from "./CommuteStage";
 import { CommuteStationPoster } from "./CommuteStationPoster";
@@ -75,7 +74,6 @@ import {
   getCommuteRiderStart,
   getSharedCommutePosition,
   getStandingPosition,
-  isNearCommuteDoor,
   moveCommuteAvatar,
   moveCommuteAvatarToward,
   shouldExitCommuteThroughDoor,
@@ -791,7 +789,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
     const clickDestination = useRef<CommutePoint | null>(null);
     const pendingSeatId = useRef<number | null>(null);
     const pressedKeys = useRef(new Set<string>());
-    const mobileActionRef = useRef<CommuteMobileAction | null>(null);
     const exitPending = useRef(false);
     const portalTimer = useRef<number | undefined>(undefined);
     const exitTrainRef = useRef<(navigateCurrentTab?: boolean) => void>(
@@ -1013,9 +1010,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
       mobileBoarded && mySeatId === null
         ? findNearbyCommuteSeat(avatarPosition, SEATS, occupiedSeatIds)
         : null;
-    const nearDoor =
-      mobileBoarded && isNearCommuteDoor(avatarPosition, DOOR_GEOMETRY);
-
     useEffect(() => {
       onSeatStateChange(mySeatId !== null);
     }, [mySeatId, onSeatStateChange]);
@@ -1130,38 +1124,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
       }, 2_000);
     };
 
-    const standUp = () => {
-      if (mySeatId === null) return;
-      pendingSeatId.current = null;
-      clickDestination.current = null;
-      const seat = SEATS.find((candidate) => candidate.id === mySeatId);
-      publishPosition(null, avatarPositionRef.current);
-      setAvatarWalking(false);
-      if (seat) updateAvatarPosition(getStandingPosition(seat));
-    };
-
-    let mobileAction: CommuteMobileAction | null = null;
-    if (mySeatId !== null) {
-      mobileAction = {
-        label: "stand up",
-        tone: "stand",
-        onSelect: standUp,
-      };
-    } else if (nearDoor && props.phase === "stopped" && !props.atOrigin) {
-      mobileAction = {
-        label: `step off at ${props.currentStop.domain}`,
-        tone: "exit",
-        onSelect: () => exitTrain(true),
-      };
-    } else if (nearbySeat) {
-      mobileAction = {
-        label: "sit down",
-        tone: "sit",
-        onSelect: () => chooseSeat(nearbySeat.id),
-      };
-    }
-    mobileActionRef.current = mobileAction;
-
     const updateMovement = useCallback((vector: CommutePoint) => {
       movementVector.current = vector;
     }, []);
@@ -1189,13 +1151,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
           }
           event.preventDefault();
           return;
-        }
-        if (
-          event.type === "keydown" &&
-          (event.key === "Enter" || event.key === " ")
-        ) {
-          mobileActionRef.current?.onSelect();
-          event.preventDefault();
         }
       };
 
@@ -1439,7 +1394,6 @@ const CommuteCar = withSharedState<CarData, RiderAwareness, CommuteCarProps>(
         )}
         {createPortal(
           <CommuteMobileControls
-            action={mobileAction}
             boarded={mobileBoarded}
             onBoard={() => {
               pendingSeatId.current = null;

--- a/extension/worker/src/__tests__/commute.test.ts
+++ b/extension/worker/src/__tests__/commute.test.ts
@@ -46,7 +46,7 @@ describe('handleCommute', () => {
       const events =
         type === 'navigation'
           ? [event('navigation', 'https://public.example/article')]
-          : [event('cursor', 'https://private.example/account')];
+          : [event('keyboard', 'https://private.example/account')];
       return new Response(JSON.stringify(events), {
         headers: { 'Content-Type': 'application/json' },
       });
@@ -63,8 +63,8 @@ describe('handleCommute', () => {
     expect(response.status).toBe(200);
     expect(handleRecent).toHaveBeenCalledTimes(2);
     expect(
-      new URL(handleRecent.mock.calls[1][0].url).searchParams.has('type'),
-    ).toBe(false);
+      new URL(handleRecent.mock.calls[1][0].url).searchParams.get('type'),
+    ).toBe('all');
     expect(payload.destinations).toEqual([
       expect.objectContaining({
         domain: 'public.example',

--- a/extension/worker/src/__tests__/commute.test.ts
+++ b/extension/worker/src/__tests__/commute.test.ts
@@ -62,6 +62,9 @@ describe('handleCommute', () => {
 
     expect(response.status).toBe(200);
     expect(handleRecent).toHaveBeenCalledTimes(2);
+    expect(
+      new URL(handleRecent.mock.calls[1][0].url).searchParams.has('type'),
+    ).toBe(false);
     expect(payload.destinations).toEqual([
       expect.objectContaining({
         domain: 'public.example',

--- a/extension/worker/src/__tests__/commutePolicy.test.ts
+++ b/extension/worker/src/__tests__/commutePolicy.test.ts
@@ -1318,7 +1318,7 @@ describe('buildCommuteResponse', () => {
         ),
         event(
           'recent-two',
-          'cursor',
+          'keyboard',
           'https://private.example/two',
           900_000,
           'person-two',

--- a/extension/worker/src/__tests__/recent.test.ts
+++ b/extension/worker/src/__tests__/recent.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getEarlierEventFilter,
+  getRecentEventTypeFilter,
   loadRecentEventRows,
 } from '../routes/recent';
 
@@ -23,6 +24,22 @@ function makeRow(index: number): Record<string, unknown> {
 }
 
 describe('recent event pagination', () => {
+  it('defaults to cursor events and supports an explicit all-event request', () => {
+    expect(
+      getRecentEventTypeFilter(new URL('https://worker.example/events/recent')),
+    ).toBe('cursor');
+    expect(
+      getRecentEventTypeFilter(
+        new URL('https://worker.example/events/recent?type=keyboard'),
+      ),
+    ).toBe('keyboard');
+    expect(
+      getRecentEventTypeFilter(
+        new URL('https://worker.example/events/recent?type=all'),
+      ),
+    ).toBeNull();
+  });
+
   it('continues after the last row instead of using a shifted offset', async () => {
     const storedRows = Array.from({ length: 1001 }, (_, index) => makeRow(index));
     let pageCount = 0;

--- a/extension/worker/src/routes/commute.ts
+++ b/extension/worker/src/routes/commute.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Serves the privacy-limited recent route used by Internet Commute.
-// ABOUTME: Reduces navigation and cursor events before returning them to the extension.
+// ABOUTME: Reduces navigation and recent activity events before returning them to the extension.
 
 import type { CollectionEvent } from '@playhtml/extension-types';
 import type { Env } from '../lib/supabase';
@@ -12,11 +12,11 @@ const ACTIVITY_LIMIT = 1000;
 async function fetchRecentEvents(
   request: Request,
   env: Env,
-  type: 'navigation' | null,
+  type: 'navigation' | 'all',
   limit: number,
 ): Promise<CollectionEvent[]> {
   const url = new URL('/events/recent', request.url);
-  if (type) url.searchParams.set('type', type);
+  url.searchParams.set('type', type);
   url.searchParams.set('limit', limit.toString());
   if (type === 'navigation') {
     url.searchParams.set('require_title', 'true');
@@ -41,7 +41,7 @@ export async function handleCommute(
   try {
     const [navigationEvents, activityEvents] = await Promise.all([
       fetchRecentEvents(request, env, 'navigation', NAVIGATION_LIMIT),
-      fetchRecentEvents(request, env, null, ACTIVITY_LIMIT),
+      fetchRecentEvents(request, env, 'all', ACTIVITY_LIMIT),
     ]);
     const response = buildCommuteResponse(
       navigationEvents,

--- a/extension/worker/src/routes/commute.ts
+++ b/extension/worker/src/routes/commute.ts
@@ -7,16 +7,16 @@ import { buildCommuteResponse } from './commutePolicy';
 import { handleRecent } from './recent';
 
 const NAVIGATION_LIMIT = 2000;
-const CURSOR_LIMIT = 1000;
+const ACTIVITY_LIMIT = 1000;
 
 async function fetchRecentEvents(
   request: Request,
   env: Env,
-  type: 'navigation' | 'cursor',
+  type: 'navigation' | null,
   limit: number,
 ): Promise<CollectionEvent[]> {
   const url = new URL('/events/recent', request.url);
-  url.searchParams.set('type', type);
+  if (type) url.searchParams.set('type', type);
   url.searchParams.set('limit', limit.toString());
   if (type === 'navigation') {
     url.searchParams.set('require_title', 'true');
@@ -39,13 +39,13 @@ export async function handleCommute(
   env: Env,
 ): Promise<Response> {
   try {
-    const [navigationEvents, cursorEvents] = await Promise.all([
+    const [navigationEvents, activityEvents] = await Promise.all([
       fetchRecentEvents(request, env, 'navigation', NAVIGATION_LIMIT),
-      fetchRecentEvents(request, env, 'cursor', CURSOR_LIMIT),
+      fetchRecentEvents(request, env, null, ACTIVITY_LIMIT),
     ]);
     const response = buildCommuteResponse(
       navigationEvents,
-      cursorEvents,
+      activityEvents,
       Date.now(),
     );
 

--- a/extension/worker/src/routes/commutePolicy.ts
+++ b/extension/worker/src/routes/commutePolicy.ts
@@ -899,15 +899,14 @@ function buildDestinations(
 }
 
 function countActivePeople(
-  cursorEvents: CollectionEvent[],
+  activityEvents: CollectionEvent[],
   now: number,
 ): number {
   const cutoff = now - ACTIVE_PEOPLE_WINDOW_MS;
   const activePeople = new Set<string>();
 
-  for (const event of cursorEvents) {
+  for (const event of activityEvents) {
     if (
-      event.type !== 'cursor' ||
       !event.meta?.pid ||
       Math.min(event.ts, now) < cutoff
     ) {
@@ -921,7 +920,7 @@ function countActivePeople(
 
 export function buildCommuteResponse(
   navigationEvents: CollectionEvent[],
-  cursorEvents: CollectionEvent[],
+  activityEvents: CollectionEvent[],
   now = Date.now(),
 ): CommuteResponse {
   const newestFirst = navigationEvents
@@ -944,7 +943,7 @@ export function buildCommuteResponse(
 
   return {
     generatedAt: now,
-    activePeople: countActivePeople(cursorEvents, now),
+    activePeople: countActivePeople(activityEvents, now),
     scenery: buildScenery(candidates, getSceneryLimit(candidates.length)),
     destinations: buildDestinations(candidates),
   };

--- a/extension/worker/src/routes/recent.ts
+++ b/extension/worker/src/routes/recent.ts
@@ -77,6 +77,11 @@ export async function loadRecentEventRows(
   return { rows, error: null };
 }
 
+export function getRecentEventTypeFilter(url: URL): string | null {
+  const requestedType = url.searchParams.get('type');
+  return requestedType === 'all' ? null : requestedType || 'cursor';
+}
+
 type PageMeta = { title?: string; favicon_url?: string };
 
 /**
@@ -118,7 +123,7 @@ async function fetchMetaByPageRef(
  * Public endpoint (no auth required)
  *
  * Query parameters:
- * - type: Event type filter (default: 'cursor')
+ * - type: Event type filter (default: 'cursor'; 'all' disables the filter)
  * - limit: Maximum number of events (default: 1000, max: 20000). Pagination is used internally.
  * - domain: Domain filter (optional) - filters events by URL domain
  * - pid: Participant ID filter (optional) - restore-from-server flow uses this
@@ -134,7 +139,7 @@ export async function handleRecent(
 ): Promise<Response> {
   try {
     const url = new URL(request.url);
-    const type = url.searchParams.get('type') || 'cursor';
+    const typeFilter = getRecentEventTypeFilter(url);
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '1000', 10), 20000);
     const domainFilter = url.searchParams.get('domain') || null;
     const pidFilter = url.searchParams.get('pid') || null;
@@ -144,8 +149,11 @@ export async function handleRecent(
     const { rows, error } = await loadRecentEventRows(limit, async (cursor, pageSize) => {
       let query = supabase
         .from('collection_events')
-        .select('*')
-        .eq('type', type);
+        .select('*');
+
+      if (typeFilter !== null) {
+        query = query.eq('type', typeFilter);
+      }
 
       if (domainFilter) {
         query = query.eq('domain', domainFilter);


### PR DESCRIPTION
## Summary

- let mobile riders use train seats and doors directly instead of showing a contextual action button
- shrink and reposition the joystick and rider counts to keep more of the carriage visible
- count recent activity events, not only cursor events, when reporting active people

## Why

The contextual mobile action obscured the carriage and duplicated interactions already available on seats and doors. The active-people count also missed riders whose recent activity was not a cursor event.

## Testing

- `bun run test:extension -- CommuteMobileControls.test.tsx` (9 tests)
- `bun run test:extension-worker -- recent.test.ts commute.test.ts commutePolicy.test.ts` (28 tests)
- `bun run check:extension`
- `bun run check:extension-worker`
- `bun run check:extension-website`
- `git diff --check origin/main...HEAD`
- verified the boarding and boarded states on the local public `/commute/` route at 844x390; screenshots are in the PR Evidence comment

## Release notes

- updated `extension/PENDING.md`
- no changeset, public docs, or starter-template update is needed because this does not change a published package API