### PR TITLE
Add headless cloud-agent extension testing

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bun run setup:agent"
+}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -54,6 +54,9 @@ jobs:
       run: bunx playwright install --with-deps chromium
       working-directory: smoke-tests
 
+    - name: Run extension smoke tests
+      run: bun run smoke:extension
+
     - name: Run smoke tests
       run: bun smoke
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ playhtml is a collaborative, interactive HTML library that allows elements to be
 ## Development Commands
 
 - `bun run setup`: install locked dependencies, prepare WXT metadata, build packages, and verify workspace readiness
+- `bun run setup:agent`: run the full workspace setup and install headless Chromium for cloud and local agents
 - `bun run doctor`: check whether dependencies, WXT metadata, and package build outputs are ready
 - `bun dev`: Website dev server (Vite)
 - `bun dev-server`: PartyKit dev server for real-time sync
@@ -30,8 +31,15 @@ playhtml is a collaborative, interactive HTML library that allows elements to be
 - `bun build-packages`: Build all library packages
 - `bun run lint`: Type-check all packages
 - `bun run smoke:extension-worker`: bundle the extension Worker without deploying or starting a watcher
+- `bun run smoke:extension`: build and load the real extension in isolated headless Chromium with a loopback-only backend
 
 Per-package and deploy scripts are in the root `package.json`.
+
+### Cloud agents
+
+Use `bun run setup:agent` as the environment setup command for Codex Cloud, Cursor Cloud Agents, and Claude Code cloud sessions. Cursor reads this command from `.cursor/environment.json`. Configure the same command as the cached environment setup script in the Codex and Claude environment dashboards.
+
+For Claude Code cloud, use the environment setup script rather than a `SessionStart` hook. Claude caches environment setup output, while session hooks rerun after every start or resume and Bun has known compatibility issues with Claude's network proxy. Keep the default agent setup free of secrets and start long-running services only within the task that needs them.
 
 ### Testing
 

--- a/extension/src/storage/sync.ts
+++ b/extension/src/storage/sync.ts
@@ -18,29 +18,19 @@ const PROD_WORKER_URL = 'https://playhtml-game-api.spencerc99.workers.dev';
  * Development worker URL (localhost)
  * Run with: cd extension/worker && wrangler dev
  */
