### PR TITLE
Fix 6 issues from codebase audit: privacy, auth, and correctness bugs

### DIFF
--- a/.changeset/fix-can-grow-listener-leak.md
+++ b/.changeset/fix-can-grow-listener-leak.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Fix a `can-grow` element leaking document-level keydown/keyup listeners when it's removed from the DOM while hovered (e.g. an SPA route change or React unmount that doesn't fire `mouseleave` first). The listeners are now cleaned up on unmount regardless of hover state.

--- a/.changeset/fix-react-identity-resolution.md
+++ b/.changeset/fix-react-identity-resolution.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Fix two bugs in `@playhtml/react`: function-form `defaultData`/`myDefaultAwareness` (e.g. `(el) => ({ text: el.id })`) was resolved against `null` during the first render instead of the real element, crashing on mount — it now resolves once the element is attached. Also, `usePresence().myIdentity` used to freeze at sync completion and never reflect a later identity change (e.g. the "we were online" extension injecting identity post-sync); it now updates reactively like `usePlayerIdentity`.

--- a/extension/src/__tests__/bottles.visibility.test.ts
+++ b/extension/src/__tests__/bottles.visibility.test.ts
@@ -67,6 +67,7 @@ describe("bottles inventory visibility", () => {
       presence: {} as PresenceAPI,
       playerColor: "#4a9a8a",
       playerPid: "me",
+      signPlayerPayload: async () => null,
       inventory: inventoryManager.api,
     });
     const host = document.querySelector<HTMLElement>("#we-were-online-bottles");

--- a/extension/src/__tests__/quarantine-tape-signing.test.ts
+++ b/extension/src/__tests__/quarantine-tape-signing.test.ts
@@ -1,0 +1,103 @@
+// ABOUTME: Verifies QuarantineTapeManager signs strip/rip writes with the caller's identity
+// ABOUTME: and skips the network write entirely when no signable identity is available.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QuarantineTapeManager } from "../features/social/quarantine-tape/QuarantineTapeManager";
+import { quarantineRipPayload, quarantineStripPayload } from "../features/social/quarantine-tape/quarantineProof";
+import type { Strip } from "../features/social/quarantine-tape/types";
+
+const postStrip = vi.hoisted(() => vi.fn());
+const postRip = vi.hoisted(() => vi.fn());
+
+vi.mock("../features/social/quarantine-tape/quarantine-api", () => ({
+  getVerdict: vi.fn().mockResolvedValue([]),
+  postStrip,
+  postRip,
+}));
+
+const EDGE_A = { wall: "left" as const, t: 0.2 };
+const EDGE_B = { wall: "right" as const, t: 0.8 };
+
+function callPrivate<T>(target: object, name: string, ...args: unknown[]): Promise<T> {
+  return Reflect.get(target, name).apply(target, args);
+}
+
+/** commitStrip/ripStrip both call this.renderStrips(), which needs a real SVG
+ * tree set up by init(). These tests only care about the signing/network
+ * behavior, so stub it out rather than exercising the full render pipeline. */
+function withoutRendering(manager: QuarantineTapeManager): void {
+  Reflect.set(manager, "renderStrips", () => {});
+}
+
+afterEach(() => {
+  postStrip.mockReset();
+  postRip.mockReset();
+});
+
+describe("QuarantineTapeManager ownership proof", () => {
+  it("signs the exact strip content before posting it", async () => {
+    const signPayload = vi.fn().mockResolvedValue("sig-strip");
+    postStrip.mockResolvedValue({ id: "s1" } as Strip);
+    const manager = new QuarantineTapeManager("pk_player", signPayload);
+    withoutRendering(manager);
+
+    await callPrivate(manager, "commitStrip", EDGE_A, EDGE_B, "slop");
+
+    expect(postStrip).toHaveBeenCalledWith(
+      expect.objectContaining({ createdBy: "pk_player", signature: "sig-strip", type: "slop" }),
+    );
+    // The signed payload must bind the exact seed that was actually posted —
+    // pull it from the postStrip call rather than predicting the random value.
+    const postedSeed = postStrip.mock.calls[0][0].seed;
+    expect(signPayload).toHaveBeenCalledWith(
+      quarantineStripPayload("pk_player", location.href, "slop", EDGE_A, EDGE_B, postedSeed),
+    );
+  });
+
+  it("never calls the network when no signable identity is available", async () => {
+    const signPayload = vi.fn().mockResolvedValue(null);
+    const manager = new QuarantineTapeManager("pk_player", signPayload);
+    withoutRendering(manager);
+
+    await callPrivate(manager, "commitStrip", EDGE_A, EDGE_B, "slop");
+
+    expect(signPayload).toHaveBeenCalled();
+    expect(postStrip).not.toHaveBeenCalled();
+  });
+
+  it("defaults to a no-signature signer when none is provided, so writes never reach the network unsigned", async () => {
+    const manager = new QuarantineTapeManager("pk_player");
+    withoutRendering(manager);
+
+    await callPrivate(manager, "commitStrip", EDGE_A, EDGE_B, "slop");
+
+    expect(postStrip).not.toHaveBeenCalled();
+  });
+
+  it("signs the exact rip content before posting it", async () => {
+    const signPayload = vi.fn().mockResolvedValue("sig-rip");
+    postRip.mockResolvedValue({ id: "s1", rips: [] } as unknown as Strip);
+    const manager = new QuarantineTapeManager("pk_player", signPayload);
+    withoutRendering(manager);
+    const strip: Strip = {
+      id: "s1",
+      type: "slop",
+      a: EDGE_A,
+      b: EDGE_B,
+      seed: 1,
+      createdBy: "pk_other",
+      createdAt: "t",
+      rips: [],
+      ripsRequired: null,
+    };
+
+    await callPrivate(manager, "ripStrip", strip, 0.5);
+
+    expect(signPayload).toHaveBeenCalledWith(
+      quarantineRipPayload("pk_player", location.href, "s1", 0.5),
+    );
+    expect(postRip).toHaveBeenCalledWith(
+      expect.objectContaining({ by: "pk_player", signature: "sig-rip", stripId: "s1", pos: 0.5 }),
+    );
+  });
+});

