### PR TITLE
Fix hosted Slow Mode bridge startup race

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Slow Mode commute rides now connect reliably when the hosted route loads before the extension.
+
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow
 watches this file: when there are bullets, it opens (or updates) a release PR

--- a/extension/src/features/slowMode/slowModeHostedBridge.test.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.test.ts
@@ -1,15 +1,17 @@
 // ABOUTME: Tests hosted Slow Mode bridge validation and fragment parsing.
 // ABOUTME: Verifies that only opaque ride metadata crosses into the hosted page.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   SLOW_MODE_HOSTED_BRIDGE_SOURCE,
   SLOW_MODE_HOSTED_OUTCOME,
   SLOW_MODE_HOSTED_REQUEST,
+  SLOW_MODE_HOSTED_RESPONSE,
   getHostedSlowModeRideId,
   isHostedCommuteUrl,
   isHostedSlowModeOutcome,
   isHostedSlowModeRequest,
+  requestHostedSlowModeRide,
 } from "./slowModeHostedBridge";
 
 const RIDE_ID = "8cc8e2ef-63cf-4cb6-86c7-6d4999e5641d";
@@ -54,5 +56,46 @@ describe("hosted Slow Mode bridge", () => {
         navigate: true,
       }),
     ).toBe(false);
+  });
+
+  it("keeps requesting while the extension bridge starts", async () => {
+    vi.useFakeTimers();
+    let requestCount = 0;
+    const ride = {
+      rideId: RIDE_ID,
+      destinationDomain: "example.com",
+      stopVisibility: "domain" as const,
+    };
+    const postMessage = vi
+      .spyOn(window, "postMessage")
+      .mockImplementation((message: unknown) => {
+        if (!isHostedSlowModeRequest(message)) return;
+        requestCount += 1;
+        if (requestCount !== 2) return;
+        queueMicrotask(() => {
+          window.dispatchEvent(
+            new MessageEvent("message", {
+              data: {
+                source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+                type: SLOW_MODE_HOSTED_RESPONSE,
+                requestId: message.requestId,
+                ride,
+              },
+              source: window,
+            }),
+          );
+        });
+      });
+
+    try {
+      const result = requestHostedSlowModeRide(RIDE_ID);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(requestCount).toBe(2);
+      await expect(result).resolves.toEqual(ride);
+    } finally {
+      postMessage.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/extension/src/features/slowMode/slowModeHostedBridge.ts
+++ b/extension/src/features/slowMode/slowModeHostedBridge.ts
@@ -11,6 +11,8 @@ export const SLOW_MODE_HOSTED_REQUEST = "request-ride";
 export const SLOW_MODE_HOSTED_RESPONSE = "ride-response";
 export const SLOW_MODE_HOSTED_OUTCOME = "ride-outcome";
 
+const SLOW_MODE_HOSTED_REQUEST_RETRY_MS = 250;
+
 export interface HostedSlowModeRide {
   rideId: string;
   destinationDomain: string;
@@ -95,11 +97,19 @@ export function requestHostedSlowModeRide(
   timeoutMs = 1_000,
 ): Promise<HostedSlowModeRide | null> {
   const requestId = crypto.randomUUID();
+  const request = {
+    source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
+    type: SLOW_MODE_HOSTED_REQUEST,
+    requestId,
+    rideId,
+  } satisfies HostedSlowModeRequestMessage;
   return new Promise((resolve) => {
-    const timer = window.setTimeout(() => {
+    const finish = (ride: HostedSlowModeRide | null) => {
+      window.clearInterval(retryTimer);
+      window.clearTimeout(timeoutTimer);
       window.removeEventListener("message", receiveResponse);
-      resolve(null);
-    }, timeoutMs);
+      resolve(ride);
+    };
     const receiveResponse = (event: MessageEvent) => {
       if (event.source !== window) return;
       const message = event.data as Partial<HostedSlowModeResponseMessage>;
@@ -110,20 +120,18 @@ export function requestHostedSlowModeRide(
       ) {
         return;
       }
-      window.clearTimeout(timer);
-      window.removeEventListener("message", receiveResponse);
-      resolve(message.ride ?? null);
+      finish(message.ride ?? null);
     };
-    window.addEventListener("message", receiveResponse);
-    window.postMessage(
-      {
-        source: SLOW_MODE_HOSTED_BRIDGE_SOURCE,
-        type: SLOW_MODE_HOSTED_REQUEST,
-        requestId,
-        rideId,
-      } satisfies HostedSlowModeRequestMessage,
-      window.location.origin,
+    const sendRequest = () => {
+      window.postMessage(request, window.location.origin);
+    };
+    const retryTimer = window.setInterval(
+      sendRequest,
+      SLOW_MODE_HOSTED_REQUEST_RETRY_MS,
     );
+    const timeoutTimer = window.setTimeout(() => finish(null), timeoutMs);
+    window.addEventListener("message", receiveResponse);
+    sendRequest();
   });
 }
 


### PR DESCRIPTION
## Summary
- retry hosted Slow Mode ride requests during the existing one-second bridge window
- stop retries as soon as the extension responds or the request times out
- add a regression test for a content bridge that misses the initial request
- add the user-facing fix to pending extension release notes

## Root cause
The hosted commute page sent its ride lookup once during React startup. The extension content bridge starts at `document_idle`, so a fast cached page could post before the listener existed. That request was permanently lost and the page showed the public-route fallback.

The requester now repeats the same opaque request every 250 ms until it receives a response or reaches the existing timeout. This fixes the hosted page for already-installed extensions; it does not expose destination URLs or change extension permissions.

## Verification
- failing-before regression: `expected 1 to be 2` because only the initial request was sent
- `bun run --cwd extension test src/features/slowMode/slowModeHostedBridge.test.ts`
- `bun run test:extension` (140 files, 902 tests)
- `bun run check:extension`
- `bun run check:extension-website`
- `bun run build-extension`
- `bun run --cwd extension/website build`

## Docs and templates
No public developer docs or starter templates change: this fixes an internal extension-to-page transport race without changing a public package API.