-const DEV_WORKER_URL = 'http://localhost:8787';
+const DEV_WORKER_URL =
+  import.meta.env.VITE_WORKER_URL || 'http://localhost:8787';
 
 /**
  * Detect if we're in development mode
  * Checks build environment (WXT sets this when running `wxt dev`)
  */
 function isDevelopment(): boolean {
-  try {
-    // Check build mode (WXT sets this when running `wxt dev`)
-    if (typeof import.meta !== 'undefined' && import.meta.env) {
-      const isDev = import.meta.env.DEV === true || import.meta.env.MODE === 'development';
-      if (isDev && VERBOSE) {
-        console.log('[Sync] Development mode detected from build environment');
-      }
-      return isDev;
-    }
-    
-    return false;
-  } catch (error) {
-    // Service worker context may lack DOM APIs — this is expected, not an error.
-    if (VERBOSE) console.warn('[Sync] Error detecting development mode:', error);
-    return false;
+  const isDev = import.meta.env.DEV || import.meta.env.MODE === 'development';
+  if (isDev && VERBOSE) {
+    console.log('[Sync] Development mode detected from build environment');
   }
+  return isDev;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "setup": "bun install --frozen-lockfile && bun run build-packages && bun run doctor",
+    "setup:agent": "bun run setup && bunx playwright install --with-deps chromium",
     "doctor": "node scripts/check-workspace-readiness.mjs",
     "test:doctor": "node --test scripts/check-workspace-readiness.test.mjs",
     "dev": "vite --config vite.config.site.mts",
@@ -67,6 +68,7 @@
     "load-test": "bun tools/load-test/src/runner.ts",
     "load-test:full": "bun tools/load-test/src/runner.ts --config full-suite",
     "smoke": "cd smoke-tests && bun run test",
+    "smoke:extension": "VITE_WORKER_URL=http://127.0.0.1:18787 bun run --cwd extension build -- --mode development && node smoke-tests/extension-smoke.mjs",
     "smoke:partykit": "cd smoke-tests && bun run test:partykit",
     "smoke:partykit:limits": "cd smoke-tests && bun run test:partykit:limits",
     "smoke:partykit:hibernation": "cd smoke-tests && bun run test:partykit:hibernation",

--- a/smoke-tests/extension-smoke.mjs
+++ b/smoke-tests/extension-smoke.mjs
@@ -1,0 +1,163 @@
+// ABOUTME: Loads the built browser extension in isolated headless Chromium.
+// ABOUTME: Verifies the MV3 worker, content script, and popup without external traffic.
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const extensionPath = resolve(
+  workspaceRoot,
+  "extension/dist/chrome-mv3-dev",
+);
+const workerPort = 18787;
+const workerOrigin = `http://127.0.0.1:${workerPort}`;
+const localWorkerRequests = [];
+const server = createServer((request, response) => {
+  if (request.method === "GET" && request.url === "/probe") {
+    response.writeHead(200, { "content-type": "text/html" });
+    response.end(
+      "<!doctype html><title>Extension smoke</title><main>extension smoke</main>",
+    );
+    return;
+  }
+
+  localWorkerRequests.push({ method: request.method, url: request.url });
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end('{"inserted":0,"duplicates":0}');
+});
+
+async function listen() {
+  await new Promise((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(workerPort, "127.0.0.1", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+}
+
+async function closeServer() {
+  if (!server.listening) return;
+  await new Promise((resolveClose, rejectClose) => {
+    server.close((error) => (error ? rejectClose(error) : resolveClose()));
+  });
+}
+
+await listen();
+let context;
+
+try {
+  context = await chromium.launchPersistentContext("", {
+    channel: "chromium",
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      "--disable-background-networking",
+      "--host-resolver-rules=MAP * 127.0.0.1, EXCLUDE localhost, EXCLUDE 127.0.0.1",
+    ],
+  });
+
+  const blockedHttpRequests = [];
+  const blockedWebSockets = [];
+  await context.routeWebSocket("**/*", (webSocket) => {
+    blockedWebSockets.push(webSocket.url());
+    webSocket.close();
+  });
+  await context.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      url.protocol === "chrome-extension:" ||
+      url.hostname === "127.0.0.1" ||
+      url.hostname === "localhost"
+    ) {
+      await route.continue();
+      return;
+    }
+    blockedHttpRequests.push({ method: route.request().method(), url: url.href });
+    await route.abort("blockedbyclient");
+  });
+
+  const worker =
+    context.serviceWorkers()[0] ??
+    (await context.waitForEvent("serviceworker", { timeout: 15_000 }));
+  const extensionId = new URL(worker.url()).host;
+  const page = await context.newPage();
+  const pageErrors = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  await page.goto(`${workerOrigin}/probe`, { waitUntil: "domcontentloaded" });
+
+  const tabId = await worker.evaluate(async (url) => {
+    const tabs = await chrome.tabs.query({ url });
+    return tabs[0]?.id;
+  }, page.url());
+  assert.equal(typeof tabId, "number", "the extension worker found the probe tab");
+
+  const contentReply = await worker.evaluate(
+    async ({ targetTabId }) =>
+      chrome.tabs.sendMessage(targetTabId, { type: "PING" }),
+    { targetTabId: tabId },
+  );
+  assert.deepEqual(contentReply, {
+    status: "pong",
+    url: `${workerOrigin}/probe`,
+  });
+
+  const popup = await context.newPage();
+  const popupErrors = [];
+  popup.on("pageerror", (error) => popupErrors.push(error.message));
+  await popup.goto(`chrome-extension://${extensionId}/popup.html`, {
+    waitUntil: "domcontentloaded",
+  });
+  await popup.locator("body").waitFor({ state: "visible" });
+  const popupText = (await popup.locator("body").innerText()).trim();
+  await page.waitForTimeout(500);
+  const unexpectedExternalHttpRequests = blockedHttpRequests.filter(
+    ({ method, url }) => {
+      const parsedUrl = new URL(url);
+      return !(
+        method === "GET" &&
+        parsedUrl.hostname === "fonts.googleapis.com" &&
+        parsedUrl.pathname === "/css2"
+      );
+    },
+  );
+
+  assert.ok(popupText.length > 0, "the popup rendered non-empty text");
+  assert.deepEqual(pageErrors, [], "the probe page had no uncaught errors");
+  assert.deepEqual(popupErrors, [], "the popup had no uncaught errors");
+  assert.deepEqual(
+    localWorkerRequests.filter(
+      ({ method, url }) => method === "PUT" && url.startsWith("/participants/"),
+    ).length,
+    1,
+    "the extension synced its generated participant color to the loopback worker",
+  );
+  assert.deepEqual(
+    unexpectedExternalHttpRequests,
+    [],
+    "the extension only attempted its known external font stylesheets",
+  );
+  assert.deepEqual(blockedWebSockets, [], "the extension did not open WebSockets");
+
+  console.log(
+    JSON.stringify(
+      {
+        serviceWorker: worker.url(),
+        contentScript: contentReply.status,
+        popupTextLength: popupText.length,
+        localWorkerRequests,
+        blockedFontStylesheets: blockedHttpRequests.length,
+        externalWebSockets: blockedWebSockets.length,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await context?.close().catch(() => {});
+  await closeServer();
+}


### PR DESCRIPTION
## Summary

- add one repo-owned setup command for Codex, Cursor, and Claude cloud agents
- run a real Manifest V3 extension smoke test in isolated headless Chromium
- configure Cursor environment builds and add the extension smoke test to PR validation
- fix development worker URL selection inside the extension service worker
- document the cached setup command for Claude Code cloud environments

## Rationale

Website tests already ran headlessly, but the extension had no blocking runtime check that loaded its service worker, content script, and popup. The first smoke run exposed a development-build bug: WXT emitted the `typeof import.meta` guard through a `document.baseURI` expression, which threw in the service worker and selected the production API URL.

The smoke test now uses a loopback worker stub, requires the expected participant-color write, blocks unexpected external HTTP and WebSocket traffic, and does not use the host display or Chrome profile.

## Verification

- `bun run setup:agent`
- `bun run test:doctor` — 3 tests
- `bun run test:extension` — 882 tests in 136 files
- `bun run check:extension`
- `bun run build-site`
- `bun run smoke` — 23 Playwright tests
- `bun run smoke:extension`
- JSON, YAML, Node syntax, and `git diff --check`

Claude Code cloud reads the committed `CLAUDE.md` and should use `bun run setup:agent` as its cached environment setup script. A live Anthropic-managed cloud run was not performed from the local agent because that requires separate authorization to send this repository to an external managed environment. PR validation provides the Ubuntu runner check for the shared setup and headless extension path.

## Release checklist

- Screenshots: not applicable; infrastructure-only change with no user-facing UI
- Changeset: not needed; no published package behavior changed
- Public docs: not needed; no public API or user workflow changed
- Starter templates: not affected
- Extension release notes: not needed; internal testing and development configuration only
