### PR TITLE
Extension: accept already-published Chrome releases

### DIFF
--- a/extension/scripts/submitChrome.mjs
+++ b/extension/scripts/submitChrome.mjs
@@ -44,7 +44,21 @@ function chromeItemIsInReview(body) {
   );
 }
 
-export async function ensureChromeResponseSucceeded(action, response) {
+function chromeItemIsPublishedVersion(body, version) {
+  if (!version) return false;
+
+  const errors = Array.isArray(body?.itemError) ? body.itemError : [];
+  return (
+    errors.length > 0 &&
+    errors.every(
+      (error) =>
+        error?.error_code === "PKG_INVALID_VERSION_NUMBER" &&
+        error?.error_detail?.includes(`published package: ${version}.`),
+    )
+  );
+}
+
+export async function ensureChromeResponseSucceeded(action, response, { publishedVersion } = {}) {
   const body = await readResponseBody(response);
 
   if (!response.ok) {
@@ -63,12 +77,22 @@ export async function ensureChromeResponseSucceeded(action, response) {
     const itemIsAlreadySubmitted =
       itemErrors.length > 0 &&
       itemErrors.every((error) => error?.error_code === "ITEM_NOT_UPDATABLE");
+    const itemIsAlreadyPublished = chromeItemIsPublishedVersion(body, publishedVersion);
 
-    if (itemErrors.length > 0 && !itemIsAlreadySubmitted) {
+    if (
+      itemErrors.length > 0 &&
+      !itemIsAlreadySubmitted &&
+      !itemIsAlreadyPublished
+    ) {
       throw new Error(`Chrome upload returned item errors: ${formatBody(itemErrors)}`);
     }
 
-    if (!itemIsAlreadySubmitted && body?.uploadState && body.uploadState !== "SUCCESS") {
+    if (
+      !itemIsAlreadySubmitted &&
+      !itemIsAlreadyPublished &&
+      body?.uploadState &&
+      body.uploadState !== "SUCCESS"
+    ) {
       throw new Error(`Chrome upload did not complete: ${body.uploadState}`);
     }
   }
@@ -150,10 +174,18 @@ export async function submitChrome({ env = process.env, fetchImpl = fetch } = {}
     },
     body: zip,
   });
-  const uploadBody = await ensureChromeResponseSucceeded("upload", uploadResponse);
+  const uploadBody = await ensureChromeResponseSucceeded("upload", uploadResponse, {
+    publishedVersion: env.VERSION,
+  });
   const itemIsAlreadySubmitted = uploadBody?.itemError?.some(
     (error) => error?.error_code === "ITEM_NOT_UPDATABLE",
   );
+  const itemIsAlreadyPublished = chromeItemIsPublishedVersion(uploadBody, env.VERSION);
+  if (itemIsAlreadyPublished) {
+    console.log(`Chrome version ${env.VERSION} is already published; skipped upload.`);
+    return;
+  }
+
   if (itemIsAlreadySubmitted) {
     console.log("Chrome item is already submitted; skipped upload.");
   } else {

--- a/extension/scripts/submitChrome.test.mjs
+++ b/extension/scripts/submitChrome.test.mjs
@@ -125,6 +125,70 @@ test("accepts an upload when the Chrome item is already submitted", async () => 
   });
 });
 
+test("accepts the expected Chrome version when it is already published", async () => {
+  const requests = [];
+  const logs = [];
+  vi.spyOn(console, "log").mockImplementation((message) => logs.push(String(message)));
+
+  await submitChrome({
+    env: {
+      VERSION: "0.1.24",
+      CHROME_ZIP: await writeTempZip(),
+      CHROME_EXTENSION_ID: "chrome-extension-id",
+      CHROME_CLIENT_ID: "client-id",
+      CHROME_CLIENT_SECRET: "client-secret",
+      CHROME_REFRESH_TOKEN: "refresh-token",
+    },
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options });
+      if (requests.length === 1) {
+        return new Response(
+          JSON.stringify({
+            access_token: "access-token",
+            token_type: "Bearer",
+          }),
+          { status: 200, statusText: "OK" },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          itemError: [
+            {
+              error_code: "PKG_INVALID_VERSION_NUMBER",
+              error_detail:
+                "Invalid version number in manifest: 0.1.24. Please make sure the newly uploaded package has a larger version in file manifest.json than the published package: 0.1.24.",
+            },
+          ],
+        }),
+        { status: 200, statusText: "OK" },
+      );
+    },
+  });
+
+  expect(requests).toHaveLength(2);
+  expect(logs).toContain("Chrome version 0.1.24 is already published; skipped upload.");
+});
+
+test("rejects a published Chrome version that does not match the release", async () => {
+  const response = new Response(
+    JSON.stringify({
+      itemError: [
+        {
+          error_code: "PKG_INVALID_VERSION_NUMBER",
+          error_detail:
+            "Invalid version number in manifest: 0.1.24. Please make sure the newly uploaded package has a larger version in file manifest.json than the published package: 0.1.25.",
+        },
+      ],
+    }),
+    { status: 200, statusText: "OK" },
+  );
+
+  await expect(
+    ensureChromeResponseSucceeded("upload", response, { publishedVersion: "0.1.24" }),
+  ).rejects.toThrow(/Chrome upload returned item errors:.*PKG_INVALID_VERSION_NUMBER/);
+});
+
 test("throws for other Chrome upload item errors", async () => {
   const response = new Response(
     JSON.stringify({


### PR DESCRIPTION
## Summary
- treat Chrome's exact same-version published response as an idempotent success
- stop before the publish call when the requested version is already live
- keep mismatched published versions as hard failures

## Why
Chrome approved and published 0.1.24 between release retries. The next retry returned `PKG_INVALID_VERSION_NUMBER` because 0.1.24 was already the live package, and the workflow incorrectly ended red.

## Testing
- `cd extension && bun test scripts` (20 passed)
- regression reproduced before the fix with the live Chrome response shape

## Validation note
`bun run build-packages` is currently blocked by an unrelated existing `NamedNodeMap` TypeScript error in `packages/playhtml/src/canMirror.ts`. The hosted release run built current main successfully before reaching the Chrome API response.