### PR TITLE
Remove Slow Mode form-state safeguard

### DIFF
--- a/extension/src/__tests__/content-slow-mode-form-state.test.ts
+++ b/extension/src/__tests__/content-slow-mode-form-state.test.ts
@@ -1,0 +1,105 @@
+// ABOUTME: Verifies typing does not trigger Slow Mode form inference on host pages.
+// ABOUTME: Exercises the real content-script entrypoint against a page with many controls.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageGet = vi.hoisted(() => vi.fn());
+const runtimeSendMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        get: storageGet,
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      sendMessage: runtimeSendMessage,
+      onMessage: { addListener: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("../collectors/CollectorManager", () => ({
+  CollectorManager: class {
+    registerCollector = vi.fn();
+    init = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn();
+    pauseAll = vi.fn();
+    resumeAll = vi.fn();
+    getCollectorStatuses = vi.fn(() => []);
+  },
+}));
+
+vi.mock("../collectors/CursorCollector", () => ({ CursorCollector: class {} }));
+vi.mock("../collectors/NavigationCollector", () => ({
+  NavigationCollector: class {},
+}));
+vi.mock("../collectors/ViewportCollector", () => ({
+  ViewportCollector: class {},
+}));
+vi.mock("../collectors/KeyboardCollector", () => ({
+  KeyboardCollector: class {},
+}));
+
+describe("content Slow Mode form-state reachability", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
+    document.documentElement.dataset.playhtml = "true";
+    document.body.innerHTML = Array.from(
+      { length: 5_000 },
+      (_, index) => `<input id="field-${index}">`,
+    ).join("");
+
+    storageGet.mockReset();
+    storageGet.mockImplementation((keys: string | string[]) => {
+      if (!Array.isArray(keys)) return Promise.resolve({});
+      return Promise.resolve(
+        Object.fromEntries(
+          keys
+            .filter((key) => key.startsWith("migration_v1_done_"))
+            .map((key) => [key, true]),
+        ),
+      );
+    });
+    runtimeSendMessage.mockReset();
+    runtimeSendMessage.mockImplementation((message: { type?: string }) => {
+      if (message.type === "GET_PUBLIC_PLAYER_IDENTITY") {
+        return Promise.resolve({
+          publicKey: "pk_test",
+          playerStyle: { colorPalette: ["#4a9a8a"] },
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it("does not scan controls or message the background when a user types", async () => {
+    const contentScript = (await import("../entrypoints/content")).default as {
+      main: () => void;
+    };
+    contentScript.main();
+    await vi.waitFor(() => {
+      expect(runtimeSendMessage).toHaveBeenCalledWith({
+        type: "UPDATE_SITE_DISCOVERY",
+        domain: window.location.hostname,
+      });
+    });
+
+    runtimeSendMessage.mockClear();
+    const querySelectorAll = vi.spyOn(document, "querySelectorAll");
+    const input = document.querySelector<HTMLInputElement>("#field-2500");
+    if (!input) throw new Error("Typing target was not created");
+    input.dispatchEvent(new InputEvent("input", { bubbles: true, data: "x" }));
+
+    expect(querySelectorAll).not.toHaveBeenCalledWith(
+      "input, textarea, select",
+    );
+    expect(runtimeSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -316,7 +316,7 @@ export default defineBackground(() => {
   // Opt-in: send new browser tabs to the walking record instead of the
   // default new tab page. Off unless the user turns it on.
   initNewTabTakeover()
-  const slowModeInterception = initSlowModeInterception()
+  initSlowModeInterception()
 
   // Forward the manifest "open-inventory" command to the active tab's content script.
   // Manifest commands are browser-routed, so this works reliably on every page.
@@ -501,15 +501,6 @@ export default defineBackground(() => {
   // Cross-site messaging coordination
   browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const reply = sendResponse as (response?: any) => void
-    if (message.type === 'SLOW_MODE_FORM_STATE' && sender.tab?.id != null) {
-      slowModeInterception.setFormInProgress(
-        sender.tab.id,
-        message.inProgress === true,
-      )
-      reply({ success: true })
-      return
-    }
-
     if (message.type === 'SLOW_MODE_RIDE_OUTCOME') {
       if (
         typeof message.rideId !== 'string' ||

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -59,41 +59,6 @@ export default defineContentScript({
 
     markExtensionInstalled(document.documentElement);
 
-    const reportsSlowModeFormState = (element: Element): boolean => {
-      if (
-        element instanceof HTMLTextAreaElement ||
-        element instanceof HTMLSelectElement
-      ) {
-        return element.value.trim().length > 0;
-      }
-      if (!(element instanceof HTMLInputElement)) return false;
-      if (
-        ["button", "checkbox", "color", "file", "hidden", "radio", "range", "reset", "submit"].includes(
-          element.type,
-        )
-      ) {
-        return false;
-      }
-      return element.value.trim().length > 0;
-    };
-    const reportSlowModeFormState = () => {
-      const inProgress = Array.from(
-        document.querySelectorAll("input, textarea, select"),
-      ).some(reportsSlowModeFormState);
-      void browser.runtime.sendMessage({
-        type: "SLOW_MODE_FORM_STATE",
-        inProgress,
-      });
-    };
-    document.addEventListener("input", reportSlowModeFormState);
-    document.addEventListener("change", reportSlowModeFormState);
-    document.addEventListener("submit", () => {
-      void browser.runtime.sendMessage({
-        type: "SLOW_MODE_FORM_STATE",
-        inProgress: false,
-      });
-    });
-
     let currentPresenceCount = 0;
 
     // Initialize PlayHTML extension on page

--- a/extension/src/features/slowMode/slowMode.test.ts
+++ b/extension/src/features/slowMode/slowMode.test.ts
@@ -110,17 +110,6 @@ describe("isFarJump", () => {
     ).toBe(false);
   });
 
-  it("rejects navigation while a form is in progress", () => {
-    expect(
-      isFarJump({
-        previousUrl: "https://garden.example/notes",
-        destinationUrl: "https://museum.example/exhibit",
-        transitionType: "typed",
-        transitionQualifiers: [],
-        formInProgress: true,
-      }),
-    ).toBe(false);
-  });
 });
 
 describe("Slow Mode consent gates", () => {

--- a/extension/src/features/slowMode/slowMode.ts
+++ b/extension/src/features/slowMode/slowMode.ts
@@ -40,7 +40,6 @@ export interface FarJumpNavigation {
   destinationUrl: string;
   transitionType: string;
   transitionQualifiers: string[];
-  formInProgress?: boolean;
 }
 
 export type SlowModeDecisionReason =
@@ -192,7 +191,6 @@ export function dayKey(timestamp: number): string {
 }
 
 export function isFarJump(navigation: FarJumpNavigation): boolean {
-  if (navigation.formInProgress) return false;
   if (NEVER_TRANSITIONS.has(navigation.transitionType)) return false;
   if (navigation.transitionQualifiers.includes("forward_back")) return false;
 

--- a/extension/src/features/slowMode/slowModeBackground.ts
+++ b/extension/src/features/slowMode/slowModeBackground.ts
@@ -33,7 +33,6 @@ export function createSlowModeNavigationHandler(
   dependencies: SlowModeNavigationDependencies,
 ) {
   const tabUrls = new Map<number, string>();
-  const formsInProgress = new Set<number>();
   let navigationQueue = Promise.resolve();
 
   return {
@@ -47,12 +46,6 @@ export function createSlowModeNavigationHandler(
 
     forgetTab(tabId: number): void {
       tabUrls.delete(tabId);
-      formsInProgress.delete(tabId);
-    },
-
-    setFormInProgress(tabId: number, inProgress: boolean): void {
-      if (inProgress) formsInProgress.add(tabId);
-      else formsInProgress.delete(tabId);
     },
 
     async onCommitted(details: CommittedNavigation): Promise<void> {
@@ -65,9 +58,7 @@ export function createSlowModeNavigationHandler(
         destinationUrl: details.url,
         transitionType: details.transitionType,
         transitionQualifiers: details.transitionQualifiers ?? [],
-        formInProgress: formsInProgress.has(details.tabId),
       };
-      formsInProgress.delete(details.tabId);
 
       const previousNavigation = navigationQueue;
       let releaseNavigation: (() => void) | undefined;
@@ -133,9 +124,7 @@ interface BrowserWithWebNavigation {
   };
 }
 
-export function initSlowModeInterception(): {
-  setFormInProgress: (tabId: number, inProgress: boolean) => void;
-} {
+export function initSlowModeInterception(): void {
   const handler = createSlowModeNavigationHandler({
     getStorage: () =>
       browser.storage.local.get([
@@ -180,5 +169,4 @@ export function initSlowModeInterception(): {
   });
   tabsApi.onRemoved?.addListener((tabId) => handler.forgetTab(tabId));
 
-  return { setFormInProgress: handler.setFormInProgress };
 }


### PR DESCRIPTION
## Summary

- remove the all-page input, change, and submit listeners that inferred unfinished form work
- remove the content-to-background form-state message, per-tab state, and Slow Mode navigation field
- keep all other Slow Mode eligibility, cooldown, chance, protected-destination, and ride behavior unchanged
- add a real-content-entrypoint regression check with 5,000 controls

## Rationale

Slow Mode should handle a deliberate navigation normally even when the current page contains edited controls. Sites remain responsible for genuine unsaved-work warnings through their own beforeunload or page logic.

The 2026-08-26 audit measured 100 background messages for 100 typed characters. Extension-minus-control TaskDuration was +6.664 ms with no other fields, +44.935 ms with 1,000 fields, and +190.848 ms with 5,000 fields. After this change, the real content-script entrypoint test dispatches typing on a page with 5,000 controls and observes zero all-control selector scans and zero runtime messages. The production bundles also contain neither the removed message name nor the removed selector.

## Verification

- bun build-packages
- focused Slow Mode and reachability tests: 29 passed
- bun run check:extension
- bun run --cwd extension build
- bun run test:extension: 138 files, 886 tests passed
- git diff --check
- repository-wide search found no remaining form-state protocol or per-tab state references

## Scope notes

- No PENDING.md bullet: this removes an internal safeguard and page-wide performance cost without adding a visible extension feature or release-note-worthy workflow.
- No screenshots: there is no visual UI change; the observable contract is covered by the real content-script reachability check.
- PR #417 overlaps the same Slow Mode and entrypoint files for hosted trains, so whichever PR lands second may need a focused rebase. Its hosted-train policy is otherwise outside this change.