--- a/extension/src/__tests__/sync.test.ts
+++ b/extension/src/__tests__/sync.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Tests that event upload strips query strings/fragments from meta.url
+// ABOUTME: before events leave the device, without touching the caller's objects.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uploadEvents } from "../storage/sync";
+import type { CollectionEvent } from "../collectors/types";
+
+function makeEvent(url: string): CollectionEvent {
+  return {
+    id: "01TESTULID",
+    type: "cursor",
+    ts: Date.now(),
+    data: { x: 0.5, y: 0.5 },
+    meta: {
+      pid: "pk_test",
+      sid: "sid_test",
+      url,
+      vw: 1024,
+      vh: 768,
+      tz: "UTC",
+    },
+  } as CollectionEvent;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("uploadEvents", () => {
+  it("strips query string and hash from meta.url for every event type, not just navigation", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ inserted: 1, duplicates: 0 }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const event = makeEvent("https://example.com/search?q=sensitive+query&session=abc123#results");
+    await uploadEvents([event]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.events[0].meta.url).toBe("https://example.com/search");
+  });
+
+  it("does not mutate the original event object passed in", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ inserted: 1, duplicates: 0 }), { status: 200 }))
+    );
+
+    const event = makeEvent("https://example.com/page?token=secret");
+    await uploadEvents([event]);
+
+    expect(event.meta.url).toBe("https://example.com/page?token=secret");
+  });
+});

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -1044,12 +1044,22 @@ export default defineContentScript({
           this.presencePlayerIdentity?.playerStyle.colorPalette[0] ?? "#4a9a8a";
         const pid = this.presencePlayerIdentity?.publicKey ?? "anon";
 
+        const signPlayerPayload = async (payload: string): Promise<string | null> => {
+          const { getStoredPlayerIdentity, signPlayerIdentityPayload } = await import(
+            "../storage/playerIdentity"
+          );
+          const stored = await getStoredPlayerIdentity();
+          if (!stored) return null;
+          return signPlayerIdentityPayload(stored.privateKey, payload);
+        };
+
         try {
           this.globalCleanup = await initGlobalFeatures({
             createPageData: this.playhtmlInstance.createPageData,
             presence: this.playhtmlInstance.presence,
             playerColor: color,
             playerPid: pid,
+            signPlayerPayload,
           });
         } catch (err) {
           console.error("[we-were-online] initGlobalFeatures failed:", err);

--- a/extension/src/features/social/quarantine-tape/QuarantineTapeManager.ts
+++ b/extension/src/features/social/quarantine-tape/QuarantineTapeManager.ts
@@ -3,6 +3,7 @@
 
 import { injectShadow } from "../../../entrypoints/content/inject-ui";
 import { getVerdict, postStrip, postRip } from "./quarantine-api";
+import { quarantineRipPayload, quarantineStripPayload } from "./quarantineProof";
 import {
   buildSharedDefs,
   buildTapeGroup,
@@ -13,6 +14,9 @@ import {
   TYPE_STYLE,
 } from "./tape-render";
 import { isFullyTorn, SET_THRESHOLD, type EdgePoint, type Strip, type TapeType } from "./types";
+
+/** Signs a quarantine-tape payload with the caller's own identity; null when no signable identity is available (write is skipped). */
+export type QuarantineSigner = (payload: string) => Promise<string | null>;
 
 const SVGNS = "http://www.w3.org/2000/svg";
 const SLASH_MIN_LEN = 36; // min drag distance (px) for a rip to count — keeps it heavy/intentional
@@ -25,6 +29,7 @@ export const QUARANTINE_TAPE_CSS = `
 
 export class QuarantineTapeManager {
   private readonly playerPid: string;
+  private readonly signPayload: QuarantineSigner;
 
   private host: HTMLElement | null = null;
   private overlay: SVGSVGElement | null = null;
@@ -47,8 +52,9 @@ export class QuarantineTapeManager {
 
   private destroyed = false;
 
-  constructor(playerPid: string) {
+  constructor(playerPid: string, signPayload: QuarantineSigner = async () => null) {
     this.playerPid = playerPid;
+    this.signPayload = signPayload;
   }
 
   async init(): Promise<() => void> {
@@ -284,14 +290,20 @@ export class QuarantineTapeManager {
     this.strips.push(optimistic);
     this.renderStrips();
 
-    const server = await postStrip({
-      url: location.href,
-      type,
-      a,
-      b,
-      seed,
-      createdBy: this.playerPid,
-    });
+    const signature = await this.signPayload(
+      quarantineStripPayload(this.playerPid, location.href, type, a, b, seed),
+    );
+    const server = signature
+      ? await postStrip({
+          url: location.href,
+          type,
+          a,
+          b,
+          seed,
+          createdBy: this.playerPid,
+          signature,
+        })
+      : null;
     if (this.destroyed) return;
 
     const idx = this.strips.findIndex((s) => s.id === tempId);
@@ -316,14 +328,20 @@ export class QuarantineTapeManager {
     strip.rips.push({ by: this.playerPid, at: Date.now(), pos });
     this.renderStrips();
 
-    const server = await postRip({
-      url: location.href,
-      stripId: strip.id,
-      by: this.playerPid,
-      pos,
-    });
+    const signature = await this.signPayload(
+      quarantineRipPayload(this.playerPid, location.href, strip.id, pos),
+    );
+    const server = signature
+      ? await postRip({
+          url: location.href,
+          stripId: strip.id,
+          by: this.playerPid,
+          pos,
+          signature,
+        })
+      : null;
     if (this.destroyed) return;
-    if (!server) return; // keep the optimistic rip; a broken fetch shouldn't undo intent
+    if (!server) return; // keep the optimistic rip; a broken fetch shouldn't undo intent (also covers the no-signature case)
 
     const idx = this.strips.findIndex((s) => s.id === server.id);
     if (idx === -1) return;

--- a/extension/src/features/social/quarantine-tape/index.ts
+++ b/extension/src/features/social/quarantine-tape/index.ts
@@ -33,7 +33,7 @@ export const quarantineTapeExperiment: SocialExperiment = {
   id: "quarantine-tape",
   flag: "QUARANTINE_TAPE",
   async init(deps: GlobalFeatureDeps) {
-    const manager = new QuarantineTapeManager(deps.playerPid);
+    const manager = new QuarantineTapeManager(deps.playerPid, deps.signPlayerPayload);
 
     deps.inventory.register({
       id: ITEM_SLOP,

--- a/extension/src/features/social/quarantine-tape/quarantine-api.ts
+++ b/extension/src/features/social/quarantine-tape/quarantine-api.ts
@@ -28,6 +28,7 @@ export async function postStrip(input: {
   b: EdgePoint;
   seed: number;
   createdBy: string;
+  signature: string;
 }): Promise<Strip | null> {
   try {
     const { workerUrl } = await getConfig();
@@ -49,6 +50,7 @@ export async function postRip(input: {
   stripId: string;
   by: string;
   pos: number;
+  signature: string;
 }): Promise<Strip | null> {
   try {
     const { workerUrl } = await getConfig();

--- a/extension/src/features/social/quarantine-tape/quarantineProof.ts
+++ b/extension/src/features/social/quarantine-tape/quarantineProof.ts
@@ -1,0 +1,24 @@
+// ABOUTME: Builds the exact payload strings signed for quarantine-tape strip/rip writes.
+// ABOUTME: Must stay byte-for-byte identical to the worker's copy in extension/worker/src/lib/quarantineProof.ts.
+
+import type { EdgePoint } from "./types";
+
+export function quarantineStripPayload(
+  actor: string,
+  url: string,
+  type: string,
+  a: EdgePoint,
+  b: EdgePoint,
+  seed: number,
+): string {
+  return `quarantine-strip-v1\n${actor}\n${url}\n${type}\n${a.wall}:${a.t}\n${b.wall}:${b.t}\n${seed}`;
+}
+
+export function quarantineRipPayload(
+  actor: string,
+  url: string,
+  stripId: string,
+  pos: number,
+): string {
+  return `quarantine-rip-v1\n${actor}\n${url}\n${stripId}\n${pos}`;
+}

--- a/extension/src/features/social/types.ts
+++ b/extension/src/features/social/types.ts
@@ -10,6 +10,8 @@ export interface GlobalFeatureDeps {
   presence: PresenceAPI;
   playerColor: string;
   playerPid: string;
+  /** Signs a payload with the caller's own identity for endpoints that require proof of ownership (e.g. quarantine-tape). Resolves null when no signable identity is available. */
+  signPlayerPayload: (payload: string) => Promise<string | null>;
   inventory: InventoryAPI;
 }
 

--- a/extension/src/storage/playerIdentity.ts
+++ b/extension/src/storage/playerIdentity.ts
@@ -168,6 +168,31 @@ export async function getPublicPlayerIdentity(): Promise<PlayerIdentity | null> 
   return storedIdentity?.public ?? null;
 }
 
+/**
+ * Sign a payload with the stored ECDSA identity so a Worker endpoint can
+ * verify it came from this participant's own key (the participant id IS the
+ * hex-encoded public key, so the Worker needs no separate identity registry).
+ */
+export async function signPlayerIdentityPayload(
+  privateKey: JsonWebKey,
+  payload: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    privateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    new TextEncoder().encode(payload),
+  );
+
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
 export async function getPlayerProfile(): Promise<PlayerProfile> {
   const storedIdentity = await getStoredPlayerIdentity();
   const result = await browser.storage.local.get(DISCOVERED_SITES_STORAGE_KEY);

--- a/extension/src/storage/sync.ts
+++ b/extension/src/storage/sync.ts
@@ -4,6 +4,22 @@
 import browser from 'webextension-polyfill';
 import type { CollectionEvent } from '../collectors/types';
 import { VERBOSE } from '../config';
+import { stripQueryAndFragment } from '../utils/urlNormalization';
+
+/**
+ * Query strings and hash fragments can carry sensitive content (search
+ * terms, order IDs, auth tokens) regardless of event type — not just
+ * navigation events. Strip them from the outgoing payload only; the local
+ * IndexedDB copy (used for the user's own history/visualization features)
+ * keeps the full URL.
+ */
+function sanitizeForUpload(events: CollectionEvent[]): CollectionEvent[] {
+  return events.map((event) =>
+    event.meta?.url
+      ? { ...event, meta: { ...event.meta, url: stripQueryAndFragment(event.meta.url) } }
+      : event
+  );
+}
 
 const STORAGE_KEYS = {
   WORKER_URL: 'collection_worker_url',
@@ -76,14 +92,15 @@ export async function uploadEvents(events: CollectionEvent[]): Promise<void> {
   }
   
   const workerUrl = await getWorkerUrl();
-  
+  const sanitizedEvents = sanitizeForUpload(events);
+
   try {
     const response = await fetch(`${workerUrl}/events`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ events }),
+      body: JSON.stringify({ events: sanitizedEvents }),
     });
     
     if (!response.ok) {

--- a/extension/src/utils/urlNormalization.ts
+++ b/extension/src/utils/urlNormalization.ts
@@ -37,6 +37,24 @@ export function normalizeUrl(url: string): string {
 }
 
 /**
+ * Strip the query string and hash fragment from a URL before it leaves the
+ * device (e.g. upload to the shared worker). Unlike `normalizeUrl`, this
+ * preserves protocol/host/path casing exactly — it exists purely to drop
+ * potentially sensitive query params (search terms, order IDs, tokens) and
+ * fragments, not to canonicalize for matching.
+ */
+export function stripQueryAndFragment(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Extract domain from URL, removing www prefix
  *
  * Examples:

--- a/extension/website/social-playground/social-playground.tsx
+++ b/extension/website/social-playground/social-playground.tsx
@@ -138,6 +138,9 @@ async function bootSocial(): Promise<() => void> {
         presence: playhtml.presence,
         playerColor: randomColor(),
         playerPid: "playground-" + Math.random().toString(36).slice(2, 8),
+        // No real ECDSA identity in the playground — features that need proof of
+        // ownership (e.g. quarantine-tape) no-op their writes here.
+        signPlayerPayload: async () => null,
       }),
     );
   } else {

--- a/extension/worker/src/__tests__/quarantine.test.ts
+++ b/extension/worker/src/__tests__/quarantine.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the /quarantine/* route handlers.
-// ABOUTME: Mocks the Supabase client and asserts validation, url normalization, rip idempotency, and setness snapshot.
+// ABOUTME: Mocks the Supabase client and asserts validation, ownership proof, url normalization, rip idempotency, and setness snapshot.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -74,6 +74,7 @@ import {
   handleQuarantineRip,
   __resetRateLimitForTests,
 } from '../routes/quarantine';
+import { quarantineRipPayload, quarantineStripPayload } from '../lib/quarantineProof';
 import type { Env } from '../lib/supabase';
 
 const ENV = {
@@ -98,6 +99,55 @@ function post(path: string, body: unknown, ip = '1.2.3.4'): Request {
 
 const EDGE_A = { wall: 'left', t: 0.5 };
 const EDGE_B = { wall: 'right', t: 0.5 };
+
+// --- signed-identity test helpers -------------------------------------------
+// Mirrors the real client: the actor id IS the raw hex-encoded P-256 public key.
+interface Identity {
+  pid: string;
+  privateKey: CryptoKey;
+}
+
+async function makeIdentity(): Promise<Identity> {
+  const keypair = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify'],
+  );
+  const rawPublicKey = new Uint8Array(await crypto.subtle.exportKey('raw', keypair.publicKey));
+  const pid = `pk_${Array.from(rawPublicKey, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+  return { pid, privateKey: keypair.privateKey };
+}
+
+async function sign(privateKey: CryptoKey, payload: string): Promise<string> {
+  const signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    new TextEncoder().encode(payload),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+async function signedStripBody(
+  identity: Identity,
+  overrides: { url: string; type: string; a: unknown; b: unknown; seed: number },
+) {
+  const signature = await sign(
+    identity.privateKey,
+    quarantineStripPayload(identity.pid, overrides.url, overrides.type, overrides.a as any, overrides.b as any, overrides.seed),
+  );
+  return { ...overrides, createdBy: identity.pid, signature };
+}
+
+async function signedRipBody(
+  identity: Identity,
+  overrides: { url: string; stripId: string; pos: number },
+) {
+  const signature = await sign(
+    identity.privateKey,
+    quarantineRipPayload(identity.pid, overrides.url, overrides.stripId, overrides.pos),
+  );
+  return { ...overrides, by: identity.pid, signature };
+}
 
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -138,16 +188,18 @@ describe('GET /quarantine/verdict', () => {
 
 describe('POST /quarantine/strip', () => {
   it('400s on invalid type', async () => {
+    const identity = await makeIdentity();
     const res = await handleQuarantineStrip(
-      post('/quarantine/strip', { url: 'https://x.com', type: 'nope', a: EDGE_A, b: EDGE_B, seed: 1, createdBy: 'p' }),
+      post('/quarantine/strip', await signedStripBody(identity, { url: 'https://x.com', type: 'nope', a: EDGE_A, b: EDGE_B, seed: 1 })),
       ENV,
     );
     expect(res.status).toBe(400);
   });
 
   it('400s on out-of-range edge t', async () => {
+    const identity = await makeIdentity();
     const res = await handleQuarantineStrip(
-      post('/quarantine/strip', { url: 'https://x.com', type: 'slop', a: { wall: 'left', t: 5 }, b: EDGE_B, seed: 1, createdBy: 'p' }),
+      post('/quarantine/strip', await signedStripBody(identity, { url: 'https://x.com', type: 'slop', a: { wall: 'left', t: 5 }, b: EDGE_B, seed: 1 })),
       ENV,
     );
     expect(res.status).toBe(400);
@@ -161,21 +213,65 @@ describe('POST /quarantine/strip', () => {
     expect(res.status).toBe(400);
   });
 
-  it('inserts a strip and returns it', async () => {
+  it('400s when createdBy is not a valid participant public key', async () => {
     const res = await handleQuarantineStrip(
-      post('/quarantine/strip', { url: 'https://x.com/p', type: 'spam', a: EDGE_A, b: EDGE_B, seed: 7, createdBy: 'pid9' }),
+      post('/quarantine/strip', { url: 'https://x.com', type: 'slop', a: EDGE_A, b: EDGE_B, seed: 1, createdBy: 'someone-else', signature: 'whatever' }),
+      ENV,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('401s on missing signature', async () => {
+    const identity = await makeIdentity();
+    const res = await handleQuarantineStrip(
+      post('/quarantine/strip', { url: 'https://x.com', type: 'slop', a: EDGE_A, b: EDGE_B, seed: 1, createdBy: identity.pid }),
+      ENV,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('401s when the signature was captured for a different actor (forged createdBy)', async () => {
+    const author = await makeIdentity();
+    const attacker = await makeIdentity();
+    const forged = await signedStripBody(author, { url: 'https://x.com/p', type: 'spam', a: EDGE_A, b: EDGE_B, seed: 7 });
+    // Attacker claims the write as their own identity but reuses the author's signature.
+    const res = await handleQuarantineStrip(
+      post('/quarantine/strip', { ...forged, createdBy: attacker.pid }),
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(fake.inserted).toBeNull();
+  });
+
+  it('401s when the signature was captured for a different url (content mismatch)', async () => {
+    const identity = await makeIdentity();
+    const signed = await signedStripBody(identity, { url: 'https://x.com/p', type: 'spam', a: EDGE_A, b: EDGE_B, seed: 7 });
+    const res = await handleQuarantineStrip(
+      post('/quarantine/strip', { ...signed, url: 'https://x.com/other-page' }),
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(fake.inserted).toBeNull();
+  });
+
+  it('inserts a strip and returns it when the proof is valid', async () => {
+    const identity = await makeIdentity();
+    const res = await handleQuarantineStrip(
+      post('/quarantine/strip', await signedStripBody(identity, { url: 'https://x.com/p', type: 'spam', a: EDGE_A, b: EDGE_B, seed: 7 })),
       ENV,
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as any;
     expect(body.strip.type).toBe('spam');
-    expect(body.strip.createdBy).toBe('pid9');
-    expect(fake.inserted.created_by).toBe('pid9');
+    expect(body.strip.createdBy).toBe(identity.pid);
+    expect(fake.inserted.created_by).toBe(identity.pid);
   });
 
   it('keeps the query string in the url key (artifact identity)', async () => {
+    const identity = await makeIdentity();
+    const url = 'https://cdn.x.com/img.png?w=800&sig=abc#frag';
     await handleQuarantineStrip(
-      post('/quarantine/strip', { url: 'https://cdn.x.com/img.png?w=800&sig=abc#frag', type: 'slop', a: EDGE_A, b: EDGE_B, seed: 1, createdBy: 'p' }),
+      post('/quarantine/strip', await signedStripBody(identity, { url, type: 'slop', a: EDGE_A, b: EDGE_B, seed: 1 })),
       ENV,
     );
     // hash dropped, query kept
@@ -190,19 +286,51 @@ describe('POST /quarantine/rip', () => {
     seed: 1, created_by: 'author', created_at: 't', rips: [], rips_required: null,
   };
 
+  it('400s when by is not a valid participant public key', async () => {
+    const res = await handleQuarantineRip(
+      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: 'not-a-pubkey', pos: 0.5, signature: 'x' }),
+      ENV,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('401s on missing signature', async () => {
+    const identity = await makeIdentity();
+    const res = await handleQuarantineRip(
+      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: identity.pid, pos: 0.5 }),
+      ENV,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('401s when the signature was captured for a different player (forged by)', async () => {
+    fake.rows = [{ ...baseStrip, rips: [], rips_required: 1 }];
+    const author = await makeIdentity();
+    const attacker = await makeIdentity();
+    const forged = await signedRipBody(author, { url: 'https://x.com/p', stripId: 'r1', pos: 0.5 });
+    const res = await handleQuarantineRip(
+      post('/quarantine/rip', { ...forged, by: attacker.pid }),
+      ENV,
+    );
+    expect(res.status).toBe(401);
+    expect(fake.updated).toBeNull();
+  });
+
   it('404s when the strip is gone', async () => {
     fake.rows = [];
+    const identity = await makeIdentity();
     const res = await handleQuarantineRip(
-      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'missing', by: 'p', pos: 0.5 }),
+      post('/quarantine/rip', await signedRipBody(identity, { url: 'https://x.com/p', stripId: 'missing', pos: 0.5 })),
       ENV,
     );
     expect(res.status).toBe(404);
   });
 
   it('is idempotent per player — a second rip by the same pid is a no-op', async () => {
-    fake.rows = [{ ...baseStrip, rips: [{ by: 'p1', at: 1, pos: 0.5 }], rips_required: 1 }];
+    const identity = await makeIdentity();
+    fake.rows = [{ ...baseStrip, rips: [{ by: identity.pid, at: 1, pos: 0.5 }], rips_required: 1 }];
     const res = await handleQuarantineRip(
-      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: 'p1', pos: 0.5 }),
+      post('/quarantine/rip', await signedRipBody(identity, { url: 'https://x.com/p', stripId: 'r1', pos: 0.5 })),
       ENV,
     );
     expect(res.status).toBe(200);
@@ -210,10 +338,11 @@ describe('POST /quarantine/rip', () => {
   });
 
   it('snapshots ripsRequired=1 when the page is provisional (<3 strips)', async () => {
+    const identity = await makeIdentity();
     fake.rows = [{ ...baseStrip }];
     fake.countValue = 2; // provisional
     await handleQuarantineRip(
-      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: 'p1', pos: 0.5 }),
+      post('/quarantine/rip', await signedRipBody(identity, { url: 'https://x.com/p', stripId: 'r1', pos: 0.5 })),
       ENV,
     );
     expect(fake.updated.rips_required).toBe(1);
@@ -221,20 +350,23 @@ describe('POST /quarantine/rip', () => {
   });
 
   it('snapshots ripsRequired=SET_THRESHOLD when the page is set (>=3 strips)', async () => {
+    const identity = await makeIdentity();
     fake.rows = [{ ...baseStrip }];
     fake.countValue = 4; // set
     await handleQuarantineRip(
-      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: 'p1', pos: 0.5 }),
+      post('/quarantine/rip', await signedRipBody(identity, { url: 'https://x.com/p', stripId: 'r1', pos: 0.5 })),
       ENV,
     );
     expect(fake.updated.rips_required).toBe(3);
   });
 
   it('does not recompute ripsRequired once snapshotted', async () => {
-    fake.rows = [{ ...baseStrip, rips: [{ by: 'x', at: 1, pos: 0.5 }], rips_required: 3 }];
+    const identityX = await makeIdentity();
+    const identityP2 = await makeIdentity();
+    fake.rows = [{ ...baseStrip, rips: [{ by: identityX.pid, at: 1, pos: 0.5 }], rips_required: 3 }];
     fake.countValue = 1; // even though page is now provisional
     await handleQuarantineRip(
-      post('/quarantine/rip', { url: 'https://x.com/p', stripId: 'r1', by: 'p2', pos: 0.5 }),
+      post('/quarantine/rip', await signedRipBody(identityP2, { url: 'https://x.com/p', stripId: 'r1', pos: 0.5 })),
       ENV,
     );
     expect(fake.updated.rips_required).toBe(3); // unchanged

--- a/extension/worker/src/lib/quarantineProof.ts
+++ b/extension/worker/src/lib/quarantineProof.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Verifies signed quarantine-tape strip/rip writes against the actor's own P-256 public key.
+// ABOUTME: The actor id IS the raw hex-encoded public key (same scheme as participant identity), so no separate registry is needed.
+
+const ACTOR_ID_REGEX = /^pk_([0-9a-f]{130})$/i;
+
+export function isValidQuarantineActorId(id: string): boolean {
+  return ACTOR_ID_REGEX.test(id);
+}
+
+// Keep these byte-for-byte identical to the client-side copies in
+// extension/src/features/social/quarantine-tape/quarantineProof.ts — both
+// sides build the exact string that gets signed/verified.
+export function quarantineStripPayload(
+  actor: string,
+  url: string,
+  type: string,
+  a: { wall: string; t: number },
+  b: { wall: string; t: number },
+  seed: number,
+): string {
+  return `quarantine-strip-v1\n${actor}\n${url}\n${type}\n${a.wall}:${a.t}\n${b.wall}:${b.t}\n${seed}`;
+}
+
+export function quarantineRipPayload(
+  actor: string,
+  url: string,
+  stripId: string,
+  pos: number,
+): string {
+  return `quarantine-rip-v1\n${actor}\n${url}\n${stripId}\n${pos}`;
+}
+
+function decodeBase64(value: string): Uint8Array | null {
+  try {
+    return Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+function decodeHex(value: string): Uint8Array {
+  return Uint8Array.from(value.match(/.{2}/g) ?? [], (pair) => Number.parseInt(pair, 16));
+}
+
+export async function verifyQuarantineSignature(
+  actor: string,
+  payload: string,
+  signature: string,
+): Promise<boolean> {
+  const match = ACTOR_ID_REGEX.exec(actor);
+  const signatureBytes = decodeBase64(signature);
+  if (!match || !signatureBytes) return false;
+
+  try {
+    const publicKey = await crypto.subtle.importKey(
+      'raw',
+      decodeHex(match[1]).buffer as ArrayBuffer,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      false,
+      ['verify'],
+    );
+    return crypto.subtle.verify(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      publicKey,
+      signatureBytes.buffer as ArrayBuffer,
+      new TextEncoder().encode(payload).buffer as ArrayBuffer,
+    );
+  } catch {
+    return false;
+  }
+}

--- a/extension/worker/src/routes/quarantine.ts
+++ b/extension/worker/src/routes/quarantine.ts
@@ -3,6 +3,12 @@
 
 import { createSupabaseClient, type Env } from '../lib/supabase';
 import { createIpRateLimiter } from '../lib/ipRateLimit';
+import {
+  isValidQuarantineActorId,
+  quarantineRipPayload,
+  quarantineStripPayload,
+  verifyQuarantineSignature,
+} from '../lib/quarantineProof';
 
 const CORS_HEADERS = {
   'Content-Type': 'application/json',
@@ -146,6 +152,7 @@ interface StripBody {
   b?: unknown;
   seed?: unknown;
   createdBy?: unknown;
+  signature?: unknown;
 }
 
 // POST /quarantine/strip — lay a new strip on a URL
@@ -172,10 +179,22 @@ export async function handleQuarantineStrip(request: Request, env: Env): Promise
   const seed = typeof body.seed === 'number' ? Math.trunc(body.seed) : NaN;
   if (!Number.isFinite(seed)) return jsonResponse(400, { error: 'Invalid seed' });
   const createdBy = typeof body.createdBy === 'string' ? body.createdBy : '';
-  if (!createdBy) return jsonResponse(400, { error: 'Missing createdBy' });
+  if (!createdBy || !isValidQuarantineActorId(createdBy)) {
+    return jsonResponse(400, { error: 'Invalid or missing createdBy' });
+  }
+  const signature = typeof body.signature === 'string' ? body.signature : '';
+  if (!signature) return jsonResponse(401, { error: 'Missing quarantine proof' });
 
   const a = body.a as EdgePoint;
   const b = body.b as EdgePoint;
+
+  const rawUrl = body.url as string;
+  const isSigned = await verifyQuarantineSignature(
+    createdBy,
+    quarantineStripPayload(createdBy, rawUrl, body.type as string, a, b, seed),
+    signature,
+  );
+  if (!isSigned) return jsonResponse(401, { error: 'Invalid quarantine proof' });
 
   const supabase = createSupabaseClient(env);
   const { data, error } = await supabase
@@ -206,6 +225,7 @@ interface RipBody {
   stripId?: unknown;
   by?: unknown;
   pos?: unknown;
+  signature?: unknown;
 }
 
 // POST /quarantine/rip — tear at a strip
@@ -226,9 +246,21 @@ export async function handleQuarantineRip(request: Request, env: Env): Promise<R
   const stripId = typeof body.stripId === 'string' ? body.stripId : '';
   if (!stripId) return jsonResponse(400, { error: 'Missing stripId' });
   const by = typeof body.by === 'string' ? body.by : '';
-  if (!by) return jsonResponse(400, { error: 'Missing by' });
+  if (!by || !isValidQuarantineActorId(by)) {
+    return jsonResponse(400, { error: 'Invalid or missing by' });
+  }
   const pos =
     typeof body.pos === 'number' && body.pos >= 0 && body.pos <= 1 ? body.pos : 0.5;
+  const signature = typeof body.signature === 'string' ? body.signature : '';
+  if (!signature) return jsonResponse(401, { error: 'Missing quarantine proof' });
+
+  const rawUrl = body.url as string;
+  const isSigned = await verifyQuarantineSignature(
+    by,
+    quarantineRipPayload(by, rawUrl, stripId, pos),
+    signature,
+  );
+  if (!isSigned) return jsonResponse(401, { error: 'Invalid quarantine proof' });
 
   const supabase = createSupabaseClient(env);
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -692,6 +692,17 @@ export const TagTypeToElement: DefaultTagInitializers = {
 
       element.addEventListener("mouseenter", onMouseEnter);
       element.addEventListener("mouseleave", onMouseLeave);
+
+      // The mouseenter/mouseleave listeners die with the element, but the
+      // document-level keydown/keyup listeners don't — if the element is
+      // removed while hovered (SPA navigation, React unmount), mouseleave
+      // never fires and they'd otherwise leak for the life of the page.
+      return () => {
+        element.removeEventListener("mouseenter", onMouseEnter);
+        element.removeEventListener("mouseleave", onMouseLeave);
+        document.removeEventListener("keydown", onKeyDownUp);
+        document.removeEventListener("keyup", onKeyDownUp);
+      };
     },
     resetShortcut: "shiftKey",
   },

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies handler-level write semantics used by playhtml capabilities.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ElementHandler } from "../elements";
+import { TagType, TagTypeToElement } from "@playhtml/common";
 import type {
   ElementAwarenessEventHandlerData,
   ElementData,
@@ -374,5 +375,71 @@ describe("ElementHandler", () => {
     handler.setMyAwareness({ me: "X" } as any);
     expect(onAwarenessChange).toHaveBeenCalledWith({ me: "X" });
     expect(triggerAwarenessUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("CanGrow onMount cleanup", () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    element = document.createElement("div");
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("removes the document-level keydown/keyup listeners on destroy, even without a preceding mouseleave", () => {
+    const canGrow = TagTypeToElement[TagType.CanGrow];
+    const handler = new ElementHandler({
+      element,
+      defaultData: canGrow.defaultData,
+      defaultLocalData: canGrow.defaultLocalData,
+      updateElement: canGrow.updateElement,
+      onMount: canGrow.onMount,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: () => {},
+    } as unknown as ElementData);
+
+    // Hover without a mouseleave — the failure scenario from a SPA
+    // navigation/React unmount that removes the element mid-hover.
+    element.dispatchEvent(new MouseEvent("mouseenter"));
+
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    handler.destroy();
+
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("keyup", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("does not leave a live keydown listener reacting after destroy", () => {
+    const canGrow = TagTypeToElement[TagType.CanGrow];
+    const handler = new ElementHandler({
+      element,
+      defaultData: canGrow.defaultData,
+      defaultLocalData: canGrow.defaultLocalData,
+      updateElement: canGrow.updateElement,
+      onMount: canGrow.onMount,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: () => {},
+    } as unknown as ElementData);
+
+    // mouseenter arms the document keydown/keyup listeners AND sets the
+    // cursor once (no altKey held yet, scale 1 < maxScale 2 -> grow cursor).
+    element.dispatchEvent(new MouseEvent("mouseenter"));
+    const cursorAfterMouseEnter = element.style.cursor;
+    expect(cursorAfterMouseEnter).not.toBe("");
+
+    // No mouseleave — destroy the handler while still "hovering".
+    handler.destroy();
+
+    // A leaked document keydown listener would flip the cursor to the
+    // alt/cut style here; a cleaned-up one leaves it untouched.
+    document.dispatchEvent(new KeyboardEvent("keydown", { altKey: true }));
+    expect(element.style.cursor).toBe(cursorAfterMouseEnter);
   });
 });

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -128,6 +128,56 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect((element as any).onDrag).toBe(capabilityOnDrag);
   });
 
+  it("resolves function-form defaultData against the real element instead of null", async () => {
+    // Regression test: resolving this synchronously during render (before
+    // ref.current is attached) throws `Cannot read properties of null`.
+    const { container } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={(el: HTMLElement) => ({ tag: el.tagName })}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+        resetShortcut="shiftKey"
+      >
+        {({ data }) => <div id="fn-default-data-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-move]") as HTMLElement;
+    expect(element).toBeTruthy();
+
+    await act(async () => {});
+
+    const child = container.querySelector("#fn-default-data-child") as HTMLElement;
+    expect(child.textContent).toBe(JSON.stringify({ tag: element.tagName }));
+  });
+
+  it("resolves function-form myDefaultAwareness against the real element instead of null", async () => {
+    const { container } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanHover]}
+        defaultData={{}}
+        myDefaultAwareness={(el: HTMLElement) => ({ tag: el.tagName })}
+        updateElement={() => {}}
+        updateElementAwareness={() => {}}
+      >
+        {({ myAwareness }) => (
+          <div id="fn-default-awareness-child">{JSON.stringify(myAwareness)}</div>
+        )}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-hover]") as HTMLElement;
+    expect(element).toBeTruthy();
+
+    await act(async () => {});
+
+    const child = container.querySelector("#fn-default-awareness-child") as HTMLElement;
+    expect(child.textContent).toBe(JSON.stringify({ tag: element.tagName }));
+  });
+
   it("does not remove the element when synced data updates React state", () => {
     const setupSpy = vi
       .spyOn(playhtml, "setupPlayElement")

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -26,6 +26,12 @@ const mockedPlayhtml = (globalThis as any).MOCKED_PLAYHTML as {
   resolveReady: () => void;
   createPresenceRoom: ReturnType<typeof vi.fn>;
   presence: unknown;
+  setMockPlayerIdentity: (next: {
+    publicKey?: string;
+    name?: string;
+    playerStyle?: { colorPalette: string[]; cursorStyle?: string };
+    createdAt?: number;
+  }) => void;
 };
 
 describe("usePresence", () => {
@@ -102,6 +108,35 @@ describe("usePresence", () => {
       });
     });
     expect(captured!.presences.get("me")).not.toHaveProperty("x");
+  });
+
+  it("re-derives myIdentity on a later identity change instead of freezing at sync completion", async () => {
+    let captured: ReturnType<typeof usePresence<"selection">> | null = null;
+
+    function TestComponent() {
+      captured = usePresence("selection");
+      return <div />;
+    }
+
+    render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(captured!.myIdentity).not.toBeNull();
+    });
+    expect(captured!.myIdentity?.publicKey).toBe("me");
+
+    // Simulates the "we were online" extension injecting identity post-sync.
+    act(() => {
+      mockedPlayhtml.setMockPlayerIdentity({ publicKey: "injected-pid" });
+    });
+
+    await waitFor(() => {
+      expect(captured!.myIdentity?.publicKey).toBe("injected-pid");
+    });
   });
 });
 

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -31,6 +31,18 @@ function notifyUsersChange() {
   for (const cb of usersChangeListeners) cb(snapshot);
 }
 
+// Mutable so tests can simulate an identity change (e.g. the extension
+// injecting identity post-sync) and assert usePresence().myIdentity updates.
+const mockPlayerIdentity = {
+  publicKey: "me",
+  name: "Me" as string | undefined,
+  playerStyle: {
+    colorPalette: ["#fff"] as string[],
+    cursorStyle: undefined as string | undefined,
+  },
+  createdAt: undefined as number | undefined,
+};
+
 function mockGetAllUsers(): Array<Record<string, unknown>> {
   return [
     {
@@ -155,9 +167,18 @@ const mockedPlayhtml = {
         return () => set!.delete(callback);
       },
     ),
-    getMyIdentity: vi.fn(() => ({ stableId: "me", name: "Me", color: "#fff" })),
+    getMyIdentity: vi.fn(() => ({
+      publicKey: mockPlayerIdentity.publicKey,
+      name: mockPlayerIdentity.name,
+      playerStyle: { ...mockPlayerIdentity.playerStyle },
+      createdAt: mockPlayerIdentity.createdAt,
+    })),
   },
   users: mockUsers,
+  setMockPlayerIdentity: (next: Partial<typeof mockPlayerIdentity>) => {
+    Object.assign(mockPlayerIdentity, next);
+    notifyUsersChange();
+  },
   createPageData: vi.fn((_name: string, defaultValue: unknown) => {
     let data = defaultValue;
     const listeners = new Set<(d: unknown) => void>();

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Custom React hooks for playhtml functionality
 // ABOUTME: Cursor, presence, page-data, and presence-room hooks that safely no-op pre-sync
 
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import type * as React from "react";
 import { PlayContext } from "./PlayProvider";
 import playhtml from "./playhtml-singleton";
@@ -44,6 +44,24 @@ function usePlayhtmlSubscription<T>(
   }, [isLoading, ...dependencies]);
 
   return value;
+}
+
+function identityEquals(
+  a: PlayerIdentity | null,
+  b: PlayerIdentity | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.publicKey === b.publicKey &&
+    a.name === b.name &&
+    a.createdAt === b.createdAt &&
+    a.playerStyle.cursorStyle === b.playerStyle.cursorStyle &&
+    a.playerStyle.colorPalette.length === b.playerStyle.colorPalette.length &&
+    a.playerStyle.colorPalette.every(
+      (color, i) => color === b.playerStyle.colorPalette[i],
+    )
+  );
 }
 
 function isPresenceRoomNotReadyError(error: unknown): boolean {
@@ -140,10 +158,24 @@ export function usePresence<
     [isLoading, channel],
   );
 
-  const myIdentity = useMemo(
-    () => (isLoading ? null : playhtml.presence.getMyIdentity()),
-    [isLoading],
-  );
+  // Re-derived on every identity change (not just once at sync completion) —
+  // e.g. the "we were online" extension can inject identity post-sync via the
+  // `playhtml:configure-identity` event. `users.onChange` fires on every
+  // presence tick, so dedupe by value to avoid re-rendering consumers when the
+  // identity itself hasn't changed.
+  const [myIdentity, setMyIdentity] = useState<PlayerIdentity | null>(null);
+  useEffect(() => {
+    if (isLoading) {
+      setMyIdentity(null);
+      return;
+    }
+    const readIdentity = () => {
+      const next = playhtml.presence.getMyIdentity();
+      setMyIdentity((prev) => (identityEquals(prev, next) ? prev : next));
+    };
+    readIdentity();
+    return playhtml.users.onChange(readIdentity);
+  }, [isLoading]);
 
   return { presences, setMyPresence, myIdentity };
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -273,14 +273,20 @@ export function CanPlayElement<T extends object, V = any>({
         (fnOrValue as (el: HTMLElement) => V)(ref.current as HTMLElement)
       : fnOrValue;
 
+  // Function-form defaultData/myDefaultAwareness receive the real element, but
+  // `ref.current` is still null during this first render (React hasn't attached
+  // the ref yet) — resolving them here would call the consumer's function with
+  // null and crash. Seed with a plain value only; resolve the function form in
+  // a layout effect below, once ref.current is populated.
   const [data, setData] = useState<T | undefined>(
-    defaultData !== undefined
-      ? resolveDefaultData(defaultData as T | ((el: HTMLElement) => T))
+    defaultData !== undefined && typeof defaultData !== "function"
+      ? (defaultData as T)
       : undefined,
   );
-  const initialAwareness = resolveDefaultAwareness(
-    myDefaultAwareness as V | ((el: HTMLElement) => V) | undefined,
-  );
+  const initialAwareness =
+    typeof myDefaultAwareness === "function"
+      ? undefined
+      : (myDefaultAwareness as V | undefined);
   const [awareness, setAwareness] = useState<V[]>(
     initialAwareness ? [initialAwareness] : [],
   );
@@ -290,6 +296,28 @@ export function CanPlayElement<T extends object, V = any>({
   const [myAwareness, setMyAwareness] = useState<V | undefined>(
     initialAwareness,
   );
+
+  useElementRegistrationEffect(() => {
+    if (typeof defaultData === "function") {
+      setData((prev) =>
+        prev === undefined
+          ? resolveDefaultData(defaultData as T | ((el: HTMLElement) => T))
+          : prev,
+      );
+    }
+    if (typeof myDefaultAwareness === "function") {
+      const resolved = resolveDefaultAwareness(
+        myDefaultAwareness as (el: HTMLElement) => V,
+      );
+      if (resolved !== undefined) {
+        setMyAwareness((prev) => (prev === undefined ? resolved : prev));
+        setAwareness((prev) => (prev.length === 0 ? [resolved] : prev));
+      }
+    }
+    // Resolve function-form defaults exactly once, right after the element
+    // mounts — not on every re-render of this effect's inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Capture the capability's original updateElement/updateElementAwareness so we can
   // compose them with the React state updater below. These come from the built-in

--- a/partykit/__tests__/adminAuth.test.ts
+++ b/partykit/__tests__/adminAuth.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Tests the shared admin-token gate used by PartyKit and Worker admin routes.
+// ABOUTME: A missing ADMIN_TOKEN must fail closed, not silently authorize every request.
+import { describe, expect, it } from "bun:test";
+import { getAdminAuthError } from "../adminAuth";
+
+function request(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers });
+}
+
+describe("getAdminAuthError", () => {
+  it("rejects with 500 when ADMIN_TOKEN is unset, rather than authorizing the request", () => {
+    const res = getAdminAuthError(request("https://api.example.com/admin/hard-reset"), undefined);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(500);
+  });
+
+  it("rejects with 500 when ADMIN_TOKEN is an empty string", () => {
+    const res = getAdminAuthError(request("https://api.example.com/admin/hard-reset"), "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(500);
+  });
+
+  it("rejects requests with no token when ADMIN_TOKEN is configured", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset"),
+      "secret",
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("rejects requests with the wrong token", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset?token=wrong"),
+      "secret",
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("authorizes a request with the correct token via query param", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset?token=secret"),
+      "secret",
+    );
+    expect(res).toBeNull();
+  });
+
+  it("authorizes a request with the correct token via Authorization header", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset", {
+        Authorization: "Bearer secret",
+      }),
+      "secret",
+    );
+    expect(res).toBeNull();
+  });
+});

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -42,12 +42,18 @@ const quarantineKvStub = {
   },
 };
 
+// getAdminAuthError now fails closed on a missing ADMIN_TOKEN, so every admin
+// route exercised below needs both a configured token and a matching one on
+// the request (see the `?token=` suffix on each admin URL below).
+const ADMIN_TOKEN = "test-admin-token";
+
 const workerEnv: Record<string, unknown> = {
   QUARANTINE_CONTROL: quarantineKvStub,
   SUPABASE_LOAD_ATTEMPTS: "3",
   SUPABASE_LOAD_RETRY_DELAY_MS: "1",
   SUPABASE_RECOVERY_RETRY_DELAY_MS: "1",
   SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS: "5",
+  ADMIN_TOKEN,
 };
 
 mock.module("cloudflare:workers", () => ({
@@ -249,7 +255,7 @@ function adminPost(
 ): Promise<Response> {
   return room.adminHandler.handleRequest(
     new Request(
-      `https://example.com/parties/main/example-room/admin/${endpoint}`,
+      `https://example.com/parties/main/example-room/admin/${endpoint}?token=${ADMIN_TOKEN}`,
       {
         method: "POST",
         body: JSON.stringify(body),
@@ -334,7 +340,7 @@ describe("admin mutations use the authoritative live document", () => {
 
     const responsePromise = room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -367,7 +373,7 @@ describe("admin mutations use the authoritative live document", () => {
     try {
       response = await room.onRequest(
         new Request(
-          "https://example.com/parties/main/example-room/admin/force-save-live",
+          `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
           { method: "POST" }
         )
       );
@@ -779,7 +785,7 @@ describe("hydration write guards", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -804,7 +810,7 @@ describe("hydration write guards", () => {
     });
     const adminResponse = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -1026,7 +1032,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -1045,7 +1051,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -1064,7 +1070,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        `https://example.com/parties/main/example-room/admin/quarantine-set?token=${ADMIN_TOKEN}`,
         {
           method: "POST",
           body: JSON.stringify({ reason: "operator intervention" }),
@@ -1984,8 +1990,9 @@ describe("hardening", () => {
 
 describe("admin quarantine endpoints", () => {
   function adminRequest(path: string, init?: RequestInit) {
+    const separator = path.includes("?") ? "&" : "?";
     return new Request(
-      `https://example.com/parties/main/example-room/admin/${path}`,
+      `https://example.com/parties/main/example-room/admin/${path}${separator}token=${ADMIN_TOKEN}`,
       init
     );
   }
@@ -2864,7 +2871,7 @@ describe("quarantine data safety", () => {
     expect(persistedRow.document).toBe(candidate.base64);
   });
 
-  test("an unavailable room consumes an expired save retry", async () => {
+  test("an unavailable room reschedules (does not drop) an expired save retry", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
     room.persistenceMode = {
@@ -2876,7 +2883,13 @@ describe("quarantine data safety", () => {
 
     await room.onAlarm();
 
-    expect(storage.values.has("documentSaveRetry")).toBe(false);
+    // The room can't persist while transient, but the retry must survive so a
+    // later alarm can try again once persistence recovers — dropping it here
+    // would silently lose the pending save if no further edit ever occurs.
+    expect(storage.values.has("documentSaveRetry")).toBe(true);
+    expect(
+      (storage.values.get("documentSaveRetry") as { retryAt: number }).retryAt
+    ).toBeGreaterThan(Date.now());
     expect(upsertCalls).toEqual([]);
   });
 
@@ -2893,7 +2906,7 @@ describe("quarantine data safety", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -3052,7 +3065,7 @@ describe("quarantine data safety", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/hard-reset",
+        `https://example.com/parties/main/example-room/admin/hard-reset?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -33,8 +33,10 @@ const quarantineKvStub = {
   },
 };
 
+const TEST_ADMIN_TOKEN = "test-admin-token";
+
 mock.module("cloudflare:workers", () => ({
-  env: { QUARANTINE_CONTROL: quarantineKvStub },
+  env: { QUARANTINE_CONTROL: quarantineKvStub, ADMIN_TOKEN: TEST_ADMIN_TOKEN },
   DurableObject: class {
     constructor(
       public ctx: unknown,
@@ -195,6 +197,34 @@ describe("alarm entry point", () => {
     expect(storage.alarm).toBe(loadRetryAfter);
   });
 
+  test("a due save retry is kept (not dropped) when the room is mid-maintenance instead of ready", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    // Simulate a concurrent admin operation (restoreFromSnapshot/hard-reset)
+    // holding the write lock when the retry's alarm fires.
+    (server as any).documentMaintenanceInProgress = true;
+
+    await server.alarm();
+
+    // The retry marker must survive so the next alarm tries again — clearing
+    // it here would silently drop the save forever if no further edit occurs.
+    expect(storage.values.has("documentSaveRetry")).toBe(true);
+    expect((storage.values.get("documentSaveRetry") as { retryAt: number }).retryAt).toBeGreaterThan(
+      Date.now()
+    );
+    expect(storage.alarm).not.toBeNull();
+  });
+
+  test("a due save retry is cleared and the document persisted once the room is ready", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    await server.alarm();
+
+    expect(storage.values.has("documentSaveRetry")).toBe(false);
+  });
+
   test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
     const { server } = createServer();
     kvStore.set("quarantine:example-room", "operator stop");
@@ -243,7 +273,7 @@ describe("alarm entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -320,7 +350,7 @@ describe("persistence recovery admission", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -339,7 +369,7 @@ describe("persistence recovery admission", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -517,7 +547,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -535,7 +565,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -543,7 +573,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -565,7 +595,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -573,7 +603,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        `https://example.com/parties/main/example-room/admin/quarantine-set?token=${TEST_ADMIN_TOKEN}`,
         {
           method: "POST",
           body: JSON.stringify({ reason: "operator stop" }),
@@ -594,7 +624,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -603,7 +633,7 @@ describe("fetch entry point", () => {
 
     const cleared = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-clear",
+        `https://example.com/parties/main/example-room/admin/quarantine-clear?token=${TEST_ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -615,7 +645,7 @@ describe("fetch entry point", () => {
 
     const status = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );

--- a/partykit/adminAuth.ts
+++ b/partykit/adminAuth.ts
@@ -4,7 +4,21 @@ export function getAdminAuthError(
   request: Request,
   adminToken: string | undefined
 ): Response | null {
-  if (!adminToken) return null;
+  // Fail closed: a missing ADMIN_TOKEN (unset secret, misconfigured
+  // deployment) must not silently authorize every admin request — these
+  // routes can overwrite or destroy live room data.
+  if (!adminToken) {
+    return new Response(
+      JSON.stringify({ error: "Admin endpoint misconfigured: ADMIN_TOKEN is not set" }),
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
 
   const url = new URL(request.url);
   const token =

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -3099,14 +3099,21 @@ export class PartyServer extends YServer {
         documentSaveRetry !== null &&
         documentSaveRetry.retryAt <= Date.now()
       ) {
-        await this.clearDocumentSaveRetry();
         if (this.roomState() === "ready") {
+          await this.clearDocumentSaveRetry();
           try {
             await this.persistLiveDocument({ allowCompaction: false });
           } catch (error) {
             await this.scheduleDocumentSaveRetry();
             throw error;
           }
+        } else {
+          // Room isn't ready yet (e.g. a concurrent admin operation such as
+          // restoreFromSnapshot/hard-reset holds the write lock). Keep the
+          // retry marker and try again on the next alarm instead of clearing
+          // it here — clearing unconditionally would silently drop this save
+          // forever if no further edit ever re-triggers persistence.
+          await this.scheduleDocumentSaveRetry();
         }
       }
 


### PR DESCRIPTION
## Summary

Fixes findings #2–#8 from a scheduled read-only codebase audit (finding #1, a PartyKit shared-permission overwrite bug, was intentionally left out — it may overlap with the in-flight identity/permissions PR #264 and needs that diff checked first before a fix is written). Six independent fixes, one per commit:

- **`extension`: strip query strings/fragments from uploaded event URLs** — `meta.url` was uploaded to the shared worker unmodified for *every* event type (cursor, viewport, keyboard — not just navigation), leaking search queries, tokens, and other sensitive query-string content through a publicly-served endpoint (`GET /events/recent`). Local IndexedDB storage keeps the full URL for the user's own history features; only the outgoing payload is sanitized.
- **`extension`: require signed ownership proof for quarantine-tape writes** — `createdBy`/`by` on the strip/rip endpoints were taken verbatim from the request body with no proof of identity, letting anyone forge another participant's identity to burn their rip allowance or frame their identity in the public verdict feed (same problem class as the open participant-color-proof PR #307, different endpoint). Payloads are now signed with the caller's ECDSA identity and verified against their public-key participant id.
- **`@playhtml/react`: fix function-form `defaultData` crash** — `(el) => ({ text: el.id })`-style `defaultData`/`myDefaultAwareness` was resolved against `ref.current` during the initial render, before React attaches the ref, crashing any consumer using the documented pattern. Resolution now defers to a layout effect.
- **`@playhtml/react`: fix stale `usePresence().myIdentity`** — it was memoized once at sync completion and never updated afterward, so a later identity change (e.g. the "we were online" extension injecting identity post-sync) went unseen. It now subscribes to identity changes like `usePlayerIdentity` does.
- **`@playhtml/common`: fix `can-grow` document-listener leak** — `onMount` added document-level `keydown`/`keyup` listeners on `mouseenter` but only removed them on `mouseleave`. Removing the element while hovered (SPA navigation, React unmount) skips `mouseleave`, leaking the listeners for the life of the page.
- **`partykit`: fail closed on missing `ADMIN_TOKEN`** — a missing/unset admin secret silently authorized every admin request (hard-reset, raw-snapshot-restore) instead of rejecting. Now rejects with 500.
- **`partykit`: stop silently dropping a due autosave retry** — `onAlarm` cleared the save-retry marker before checking whether the room was actually ready to persist; if a concurrent admin operation held the write lock (or persistence was transient) when the retry fired, the save was dropped with no reschedule. The marker is now only cleared once the save is attempted.

## Verification

- `bun run check:common`, `check:playhtml`, `check:react`, `check:extension`, `check:extension-worker`, `check:partykit` — all clean
- `bun run test:common` (18/18), `test:playhtml` (535/535), `test:react` (56 + 3 integration), `test:extension` (909/909), `test:extension-worker` (138/138), `bun test` in `partykit/` (297/297) — all green
- `bun run build-packages` — all four published packages (`common`, `extension-types`, `playhtml`, `react`) build cleanly
- Every fix has a dedicated regression test; for the `can-grow` leak and the PartyKit autosave-retry fix, I verified each new test actually fails against the pre-fix code (temporarily reverted, confirmed red, restored) before finalizing
- Added changesets for `@playhtml/common` and `@playhtml/react` (patch); `playhtml` and `@playhtml/extension` pick up the `@playhtml/common` bump automatically via `updateInternalDependencies`. No changeset needed for the `extension`/`extension/worker`/`partykit` changes — none are published npm packages.
- No `apps/docs/` changes: none of these fixes change documented public API/behavior — the React fixes make the implementation match already-correct docs, and the rest are internal hardening.
- No `extension/PENDING.md` bullet: both extension-side fixes are invisible backend/privacy hardening with no user-visible workflow change to describe in plain language.

## Extension feature real-browser verification

Not applicable — no new extension feature is added. The quarantine-tape and URL-upload changes modify existing, already-shipped functionality under test coverage (unit + integration tests listed above), not a new user-facing capability.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_