### PR TITLE
Require automated integration tests for extension features

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why? -->
+
+## Verification
+
+<!-- List the exact tests, checks, builds, and browser verification performed. -->
+
+## Extension feature integration
+
+<!-- Delete this section when the PR does not add a new extension feature. -->
+
+- Automated integration test command:
+- Runtime boundaries exercised:
+- Failure-prone lifecycle exercised:
+- Final observable outcome asserted:
+
+Manual browser verification, screenshots, unit tests, component tests, mocked browser APIs, and the generic extension shell smoke do not replace this feature-level integration test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ When building or modifying playhtml elements, follow the `building-playhtml-elem
 ## Testing Requirements
 
 - Run relevant package tests locally before PRs
+- **Automated integration tests for extension features:** Every new extension feature MUST include an automated integration test in the same PR. The test must drive the feature through the real runtime boundaries it depends on, using built artifacts where applicable. These boundaries may include the MV3 service worker, content script, injected or hosted page, browser storage, navigation lifecycle, and Worker API. Unit tests, component tests, mocked browser APIs, the generic extension shell smoke, screenshots, and manual browser verification do not satisfy this requirement. Exercise the user entrypoint, the final observable outcome, and at least one relevant failure-prone lifecycle such as cold start, reload, delayed script or service-worker readiness, or a client/server deployment contract. Run the integration test locally and in required CI before merge. If a reliable automated integration test is technically blocked, stop and tell Spencer; do not merge the feature based on manual evidence alone.
 - **Screenshots for user-facing changes:** Every user-facing change MUST be verified on the real affected surface and accompanied by screenshots of the finished result. For interactive changes, capture the key states of the flow (for example, closed, open, and success states), not only the initial screen. Include the screenshots in the handoff and PR. If the surface cannot be captured, stop and tell Spencer what blocks it rather than omitting them.
 
 ## Commit & PR Guidelines
@@ -137,6 +138,7 @@ When building or modifying playhtml elements, follow the `building-playhtml-elem
 | Changed published package behavior | Add a changeset + audit `apps/docs/` |
 | Changed the public core API | Update both starter templates |
 | Changed package deps or exports | Run the tarball install simulation |
+| Added a new extension feature | Add and run an automated feature-level integration test in required CI |
 | Added a meaningful feature, common-workflow change, or broadly relevant fix to the released extension | Add a bullet to `extension/PENDING.md` |
 | Added, removed, or changed an extension manifest permission | Update `extension/STORE_LISTING.md` and flag the Chrome Privacy practices dashboard change |
 

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -321,6 +321,22 @@ Cloudflare Worker + Supabase PostgreSQL + Resend:
 - **Test files:** CursorCollector, NavigationCollector, ViewportCollector, collectors integration
 - **Test utils:** `src/__tests__/test-utils.ts`
 
+### New feature integration requirement
+
+Every new extension feature must add an automated feature-level integration test in the same PR and run it in required CI. Start from the user entrypoint and assert the final user-visible or externally observable outcome.
+
+Use the real runtime boundaries the feature depends on:
+
+- Load the built extension in a real browser when the feature uses the service worker, content scripts, extension pages, browser storage, permissions, or navigation.
+- Run the built `extension/website` page when a hosted page participates in the feature.
+- Run the real local Worker or a deployable preview when the feature depends on an API. Assert the request and response contract at that boundary.
+- Exercise relevant lifecycle ordering, such as a cold start, cached page, reload, delayed content-script or service-worker readiness, reconnect, or upgrade from the currently released extension.
+- Assert privacy and failure behavior when the feature crosses a trust boundary.
+
+Unit and component tests still cover isolated logic. The generic extension smoke only proves that the extension shell starts, a content script responds, and the popup renders. Neither that smoke, mocked browser APIs, screenshots, nor a manual browser pass replaces the feature integration test.
+
+Give each feature integration test a dedicated command such as `smoke:<feature>` or include it in a clearly named feature suite. The PR description must name the command, runtime boundaries, lifecycle case, and result. If the feature cannot be tested reliably through automation, stop and tell Spencer before opening or merging the PR.
+
 ## Key Design Patterns
 
 1. **Dual-layer collection**: High-frequency real-time (PartyKit) + sparse archival (IndexedDB/Supabase)


### PR DESCRIPTION
## Summary

- require every new extension feature to include an automated feature-level integration test in the same PR
- define the real browser, hosted page, storage, navigation, and Worker boundaries those tests must exercise when applicable
- distinguish feature integration from unit tests, mocked browser APIs, generic shell smoke, screenshots, and manual verification
- add a PR template that requires the integration command, runtime boundaries, lifecycle case, and asserted outcome

## Verification

- `git diff --check`
- reviewed the rendered Markdown structure and GitHub PR template fields

Documentation and process only; no runtime behavior changed.