### PR TITLE
Remove dead Slow Mode app-open safeguard

### DIFF
--- a/extension/src/features/slowMode/slowMode.ts
+++ b/extension/src/features/slowMode/slowMode.ts
@@ -41,7 +41,6 @@ export interface FarJumpNavigation {
   transitionType: string;
   transitionQualifiers: string[];
   formInProgress?: boolean;
-  openedByAnotherApp?: boolean;
 }
 
 export type SlowModeDecisionReason =
@@ -193,7 +192,7 @@ export function dayKey(timestamp: number): string {
 }
 
 export function isFarJump(navigation: FarJumpNavigation): boolean {
-  if (navigation.formInProgress || navigation.openedByAnotherApp) return false;
+  if (navigation.formInProgress) return false;
   if (NEVER_TRANSITIONS.has(navigation.transitionType)) return false;
   if (navigation.transitionQualifiers.includes("forward_back")) return false;
 


### PR DESCRIPTION
## Summary

- remove openedByAnotherApp from the Slow Mode navigation policy input
- remove the unreachable eligibility check while preserving every working exclusion

## Rationale

No browser path supplies this field, so the safeguard cannot affect a real navigation. Removing it narrows the policy contract to inputs the extension actually produces.

## Verification

- bun run build-packages
- focused Slow Mode policy suite: 27 tests passed
- bun run check:extension
- bun run --cwd extension build
- bun run test:extension: 137 files, 886 tests passed
- git diff --check
- repository-wide search found no remaining openedByAnotherApp references

## Overlap notes

- PR #417 changes nearby Slow Mode files for hosted trains but does not touch this field or guard.
- PR #420 removes the separate form-state safeguard and intentionally leaves this field behind. If it lands first, this PR may need a small rebase around the adjacent policy line; this PR does not duplicate or undo its form-state work.

## Scope notes

- No regression test added: there was no browser producer or reachable behavior to exercise, and the type check plus dead-symbol search prove the protocol surface is gone.
- No PENDING.md bullet, screenshots, changeset, public docs, or starter update: this is an internal unreachable-policy cleanup with no visible or published package behavior change.