### PR TITLE
Fix fridge words after creation and remount

### DIFF
--- a/.changeset/fast-fridge-words.md
+++ b/.changeset/fast-fridge-words.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Register newly mounted interactive elements before the browser can receive input so they respond immediately without requiring a refresh.

--- a/packages/react/src/__tests__/binding.integration.test.tsx
+++ b/packages/react/src/__tests__/binding.integration.test.tsx
@@ -59,6 +59,74 @@ describe("CanPlayElement binding lifecycle", () => {
 
     unmount();
   });
+
+  it("lets a newly mounted movable element respond during the same commit", async () => {
+    const MovableWord = withSharedState<
+      { x: number; y: number },
+      { startMouseX: number; startMouseY: number }
+    >(
+      {
+        id: "new-word",
+        standalone: true,
+        tagInfo: [TagType.CanMove],
+        defaultData: { x: 0, y: 0 },
+        defaultLocalData: { startMouseX: 0, startMouseY: 0 },
+        onDragStart: (event, { setLocalData }) => {
+          const mouseEvent = event as MouseEvent;
+          setLocalData({
+            startMouseX: mouseEvent.clientX,
+            startMouseY: mouseEvent.clientY,
+          });
+        },
+        onDrag: (event, { data, localData, setData }) => {
+          const mouseEvent = event as MouseEvent;
+          setData({
+            x: data.x + mouseEvent.clientX - localData.startMouseX,
+            y: data.y + mouseEvent.clientY - localData.startMouseY,
+          });
+        },
+      },
+      ({ data }) => (
+        <div
+          data-testid="new-word"
+          style={{ transform: `translate(${data.x}px, ${data.y}px)` }}
+        />
+      ),
+    );
+
+    function FridgeWordCommit() {
+      React.useLayoutEffect(() => {
+        const word = document.querySelector(
+          '[data-testid="new-word"]',
+        ) as HTMLElement;
+        word.dispatchEvent(
+          new MouseEvent("mousedown", {
+            bubbles: true,
+            clientX: 20,
+            clientY: 30,
+          }),
+        );
+        document.dispatchEvent(
+          new MouseEvent("mousemove", {
+            bubbles: true,
+            clientX: 70,
+            clientY: 80,
+          }),
+        );
+        document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      }, []);
+
+      return <MovableWord />;
+    }
+
+    const rendered = render(<FridgeWordCommit />);
+
+    await waitFor(() => {
+      expect(rendered.getByTestId("new-word").style.transform).toBe(
+        "translate(50px, 50px)",
+      );
+    });
+  });
 });
 
 describe("usePresenceRoom navigation readiness", () => {

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -2,7 +2,13 @@
 // ABOUTME: Registers can-play elements and shared-state helpers for React apps.
 // TODO: idk why but this is not getting registered otherwise??
 import * as React from "react";
-import { useContext, useEffect, useRef, useState } from "react";
+import {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { ElementAwarenessEventHandlerData, ElementInitializer, TagType, elementHandlers, getIdForElement } from "playhtml";
 import playhtml from "./playhtml-singleton";
 import {
@@ -15,6 +21,9 @@ import type {
   ReactElementEventHandlerData,
 } from "./utils";
 import { PlayContext } from "./PlayProvider";
+
+const useElementRegistrationEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 // Structural equality used to decide whether a sync actually changed React
 // state. Capability data can arrive as a fresh object/array reference on every
@@ -355,7 +364,7 @@ export function CanPlayElement<T extends object, V = any>({
     return currentHandler;
   };
 
-  useEffect(() => {
+  useElementRegistrationEffect(() => {
     if (ref.current) {
       const element = ref.current;
       for (const [key, value] of Object.entries(elementProps)) {

--- a/website/fridge.tsx
+++ b/website/fridge.tsx
@@ -15,6 +15,7 @@ import {
 import React, { useContext, useEffect, useState, useRef } from "react";
 import { PlayProvider } from "../packages/react/src";
 import { canDeleteFridgeWord, DeleteWordLimit } from "./fridgeDeletion";
+import { getDefaultFridgeWordId } from "./fridgeWordIdentity";
 import { useLocation } from "./useLocation";
 
 // Detect mobile viewport
@@ -1166,7 +1167,9 @@ const FridgeWordsContent = withSharedState(
     ) : (
       <>
         {data.showDefaultWords &&
-          Words.map((w, i) => <FridgeWord key={i} word={w} />)}
+          Words.map((w, i) => (
+            <FridgeWord id={getDefaultFridgeWordId(i)} key={i} word={w} />
+          ))}
         <WordControls
           wall={wall}
           onChangeWall={onChangeWall}

--- a/website/fridgeWordIdentity.ts
+++ b/website/fridgeWordIdentity.ts
@@ -1,0 +1,8 @@
+// ABOUTME: Provides stable shared-state IDs for the fridge's built-in words.
+// ABOUTME: Preserves the selector-derived IDs used by existing saved positions.
+
+const FridgeWordSelector = "#fridge .fridgeWordHolder";
+
+export function getDefaultFridgeWordId(index: number): string {
+  return btoa(`can-move-${FridgeWordSelector}-${index}`);
+}

--- a/website/test/fridgeWordIdentity.test.ts
+++ b/website/test/fridgeWordIdentity.test.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Verifies built-in fridge words keep their historical shared-state IDs.
+// ABOUTME: Prevents remounts from rebinding words to different saved positions.
+
+import { describe, expect, test } from "bun:test";
+import { getDefaultFridgeWordId } from "../fridgeWordIdentity";
+
+describe("default fridge word identity", () => {
+  test("uses the historical selector IDs on every mount", () => {
+    const firstMount = Array.from({ length: 56 }, (_, index) =>
+      getDefaultFridgeWordId(index),
+    );
+    const secondMount = Array.from({ length: 56 }, (_, index) =>
+      getDefaultFridgeWordId(index),
+    );
+
+    expect(secondMount).toEqual(firstMount);
+    expect(firstMount[0]).toBe(
+      "Y2FuLW1vdmUtI2ZyaWRnZSAuZnJpZGdlV29yZEhvbGRlci0w",
+    );
+    expect(firstMount[55]).toBe(
+      "Y2FuLW1vdmUtI2ZyaWRnZSAuZnJpZGdlV29yZEhvbGRlci01NQ==",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Register newly mounted React elements before the browser can receive input.
- Give the fridge's built-in words stable IDs that preserve their existing shared position keys across remounts.
- Add regressions for immediate dragging and historical built-in word identities.

## Why

New custom words could appear before their drag handlers were registered, leaving them immovable until refresh. Long-lived tabs could also remount the built-in word set after the selector ID counter advanced. Those words then loaded positions belonging to different IDs and collapsed together. Fresh private tabs reset the counter, which is why the second failure appeared profile-specific.

## Reproduction

1. Create a custom word and drag it before refreshing.
2. In a long-lived fridge tab, unmount and remount the built-in words.
3. Before this fix, the custom word could ignore input and the remounted built-ins could bind to different saved coordinates.

## Verification

- React package tests: 56 passed.
- Website Bun tests: 31 passed.
- Website Vitest tests: 6 passed.
- React and website type-checks passed.
- Production website build passed.
- Automated Chromium create-and-drag flow moved a new word without refresh.
- Automated Chromium hide-and-show cycle preserved the first built-in word's historical ID and transform with no page or console errors.

PR Evidence contains screenshots from both production-built browser flows.

## Release notes

Adds a patch changeset for `@playhtml/react`. No docs or starter-template updates are needed because the public API and usage remain unchanged.
