### PR TITLE
Keep Firefox new tab address bar ready

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -15,4 +15,4 @@ extension/website/public/changelog/media/ and reference them here:
 ![video: Demo title](/changelog/media/file.mp4)
 -->
 
-- Firefox new tabs now keep the address bar ready for immediate typing.
+- Firefox new tabs now keep the address bar ready for immediate typing. (#428)

--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -14,3 +14,5 @@ extension/website/public/changelog/media/ and reference them here:
 ![Screenshot title](/changelog/media/file.png)
 ![video: Demo title](/changelog/media/file.mp4)
 -->
+
+- Firefox new tabs now keep the address bar ready for immediate typing.

--- a/extension/src/__tests__/SetupPage.newtab.test.tsx
+++ b/extension/src/__tests__/SetupPage.newtab.test.tsx
@@ -6,7 +6,10 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import browser from "webextension-polyfill";
 
+const platform = vi.hoisted(() => ({ isFirefox: false }));
+
 vi.mock("../utils/extensionPage", () => ({
+  isFirefoxExtensionPageUrl: () => platform.isFirefox,
   isSafariExtensionPageUrl: vi.fn(() => false),
 }));
 vi.mock("../storage/playerIdentity", () => ({
@@ -28,6 +31,7 @@ class ResizeObserverStub {
 }
 
 beforeEach(() => {
+  platform.isFirefox = false;
   vi.stubGlobal("ResizeObserver", ResizeObserverStub);
   vi.mocked(browser.storage.local.set).mockReset();
   vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
@@ -113,6 +117,25 @@ it("records declining the new tab takeover on Finish", async () => {
   await finish(container);
   expect(browser.storage.local.set).toHaveBeenCalledWith(
     expect.objectContaining({ newtab_takeover_enabled: false }),
+  );
+
+  act(() => root.unmount());
+  container.remove();
+});
+
+it("defers the Firefox new tab choice to Firefox", async () => {
+  platform.isFirefox = true;
+  const { container, root } = await renderCompletionStep();
+
+  expect(container.textContent).toContain(
+    "Firefox will ask you to confirm the new tab page",
+  );
+  expect(container.textContent).not.toContain("make this my new tab");
+  expect(container.querySelector('input[type="checkbox"]')).toBeNull();
+
+  await finish(container);
+  expect(browser.storage.local.set).toHaveBeenCalledWith(
+    expect.objectContaining({ newtab_takeover_enabled: true }),
   );
 
   act(() => root.unmount());

--- a/extension/src/__tests__/SetupPage.safari.test.tsx
+++ b/extension/src/__tests__/SetupPage.safari.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import browser from "webextension-polyfill";
 
 vi.mock("../utils/extensionPage", () => ({
+  isFirefoxExtensionPageUrl: vi.fn(() => false),
   isSafariExtensionPageUrl: vi.fn(() => true),
 }));
 vi.mock("../storage/playerIdentity", () => ({

--- a/extension/src/__tests__/wxt-config.test.ts
+++ b/extension/src/__tests__/wxt-config.test.ts
@@ -57,10 +57,14 @@ describe("WXT manifest", () => {
     });
   });
 
-  it("leaves the browser's own new tab page in place", async () => {
-    const manifest = await manifestFor("chrome");
+  it("uses the native history new tab only in Firefox", async () => {
+    const chromeManifest = await manifestFor("chrome");
+    const firefoxManifest = await manifestFor("firefox");
 
-    expect(manifest.chrome_url_overrides).toBeUndefined();
+    expect(chromeManifest.chrome_url_overrides).toBeUndefined();
+    expect(firefoxManifest.chrome_url_overrides).toEqual({
+      newtab: "walking-record.html",
+    });
   });
 
   it("removes unsupported idle and options tab settings in Safari", async () => {

--- a/extension/src/components/OptionsPage.test.tsx
+++ b/extension/src/components/OptionsPage.test.tsx
@@ -10,6 +10,7 @@ import { OptionsPage } from "./OptionsPage";
 const featureState = vi.hoisted(() => ({
   experimentAccess: false,
   bagSettingsEnabled: true,
+  isFirefox: false,
 }));
 
 vi.mock("./OptionsPage.scss", () => ({}));
@@ -26,6 +27,7 @@ vi.mock("../features/useFeatureAccess", () => ({
   useFeatureState: () => ({ enabled: featureState.bagSettingsEnabled }),
 }));
 vi.mock("../utils/extensionPage", () => ({
+  isFirefoxExtensionPageUrl: () => featureState.isFirefox,
   isSafariExtensionPageUrl: () => false,
 }));
 vi.mock("../storage/playerIdentity", () => ({
@@ -62,6 +64,7 @@ describe("OptionsPage", () => {
     ).IS_REACT_ACT_ENVIRONMENT = true;
     featureState.experimentAccess = false;
     featureState.bagSettingsEnabled = true;
+    featureState.isFirefox = false;
     vi.mocked(browser.storage.local.get).mockResolvedValue({});
   });
 
@@ -121,6 +124,22 @@ describe("OptionsPage", () => {
         "community",
         "your data",
       ]);
+    } finally {
+      cleanup(root, container);
+    }
+  });
+
+  it("defers Firefox new tab management to Firefox", async () => {
+    featureState.isFirefox = true;
+    const { container, root } = await renderOptions();
+    try {
+      const browserSection = container.querySelector("#browser");
+      expect(browserSection?.textContent).toContain(
+        "Firefox manages this new tab page",
+      );
+      expect(
+        browserSection?.querySelector('input[type="checkbox"]'),
+      ).toBeNull();
     } finally {
       cleanup(root, container);
     }

--- a/extension/src/components/OptionsPage.tsx
+++ b/extension/src/components/OptionsPage.tsx
@@ -22,7 +22,10 @@ import {
   PLAYER_IDENTITY_STORAGE_KEY,
 } from "../storage/playerIdentity";
 import { hslToHex } from "../utils/color";
-import { isSafariExtensionPageUrl } from "../utils/extensionPage";
+import {
+  isFirefoxExtensionPageUrl,
+  isSafariExtensionPageUrl,
+} from "../utils/extensionPage";
 import { NEWTAB_TAKEOVER_KEY } from "../features/newtab/takeover";
 import {
   useExperimentAccess,
@@ -182,6 +185,7 @@ export function OptionsPage() {
   const experimentAccess = useExperimentAccess();
   const bagSettingsEnabled = useFeatureState("BAG_SETTINGS").enabled;
   const isSafari = isSafariExtensionPageUrl(window.location.href);
+  const isFirefox = isFirefoxExtensionPageUrl(window.location.href);
 
   const sections = bagSettingsEnabled
     ? SECTIONS
@@ -406,6 +410,11 @@ export function OptionsPage() {
               <p className="options-page__mono-note">
                 Safari doesn't let extensions change the new tab — bookmark or
                 pin the history page to keep it a click away.
+              </p>
+            ) : isFirefox ? (
+              <p className="options-page__mono-note">
+                Firefox manages this new tab page. Use Firefox's new-tab prompt
+                to keep History or change it.
               </p>
             ) : (
               <label className="options-page__checkbox">

--- a/extension/src/components/SetupPage.tsx
+++ b/extension/src/components/SetupPage.tsx
@@ -19,7 +19,10 @@ import { LEGIBILITY_KEY } from "../utils/keyboardRedaction";
 import "./SetupPage.scss";
 import { hslToHex } from "../utils/color";
 import { MilestoneToastPreview } from "./MilestoneToastPreview";
-import { isSafariExtensionPageUrl } from "../utils/extensionPage";
+import {
+  isFirefoxExtensionPageUrl,
+  isSafariExtensionPageUrl,
+} from "../utils/extensionPage";
 import { WORKER_URL } from "@movement/config";
 import {
   hasSafariWebsiteAccess,
@@ -129,6 +132,7 @@ export default function SetupPage() {
   const heroRef = useRef<HTMLDivElement>(null);
   const [heroSize, setHeroSize] = useState({ width: 0, height: 0 });
   const isSafari = isSafariExtensionPageUrl(window.location.href);
+  const isFirefox = isFirefoxExtensionPageUrl(window.location.href);
   const [websiteAccess, setWebsiteAccess] = useState<WebsiteAccess>(
     isSafari ? "checking" : "granted",
   );
@@ -561,6 +565,11 @@ export default function SetupPage() {
                       Open History ↗
                     </a>
                   </>
+                ) : isFirefox ? (
+                  <p className="setup-step__newtab-note">
+                    Firefox will ask you to confirm the new tab page. Choose
+                    Keep Changes to use History when you open a new tab.
+                  </p>
                 ) : (
                   <label className="setup-step__newtab-optin">
                     <input

--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -316,9 +316,10 @@ export default defineBackground(() => {
   // false in extensions regardless of actual protection status (known
   // Chromium issue #357622670), so it's a misleading signal to rely on.
 
-  // Opt-in: send new browser tabs to the walking record instead of the
-  // default new tab page. Off unless the user turns it on.
-  initNewTabTakeover()
+  // Chromium opt-in: send new browser tabs to the walking record instead of
+  // the default new tab page. Firefox uses the manifest override so the
+  // address bar keeps native new-tab behavior.
+  if (!import.meta.env.FIREFOX) initNewTabTakeover()
   initSlowModeInterception()
 
   // Forward the manifest "open-inventory" command to the active tab's content script.

--- a/extension/src/entrypoints/walking-record/walking-record.tsx
+++ b/extension/src/entrypoints/walking-record/walking-record.tsx
@@ -37,7 +37,10 @@ import {
 import type { ScreenTimeSession } from "../../storage/LocalEventStore";
 import { getPublicPlayerIdentity } from "../../storage/playerIdentity";
 import { NEWTAB_TAKEOVER_KEY } from "../../features/newtab/takeover";
-import { isSafariExtensionPageUrl } from "../../utils/extensionPage";
+import {
+  isFirefoxExtensionPageUrl,
+  isSafariExtensionPageUrl,
+} from "../../utils/extensionPage";
 import {
   createMovementLoadingPreview,
   isMovementLoadingPreview,
@@ -377,16 +380,17 @@ const NEWTAB_CONTROL_STYLE = {
 /** Controls whether new browser tabs open this walking record. */
 function NewTabTakeoverToggle() {
   const [enabled, setEnabled] = useState(false);
-  // Safari has no new tab override, so there is no preference to offer.
+  // Browser-managed new tab pages do not use the stored preference.
   const isSafari = isSafariExtensionPageUrl(window.location.href);
+  const isFirefox = isFirefoxExtensionPageUrl(window.location.href);
 
   useEffect(() => {
-    if (isSafari) return;
+    if (isFirefox || isSafari) return;
     browser.storage.local
       .get([NEWTAB_TAKEOVER_KEY])
       .then((result) => setEnabled(Boolean(result[NEWTAB_TAKEOVER_KEY])))
       .catch(() => setEnabled(false));
-  }, [isSafari]);
+  }, [isFirefox, isSafari]);
 
   const toggle = (next: boolean) => {
     setEnabled(next);
@@ -398,6 +402,15 @@ function NewTabTakeoverToggle() {
       <p style={{ ...NEWTAB_CONTROL_STYLE, maxWidth: "320px", margin: 0 }}>
         Safari doesn't let extensions change the new tab — bookmark or pin this
         page to keep it a click away.
+      </p>
+    );
+  }
+
+  if (isFirefox) {
+    return (
+      <p style={{ ...NEWTAB_CONTROL_STYLE, maxWidth: "320px", margin: 0 }}>
+        Firefox manages this new tab page. Use its new-tab prompt to keep or
+        change it.
       </p>
     );
   }

--- a/extension/src/utils/extensionPage.test.ts
+++ b/extension/src/utils/extensionPage.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import {
   isExtensionPageUrl,
+  isFirefoxExtensionPageUrl,
   isSafariExtensionPageUrl,
 } from "./extensionPage";
 
@@ -33,5 +34,17 @@ describe("isSafariExtensionPageUrl", () => {
       false,
     );
     expect(isSafariExtensionPageUrl("not a url")).toBe(false);
+  });
+});
+
+describe("isFirefoxExtensionPageUrl", () => {
+  it("recognizes Firefox extension pages only", () => {
+    expect(
+      isFirefoxExtensionPageUrl("moz-extension://test/setup.html"),
+    ).toBe(true);
+    expect(isFirefoxExtensionPageUrl("chrome-extension://test/setup.html")).toBe(
+      false,
+    );
+    expect(isFirefoxExtensionPageUrl("not a url")).toBe(false);
   });
 });

--- a/extension/src/utils/extensionPage.ts
+++ b/extension/src/utils/extensionPage.ts
@@ -22,3 +22,11 @@ export function isSafariExtensionPageUrl(url: string): boolean {
     return false;
   }
 }
+
+export function isFirefoxExtensionPageUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "moz-extension:";
+  } catch {
+    return false;
+  }
+}

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
     action: {
       default_title: "we were online",
     },
+    chrome_url_overrides:
+      browser === "firefox"
+        ? {
+            newtab: "walking-record.html",
+          }
+        : undefined,
     commands: {
       "open-inventory": {
         suggested_key: {


### PR DESCRIPTION
## Summary

- use Firefox’s native new-tab override for the History page so the address bar keeps native focus and selection behavior
- leave the existing runtime opt-in unchanged in Chrome and Edge
- replace Firefox’s ineffective extension checkbox with browser-managed guidance in onboarding, Settings, and History

## Verification

- `bun run build-packages`
- `bun run test:extension` (899 tests)
- `bun run check:extension`
- `bun run build` in `extension/`
- `bun run build:firefox` in `extension/`
- Firefox 154: verified both Command+T and the new-tab button focus the address bar after History loads; typing produces only the entered query, without a `moz-extension://` prefix

Screenshots are attached in the PR evidence comment.

No package API, starter template, or public developer documentation changes are needed; this only changes the Firefox extension’s new-tab integration.