### PR TITLE
partykit: recover Supabase hydration outages

### DIFF
--- a/partykit/__tests__/persistenceMode.test.ts
+++ b/partykit/__tests__/persistenceMode.test.ts
@@ -148,8 +148,8 @@ describe("formatPersistenceFailureLog", () => {
     expect(message).toContain("timeoutMs=5000");
     expect(message).toContain("attempts=3");
     expect(message).toContain("connection timeout");
-    expect(message).toContain("TRANSIENT MODE");
-    expect(message).toContain("awareness may continue");
+    expect(message).toContain("RECOVERY MODE");
+    expect(message).toContain("connections closed with 1013");
     expect(message).toContain("shared-data writes disabled");
     expect(message).toContain("autosave disabled");
   });
@@ -170,7 +170,7 @@ describe("createPersistenceUnavailableResponse", () => {
     expect(body).toEqual({
       error: "persistence_unavailable",
       message:
-        "Supabase persistence is unavailable for this room; shared-data and admin writes are disabled while awareness runs in transient mode.",
+        "Supabase persistence is unavailable for this room; clients reconnect after document recovery completes.",
       roomId: "example-room",
       failedAt: "2026-05-26T21:05:45.000Z",
       reason: "connection timeout",

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1659,6 +1659,40 @@ describe("hardening", () => {
     expect(room.isPersistenceAvailable()).toBe(false);
   });
 
+  test("a restarted provider outage keeps guarded cadence after another failed read", async () => {
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const storage = new FakeStorage();
+    storage.values.set("persistenceRecoveryPending", true);
+    storage.values.set("loadRetryAfter", Date.now() - 1);
+    const room = restartRoom(storage);
+    const previousRetryMax =
+      workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS;
+    workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS = "60000";
+    const before = Date.now();
+    const originalError = console.error;
+    console.error = () => {};
+
+    try {
+      await startRoom(room);
+    } finally {
+      console.error = originalError;
+      workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS = previousRetryMax;
+    }
+
+    expect(documentReadCount).toBe(3);
+    expect(storage.values.get("loadRetryAfter")).toBeGreaterThanOrEqual(
+      before + 30_000
+    );
+    expect(storage.values.get("loadRetryAfter")).toBeLessThanOrEqual(
+      Date.now() + 60_000
+    );
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+  });
+
   test("successful hydration resets clients that connected during transient mode", async () => {
     persistedRow.document = SMALL_DOCUMENT;
     documentReadErrors = [

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -1853,6 +1853,24 @@ describe("hardening", () => {
     expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 
+  test("an observed load failure preserves a guarded reload deadline", async () => {
+    const { room, storage } = createRoom();
+    const guardedRetryAt = Date.now() + 60_000;
+    storage.values.set("loadRetryAfter", guardedRetryAt);
+    const previousRetryMax =
+      workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS;
+    workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS = "60000";
+
+    try {
+      await room.circuitBreaker.deferObservedLoadFailure(1);
+    } finally {
+      workerEnv.SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS = previousRetryMax;
+    }
+
+    expect(storage.values.get("loadRetryAfter")).toBe(guardedRetryAt);
+    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+  });
+
   // L2: the flag is applied from the control plane and then resumed from durable
   // storage in the same start.
   test("a KV-flagged start logs the quarantine only once", async () => {

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -46,6 +46,8 @@ const workerEnv: Record<string, unknown> = {
   QUARANTINE_CONTROL: quarantineKvStub,
   SUPABASE_LOAD_ATTEMPTS: "3",
   SUPABASE_LOAD_RETRY_DELAY_MS: "1",
+  SUPABASE_RECOVERY_RETRY_DELAY_MS: "1",
+  SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS: "5",
 };
 
 mock.module("cloudflare:workers", () => ({
@@ -635,7 +637,7 @@ describe("hydration write guards", () => {
     expect(warnings).toHaveLength(2);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBe(
-      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=hydration timed out Entering RECOVERY MODE: connections closed with 1013, shared-data writes disabled, autosave disabled, admin writes disabled."
     );
     expect(logs).toEqual([
       "[PartyServer] Supabase persistence restored for room=example-room; leaving transient mode.",
@@ -700,8 +702,11 @@ describe("hydration write guards", () => {
     expect(room.isReadOnly({})).toBe(true);
   });
 
-  test("awareness messages still apply while shared-data writes are read-only", () => {
-    const { room } = createRoom();
+  test("a hibernated socket closes before its message reaches a recovering document", async () => {
+    const { room, storage } = createRoom();
+    const retryAfter = Date.now() + 5_000;
+    storage.values.set("loadRetryAfter", retryAfter);
+    room.circuitBreaker.setLoadDeferredUntil(retryAfter);
     const sourceDoc = new Y.Doc();
     const sourceAwareness = new awarenessProtocol.Awareness(sourceDoc);
     sourceAwareness.setLocalState({ online: true });
@@ -713,8 +718,10 @@ describe("hydration write guards", () => {
     encoding.writeVarUint(encoder, 1);
     encoding.writeVarUint8Array(encoder, awarenessUpdate);
     const connectionState: Record<string, unknown> = {};
+    const closes: Array<{ code: number; reason: string }> = [];
     const connection = {
       id: "awareness-client",
+      close: (code: number, reason: string) => closes.push({ code, reason }),
       send: () => {},
       state: connectionState,
       setState: (next: unknown) => {
@@ -725,21 +732,26 @@ describe("hydration write guards", () => {
       },
     };
     room.document.awareness = new awarenessProtocol.Awareness(room.document);
+    const originalWarn = console.warn;
+    console.warn = () => {};
 
-    room.handleMessage(connection, encoding.toUint8Array(encoder));
+    try {
+      await room.onMessage(connection, encoding.toUint8Array(encoder));
+    } finally {
+      console.warn = originalWarn;
+    }
 
     expect(room.isReadOnly(connection)).toBe(true);
-    expect(room.document.awareness.getStates().get(sourceDoc.clientID)).toEqual(
-      {
-        online: true,
-      }
-    );
+    expect(closes).toEqual([{ code: 1013, reason: "Room Loading" }]);
+    expect(
+      room.document.awareness.getStates().has(sourceDoc.clientID)
+    ).toBe(false);
     sourceAwareness.destroy();
     room.document.awareness.destroy();
     sourceDoc.destroy();
   });
 
-  test("Yjs document updates are rejected while awareness remains available", () => {
+  test("Yjs document updates are rejected while the room is read-only", () => {
     const { room } = createRoom();
     const sourceDoc = new Y.Doc();
     sourceDoc.getMap("play").set("danger", "must not be applied");
@@ -1082,23 +1094,44 @@ describe("load path", () => {
       setState: () => {},
       state: {},
     };
+    const originalWarn = console.warn;
+    console.warn = () => {};
 
-    await room.onConnect(connection, {
-      request: new Request("https://example.com/parties/main/example-room"),
-    });
+    try {
+      await room.onConnect(connection, {
+        request: new Request("https://example.com/parties/main/example-room"),
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
 
-    expect(closes).toEqual([{ code: 1013, reason: "Room Load Deferred" }]);
+    expect(closes).toEqual([{ code: 1013, reason: "Room Loading" }]);
   });
 
-  test("a caught provider outage does not reject transient connections", async () => {
-    const { room } = createRoom();
+  test("a new socket cannot join a document waiting for provider recovery", async () => {
+    const { room, storage } = createRoom();
+    const retryAfter = Date.now() + 5_000;
+    storage.values.set("loadRetryAfter", retryAfter);
+    room.circuitBreaker.setLoadDeferredUntil(retryAfter);
+    const closes: Array<{ code: number; reason: string }> = [];
+    const connection = {
+      id: "new-client",
+      close: (code: number, reason: string) => closes.push({ code, reason }),
+      setState: () => {},
+      state: {},
+    };
+    const originalWarn = console.warn;
+    console.warn = () => {};
 
-    await room.circuitBreaker.deferObservedLoadFailure();
+    try {
+      await room.onConnect(connection, {
+        request: new Request("https://example.com/parties/main/example-room"),
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
 
-    expect(
-      await room.circuitBreaker.getClientLoadDeferredResponse()
-    ).toBeNull();
-    expect(await room.circuitBreaker.getLoadDeferredResponse()).not.toBeNull();
+    expect(closes).toEqual([{ code: 1013, reason: "Room Loading" }]);
   });
 
   // At the deadline exactly one attempt proceeds. The next deadline is written
@@ -1543,9 +1576,57 @@ describe("hardening", () => {
     ]);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toBe(
-      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled."
+      "[PartyServer] SUPABASE PERSISTENCE UNAVAILABLE: room=example-room timeoutMs=5000 attempts=3 reason=failure 3 Entering RECOVERY MODE: connections closed with 1013, shared-data writes disabled, autosave disabled, admin writes disabled."
     );
     expect(storage.alarm).toBe(storage.values.get("loadRetryAfter"));
+  });
+
+  test("three failed reads close clients and recover through the scheduled alarm", async () => {
+    persistedRow.document = SMALL_DOCUMENT;
+    documentReadErrors = [
+      new Error("failure 1"),
+      new Error("failure 2"),
+      new Error("failure 3"),
+    ];
+    const { room, storage } = createRoom();
+    const closes: Array<{ code: number; reason: string }> = [];
+    room.getConnections = () => [
+      {
+        close(code: number, reason: string) {
+          closes.push({ code, reason });
+        },
+      },
+    ];
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    const originalLog = console.log;
+    console.warn = () => {};
+    console.error = () => {};
+    console.log = () => {};
+
+    try {
+      await startRoom(room);
+
+      expect(documentReadCount).toBe(3);
+      expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+      expect(storage.values.get("loadRetryAfter")).toBeNumber();
+      expect(storage.alarm).toBe(storage.values.get("loadRetryAfter"));
+      expect(closes).toEqual([{ code: 1013, reason: "Room Loading" }]);
+
+      storage.values.set("loadRetryAfter", Date.now() - 1);
+      room.circuitBreaker.setLoadDeferredUntil(Date.now() - 1);
+      await room.onAlarm();
+    } finally {
+      console.warn = originalWarn;
+      console.error = originalError;
+      console.log = originalLog;
+    }
+
+    expect(documentReadCount).toBe(4);
+    expect(room.isPersistenceAvailable()).toBe(true);
+    expect(room.document.getMap("play").get("greeting")).toBe("hello");
+    expect(storage.values.has("loadRetryAfter")).toBe(false);
+    expect(storage.values.has("persistenceRecoveryPending")).toBe(false);
   });
 
   test("a warm transient room does not retry before its recovery deadline", async () => {
@@ -1763,12 +1844,12 @@ describe("hardening", () => {
     }
 
     expect(storage.values.get("loadRetryAfter")).toBeGreaterThanOrEqual(
-      before + 60_000
+      before + 5
     );
     expect(storage.values.get("loadRetryAfter")).toBeLessThanOrEqual(
-      Date.now() + 60_000
+      Date.now() + 5
     );
-    expect(storage.values.get("quarantineLoadAttempts")).toBeUndefined();
+    expect(storage.values.get("quarantineLoadAttempts")).toBe(7);
     expect(room.circuitBreaker.isQuarantined()).toBe(false);
   });
 

--- a/partykit/const.ts
+++ b/partykit/const.ts
@@ -116,6 +116,8 @@ export const DEFAULT_SUPABASE_LOAD_ATTEMPTS = (() => {
 export const DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS = (() => {
   return 250;
 })();
+export const DEFAULT_SUPABASE_RECOVERY_RETRY_DELAY_MS = 5_000;
+export const DEFAULT_SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS = 5 * 60_000;
 // Save retries use a single deadline while limiting database traffic during outages.
 export const DEFAULT_DOCUMENT_SAVE_RETRY_MS = 60_000;
 export const ORIGIN_S2C = "__bridge_s2c__";

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -40,6 +40,8 @@ import {
   DEFAULT_SUPABASE_LOAD_ATTEMPTS,
   DEFAULT_SUPABASE_LOAD_RETRY_DELAY_MS,
   DEFAULT_SUPABASE_LOAD_TIMEOUT_MS,
+  DEFAULT_SUPABASE_RECOVERY_RETRY_DELAY_MS,
+  DEFAULT_SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS,
   DEFAULT_DOCUMENT_SAVE_RETRY_MS,
   DEFAULT_PRUNE_INTERVAL_MS,
   DEFAULT_SUBSCRIBER_LEASE_MS,
@@ -262,6 +264,10 @@ export class PartyServer extends YServer {
           failureThreshold: DEFAULT_QUARANTINE_FAILURE_THRESHOLD,
           failureBackoffMs: DEFAULT_FAILURE_BACKOFF_MS,
           failureBackoffMaxMs: DEFAULT_FAILURE_BACKOFF_MAX_MS,
+          observedLoadFailureBackoffMs:
+            DEFAULT_SUPABASE_RECOVERY_RETRY_DELAY_MS,
+          observedLoadFailureBackoffMaxMs:
+            DEFAULT_SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS,
         },
         activateTransientPersistence: (quarantine) => {
           this.persistenceMode = {
@@ -655,7 +661,9 @@ export class PartyServer extends YServer {
     );
   }
 
-  private async schedulePersistenceRecovery(): Promise<void> {
+  private async schedulePersistenceRecovery(
+    loadAttempts: number
+  ): Promise<void> {
     try {
       await this.ctx.storage.put(STORAGE_KEYS.persistenceRecoveryPending, true);
     } catch (error) {
@@ -665,7 +673,7 @@ export class PartyServer extends YServer {
     }
 
     try {
-      await this.circuitBreaker.deferObservedLoadFailure();
+      await this.circuitBreaker.deferObservedLoadFailure(loadAttempts);
       await this.scheduleNextAlarm();
     } catch (error) {
       console.error(
@@ -1027,6 +1035,22 @@ export class PartyServer extends YServer {
       : undefined;
   }
 
+  private async closeConnectionWhileLoadDeferred(
+    connection: Party.Connection
+  ): Promise<boolean> {
+    if (this.documentLoadCompleted) return false;
+    const loadDeferred = await this.circuitBreaker.getLoadDeferredResponse();
+    if (loadDeferred === null) return false;
+
+    const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
+    console.warn(
+      `[PartyServer] Refusing connection until document hydration recovers: room=${this.name}, ` +
+        `connectionId=${connection.id}, retryAfterSeconds=${retryAfterSeconds}`
+    );
+    connection.close(1013, "Room Loading");
+    return true;
+  }
+
   private getRoomResetMessage(resetEpoch: number): string {
     return JSON.stringify({
       type: "room-reset",
@@ -1044,11 +1068,11 @@ export class PartyServer extends YServer {
     connection.close(4000, reason);
   }
 
-  private closeConnections(reason: string): number {
+  private closeConnections(reason: string, code = 4000): number {
     const connections = [...this.getConnections()];
     connections.forEach((conn) => {
       try {
-        conn.close(4000, reason);
+        conn.close(code, reason);
       } catch (error) {
         console.error("[PartyServer] Failed to close connection:", error);
       }
@@ -1697,17 +1721,7 @@ export class PartyServer extends YServer {
   ) {
     this.setConnectionOpenedAt(connection, Date.now());
 
-    const loadDeferred =
-      await this.circuitBreaker.getClientLoadDeferredResponse();
-    if (loadDeferred) {
-      const retryAfterSeconds = loadDeferred.headers.get("retry-after") ?? "1";
-      console.warn(
-        `[PartyServer] Refusing connection to deferred room=${this.name}: ` +
-          `connectionId=${connection.id}, retryAfterSeconds=${retryAfterSeconds}`
-      );
-      connection.close(1013, "Room Load Deferred");
-      return;
-    }
+    if (await this.closeConnectionWhileLoadDeferred(connection)) return;
 
     await this.waitForEmptyRoomCompaction();
 
@@ -1789,6 +1803,8 @@ export class PartyServer extends YServer {
     connection: Party.Connection,
     message: Party.WSMessage
   ): Promise<void> {
+    if (await this.closeConnectionWhileLoadDeferred(connection)) return;
+
     const limitResult = this.checkConnectionMessageRate(connection);
     if (limitResult.violation) {
       console.warn(
@@ -1913,7 +1929,7 @@ export class PartyServer extends YServer {
   private async loadDocument(): Promise<void> {
     // Durable BEFORE the risky work: if hydration kills the isolate, this
     // increment survives and the next start counts it.
-    await this.circuitBreaker.beginRiskyOperation("load");
+    const loadAttempts = await this.circuitBreaker.beginRiskyOperation("load");
 
     // Load the document from Supabase on first connection
     const timeoutMs = this.getSupabaseLoadTimeoutMs();
@@ -1952,7 +1968,8 @@ export class PartyServer extends YServer {
     });
 
     if (result === null) {
-      await this.schedulePersistenceRecovery();
+      await this.schedulePersistenceRecovery(loadAttempts);
+      this.closeConnections("Room Loading", 1013);
       return;
     }
 
@@ -2431,7 +2448,7 @@ export class PartyServer extends YServer {
         // from it could overwrite the real snapshot with an empty document.
         if (!isLoadControlRoute) {
           const loadDeferred =
-            await this.circuitBreaker.getClientLoadDeferredResponse();
+            await this.circuitBreaker.getLoadDeferredResponse();
           if (loadDeferred) return loadDeferred;
         }
         // Awaited so a rejection lands in this method's catch rather than
@@ -2441,7 +2458,7 @@ export class PartyServer extends YServer {
 
       // The document was never read, so there is nothing to serve.
       const loadDeferred =
-        await this.circuitBreaker.getClientLoadDeferredResponse();
+        await this.circuitBreaker.getLoadDeferredResponse();
       if (loadDeferred) return loadDeferred;
 
       if (request.method !== "POST") {

--- a/partykit/persistenceMode.ts
+++ b/partykit/persistenceMode.ts
@@ -109,7 +109,7 @@ export function formatPersistenceFailureLog({
     `timeoutMs=${timeoutMs}`,
     `attempts=${attempts}`,
     `reason=${getErrorMessage(error)}`,
-    "Entering TRANSIENT MODE: awareness may continue, shared-data writes disabled, autosave disabled, admin writes disabled.",
+    "Entering RECOVERY MODE: connections closed with 1013, shared-data writes disabled, autosave disabled, admin writes disabled.",
   ].join(" ");
 }
 
@@ -120,7 +120,7 @@ export function createPersistenceUnavailableResponse(
     JSON.stringify({
       error: "persistence_unavailable",
       message:
-        "Supabase persistence is unavailable for this room; shared-data and admin writes are disabled while awareness runs in transient mode.",
+        "Supabase persistence is unavailable for this room; clients reconnect after document recovery completes.",
       roomId: mode.roomName,
       failedAt: new Date(mode.failedAt).toISOString(),
       reason: mode.reason,

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -40,6 +40,8 @@ type RoomCircuitBreakerOptions = {
     failureThreshold: number;
     failureBackoffMs: number;
     failureBackoffMaxMs: number;
+    observedLoadFailureBackoffMs: number;
+    observedLoadFailureBackoffMaxMs: number;
   };
   activateTransientPersistence: (quarantine: QuarantineState) => void;
   startRealtimeSync: () => Promise<void>;
@@ -116,6 +118,20 @@ export class RoomCircuitBreaker {
     return this.options.readPositiveNumber(
       "FAILURE_BACKOFF_MAX_MS",
       this.options.defaults.failureBackoffMaxMs
+    );
+  }
+
+  private getObservedLoadFailureBackoffMs(): number {
+    return this.options.readPositiveNumber(
+      "SUPABASE_RECOVERY_RETRY_DELAY_MS",
+      this.options.defaults.observedLoadFailureBackoffMs
+    );
+  }
+
+  private getObservedLoadFailureBackoffMaxMs(): number {
+    return this.options.readPositiveNumber(
+      "SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS",
+      this.options.defaults.observedLoadFailureBackoffMaxMs
     );
   }
 
@@ -290,6 +306,18 @@ export class RoomCircuitBreaker {
     await this.storage.delete(this.retryKeyFor(kind));
   }
 
+  private async releaseLoadAttempt(loadAttempts: number): Promise<void> {
+    const remainingAttempts = loadAttempts - 1;
+    if (remainingAttempts <= 0) {
+      await this.storage.delete(STORAGE_KEYS.quarantineLoadAttempts);
+      return;
+    }
+    await this.storage.put(
+      STORAGE_KEYS.quarantineLoadAttempts,
+      remainingAttempts
+    );
+  }
+
   private async handleRepeatedFailures({
     kind,
     failureCount,
@@ -344,12 +372,12 @@ export class RoomCircuitBreaker {
    * A returned load error proves the isolate survived, so it is not evidence
    * of the vanished work this circuit breaker quarantines.
    */
-  async deferObservedLoadFailure(): Promise<void> {
-    await this.completeRiskyOperation("load");
+  async deferObservedLoadFailure(loadAttempts: number): Promise<void> {
+    await this.releaseLoadAttempt(loadAttempts);
     const retryAt = getFailureRetryAt({
-      failureCount: 1,
-      baseMs: this.getFailureBackoffBaseMs(),
-      maxMs: this.getFailureBackoffMaxMs(),
+      failureCount: loadAttempts,
+      baseMs: this.getObservedLoadFailureBackoffMs(),
+      maxMs: this.getObservedLoadFailureBackoffMaxMs(),
       now: Date.now(),
     });
     await this.storage.put(STORAGE_KEYS.loadRetryAfter, retryAt);
@@ -579,17 +607,6 @@ export class RoomCircuitBreaker {
         },
       }
     );
-  }
-
-  /** Provider outages stay transient for clients while the alarm waits to retry. */
-  async getClientLoadDeferredResponse(): Promise<Response | null> {
-    if ((await this.getFailureCount("load")) === 0) {
-      const retryAfter = await this.getFailureRetryAfter("load");
-      if (retryAfter !== null && !isRetryDue({ retryAfter, now: Date.now() })) {
-        return null;
-      }
-    }
-    return this.getLoadDeferredResponse();
   }
 
   private async attemptDeferredReload(): Promise<boolean> {

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -373,13 +373,15 @@ export class RoomCircuitBreaker {
    * of the vanished work this circuit breaker quarantines.
    */
   async deferObservedLoadFailure(loadAttempts: number): Promise<void> {
+    const guardedRetryAt = await this.getFailureRetryAfter("load");
     await this.releaseLoadAttempt(loadAttempts);
-    const retryAt = getFailureRetryAt({
-      failureCount: loadAttempts,
-      baseMs: this.getObservedLoadFailureBackoffMs(),
-      maxMs: this.getObservedLoadFailureBackoffMaxMs(),
-      now: Date.now(),
-    });
+    const now = Date.now();
+    const firstRetryAt = now + this.getObservedLoadFailureBackoffMs();
+    const lastRetryAt = now + this.getObservedLoadFailureBackoffMaxMs();
+    const retryAt = Math.min(
+      lastRetryAt,
+      Math.max(firstRetryAt, guardedRetryAt ?? firstRetryAt)
+    );
     await this.storage.put(STORAGE_KEYS.loadRetryAfter, retryAt);
     this.loadDeferredUntil = retryAt;
   }

--- a/partykit/roomCircuitBreaker.ts
+++ b/partykit/roomCircuitBreaker.ts
@@ -135,6 +135,15 @@ export class RoomCircuitBreaker {
     );
   }
 
+  private getLoadRetryAt(failureCount: number): number {
+    return getFailureRetryAt({
+      failureCount,
+      baseMs: this.getFailureBackoffBaseMs(),
+      maxMs: this.getFailureBackoffMaxMs(),
+      now: Date.now(),
+    });
+  }
+
   isQuarantined(): boolean {
     return this.quarantine !== null;
   }
@@ -392,6 +401,11 @@ export class RoomCircuitBreaker {
       const retryAfter = await this.getFailureRetryAfter("load");
       if (retryAfter !== null && !isRetryDue({ retryAfter, now: Date.now() })) {
         this.loadDeferredUntil = retryAfter;
+      } else if (retryAfter !== null) {
+        await this.storage.put(
+          STORAGE_KEYS.loadRetryAfter,
+          this.getLoadRetryAt(1)
+        );
       }
       return false;
     }
@@ -414,12 +428,7 @@ export class RoomCircuitBreaker {
 
     const retryAfter = await this.getFailureRetryAfter("load");
     if (retryAfter === null) {
-      const firstRetryAt = getFailureRetryAt({
-        failureCount: previousFailures,
-        baseMs: this.getFailureBackoffBaseMs(),
-        maxMs: this.getFailureBackoffMaxMs(),
-        now: Date.now(),
-      });
+      const firstRetryAt = this.getLoadRetryAt(previousFailures);
       await this.storage.put(STORAGE_KEYS.loadRetryAfter, firstRetryAt);
       this.deferLoad(firstRetryAt, previousFailures);
       return true;
@@ -430,12 +439,7 @@ export class RoomCircuitBreaker {
       return true;
     }
 
-    const nextRetryAt = getFailureRetryAt({
-      failureCount: previousFailures + 1,
-      baseMs: this.getFailureBackoffBaseMs(),
-      maxMs: this.getFailureBackoffMaxMs(),
-      now: Date.now(),
-    });
+    const nextRetryAt = this.getLoadRetryAt(previousFailures + 1);
     await this.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
 
     console.error(
@@ -634,12 +638,7 @@ export class RoomCircuitBreaker {
           return false;
         }
 
-        const nextRetryAt = getFailureRetryAt({
-          failureCount: previousFailures + 1,
-          baseMs: this.getFailureBackoffBaseMs(),
-          maxMs: this.getFailureBackoffMaxMs(),
-          now: Date.now(),
-        });
+        const nextRetryAt = this.getLoadRetryAt(previousFailures + 1);
         await this.storage.put(STORAGE_KEYS.loadRetryAfter, nextRetryAt);
 
         if (previousFailures === 0) {

--- a/smoke-tests/README.md
+++ b/smoke-tests/README.md
@@ -53,9 +53,10 @@ SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:stale-compaction
 # Verifies connected-room high-watermark compaction.
 SMOKE_ENV_FILE=/path/to/.dev.vars bun smoke:partykit:emergency
 
-# Verifies awareness continues while shared-data and admin writes stay blocked
-# when Supabase startup load fails.
+# Verifies clients close with 1013 and admin writes stay blocked when Supabase
+# startup load fails.
 SUPABASE_URL=http://127.0.0.1:9 SUPABASE_KEY=bad ADMIN_TOKEN=dev \
+  PARTYKIT_BRIDGE_SECRET=dev \
   bunx wrangler dev --config partykit/wrangler.jsonc --port 1999 \
   --var SUPABASE_LOAD_TIMEOUT_MS:100
 PARTYKIT_HOST=localhost:1999 bun smoke:partykit:transient

--- a/smoke-tests/partykit/supabase-transient-smoke.mjs
+++ b/smoke-tests/partykit/supabase-transient-smoke.mjs
@@ -1,28 +1,53 @@
 // ABOUTME: Smoke tests PartyKit startup when Supabase persistence is unavailable.
-// ABOUTME: Verifies awareness continues while shared-data writes remain blocked.
-import { Y, connectRoom, getHost, sleep, waitForSync } from "./shared.mjs";
+// ABOUTME: Verifies clients close with a retryable code until hydration recovers.
+import {
+  WebSocket,
+  getHost,
+  getPartyWebSocketUrl,
+} from "./shared.mjs";
 
-function waitForCondition(label, predicate, timeoutMs = 20_000) {
+function waitForRecoveryClose(socket, label, timeoutMs = 20_000) {
   return new Promise((resolve, reject) => {
-    const startedAt = Date.now();
-    const timer = setInterval(() => {
-      try {
-        if (predicate()) {
-          clearInterval(timer);
-          resolve();
-          return;
-        }
-      } catch (error) {
-        clearInterval(timer);
-        reject(error);
+    // Local Wrangler can leave a received close frame in CLOSING until the
+    // client terminates the socket. ws retains the server code and reason.
+    const closingPoll = setInterval(() => {
+      if (socket.readyState === WebSocket.CLOSING) {
+        socket.terminate();
+      }
+    }, 25);
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`${label} did not close within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onClose = (code, reason) => {
+      cleanup();
+      const reasonText = reason.toString();
+      if (code !== 1013 || reasonText !== "Room Loading") {
+        reject(
+          new Error(
+            `${label} closed with ${code} ${JSON.stringify(reasonText)}, expected 1013 Room Loading`,
+          ),
+        );
         return;
       }
+      resolve();
+    };
 
-      if (Date.now() - startedAt > timeoutMs) {
-        clearInterval(timer);
-        reject(new Error(`${label} did not happen within ${timeoutMs}ms`));
-      }
-    }, 50);
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    function cleanup() {
+      clearInterval(closingPoll);
+      clearTimeout(timer);
+      socket.off("close", onClose);
+      socket.off("error", onError);
+    }
+
+    socket.on("close", onClose);
+    socket.on("error", onError);
   });
 }
 
@@ -33,42 +58,18 @@ const protocol =
     ? "http"
     : "https";
 
-const docA = new Y.Doc();
-const docB = new Y.Doc();
-const providerA = connectRoom(host, room, docA);
-const providerB = connectRoom(host, room, docB);
+const clients = [
+  new WebSocket(getPartyWebSocketUrl(host, room)),
+  new WebSocket(getPartyWebSocketUrl(host, room)),
+];
 
 try {
   console.log(`Connecting transient smoke room ${room} on ${host}`);
   await Promise.all([
-    waitForSync(providerA, "client A"),
-    waitForSync(providerB, "client B"),
+    waitForRecoveryClose(clients[0], "client A"),
+    waitForRecoveryClose(clients[1], "client B"),
   ]);
-
-  providerA.awareness.setLocalStateField("transientSmoke", {
-    client: "A",
-    online: true,
-  });
-
-  await waitForCondition("awareness propagation", () => {
-    return Array.from(providerB.awareness.getStates().values()).some(
-      (state) => {
-        return state?.transientSmoke?.client === "A";
-      },
-    );
-  });
-  console.log("awareness propagated while persistence was unavailable");
-
-  docA.getMap("transient-smoke").set("message", "live while transient");
-  await sleep(500);
-  if (docB.getMap("transient-smoke").has("message")) {
-    throw new Error(
-      "expected transient shared-data write to remain blocked from peers",
-    );
-  }
-  console.log(
-    "shared-data writes stayed blocked while persistence was unavailable",
-  );
+  console.log("clients closed with 1013 while persistence was unavailable");
 
   const adminResponse = await fetch(
     `${protocol}://${host}/parties/main/${encodeURIComponent(room)}/admin/force-save-live`,
@@ -80,19 +81,17 @@ try {
   const adminBody = await adminResponse.json();
   if (
     adminResponse.status !== 503 ||
-    adminBody.error !== "persistence_unavailable"
+    adminBody.error !== "room_load_deferred"
   ) {
     throw new Error(
-      `expected transient admin write to return 503, got ${adminResponse.status}: ${JSON.stringify(adminBody)}`,
+      `expected deferred admin write to return 503, got ${adminResponse.status}: ${JSON.stringify(adminBody)}`,
     );
   }
-  console.log("admin writes are blocked while persistence is unavailable");
+  console.log("admin writes are deferred while persistence is unavailable");
 
-  await sleep(100);
   console.log("supabase transient smoke passed");
 } finally {
-  providerA.destroy();
-  providerB.destroy();
-  docA.destroy();
-  docB.destroy();
+  for (const client of clients) {
+    client.close();
+  }
 }


### PR DESCRIPTION
## Summary

- build on #416's single authoritative recovery path and existing `loadRetryAfter` state
- close new, existing, and hibernated WebSocket clients with 1013 `Room Loading` while hydration recovery is pending
- treat returned Supabase timeout/HTTP failures as provider outages without adding quarantine evidence, while preserving any earlier vanished-attempt evidence
- retry provider outages after about 5 seconds with a 5-minute cap, and keep #416's one-minute save retry instead of the earlier one-second interval
- update the transient outage smoke to require 1013 client gating

## Rationale

#416 now owns durable admission, alarm scheduling, authoritative reload, reset boundaries, and the single risky-operation ledger. This follow-up only changes client admission and failure bookkeeping within that mechanism. It does not add recovery counters or storage keys.

A caught Supabase error proves the isolate survived, so the current load attempt is released from quarantine accounting and a short recovery deadline is scheduled. A vanished attempt still accrues evidence exactly as #416 defines. Existing crash evidence is preserved when a later provider outage is caught.

The product behavior is intentionally fail-closed during startup hydration: clients reconnect after receiving 1013 instead of using awareness against an empty placeholder document.

## Verification

- failing-first regression run for new-connection gating, hibernated-socket gating, three failed reads followed by alarm recovery, and outage/crash ledger separation
- `bun run check:partykit`
- `bun test partykit/__tests__/` (286 passed)
- `node --check smoke-tests/partykit/supabase-transient-smoke.mjs`
- local Wrangler outage smoke with an unreachable Supabase endpoint: both clients received 1013 `Room Loading`, and the admin write returned 503 `room_load_deferred`
- `git diff --check`

## Release notes

No changeset or public documentation update. This changes internal PartyKit recovery behavior and its operational smoke test, not the published package API or user-facing setup.
