### PR TITLE
wewere.online: live departures board from navigation events

### DIFF
--- a/extension/website/departures/departures.scss
+++ b/extension/website/departures/departures.scss
@@ -1,9 +1,9 @@
 // ABOUTME: Page layout for the departures board page.
-// ABOUTME: Centers the board on a dark station-hall background.
+// ABOUTME: Centers the board on the warm linen site background.
 
 body {
   margin: 0;
-  background: #1a1a1d;
+  background: #faf7f2;
 }
 
 .departures-page {

--- a/extension/website/departures/departures.scss
+++ b/extension/website/departures/departures.scss
@@ -1,0 +1,22 @@
+// ABOUTME: Page layout for the departures board page.
+// ABOUTME: Centers the board on a dark station-hall background.
+
+body {
+  margin: 0;
+  background: #1a1a1d;
+}
+
+.departures-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  box-sizing: border-box;
+}
+
+.departures-error {
+  color: #c4724e;
+  font-family: monospace;
+}

--- a/extension/website/departures/departures.tsx
+++ b/extension/website/departures/departures.tsx
@@ -1,0 +1,48 @@
+// ABOUTME: Entry point for the departures board page on wewere.online.
+// ABOUTME: Fetches recent navigation events and renders them as a station board.
+
+import "./departures.scss";
+import React, { useCallback, useEffect, useState } from "react";
+import ReactDOM from "react-dom/client";
+import { Departures } from "../shared/components/Departures";
+import { RECENT_EVENTS_URL } from "../shared/config";
+import { CollectionEvent } from "../shared/types";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+function DeparturesPage() {
+  const [events, setEvents] = useState<CollectionEvent[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchEvents = useCallback(async () => {
+    const params = new URLSearchParams({ type: "navigation", limit: "1000" });
+    try {
+      const response = await fetch(`${RECENT_EVENTS_URL}?${params}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch navigation events: ${response.status}`);
+      }
+      setEvents(await response.json());
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch events");
+      console.error("Error fetching events:", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEvents();
+    const interval = setInterval(fetchEvents, REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchEvents]);
+
+  return (
+    <main className="departures-page">
+      <Departures events={events} maxRows={12} />
+      {error && <p className="departures-error">{error}</p>}
+    </main>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("reactContent")!).render(
+  <DeparturesPage />,
+);

--- a/extension/website/departures/departures.tsx
+++ b/extension/website/departures/departures.tsx
@@ -48,7 +48,7 @@ function DeparturesPage() {
 
   return (
     <main className="departures-page">
-      <Departures events={mergedEvents} maxRows={12} />
+      <Departures events={mergedEvents} maxRows={20} />
       {error && <p className="departures-error">{error}</p>}
     </main>
   );

--- a/extension/website/departures/departures.tsx
+++ b/extension/website/departures/departures.tsx
@@ -1,11 +1,12 @@
 // ABOUTME: Entry point for the departures board page on wewere.online.
-// ABOUTME: Fetches recent navigation events and renders them as a station board.
+// ABOUTME: Seeds the board from recent history, then flips in live departures from the stream.
 
 import "./departures.scss";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { Departures } from "../shared/components/Departures";
 import { RECENT_EVENTS_URL } from "../shared/config";
+import { useLiveEvents } from "../shared/hooks/useLiveEvents";
 import { CollectionEvent } from "../shared/types";
 
 const REFRESH_INTERVAL_MS = 60_000;
@@ -13,6 +14,7 @@ const REFRESH_INTERVAL_MS = 60_000;
 function DeparturesPage() {
   const [events, setEvents] = useState<CollectionEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const { events: liveEvents } = useLiveEvents({ types: ["navigation"] });
 
   const fetchEvents = useCallback(async () => {
     const params = new URLSearchParams({ type: "navigation", limit: "1000" });
@@ -35,9 +37,18 @@ function DeparturesPage() {
     return () => clearInterval(interval);
   }, [fetchEvents]);
 
+  // History + live stream, deduped by id (the periodic refetch overlaps the
+  // stream once a live event lands in the database).
+  const mergedEvents = useMemo(() => {
+    const byId = new Map<string, CollectionEvent>();
+    for (const e of events) byId.set(e.id, e);
+    for (const e of liveEvents) byId.set(e.id, e);
+    return [...byId.values()];
+  }, [events, liveEvents]);
+
   return (
     <main className="departures-page">
-      <Departures events={events} maxRows={12} />
+      <Departures events={mergedEvents} maxRows={12} />
       {error && <p className="departures-error">{error}</p>}
     </main>
   );

--- a/extension/website/departures/index.html
+++ b/extension/website/departures/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=VT323&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,600;0,700;1,600;1,700&family=Atkinson+Hyperlegible:wght@400;700&family=Martian+Mono:wght@400;600&family=Source+Serif+4:ital,wght@1,200&display=swap"
       rel="stylesheet"
     />
 

--- a/extension/website/departures/index.html
+++ b/extension/website/departures/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="departures - a live station board of where people on the internet are headed"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=VT323&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>departures</title>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./departures.tsx"></script>
+  </body>
+</html>

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -1,32 +1,37 @@
-// ABOUTME: Styles for the Departures board — amber LED text on dark station slats.
-// ABOUTME: Mimics Solari-style station boards: slat rows, glow, bottom clock + notice.
+// ABOUTME: Styles for the Departures board — warm paper timetable in the wewere.online palette.
+// ABOUTME: Keeps the station-board structure (slat rows, clock, notice) in Martian Mono on linen.
 
-$board-bg: #0c0c0e;
-$slat-bg: #17171a;
-$amber: #ffb445;
-$amber-dim: rgba(255, 180, 69, 0.55);
-$label-gray: #9a9aa2;
+$bg: #faf7f2;
+$surface: #f5f0e8;
+$text: #3d3833;
+$text-muted: #8a8279;
+$accent-teal: #4a9a8a;
+$accent-rust: #c4724e;
+$border: rgba(90, 78, 65, 0.25);
+$font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
+$font-serif: "Lora", Georgia, serif;
+$font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-serif;
 
 .departures-board {
-  background: $board-bg;
+  background: $surface;
   border-radius: 10px;
-  border: 1px solid #26262b;
+  border: 1px solid $border;
   padding: 1.25rem 1.5rem 1rem;
-  font-family: "VT323", "Martian Mono", monospace;
-  color: $amber;
+  font-family: $font-mono;
+  color: $text;
   max-width: 900px;
   width: 100%;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 12px rgba(90, 78, 65, 0.12);
 }
 
 .departures-header {
-  border-bottom: 2px solid #2c2c32;
+  border-bottom: 2px solid $border;
   padding-bottom: 0.5rem;
   margin-bottom: 0.75rem;
 
   h1 {
     margin: 0;
-    font-family: Frutiger, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: $font-serif;
     font-style: italic;
     font-size: 1.6rem;
     letter-spacing: 0.01em;
@@ -34,13 +39,13 @@ $label-gray: #9a9aa2;
 }
 
 .departures-title-primary {
-  color: #7c7c85;
-  font-weight: 700;
+  color: $text-muted;
+  font-weight: 600;
 }
 
 .departures-title-secondary {
-  color: #d9d9de;
-  font-weight: 400;
+  color: $text;
+  font-weight: 700;
 }
 
 .departures-columns {
@@ -48,7 +53,7 @@ $label-gray: #9a9aa2;
   grid-template-columns: 1fr 7rem 6.5rem;
   gap: 0.75rem;
   padding: 0.25rem 0.75rem 0.5rem;
-  font-family: Frutiger, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: $font-body;
   font-size: 0.7rem;
 
   > div {
@@ -57,12 +62,12 @@ $label-gray: #9a9aa2;
     line-height: 1.3;
 
     span:first-child {
-      color: #c9c9cf;
+      color: $text;
       font-weight: 700;
     }
 
     span:last-child {
-      color: $label-gray;
+      color: $text-muted;
     }
   }
 }
@@ -83,24 +88,25 @@ $label-gray: #9a9aa2;
   grid-template-columns: 1fr 7rem 6.5rem;
   gap: 0.75rem;
   align-items: center;
-  background: linear-gradient(180deg, #1d1d21 0%, $slat-bg 45%, #121215 100%);
+  background: $bg;
+  border: 1px solid rgba(90, 78, 65, 0.15);
   border-radius: 3px;
-  padding: 0.3rem 0.75rem;
-  font-size: 1.5rem;
-  line-height: 1.1;
-  letter-spacing: 0.06em;
-  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.04em;
   animation: departures-row-in 400ms ease-out;
 }
 
 @keyframes departures-row-in {
   from {
     opacity: 0;
-    filter: brightness(2);
+    background: rgba(74, 154, 138, 0.15);
   }
   to {
     opacity: 1;
-    filter: brightness(1);
+    background: $bg;
   }
 }
 
@@ -112,6 +118,7 @@ $label-gray: #9a9aa2;
 
 .departures-time {
   font-variant-numeric: tabular-nums;
+  color: $accent-teal;
 }
 
 .departures-traveler {
@@ -120,16 +127,17 @@ $label-gray: #9a9aa2;
 }
 
 .departures-traveler-dot {
-  width: 0.85rem;
-  height: 0.85rem;
+  width: 0.8rem;
+  height: 0.8rem;
   border-radius: 50%;
-  box-shadow: 0 0 8px currentColor;
+  border: 1px solid rgba(61, 56, 51, 0.25);
+  box-shadow: 0 1px 3px rgba(90, 78, 65, 0.25);
 }
 
 .departures-row-empty {
   grid-template-columns: 1fr;
-  color: $amber-dim;
-  text-shadow: none;
+  color: $text-muted;
+  font-weight: 400;
 }
 
 .departures-footer {
@@ -137,7 +145,7 @@ $label-gray: #9a9aa2;
   align-items: stretch;
   gap: 1rem;
   margin-top: 0.9rem;
-  border-top: 2px solid #2c2c32;
+  border-top: 2px solid $border;
   padding-top: 0.75rem;
 }
 
@@ -145,7 +153,8 @@ $label-gray: #9a9aa2;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background: #101013;
+  background: $bg;
+  border: 1px dotted rgba(74, 154, 138, 0.45);
   border-radius: 3px;
   padding: 0.2rem 0.6rem;
   flex-shrink: 0;
@@ -154,21 +163,23 @@ $label-gray: #9a9aa2;
 .departures-clock-date {
   display: flex;
   flex-direction: column;
-  font-size: 0.75rem;
-  line-height: 1.05;
-  color: $amber-dim;
+  font-size: 0.6rem;
+  line-height: 1.15;
+  color: $text-muted;
 }
 
 .departures-clock-time {
-  font-size: 1.9rem;
+  font-size: 1.4rem;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
-  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+  color: $accent-rust;
 }
 
 .departures-notice {
   flex: 1;
   overflow: hidden;
-  background: #101013;
+  background: $bg;
+  border: 1px solid rgba(90, 78, 65, 0.15);
   border-radius: 3px;
   display: flex;
   align-items: center;
@@ -178,9 +189,9 @@ $label-gray: #9a9aa2;
   display: flex;
   gap: 4rem;
   white-space: nowrap;
-  font-size: 1.4rem;
-  letter-spacing: 0.08em;
-  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  color: $text-muted;
   animation: departures-notice-scroll 24s linear infinite;
 
   span {
@@ -209,10 +220,10 @@ $label-gray: #9a9aa2;
   }
 
   .departures-row {
-    font-size: 1.1rem;
+    font-size: 0.8rem;
   }
 
   .departures-clock-time {
-    font-size: 1.4rem;
+    font-size: 1.1rem;
   }
 }

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -12,7 +12,7 @@ $font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
 $font-serif: "Lora", Georgia, serif;
 $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-serif;
 
-$columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem;
+$columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
 
 .departures-board {
   background: $surface;
@@ -137,19 +137,24 @@ $columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem;
   color: $accent-teal;
 }
 
-.departures-traveler-dot-fresh {
-  animation: departures-dot-pulse 1.6s ease-in-out infinite;
+.departures-status {
+  color: $text-muted;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
 }
 
-@keyframes departures-dot-pulse {
+.departures-status-departing {
+  color: $accent-teal;
+  animation: departures-status-flicker 1.6s steps(2, jump-none) infinite;
+}
+
+@keyframes departures-status-flicker {
   0%,
   100% {
-    transform: scale(1);
     opacity: 1;
   }
   50% {
-    transform: scale(1.35);
-    opacity: 0.55;
+    opacity: 0.25;
   }
 }
 
@@ -235,7 +240,7 @@ $columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem;
   // Drop the from/spent columns on small screens to keep rows readable
   .departures-columns,
   .departures-row {
-    grid-template-columns: 1.2rem minmax(0, 1fr) 3rem;
+    grid-template-columns: 1.2rem minmax(0, 1fr) 3rem 4.4rem;
     gap: 0.4rem;
   }
 

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -1,0 +1,218 @@
+// ABOUTME: Styles for the Departures board — amber LED text on dark station slats.
+// ABOUTME: Mimics Solari-style station boards: slat rows, glow, bottom clock + notice.
+
+$board-bg: #0c0c0e;
+$slat-bg: #17171a;
+$amber: #ffb445;
+$amber-dim: rgba(255, 180, 69, 0.55);
+$label-gray: #9a9aa2;
+
+.departures-board {
+  background: $board-bg;
+  border-radius: 10px;
+  border: 1px solid #26262b;
+  padding: 1.25rem 1.5rem 1rem;
+  font-family: "VT323", "Martian Mono", monospace;
+  color: $amber;
+  max-width: 900px;
+  width: 100%;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.departures-header {
+  border-bottom: 2px solid #2c2c32;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+
+  h1 {
+    margin: 0;
+    font-family: Frutiger, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-style: italic;
+    font-size: 1.6rem;
+    letter-spacing: 0.01em;
+  }
+}
+
+.departures-title-primary {
+  color: #7c7c85;
+  font-weight: 700;
+}
+
+.departures-title-secondary {
+  color: #d9d9de;
+  font-weight: 400;
+}
+
+.departures-columns {
+  display: grid;
+  grid-template-columns: 1fr 7rem 6.5rem;
+  gap: 0.75rem;
+  padding: 0.25rem 0.75rem 0.5rem;
+  font-family: Frutiger, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.7rem;
+
+  > div {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.3;
+
+    span:first-child {
+      color: #c9c9cf;
+      font-weight: 700;
+    }
+
+    span:last-child {
+      color: $label-gray;
+    }
+  }
+}
+
+.departures-col-time,
+.departures-col-traveler {
+  text-align: left;
+}
+
+.departures-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.departures-row {
+  display: grid;
+  grid-template-columns: 1fr 7rem 6.5rem;
+  gap: 0.75rem;
+  align-items: center;
+  background: linear-gradient(180deg, #1d1d21 0%, $slat-bg 45%, #121215 100%);
+  border-radius: 3px;
+  padding: 0.3rem 0.75rem;
+  font-size: 1.5rem;
+  line-height: 1.1;
+  letter-spacing: 0.06em;
+  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+  animation: departures-row-in 400ms ease-out;
+}
+
+@keyframes departures-row-in {
+  from {
+    opacity: 0;
+    filter: brightness(2);
+  }
+  to {
+    opacity: 1;
+    filter: brightness(1);
+  }
+}
+
+.departures-destination {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.departures-time {
+  font-variant-numeric: tabular-nums;
+}
+
+.departures-traveler {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.departures-traveler-dot {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  box-shadow: 0 0 8px currentColor;
+}
+
+.departures-row-empty {
+  grid-template-columns: 1fr;
+  color: $amber-dim;
+  text-shadow: none;
+}
+
+.departures-footer {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  margin-top: 0.9rem;
+  border-top: 2px solid #2c2c32;
+  padding-top: 0.75rem;
+}
+
+.departures-clock {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #101013;
+  border-radius: 3px;
+  padding: 0.2rem 0.6rem;
+  flex-shrink: 0;
+}
+
+.departures-clock-date {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  line-height: 1.05;
+  color: $amber-dim;
+}
+
+.departures-clock-time {
+  font-size: 1.9rem;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+}
+
+.departures-notice {
+  flex: 1;
+  overflow: hidden;
+  background: #101013;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+}
+
+.departures-notice-track {
+  display: flex;
+  gap: 4rem;
+  white-space: nowrap;
+  font-size: 1.4rem;
+  letter-spacing: 0.08em;
+  text-shadow: 0 0 6px rgba(255, 180, 69, 0.45);
+  animation: departures-notice-scroll 24s linear infinite;
+
+  span {
+    padding-left: 1rem;
+  }
+}
+
+@keyframes departures-notice-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@media (max-width: 640px) {
+  .departures-board {
+    padding: 0.9rem 0.9rem 0.75rem;
+  }
+
+  .departures-columns,
+  .departures-row {
+    grid-template-columns: 1fr 4.5rem 3.5rem;
+    gap: 0.5rem;
+  }
+
+  .departures-row {
+    font-size: 1.1rem;
+  }
+
+  .departures-clock-time {
+    font-size: 1.4rem;
+  }
+}

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -1,5 +1,5 @@
 // ABOUTME: Styles for the Departures board — warm paper timetable in the wewere.online palette.
-// ABOUTME: Keeps the station-board structure (slat rows, clock, notice) in Martian Mono on linen.
+// ABOUTME: Compact slat rows with roll-in flips, flickering status, clock, and scrolling notice.
 
 $bg: #faf7f2;
 $surface: #f5f0e8;
@@ -12,11 +12,13 @@ $font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
 $font-serif: "Lora", Georgia, serif;
 $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-serif;
 
+$columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
+
 .departures-board {
   background: $surface;
   border-radius: 10px;
   border: 1px solid $border;
-  padding: 1.25rem 1.5rem 1rem;
+  padding: 1rem 1.25rem 0.85rem;
   font-family: $font-mono;
   color: $text;
   max-width: 900px;
@@ -26,94 +28,108 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
 
 .departures-header {
   border-bottom: 2px solid $border;
-  padding-bottom: 0.5rem;
-  margin-bottom: 0.75rem;
+  padding-bottom: 0.4rem;
+  margin-bottom: 0.5rem;
 
   h1 {
     margin: 0;
     font-family: $font-serif;
     font-style: italic;
-    font-size: 1.6rem;
+    font-weight: 700;
+    font-size: 1.4rem;
     letter-spacing: 0.01em;
   }
 }
 
-.departures-title-primary {
-  color: $text-muted;
-  font-weight: 600;
-}
-
-.departures-title-secondary {
-  color: $text;
-  font-weight: 700;
-}
-
 .departures-columns {
   display: grid;
-  grid-template-columns: 1fr 7rem 6.5rem;
-  gap: 0.75rem;
-  padding: 0.25rem 0.75rem 0.5rem;
+  grid-template-columns: $columns;
+  gap: 0.6rem;
+  padding: 0.15rem 0.6rem 0.35rem;
   font-family: $font-body;
-  font-size: 0.7rem;
-
-  > div {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.3;
-
-    span:first-child {
-      color: $text;
-      font-weight: 700;
-    }
-
-    span:last-child {
-      color: $text-muted;
-    }
-  }
-}
-
-.departures-col-time,
-.departures-col-traveler {
-  text-align: left;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: $text-muted;
 }
 
 .departures-rows {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 3px;
+  perspective: 600px;
 }
 
 .departures-row {
   display: grid;
-  grid-template-columns: 1fr 7rem 6.5rem;
-  gap: 0.75rem;
+  grid-template-columns: $columns;
+  gap: 0.6rem;
   align-items: center;
   background: $bg;
   border: 1px solid rgba(90, 78, 65, 0.15);
   border-radius: 3px;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.95rem;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1.2;
-  letter-spacing: 0.04em;
-  animation: departures-row-in 400ms ease-out;
+  letter-spacing: 0.03em;
+  transform-origin: top center;
+  animation: departures-row-roll 420ms ease-out backwards;
 }
 
-@keyframes departures-row-in {
+@keyframes departures-row-roll {
   from {
     opacity: 0;
-    background: rgba(74, 154, 138, 0.15);
+    transform: rotateX(-85deg);
+  }
+  60% {
+    opacity: 1;
+    transform: rotateX(12deg);
   }
   to {
     opacity: 1;
-    background: $bg;
+    transform: rotateX(0);
   }
 }
 
+.departures-traveler {
+  display: flex;
+  align-items: center;
+}
+
+.departures-traveler-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 1px solid rgba(61, 56, 51, 0.25);
+  box-shadow: 0 1px 3px rgba(90, 78, 65, 0.25);
+}
+
 .departures-destination {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+}
+
+.departures-favicon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 2px;
+}
+
+.departures-from {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: $text-muted;
+}
+
+.departures-spent {
+  color: $accent-rust;
+  font-variant-numeric: tabular-nums;
 }
 
 .departures-time {
@@ -121,17 +137,25 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
   color: $accent-teal;
 }
 
-.departures-traveler {
-  display: flex;
-  justify-content: flex-start;
+.departures-status {
+  color: $text-muted;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
 }
 
-.departures-traveler-dot {
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 50%;
-  border: 1px solid rgba(61, 56, 51, 0.25);
-  box-shadow: 0 1px 3px rgba(90, 78, 65, 0.25);
+.departures-status-departing {
+  color: $accent-teal;
+  animation: departures-status-flicker 1.6s steps(2, jump-none) infinite;
+}
+
+@keyframes departures-status-flicker {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.25;
+  }
 }
 
 .departures-row-empty {
@@ -143,10 +167,10 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
 .departures-footer {
   display: flex;
   align-items: stretch;
-  gap: 1rem;
-  margin-top: 0.9rem;
+  gap: 0.75rem;
+  margin-top: 0.7rem;
   border-top: 2px solid $border;
-  padding-top: 0.75rem;
+  padding-top: 0.6rem;
 }
 
 .departures-clock {
@@ -163,13 +187,13 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
 .departures-clock-date {
   display: flex;
   flex-direction: column;
-  font-size: 0.6rem;
+  font-size: 0.55rem;
   line-height: 1.15;
   color: $text-muted;
 }
 
 .departures-clock-time {
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   color: $accent-rust;
@@ -189,7 +213,7 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
   display: flex;
   gap: 4rem;
   white-space: nowrap;
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   letter-spacing: 0.1em;
   color: $text-muted;
   animation: departures-notice-scroll 24s linear infinite;
@@ -210,20 +234,28 @@ $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-ser
 
 @media (max-width: 640px) {
   .departures-board {
-    padding: 0.9rem 0.9rem 0.75rem;
+    padding: 0.75rem 0.75rem 0.6rem;
   }
 
+  // Drop the from/spent columns on small screens to keep rows readable
   .departures-columns,
   .departures-row {
-    grid-template-columns: 1fr 4.5rem 3.5rem;
-    gap: 0.5rem;
+    grid-template-columns: 1.2rem minmax(0, 1fr) 3rem 4.4rem;
+    gap: 0.4rem;
+  }
+
+  .departures-from,
+  .departures-spent,
+  .departures-columns span:nth-child(3),
+  .departures-columns span:nth-child(4) {
+    display: none;
   }
 
   .departures-row {
-    font-size: 0.8rem;
+    font-size: 0.7rem;
   }
 
   .departures-clock-time {
-    font-size: 1.1rem;
+    font-size: 1rem;
   }
 }

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -148,6 +148,10 @@ $columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
   animation: departures-status-flicker 1.6s steps(2, jump-none) infinite;
 }
 
+.departures-status-arrived {
+  color: $accent-rust;
+}
+
 @keyframes departures-status-flicker {
   0%,
   100% {

--- a/extension/website/shared/components/Departures.scss
+++ b/extension/website/shared/components/Departures.scss
@@ -12,7 +12,7 @@ $font-mono: "Martian Mono", ui-monospace, "SFMono-Regular", Consolas, monospace;
 $font-serif: "Lora", Georgia, serif;
 $font-body: "Atkinson Hyperlegible", -apple-system, BlinkMacSystemFont, sans-serif;
 
-$columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
+$columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem;
 
 .departures-board {
   background: $surface;
@@ -137,24 +137,19 @@ $columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
   color: $accent-teal;
 }
 
-.departures-status {
-  color: $text-muted;
-  font-size: 0.68rem;
-  letter-spacing: 0.06em;
+.departures-traveler-dot-fresh {
+  animation: departures-dot-pulse 1.6s ease-in-out infinite;
 }
 
-.departures-status-departing {
-  color: $accent-teal;
-  animation: departures-status-flicker 1.6s steps(2, jump-none) infinite;
-}
-
-@keyframes departures-status-flicker {
+@keyframes departures-dot-pulse {
   0%,
   100% {
+    transform: scale(1);
     opacity: 1;
   }
   50% {
-    opacity: 0.25;
+    transform: scale(1.35);
+    opacity: 0.55;
   }
 }
 
@@ -240,7 +235,7 @@ $columns: 1.4rem minmax(0, 1.25fr) minmax(0, 1fr) 3.4rem 3.2rem 5.6rem;
   // Drop the from/spent columns on small screens to keep rows readable
   .departures-columns,
   .departures-row {
-    grid-template-columns: 1.2rem minmax(0, 1fr) 3rem 4.4rem;
+    grid-template-columns: 1.2rem minmax(0, 1fr) 3rem;
     gap: 0.4rem;
   }
 

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Train-station departures board rendering navigation events as departures.
-// ABOUTME: Each row is a domain someone headed to, with a color dot for the traveler.
+// ABOUTME: Rows show traveler color, favicon + destination, origin, time spent, and status.
 
 import React, { useEffect, useMemo, useState } from "react";
 import { CollectionEvent } from "../types";
@@ -11,6 +11,11 @@ export interface DepartureRow {
   domain: string;
   ts: number;
   color: string;
+  faviconUrl: string | null;
+  /** Domain the traveler was on before this one. */
+  from: string | null;
+  /** Time spent on the previous domain before departing. */
+  spentMs: number | null;
 }
 
 export interface DeparturesProps {
@@ -19,6 +24,11 @@ export interface DeparturesProps {
   /** Scrolling notice text along the bottom bar. */
   notice?: string;
 }
+
+/** Departures fresher than this flicker as "departing". */
+const DEPARTING_WINDOW_MS = 10 * 60 * 1000;
+/** Gaps longer than this mean the traveler was away, not dwelling. */
+const MAX_DWELL_MS = 4 * 60 * 60 * 1000;
 
 /**
  * Collapse navigation events into departures: one row each time a traveler
@@ -32,20 +42,31 @@ export function deriveDepartures(
     .filter((e) => e.type === "navigation" && e.meta?.url)
     .sort((a, b) => a.ts - b.ts);
 
-  const lastDomainByParticipant = new Map<string, string>();
+  const lastStopByParticipant = new Map<string, { domain: string; ts: number }>();
+  const domainFavicons = new Map<string, string>();
   const rows: DepartureRow[] = [];
 
   for (const event of navEvents) {
     const domain = extractDomain(event.meta.url);
     if (!domain) continue;
+
+    const faviconUrl = ((event.data as any)?.favicon_url as string) || null;
+    if (faviconUrl) domainFavicons.set(domain, faviconUrl);
+
     const pid = event.meta.pid;
-    if (lastDomainByParticipant.get(pid) === domain) continue;
-    lastDomainByParticipant.set(pid, domain);
+    const prev = lastStopByParticipant.get(pid);
+    lastStopByParticipant.set(pid, { domain, ts: event.ts });
+    if (prev?.domain === domain) continue;
+
+    const gapMs = prev ? event.ts - prev.ts : null;
     rows.push({
       id: event.id,
       domain,
       ts: event.ts,
       color: getColorForEvent(event),
+      faviconUrl: faviconUrl || domainFavicons.get(domain) || null,
+      from: prev?.domain ?? null,
+      spentMs: gapMs !== null && gapMs <= MAX_DWELL_MS ? gapMs : null,
     });
   }
 
@@ -58,6 +79,22 @@ function formatTime(ts: number): string {
   const hh = String(d.getHours()).padStart(2, "0");
   const mm = String(d.getMinutes()).padStart(2, "0");
   return `${hh}:${mm}`;
+}
+
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60_000);
+  if (totalMinutes < 1) return "<1m";
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h${minutes}m` : `${hours}h`;
+}
+
+function faviconFor(row: DepartureRow): string {
+  return (
+    row.faviconUrl ||
+    `https://www.google.com/s2/favicons?domain=${row.domain}&sz=32`
+  );
 }
 
 function BoardClock() {
@@ -92,60 +129,81 @@ function BoardClock() {
 
 export function Departures({
   events,
-  maxRows = 10,
+  maxRows = 12,
   notice = "we were online · somewhere, someone is departing for another website",
 }: DeparturesProps) {
   const rows = useMemo(() => deriveDepartures(events, maxRows), [
     events,
     maxRows,
   ]);
+  const now = Date.now();
 
   return (
     <div className="departures-board">
       <header className="departures-header">
-        <h1>
-          <span className="departures-title-primary">Partenze</span>{" "}
-          <span className="departures-title-secondary">Departures</span>
-        </h1>
+        <h1>Departures</h1>
       </header>
 
       <div className="departures-columns">
-        <div className="departures-col-destination">
-          <span>destinazione</span>
-          <span>destination</span>
-        </div>
-        <div className="departures-col-time">
-          <span>orario</span>
-          <span>time</span>
-        </div>
-        <div className="departures-col-traveler">
-          <span>viaggiatore</span>
-          <span>traveler</span>
-        </div>
+        <span aria-hidden="true" />
+        <span>destination</span>
+        <span>from</span>
+        <span>spent</span>
+        <span>time</span>
+        <span>status</span>
       </div>
 
       <div className="departures-rows">
         {rows.length === 0 ? (
           <div className="departures-row departures-row-empty">
-            <span className="departures-destination">
-              NESSUNA PARTENZA · NO DEPARTURES
-            </span>
+            <span className="departures-destination">NO DEPARTURES</span>
           </div>
         ) : (
-          rows.map((row) => (
-            <div className="departures-row" key={row.id}>
-              <span className="departures-destination" title={row.domain}>
-                {row.domain.toUpperCase()}
-              </span>
-              <span className="departures-time">{formatTime(row.ts)}</span>
-              <span className="departures-traveler">
+          rows.map((row, index) => {
+            const departing = now - row.ts < DEPARTING_WINDOW_MS;
+            return (
+              <div
+                className="departures-row"
+                key={row.id}
+                style={{ animationDelay: `${index * 70}ms` }}
+              >
+                <span className="departures-traveler">
+                  <span
+                    className="departures-traveler-dot"
+                    style={{ backgroundColor: row.color }}
+                  />
+                </span>
+                <span className="departures-destination" title={row.domain}>
+                  <img
+                    className="departures-favicon"
+                    src={faviconFor(row)}
+                    alt=""
+                    loading="lazy"
+                    onError={(e) => {
+                      e.currentTarget.style.visibility = "hidden";
+                    }}
+                  />
+                  {row.domain.toUpperCase()}
+                </span>
+                <span className="departures-from" title={row.from ?? undefined}>
+                  {row.from ? row.from.toUpperCase() : "—"}
+                </span>
+                <span className="departures-spent">
+                  {row.spentMs !== null ? formatDuration(row.spentMs) : "—"}
+                </span>
+                <span className="departures-time">{formatTime(row.ts)}</span>
                 <span
-                  className="departures-traveler-dot"
-                  style={{ backgroundColor: row.color, color: row.color }}
-                />
-              </span>
-            </div>
-          ))
+                  className={
+                    departing
+                      ? "departures-status departures-status-departing"
+                      : "departures-status"
+                  }
+                >
+                  {departing ? "departing" : "departed"}
+                </span>
+              </div>
+            );
+          })
         )}
       </div>
 

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -16,6 +16,7 @@ export interface DepartureRow {
   from: string | null;
   /** Time spent on the previous domain before departing. */
   spentMs: number | null;
+  participantId: string;
 }
 
 export interface DeparturesProps {
@@ -33,7 +34,9 @@ const MAX_DWELL_MS = 4 * 60 * 60 * 1000;
 
 /**
  * Collapse navigation events into departures: one row each time a traveler
- * moves to a different domain than the one they were last seen on.
+ * moves to a different domain than the one they were last seen on. The board
+ * keeps only the newest row per traveler+domain, so a traveler ping-ponging
+ * between two sites holds two slots instead of filling the board.
  */
 export function deriveDepartures(
   events: CollectionEvent[],
@@ -46,6 +49,9 @@ export function deriveDepartures(
   const lastStopByParticipant = new Map<string, { domain: string; ts: number }>();
   const domainFavicons = new Map<string, string>();
   const rows: DepartureRow[] = [];
+  // Participant clocks can run fast; clamp timestamps so a skewed "future"
+  // departure can't pin itself above genuinely new rows.
+  const nowTs = Date.now();
 
   for (const event of navEvents) {
     const domain = extractDomain(event.meta.url);
@@ -63,16 +69,27 @@ export function deriveDepartures(
     rows.push({
       id: event.id,
       domain,
-      ts: event.ts,
+      ts: Math.min(event.ts, nowTs),
       color: getColorForEvent(event),
       faviconUrl: faviconUrl || domainFavicons.get(domain) || null,
       from: prev?.domain ?? null,
-      spentMs: gapMs !== null && gapMs <= MAX_DWELL_MS ? gapMs : null,
+      spentMs:
+        gapMs !== null && gapMs >= 0 && gapMs <= MAX_DWELL_MS ? gapMs : null,
+      participantId: pid,
     });
   }
 
-  // Newest departures at the top of the board
-  return rows.slice(-maxRows).reverse();
+  // Keep only the newest row per traveler+domain, preserving newest-first
+  // order (iterate from the end — later events win).
+  const seen = new Set<string>();
+  const deduped: DepartureRow[] = [];
+  for (let i = rows.length - 1; i >= 0 && deduped.length < maxRows; i--) {
+    const key = `${rows[i].participantId}|${rows[i].domain}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(rows[i]);
+  }
+  return deduped.sort((a, b) => b.ts - a.ts);
 }
 
 function formatTime(ts: number): string {

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Train-station departures board rendering navigation events as departures.
-// ABOUTME: Rows show traveler color, favicon + destination, origin, time spent, and status.
+// ABOUTME: Rows show traveler color, favicon + destination, origin, time spent, and time.
 
 import React, { useEffect, useMemo, useState } from "react";
 import { CollectionEvent } from "../types";
@@ -25,8 +25,8 @@ export interface DeparturesProps {
   notice?: string;
 }
 
-/** Departures fresher than this flicker as "departing". */
-const DEPARTING_WINDOW_MS = 10 * 60 * 1000;
+/** Departures fresher than this pulse their traveler dot as "just left". */
+const FRESH_WINDOW_MS = 2 * 60 * 1000;
 /** Gaps longer than this mean the traveler was away, not dwelling. */
 const MAX_DWELL_MS = 4 * 60 * 60 * 1000;
 
@@ -150,7 +150,6 @@ export function Departures({
         <span>from</span>
         <span>spent</span>
         <span>time</span>
-        <span>status</span>
       </div>
 
       <div className="departures-rows">
@@ -160,7 +159,7 @@ export function Departures({
           </div>
         ) : (
           rows.map((row, index) => {
-            const departing = now - row.ts < DEPARTING_WINDOW_MS;
+            const fresh = now - row.ts < FRESH_WINDOW_MS;
             return (
               <div
                 className="departures-row"
@@ -169,7 +168,11 @@ export function Departures({
               >
                 <span className="departures-traveler">
                   <span
-                    className="departures-traveler-dot"
+                    className={
+                      fresh
+                        ? "departures-traveler-dot departures-traveler-dot-fresh"
+                        : "departures-traveler-dot"
+                    }
                     style={{ backgroundColor: row.color }}
                   />
                 </span>
@@ -192,15 +195,6 @@ export function Departures({
                   {row.spentMs !== null ? formatDuration(row.spentMs) : "—"}
                 </span>
                 <span className="departures-time">{formatTime(row.ts)}</span>
-                <span
-                  className={
-                    departing
-                      ? "departures-status departures-status-departing"
-                      : "departures-status"
-                  }
-                >
-                  {departing ? "departing" : "departed"}
-                </span>
               </div>
             );
           })

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -1,0 +1,163 @@
+// ABOUTME: Train-station departures board rendering navigation events as departures.
+// ABOUTME: Each row is a domain someone headed to, with a color dot for the traveler.
+
+import React, { useEffect, useMemo, useState } from "react";
+import { CollectionEvent } from "../types";
+import { extractDomain, getColorForEvent } from "../utils/eventUtils";
+import "./Departures.scss";
+
+export interface DepartureRow {
+  id: string;
+  domain: string;
+  ts: number;
+  color: string;
+}
+
+export interface DeparturesProps {
+  events: CollectionEvent[];
+  maxRows?: number;
+  /** Scrolling notice text along the bottom bar. */
+  notice?: string;
+}
+
+/**
+ * Collapse navigation events into departures: one row each time a traveler
+ * moves to a different domain than the one they were last seen on.
+ */
+export function deriveDepartures(
+  events: CollectionEvent[],
+  maxRows: number,
+): DepartureRow[] {
+  const navEvents = events
+    .filter((e) => e.type === "navigation" && e.meta?.url)
+    .sort((a, b) => a.ts - b.ts);
+
+  const lastDomainByParticipant = new Map<string, string>();
+  const rows: DepartureRow[] = [];
+
+  for (const event of navEvents) {
+    const domain = extractDomain(event.meta.url);
+    if (!domain) continue;
+    const pid = event.meta.pid;
+    if (lastDomainByParticipant.get(pid) === domain) continue;
+    lastDomainByParticipant.set(pid, domain);
+    rows.push({
+      id: event.id,
+      domain,
+      ts: event.ts,
+      color: getColorForEvent(event),
+    });
+  }
+
+  // Newest departures at the top of the board
+  return rows.slice(-maxRows).reverse();
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+function BoardClock() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const day = now
+    .toLocaleDateString("en-US", { weekday: "short" })
+    .toUpperCase();
+  const date = String(now.getDate()).padStart(2, "0");
+  const month = now
+    .toLocaleDateString("en-US", { month: "short" })
+    .toUpperCase();
+  const time = `${String(now.getHours()).padStart(2, "0")}:${String(
+    now.getMinutes(),
+  ).padStart(2, "0")}`;
+
+  return (
+    <div className="departures-clock">
+      <div className="departures-clock-date">
+        <span>{day}</span>
+        <span>{date}</span>
+        <span>{month}</span>
+      </div>
+      <div className="departures-clock-time">{time}</div>
+    </div>
+  );
+}
+
+export function Departures({
+  events,
+  maxRows = 10,
+  notice = "we were online · somewhere, someone is departing for another website",
+}: DeparturesProps) {
+  const rows = useMemo(() => deriveDepartures(events, maxRows), [
+    events,
+    maxRows,
+  ]);
+
+  return (
+    <div className="departures-board">
+      <header className="departures-header">
+        <h1>
+          <span className="departures-title-primary">Partenze</span>{" "}
+          <span className="departures-title-secondary">Departures</span>
+        </h1>
+      </header>
+
+      <div className="departures-columns">
+        <div className="departures-col-destination">
+          <span>destinazione</span>
+          <span>destination</span>
+        </div>
+        <div className="departures-col-time">
+          <span>orario</span>
+          <span>time</span>
+        </div>
+        <div className="departures-col-traveler">
+          <span>viaggiatore</span>
+          <span>traveler</span>
+        </div>
+      </div>
+
+      <div className="departures-rows">
+        {rows.length === 0 ? (
+          <div className="departures-row departures-row-empty">
+            <span className="departures-destination">
+              NESSUNA PARTENZA · NO DEPARTURES
+            </span>
+          </div>
+        ) : (
+          rows.map((row) => (
+            <div className="departures-row" key={row.id}>
+              <span className="departures-destination" title={row.domain}>
+                {row.domain.toUpperCase()}
+              </span>
+              <span className="departures-time">{formatTime(row.ts)}</span>
+              <span className="departures-traveler">
+                <span
+                  className="departures-traveler-dot"
+                  style={{ backgroundColor: row.color, color: row.color }}
+                />
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      <footer className="departures-footer">
+        <BoardClock />
+        <div className="departures-notice">
+          <div className="departures-notice-track">
+            <span>{notice.toUpperCase()}</span>
+            <span aria-hidden="true">{notice.toUpperCase()}</span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Train-station departures board rendering navigation events as departures.
-// ABOUTME: Rows show traveler color, favicon + destination, origin, time spent, and time.
+// ABOUTME: Rows show traveler color, favicon + destination, origin, dwell time, time, and status.
 
 import React, { useEffect, useMemo, useState } from "react";
 import { CollectionEvent } from "../types";
@@ -14,9 +14,11 @@ export interface DepartureRow {
   faviconUrl: string | null;
   /** Domain the traveler was on before this one. */
   from: string | null;
-  /** Time spent on the previous domain before departing. */
+  /** Time between arriving on the previous domain and departing it. */
   spentMs: number | null;
   participantId: string;
+  /** Whether this is the domain the traveler was last seen on. */
+  current: boolean;
 }
 
 export interface DeparturesProps {
@@ -26,8 +28,8 @@ export interface DeparturesProps {
   notice?: string;
 }
 
-/** Departures fresher than this flicker as "departing" before settling into
- * "departed". Kept tight so the status only marks genuinely live activity. */
+/** Departures fresher than this flicker as "departing". Kept tight so the
+ * status only marks genuinely live activity. */
 const DEPARTING_WINDOW_MS = 2 * 60 * 1000;
 /** Gaps longer than this mean the traveler was away, not dwelling. */
 const MAX_DWELL_MS = 4 * 60 * 60 * 1000;
@@ -46,7 +48,10 @@ export function deriveDepartures(
     .filter((e) => e.type === "navigation" && e.meta?.url)
     .sort((a, b) => a.ts - b.ts);
 
-  const lastStopByParticipant = new Map<string, { domain: string; ts: number }>();
+  const stopByParticipant = new Map<
+    string,
+    { domain: string; arrivedAt: number }
+  >();
   const domainFavicons = new Map<string, string>();
   const rows: DepartureRow[] = [];
   // Participant clocks can run fast; clamp timestamps so a skewed "future"
@@ -61,11 +66,13 @@ export function deriveDepartures(
     if (faviconUrl) domainFavicons.set(domain, faviconUrl);
 
     const pid = event.meta.pid;
-    const prev = lastStopByParticipant.get(pid);
-    lastStopByParticipant.set(pid, { domain, ts: event.ts });
+    const prev = stopByParticipant.get(pid);
+    // Staying on the same domain keeps the original arrival time, so dwell is
+    // measured from when the traveler got there rather than their last move.
     if (prev?.domain === domain) continue;
+    stopByParticipant.set(pid, { domain, arrivedAt: event.ts });
 
-    const gapMs = prev ? event.ts - prev.ts : null;
+    const dwellMs = prev ? event.ts - prev.arrivedAt : null;
     rows.push({
       id: event.id,
       domain,
@@ -74,9 +81,17 @@ export function deriveDepartures(
       faviconUrl: faviconUrl || domainFavicons.get(domain) || null,
       from: prev?.domain ?? null,
       spentMs:
-        gapMs !== null && gapMs >= 0 && gapMs <= MAX_DWELL_MS ? gapMs : null,
+        dwellMs !== null && dwellMs >= 0 && dwellMs <= MAX_DWELL_MS
+          ? dwellMs
+          : null,
       participantId: pid,
+      current: false,
     });
+  }
+
+  // The map's final state is where each traveler is now.
+  for (const row of rows) {
+    row.current = stopByParticipant.get(row.participantId)?.domain === row.domain;
   }
 
   // Keep only the newest row per traveler+domain, preserving newest-first
@@ -154,8 +169,8 @@ export function Departures({
     events,
     maxRows,
   ]);
-  // Ticking clock so a "departing" row settles into "departed" as it ages,
-  // not just when new data arrives.
+  // Ticking clock so a "departing" row settles as it ages, not just when new
+  // data arrives.
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const interval = setInterval(() => setNow(Date.now()), 15_000);
@@ -184,7 +199,12 @@ export function Departures({
           </div>
         ) : (
           rows.map((row, index) => {
-            const departing = now - row.ts < DEPARTING_WINDOW_MS;
+            const fresh = now - row.ts < DEPARTING_WINDOW_MS;
+            const status = !row.current
+              ? "departed"
+              : fresh
+                ? "departing"
+                : "arrived";
             return (
               <div
                 className="departures-row"
@@ -216,14 +236,8 @@ export function Departures({
                   {row.spentMs !== null ? formatDuration(row.spentMs) : "—"}
                 </span>
                 <span className="departures-time">{formatTime(row.ts)}</span>
-                <span
-                  className={
-                    departing
-                      ? "departures-status departures-status-departing"
-                      : "departures-status"
-                  }
-                >
-                  {departing ? "departing" : "departed"}
+                <span className={`departures-status departures-status-${status}`}>
+                  {status}
                 </span>
               </div>
             );

--- a/extension/website/shared/components/Departures.tsx
+++ b/extension/website/shared/components/Departures.tsx
@@ -25,8 +25,9 @@ export interface DeparturesProps {
   notice?: string;
 }
 
-/** Departures fresher than this pulse their traveler dot as "just left". */
-const FRESH_WINDOW_MS = 2 * 60 * 1000;
+/** Departures fresher than this flicker as "departing" before settling into
+ * "departed". Kept tight so the status only marks genuinely live activity. */
+const DEPARTING_WINDOW_MS = 2 * 60 * 1000;
 /** Gaps longer than this mean the traveler was away, not dwelling. */
 const MAX_DWELL_MS = 4 * 60 * 60 * 1000;
 
@@ -136,7 +137,13 @@ export function Departures({
     events,
     maxRows,
   ]);
-  const now = Date.now();
+  // Ticking clock so a "departing" row settles into "departed" as it ages,
+  // not just when new data arrives.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 15_000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div className="departures-board">
@@ -150,6 +157,7 @@ export function Departures({
         <span>from</span>
         <span>spent</span>
         <span>time</span>
+        <span>status</span>
       </div>
 
       <div className="departures-rows">
@@ -159,7 +167,7 @@ export function Departures({
           </div>
         ) : (
           rows.map((row, index) => {
-            const fresh = now - row.ts < FRESH_WINDOW_MS;
+            const departing = now - row.ts < DEPARTING_WINDOW_MS;
             return (
               <div
                 className="departures-row"
@@ -168,11 +176,7 @@ export function Departures({
               >
                 <span className="departures-traveler">
                   <span
-                    className={
-                      fresh
-                        ? "departures-traveler-dot departures-traveler-dot-fresh"
-                        : "departures-traveler-dot"
-                    }
+                    className="departures-traveler-dot"
                     style={{ backgroundColor: row.color }}
                   />
                 </span>
@@ -195,6 +199,15 @@ export function Departures({
                   {row.spentMs !== null ? formatDuration(row.spentMs) : "—"}
                 </span>
                 <span className="departures-time">{formatTime(row.ts)}</span>
+                <span
+                  className={
+                    departing
+                      ? "departures-status departures-status-departing"
+                      : "departures-status"
+                  }
+                >
+                  {departing ? "departing" : "departed"}
+                </span>
               </div>
             );
           })

--- a/extension/website/shared/hooks/useLiveEvents.ts
+++ b/extension/website/shared/hooks/useLiveEvents.ts
@@ -12,6 +12,9 @@ interface StreamFrame {
 interface UseLiveEventsOptions {
   /** Max events retained in memory. Older events fall off the front. */
   maxEvents?: number;
+  /** Event types to subscribe to. The server defaults to cursor-only when
+   * omitted, so existing consumers keep their behavior. */
+  types?: string[];
 }
 
 interface UseLiveEventsResult {
@@ -29,6 +32,7 @@ export function useLiveEvents(
   options: UseLiveEventsOptions = {},
 ): UseLiveEventsResult {
   const maxEvents = options.maxEvents ?? 500;
+  const typesKey = options.types?.join(",") ?? "";
   const [events, setEvents] = useState<CollectionEvent[]>([]);
   const [connected, setConnected] = useState(false);
   const maxRef = useRef(maxEvents);
@@ -55,7 +59,10 @@ export function useLiveEvents(
 
     const connect = () => {
       if (closed) return;
-      ws = new WebSocket(STREAM_URL);
+      const url = typesKey
+        ? `${STREAM_URL}?types=${encodeURIComponent(typesKey)}`
+        : STREAM_URL;
+      ws = new WebSocket(url);
 
       ws.onopen = () => {
         setConnected(true);
@@ -128,7 +135,7 @@ export function useLiveEvents(
       if (reconnectTimer) clearTimeout(reconnectTimer);
       ws?.close();
     };
-  }, []);
+  }, [typesKey]);
 
   return { events, connected };
 }

--- a/extension/worker/src/__tests__/LiveEventsHub.test.ts
+++ b/extension/worker/src/__tests__/LiveEventsHub.test.ts
@@ -50,10 +50,14 @@ beforeEach(() => {
 import { LiveEventsHub } from '../live/LiveEventsHub';
 import type { CollectionEvent } from '@playhtml/extension-types';
 
-function ev(id: string, ts: number = Date.now()): CollectionEvent {
+function ev(
+  id: string,
+  ts: number = Date.now(),
+  type: CollectionEvent['type'] = 'cursor',
+): CollectionEvent {
   return {
     id,
-    type: 'cursor',
+    type,
     ts,
     data: { x: 0.5, y: 0.5 },
     meta: { pid: 'pk_x', sid: 'sid_y' },
@@ -135,5 +139,73 @@ describe('LiveEventsHub', () => {
 
     const newFrames = server.sent.slice(beforeCount).map((s) => JSON.parse(s));
     expect(newFrames.some((f) => f.events?.[0]?.id === 'live1')).toBe(true);
+  });
+
+  it('sends each socket only the event types it subscribed to', async () => {
+    const hub = makeHub();
+    await hub.fetch(new Request('https://do/ws', { headers: { Upgrade: 'websocket' } }));
+    await hub.fetch(
+      new Request('https://do/ws?types=navigation', { headers: { Upgrade: 'websocket' } }),
+    );
+    const [cursorSocket, navSocket] = hub.socketsForTest() as unknown as FakeWebSocket[];
+
+    await hub.fetch(
+      new Request('https://do/broadcast', {
+        method: 'POST',
+        body: JSON.stringify({
+          events: [ev('c1'), ev('n1', Date.now(), 'navigation')],
+        }),
+      }),
+    );
+
+    const cursorIds = cursorSocket.sent
+      .flatMap((s) => JSON.parse(s).events)
+      .map((e: CollectionEvent) => e.id);
+    const navIds = navSocket.sent
+      .flatMap((s) => JSON.parse(s).events)
+      .map((e: CollectionEvent) => e.id);
+    expect(cursorIds).toEqual(['c1']);
+    expect(navIds).toEqual(['n1']);
+  });
+
+  it('filters the replay buffer by the socket type selection', async () => {
+    const hub = makeHub();
+    await hub.fetch(
+      new Request('https://do/broadcast', {
+        method: 'POST',
+        body: JSON.stringify({
+          events: [ev('c1'), ev('n1', Date.now(), 'navigation')],
+        }),
+      }),
+    );
+
+    await hub.fetch(
+      new Request('https://do/ws?types=navigation', { headers: { Upgrade: 'websocket' } }),
+    );
+    const server = hub.socketsForTest()[0] as unknown as FakeWebSocket;
+    const replay = JSON.parse(server.sent[0]);
+    expect(replay.events.map((e: CollectionEvent) => e.id)).toEqual(['n1']);
+  });
+
+  it('falls back to cursor-only for an invalid types param', async () => {
+    const hub = makeHub();
+    await hub.fetch(
+      new Request('https://do/ws?types=bogus', { headers: { Upgrade: 'websocket' } }),
+    );
+    const server = hub.socketsForTest()[0] as unknown as FakeWebSocket;
+
+    await hub.fetch(
+      new Request('https://do/broadcast', {
+        method: 'POST',
+        body: JSON.stringify({
+          events: [ev('c1'), ev('n1', Date.now(), 'navigation')],
+        }),
+      }),
+    );
+
+    const ids = server.sent
+      .flatMap((s) => JSON.parse(s).events)
+      .map((e: CollectionEvent) => e.id);
+    expect(ids).toEqual(['c1']);
   });
 });

--- a/extension/worker/src/__tests__/broadcast.test.ts
+++ b/extension/worker/src/__tests__/broadcast.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the ingest→DO broadcast forwarder.
-// ABOUTME: Verifies cursor-only forwarding, cursor-color enrichment, and that failures never throw.
+// ABOUTME: Verifies live-type forwarding, cursor-color enrichment, and that failures never throw.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -48,7 +48,7 @@ describe('broadcastLiveEvents', () => {
     mockColorRows.length = 0;
   });
 
-  it('forwards only cursor events to the DO', async () => {
+  it('forwards cursor and navigation events to the DO, dropping other types', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
     const pid = uniquePid();
@@ -56,14 +56,19 @@ describe('broadcastLiveEvents', () => {
     await broadcastLiveEvents(
       ns,
       ENV,
-      [ev('a', 'cursor', pid), ev('b', 'navigation', pid), ev('c', 'cursor', pid)],
+      [
+        ev('a', 'cursor', pid),
+        ev('b', 'navigation', pid),
+        ev('c', 'viewport', pid),
+        ev('d', 'keyboard', pid),
+      ],
       1000,
     );
 
     expect(stubFetch).toHaveBeenCalledTimes(1);
     const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
     const body = (await sentReq.json()) as { events: CollectionEvent[] };
-    expect(body.events.map((e) => e.id)).toEqual(['a', 'c']);
+    expect(body.events.map((e) => e.id)).toEqual(['a', 'b']);
   });
 
   it('enriches forwarded events with the participant cursor color', async () => {
@@ -91,10 +96,10 @@ describe('broadcastLiveEvents', () => {
     expect(body.events[0].meta.cursor_color).toBeUndefined();
   });
 
-  it('does nothing when there are no cursor events', async () => {
+  it('does nothing when there are no live-streamable events', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
-    await broadcastLiveEvents(ns, ENV, [ev('b', 'navigation')], 1000);
+    await broadcastLiveEvents(ns, ENV, [ev('b', 'viewport')], 1000);
     expect(stubFetch).not.toHaveBeenCalled();
   });
 

--- a/extension/worker/src/live/LiveEventsHub.ts
+++ b/extension/worker/src/live/LiveEventsHub.ts
@@ -1,8 +1,8 @@
 // ABOUTME: Durable Object that holds website WebSocket connections and a ring buffer.
-// ABOUTME: Replays recent cursor events on connect, then broadcasts live events from ingest.
+// ABOUTME: Replays recent events on connect, then broadcasts live events filtered per socket.
 
 import type { Env } from '../lib/supabase';
-import type { CollectionEvent } from '@playhtml/extension-types';
+import { getValidEventTypes, type CollectionEvent } from '@playhtml/extension-types';
 
 // The buffer is a TIME window, not a count: it holds (and replays on connect)
 // only events from roughly the last couple of minutes, so the live portrait is
@@ -23,9 +23,25 @@ interface StreamFrame {
   events: CollectionEvent[];
 }
 
+/** Sockets that connect without a `types` query param get cursor events only,
+ * matching the behavior clients relied on before per-socket filtering. */
+const DEFAULT_TYPES: ReadonlySet<string> = new Set(['cursor']);
+
+/** Parse the `types` query param into a set of valid event types. Invalid or
+ * empty selections fall back to the cursor-only default. */
+function parseTypesParam(raw: string | null): ReadonlySet<string> {
+  if (!raw) return DEFAULT_TYPES;
+  const valid = new Set<string>(getValidEventTypes());
+  const requested = raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => valid.has(t));
+  return requested.length > 0 ? new Set(requested) : DEFAULT_TYPES;
+}
+
 export class LiveEventsHub {
   private buffer: CollectionEvent[] = [];
-  private sockets = new Set<WebSocket>();
+  private sockets = new Map<WebSocket, ReadonlySet<string>>();
 
   constructor(
     private state: DurableObjectState,
@@ -42,7 +58,7 @@ export class LiveEventsHub {
     }
 
     if (url.pathname === '/ws') {
-      return this.handleWebSocket();
+      return this.handleWebSocket(parseTypesParam(url.searchParams.get('types')));
     }
 
     return new Response('Not found', { status: 404 });
@@ -67,20 +83,21 @@ export class LiveEventsHub {
     }
   }
 
-  private handleWebSocket(): Response {
+  private handleWebSocket(types: ReadonlySet<string>): Response {
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
 
     server.accept();
-    this.sockets.add(server);
+    this.sockets.set(server, types);
 
     // Drop anything that aged out since the last ingest so a freshly-connected
     // client only ever receives recent activity.
     this.pruneBuffer();
-    if (this.buffer.length > 0) {
+    const replay = this.buffer.filter((e) => types.has(e.type));
+    if (replay.length > 0) {
       try {
-        server.send(JSON.stringify({ events: this.buffer } as StreamFrame));
+        server.send(JSON.stringify({ events: replay } as StreamFrame));
       } catch {
         // connection may have closed instantly
       }
@@ -94,8 +111,17 @@ export class LiveEventsHub {
   }
 
   private send(frame: StreamFrame): void {
-    const payload = JSON.stringify(frame);
-    for (const ws of [...this.sockets]) {
+    // Serialize once per distinct type selection, not per socket.
+    const payloads = new Map<string, string | null>();
+    for (const [ws, types] of [...this.sockets]) {
+      const key = [...types].sort().join(',');
+      let payload = payloads.get(key);
+      if (payload === undefined) {
+        const events = frame.events.filter((e) => types.has(e.type));
+        payload = events.length > 0 ? JSON.stringify({ events } as StreamFrame) : null;
+        payloads.set(key, payload);
+      }
+      if (payload === null) continue;
       try {
         ws.send(payload);
       } catch {
@@ -111,6 +137,6 @@ export class LiveEventsHub {
     return this.buffer;
   }
   socketsForTest(): WebSocket[] {
-    return [...this.sockets];
+    return [...this.sockets.keys()];
   }
 }

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Forwards newly ingested cursor events to the LiveEventsHub durable object.
+// ABOUTME: Forwards newly ingested cursor and navigation events to the LiveEventsHub durable object.
 // ABOUTME: Enriches events with participant cursor colors; fire-and-forget, never fails ingest.
 
 import type { CollectionEvent } from '@playhtml/extension-types';
@@ -65,20 +65,24 @@ async function resolveCursorColors(
   return result;
 }
 
+/** Event types forwarded to the live stream hub. Sockets pick which of these
+ * they receive via the /stream `types` query param. */
+const LIVE_TYPES = new Set<CollectionEvent['type']>(['cursor', 'navigation']);
+
 export async function broadcastLiveEvents(
   namespace: DurableObjectNamespace,
   env: Env,
   events: CollectionEvent[],
   nowMs: number,
 ): Promise<void> {
-  const cursorEvents = events.filter((e) => e.type === 'cursor');
-  if (cursorEvents.length === 0) return;
+  const liveEvents = events.filter((e) => LIVE_TYPES.has(e.type));
+  if (liveEvents.length === 0) return;
 
   try {
-    const pids = [...new Set(cursorEvents.map((e) => e.meta.pid))];
+    const pids = [...new Set(liveEvents.map((e) => e.meta.pid))];
     const colors = await resolveCursorColors(env, pids, nowMs);
 
-    const enriched = cursorEvents.map((e) => {
+    const enriched = liveEvents.map((e) => {
       const color = colors.get(e.meta.pid);
       if (!color) return e;
       return { ...e, meta: { ...e.meta, cursor_color: color } };

--- a/extension/worker/src/routes/ingest.ts
+++ b/extension/worker/src/routes/ingest.ts
@@ -337,10 +337,10 @@ export async function handleIngest(
       console.log(`[Ingest] Inserted ${inserted} new events, ${duplicates} duplicates ignored`);
     }
     
-    // Fan out cursor events to the live stream. Fire-and-forget — must never
-    // affect the ingest result. The cast is sound for cursor events: the live
-    // consumers read cursor position from `data`, and tolerate the optional
-    // `meta` fields (url/vw/vh/tz) being absent.
+    // Fan out cursor and navigation events to the live stream. Fire-and-forget
+    // — must never affect the ingest result. The cast is sound for these types:
+    // the live consumers read cursor position / navigation URLs from `data`,
+    // and tolerate the optional `meta` fields (url/vw/vh/tz) being absent.
     ctx.waitUntil(
       broadcastLiveEvents(
         env.LIVE_EVENTS_HUB,

--- a/extension/worker/src/routes/stream.ts
+++ b/extension/worker/src/routes/stream.ts
@@ -10,6 +10,8 @@ export function handleStream(request: Request, env: Env): Promise<Response> {
   }
   const id = env.LIVE_EVENTS_HUB.idFromName(HUB_NAME);
   const stub = env.LIVE_EVENTS_HUB.get(id);
-  // Forward the upgrade to the DO's /ws path.
-  return stub.fetch(new Request('https://do/ws', request));
+  // Forward the upgrade to the DO's /ws path, preserving the query string so
+  // the hub can apply the client's `types` selection.
+  const url = new URL(request.url);
+  return stub.fetch(new Request(`https://do/ws${url.search}`, request));
 }


### PR DESCRIPTION
## Summary

Adds a live train-station departures board to wewere.online at `/departures/`, rendering navigation events as departures: each row is a traveler (color dot) hopping to a new domain, with favicon, origin domain, dwell time on the previous site, local time, and a live status.


- **Shared component** `extension/website/shared/components/Departures.tsx` + SCSS — Martian Mono board text, Lora header, design-system palette (linen/paper/teal/rust), split-flap roll-in animation for new rows, scrolling notice bar, live clock.
- **Row derivation** (`deriveDepartures`): one row per domain hop per participant; collapses to the newest row per traveler+domain so ping-ponging doesn't fill the board; clamps client-clock-skewed "future" timestamps so new arrivals always sort to the top; dwell ("spent") measured from arrival on the previous domain, capped at 4h.
- **Status**: `departing` (teal flicker, hop < 2 min old) → `arrived` (rust, traveler still there) → `departed` (muted, traveler moved on). A ticking clock re-evaluates every 15s.
- **Live stream**: the worker's `/stream` WebSocket now carries navigation events alongside cursor events, with a per-socket `?types=` filter (`LiveEventsHub` filters replay + broadcast per connection). Clients that don't pass `types` get cursor-only, so the deployed portrait page is unaffected. `useLiveEvents` gained a `types` option. The departures page seeds from `/events/recent` and then flips in live rows from the socket (60s poll kept as fallback).

## Verification

- `bun run test:extension-worker`: 134 tests pass, including new coverage for per-socket type filtering (subscribed types only, filtered replay, invalid `types` falls back to cursor-only) and cursor+navigation broadcast forwarding. Two existing tests asserting navigation events were dropped from the stream were updated to the new intended behavior.
- `bun run check:extension-website` and worker typecheck clean.
- Worker deployed; verified against production: a `?types=navigation` socket received real navigation frames (URLs + participant colors enriched), a default socket still received cursor-only.
- Board verified live in-browser against real data (desktop + mobile); screenshots in the PR Evidence comment.

## Notes

- No changeset: no `packages/` changes (website + worker only, which deploy independently). No `extension/PENDING.md` bullet per the website/worker rule.
- Navigation domains were already public via `/events/recent`; the stream exposes the same data, no new surface.
