### PR TITLE
Run extension performance traces headlessly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,9 @@ The extension and PartyKit use one Supabase project with different tables. All n
 
 ### Extension Performance
 
-- `bun run perf:extension:trace -- --extension local:extension/dist/chrome-mv3`: Trace a built extension locally. Build packages and the extension first.
-- `bun run perf:extension:compare -- --summary <summary.json>`: Compare trace summaries and write reports.
-- For extension changes that touch collectors, storage, content-script observers, or page-wide work, check the `Extension Performance Report` workflow or run a local trace before merge. Treat large increases in `TaskDuration`, `ScriptDuration`, `LayoutDuration`, `RecalcStyleDuration`, or `JSHeapUsedSize` as regression signals to investigate. The workflow is report-only unless `--fail-on-regression` is passed locally.
+- The `Extension Performance Report` workflow runs extension performance traces in CI.
+- Do not run `perf:extension:trace` during local agent work. It launches headed Chrome windows that interrupt the user's desktop. Check the CI workflow result instead.
+- Run a local trace only when Spencer explicitly requests one. Treat large increases in `TaskDuration`, `ScriptDuration`, `LayoutDuration`, `RecalcStyleDuration`, or `JSHeapUsedSize` as regression signals to investigate.
 
 ## Papercuts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ The extension and PartyKit use one Supabase project with different tables. All n
 ### Extension Performance
 
 - The `Extension Performance Report` workflow runs extension performance traces in CI.
-- Do not run `perf:extension:trace` during local agent work. It launches headed Chrome windows that interrupt the user's desktop. Check the CI workflow result instead.
+- Do not run `perf:extension:trace` during local agent work. Repeated traces consume local resources and duplicate CI coverage. Check the CI workflow result instead.
 - Run a local trace only when Spencer explicitly requests one. Treat large increases in `TaskDuration`, `ScriptDuration`, `LayoutDuration`, `RecalcStyleDuration`, or `JSHeapUsedSize` as regression signals to investigate.
 
 ## Papercuts

--- a/scripts/trace-extension-performance.mjs
+++ b/scripts/trace-extension-performance.mjs
@@ -337,7 +337,7 @@ async function runOne({
   const userDataDir = resolve(outDir, `${safeLabel}-profile-${runIndex}-${process.pid}`);
   const context = await chromium.launchPersistentContext(userDataDir, {
     executablePath: chromePath,
-    headless: false,
+    headless: true,
     ignoreDefaultArgs: ["--disable-extensions"],
     viewport: { width: 1280, height: 900 },
     args: [


### PR DESCRIPTION
## Summary

- keep routine agent work from running redundant local extension traces
- force the performance trace harness to launch Chrome headlessly
- keep the weekly performance audit active and CI coverage unchanged

## Verification

- bun install --frozen-lockfile
- bun run build-packages
- bun run build-extension
- node --check scripts/trace-extension-performance.mjs
- completed a real one-run headless extension trace with metrics and trace output
- git diff --check