### PR TITLE
extension: remove startup PlayHTML capability scan

### DIFF
--- a/extension/src/__tests__/content-playhtml-status.test.ts
+++ b/extension/src/__tests__/content-playhtml-status.test.ts
@@ -1,0 +1,124 @@
+// ABOUTME: Verifies PlayHTML capability scans run only for explicit status requests.
+// ABOUTME: Exercises content-script initialization and status messaging against the real DOM.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storageGet = vi.hoisted(() => vi.fn());
+const runtimeSendMessage = vi.hoisted(() => vi.fn());
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        get: storageGet,
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+      onChanged: { addListener: vi.fn() },
+    },
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+      sendMessage: runtimeSendMessage,
+      onMessage: { addListener: vi.fn() },
+    },
+  },
+}));
+
+vi.mock("../collectors/CollectorManager", () => ({
+  CollectorManager: class {
+    registerCollector = vi.fn();
+    init = vi.fn().mockResolvedValue(undefined);
+    stopAll = vi.fn();
+    pauseAll = vi.fn();
+    resumeAll = vi.fn();
+    getCollectorStatuses = vi.fn(() => []);
+  },
+}));
+
+vi.mock("../collectors/CursorCollector", () => ({ CursorCollector: class {} }));
+vi.mock("../collectors/NavigationCollector", () => ({
+  NavigationCollector: class {},
+}));
+vi.mock("../collectors/ViewportCollector", () => ({
+  ViewportCollector: class {},
+}));
+vi.mock("../collectors/KeyboardCollector", () => ({
+  KeyboardCollector: class {},
+}));
+
+const capabilitySelector =
+  "[can-move], [can-spin], [can-toggle], [can-grow], [can-duplicate], [can-mirror], [can-play]";
+
+type RuntimeMessageListener = (
+  message: unknown,
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean | void;
+
+describe("content PlayHTML status scans", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.stubGlobal("defineContentScript", (definition: unknown) => definition);
+    document.documentElement.dataset.playhtml = "true";
+    document.body.innerHTML = '<div id="initial" can-move></div>';
+
+    storageGet.mockReset();
+    storageGet.mockImplementation((keys: string | string[]) => {
+      if (!Array.isArray(keys)) return Promise.resolve({});
+      return Promise.resolve(
+        Object.fromEntries(
+          keys
+            .filter((key) => key.startsWith("migration_v1_done_"))
+            .map((key) => [key, true]),
+        ),
+      );
+    });
+    runtimeSendMessage.mockReset();
+    runtimeSendMessage.mockImplementation((message: { type?: string }) => {
+      if (message.type === "GET_PUBLIC_PLAYER_IDENTITY") {
+        return Promise.resolve({
+          publicKey: "pk_test",
+          playerStyle: { colorPalette: ["#4a9a8a"] },
+        });
+      }
+      return Promise.resolve({});
+    });
+  });
+
+  it("skips the startup scan and returns the live count on demand", async () => {
+    const querySelectorAll = vi.spyOn(document, "querySelectorAll");
+    const browser = (await import("webextension-polyfill")).default;
+    const contentScript = (await import("../entrypoints/content")).default as {
+      main: () => void;
+    };
+
+    contentScript.main();
+
+    await vi.waitFor(() => {
+      expect(runtimeSendMessage).toHaveBeenCalledWith({
+        type: "UPDATE_SITE_DISCOVERY",
+        domain: window.location.hostname,
+      });
+    });
+    expect(querySelectorAll).not.toHaveBeenCalledWith(capabilitySelector);
+
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      '<button id="added" can-toggle></button>',
+    );
+
+    const addListener = vi.mocked(browser.runtime.onMessage.addListener);
+    const listener = addListener.mock.calls[0][0] as RuntimeMessageListener;
+    const sendResponse = vi.fn();
+
+    expect(listener({ type: "CHECK_PLAYHTML_STATUS" }, {}, sendResponse)).toBe(
+      true,
+    );
+    expect(querySelectorAll).toHaveBeenCalledTimes(1);
+    expect(querySelectorAll).toHaveBeenCalledWith(capabilitySelector);
+    expect(sendResponse).toHaveBeenCalledWith({
+      elementCount: 2,
+      detected: true,
+    });
+  });
+});

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -95,9 +95,6 @@ export default defineContentScript({
             domain: window.location.hostname,
           });
 
-          // Check if page already has PlayHTML
-          this.detectExistingPlayHTML();
-
           // Initialize extension features
           this.setupElementPicker();
           this.setupPresenceDetection();
@@ -114,19 +111,6 @@ export default defineContentScript({
         } catch (error) {
           console.error("Failed to initialize PlayHTML Extension:", error);
         }
-      }
-
-      private detectExistingPlayHTML() {
-        // Look for existing PlayHTML elements
-        const existingElements = document.querySelectorAll(
-          "[can-move], [can-spin], [can-toggle], [can-grow], [can-duplicate], [can-mirror], [can-play]",
-        );
-
-        if (existingElements.length > 0) {
-          // TODO: Coordinate with existing PlayHTML instance
-        }
-
-        return existingElements.length;
       }
 
       public checkPlayHTMLStatus() {


### PR DESCRIPTION
## Summary

- stop scanning every page for PlayHTML capability attributes during content-script initialization
- remove the now-unreachable startup scan method
- preserve the on-demand CHECK_PLAYHTML_STATUS path and its live DOM count
- add executable content-entrypoint coverage that proves startup skips the selector while an explicit status request sees elements added after initialization

## Rationale

The startup result was discarded, so every supported page paid for a full capability-selector query without changing extension behavior. The popup status request still needs a current count and continues to scan on demand.

## Verification

- bun run build-packages
- focused regression test, including a pre-fix failure on the startup selector
- bun run test:extension: 141 files and 897 tests passed
- bun run check:extension
- production Chrome MV3 build
- bun run smoke:extension: service worker, content script, and popup loaded in isolated headless Chrome
- git diff --check
- final conservative diff review: no findings

## Scope and overlap

PR #422 was checked and is closed without this cleanup. Current open extension PRs were checked; #264 also touches content.ts for an unrelated auth challenge bridge and does not duplicate this removal.

No screenshots because visible UI behavior is unchanged. No extension/PENDING.md entry because this is internal startup maintenance. No package docs, starter templates, or changeset are needed because published package behavior and APIs are unchanged.