### PR TITLE
Update the Worker deploy checkout action

### DIFF
--- a/.github/workflows/extension-worker-deploy.yml
+++ b/.github/workflows/extension-worker-deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- use `actions/checkout@v6` in the extension Worker deployment workflow

## Rationale
The first successful automated deployment reported that checkout v4 targets deprecated Node.js 20 and was being forced onto Node.js 24. Checkout v6 removes that workflow annotation.

## Verification
- workflow YAML parsed successfully
- `git diff --check`

No screenshots: CI-only change.