### PR TITLE
Show invalid public ID feedback in WWO admin

### DIFF
--- a/extension/website/admin/accessControlApi.ts
+++ b/extension/website/admin/accessControlApi.ts
@@ -41,6 +41,17 @@ export type AccessOverview = {
 };
 
 export type PersonInput = { publicId: string; email: string | null };
+export type PersonInputField = "publicId" | "email";
+
+export class PersonInputError extends Error {
+  constructor(
+    readonly field: PersonInputField,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PersonInputError";
+  }
+}
 
 const PUBLIC_ID_PATTERN = /^pk_[0-9a-f]{130}$/i;
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -51,9 +62,13 @@ export function isValidPublicId(publicId: string): boolean {
 
 export function parsePersonInput(publicIdValue: string, emailValue: string): PersonInput {
   const publicId = publicIdValue.trim().toLowerCase();
-  if (!isValidPublicId(publicId)) throw new Error("Enter a valid public ID");
+  if (!isValidPublicId(publicId)) {
+    throw new PersonInputError("publicId", "Enter a valid public ID");
+  }
   const email = emailValue.trim().toLowerCase() || null;
-  if (email && !EMAIL_PATTERN.test(email)) throw new Error("Enter a valid email");
+  if (email && !EMAIL_PATTERN.test(email)) {
+    throw new PersonInputError("email", "Enter a valid email");
+  }
   return { publicId, email };
 }
 

--- a/extension/website/admin/admin.test.tsx
+++ b/extension/website/admin/admin.test.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Verifies feedback from the WWO access-control admin form.
-// ABOUTME: Covers invalid public IDs without making a Worker request.
+// ABOUTME: Covers field-specific validation without making a Worker request.
 
 // @vitest-environment jsdom
 
@@ -29,14 +29,25 @@ describe("WWO admin access form", () => {
     await screen.findByRole("heading", { name: "Add person" });
   });
 
-  it("shows invalid public ID feedback next to the form", () => {
+  it("associates validation feedback with the invalid field", () => {
     const publicIdInput = screen.getByRole("textbox", { name: "Public ID" });
+    const emailInput = screen.getByRole("textbox", { name: "Email" });
     fireEvent.change(publicIdInput, { target: { value: "pk_short" } });
     fireEvent.click(screen.getByRole("button", { name: "Add person" }));
 
     expect(screen.getByRole("alert").textContent).toBe("Enter a valid public ID");
     expect(publicIdInput.getAttribute("aria-invalid")).toBe("true");
-    expect(publicIdInput.getAttribute("aria-describedby")).toBe("add-person-error");
+    expect(publicIdInput.getAttribute("aria-describedby")).toBe("add-person-public-id-error");
+    expect(emailInput.getAttribute("aria-invalid")).toBe("false");
+
+    fireEvent.change(publicIdInput, { target: { value: `pk_${"a".repeat(130)}` } });
+    fireEvent.change(emailInput, { target: { value: "user@localhost" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+
+    expect(screen.getByRole("alert").textContent).toBe("Enter a valid email");
+    expect(publicIdInput.getAttribute("aria-invalid")).toBe("false");
+    expect(emailInput.getAttribute("aria-invalid")).toBe("true");
+    expect(emailInput.getAttribute("aria-describedby")).toBe("add-person-email-error");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extension/website/admin/admin.test.tsx
+++ b/extension/website/admin/admin.test.tsx
@@ -1,0 +1,42 @@
+// ABOUTME: Verifies feedback from the WWO access-control admin form.
+// ABOUTME: Covers invalid public IDs without making a Worker request.
+
+// @vitest-environment jsdom
+
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@movement/config", () => ({ WORKER_URL: "https://worker.example" }));
+
+const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+  features: [],
+  cohorts: [{
+    id: "closed-beta",
+    name: "Closed beta",
+    grantsAllUnreleased: true,
+    featureIds: [],
+  }],
+  people: [],
+  requests: [],
+}), { status: 200 }));
+
+describe("WWO admin access form", () => {
+  beforeAll(async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    sessionStorage.setItem("wwo-admin-token", "secret");
+    vi.stubGlobal("fetch", fetchMock);
+    await import("./admin");
+    await screen.findByRole("heading", { name: "Add person" });
+  });
+
+  it("shows invalid public ID feedback next to the form", () => {
+    const publicIdInput = screen.getByRole("textbox", { name: "Public ID" });
+    fireEvent.change(publicIdInput, { target: { value: "pk_short" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+
+    expect(screen.getByRole("alert").textContent).toBe("Enter a valid public ID");
+    expect(publicIdInput.getAttribute("aria-invalid")).toBe("true");
+    expect(publicIdInput.getAttribute("aria-describedby")).toBe("add-person-error");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/website/admin/admin.test.tsx
+++ b/extension/website/admin/admin.test.tsx
@@ -4,6 +4,7 @@
 // @vitest-environment jsdom
 
 import { fireEvent, screen } from "@testing-library/react";
+import { act } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("@movement/config", () => ({ WORKER_URL: "https://worker.example" }));
@@ -25,24 +26,30 @@ describe("WWO admin access form", () => {
     document.body.innerHTML = '<div id="root"></div>';
     sessionStorage.setItem("wwo-admin-token", "secret");
     vi.stubGlobal("fetch", fetchMock);
-    await import("./admin");
+    await act(async () => {
+      await import("./admin");
+    });
     await screen.findByRole("heading", { name: "Add person" });
   });
 
-  it("associates validation feedback with the invalid field", () => {
+  it("associates validation feedback with the invalid field", async () => {
     const publicIdInput = screen.getByRole("textbox", { name: "Public ID" });
     const emailInput = screen.getByRole("textbox", { name: "Email" });
-    fireEvent.change(publicIdInput, { target: { value: "pk_short" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+    await act(async () => {
+      fireEvent.change(publicIdInput, { target: { value: "pk_short" } });
+      fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+    });
 
     expect(screen.getByRole("alert").textContent).toBe("Enter a valid public ID");
     expect(publicIdInput.getAttribute("aria-invalid")).toBe("true");
     expect(publicIdInput.getAttribute("aria-describedby")).toBe("add-person-public-id-error");
     expect(emailInput.getAttribute("aria-invalid")).toBe("false");
 
-    fireEvent.change(publicIdInput, { target: { value: `pk_${"a".repeat(130)}` } });
-    fireEvent.change(emailInput, { target: { value: "user@localhost" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+    await act(async () => {
+      fireEvent.change(publicIdInput, { target: { value: `pk_${"a".repeat(130)}` } });
+      fireEvent.change(emailInput, { target: { value: "user@localhost" } });
+      fireEvent.click(screen.getByRole("button", { name: "Add person" }));
+    });
 
     expect(screen.getByRole("alert").textContent).toBe("Enter a valid email");
     expect(publicIdInput.getAttribute("aria-invalid")).toBe("false");

--- a/extension/website/admin/admin.tsx
+++ b/extension/website/admin/admin.tsx
@@ -63,6 +63,7 @@ function InternalOffice() {
   const [approvalCohortId, setApprovalCohortId] = useState("closed-beta");
   const [query, setQuery] = useState("");
   const [error, setError] = useState("");
+  const [addPersonError, setAddPersonError] = useState("");
   const [notice, setNotice] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -117,8 +118,16 @@ function InternalOffice() {
 
   const submitPerson = async (event: FormEvent) => {
     event.preventDefault();
+    setAddPersonError("");
+    let person;
+    try {
+      person = parsePersonInput(publicId, email);
+    } catch (inputError) {
+      setNotice("");
+      setAddPersonError(inputError instanceof Error ? inputError.message : String(inputError));
+      return;
+    }
     await mutate(async () => {
-      const person = parsePersonInput(publicId, email);
       const cohort = overview.cohorts.find((candidate) => candidate.id === cohortId);
       if (!cohort) throw new Error("Selected cohort is unavailable");
       await addPeople(token, cohortId, [person]);
@@ -218,13 +227,18 @@ function InternalOffice() {
             <div className="office-list-header"><div><span className="office-section-number">DESK 03</span><h3>Add person</h3></div></div>
             <form className="office-add office-add--person" onSubmit={submitPerson}>
               <label><span>Public ID</span><input aria-label="Public ID" value={publicId}
-                onChange={(event) => setPublicId(event.target.value)} placeholder="pk_…" spellCheck={false} autoComplete="off" /></label>
+                aria-invalid={Boolean(addPersonError)} aria-describedby={addPersonError ? "add-person-error" : undefined}
+                onChange={(event) => {
+                  setPublicId(event.target.value);
+                  setAddPersonError("");
+                }} placeholder="pk_…" spellCheck={false} autoComplete="off" /></label>
               <label><span>Email <small>optional</small></span><input aria-label="Email" type="email" value={email}
                 onChange={(event) => setEmail(event.target.value)} placeholder="tester@example.com" autoComplete="off" /></label>
               <label><span>Cohort</span><select aria-label="Cohort" value={cohortId} onChange={(event) => setCohortId(event.target.value)}>
                 {overview.cohorts.map((cohort) => <option key={cohort.id} value={cohort.id}>{cohort.name}</option>)}
               </select></label>
               <button type="submit" disabled={!publicId.trim() || saving}>Add person</button>
+              {addPersonError && <p id="add-person-error" className="office-add__error" role="alert">{addPersonError}</p>}
               {notice && <p className="office-add__success" role="status">{notice}</p>}
             </form>
             <details className="office-bulk-import">

--- a/extension/website/admin/admin.tsx
+++ b/extension/website/admin/admin.tsx
@@ -9,6 +9,7 @@ import {
   getAccessOverview,
   parsePeopleInput,
   parsePersonInput,
+  PersonInputError,
   reviewAccessRequest,
   updateCohortFeatures,
   updateFeatureStage,
@@ -63,7 +64,7 @@ function InternalOffice() {
   const [approvalCohortId, setApprovalCohortId] = useState("closed-beta");
   const [query, setQuery] = useState("");
   const [error, setError] = useState("");
-  const [addPersonError, setAddPersonError] = useState("");
+  const [addPersonError, setAddPersonError] = useState<PersonInputError | null>(null);
   const [notice, setNotice] = useState("");
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -118,13 +119,17 @@ function InternalOffice() {
 
   const submitPerson = async (event: FormEvent) => {
     event.preventDefault();
-    setAddPersonError("");
+    setAddPersonError(null);
     let person;
     try {
       person = parsePersonInput(publicId, email);
     } catch (inputError) {
       setNotice("");
-      setAddPersonError(inputError instanceof Error ? inputError.message : String(inputError));
+      if (inputError instanceof PersonInputError) {
+        setAddPersonError(inputError);
+      } else {
+        setError(inputError instanceof Error ? inputError.message : String(inputError));
+      }
       return;
     }
     await mutate(async () => {
@@ -227,18 +232,25 @@ function InternalOffice() {
             <div className="office-list-header"><div><span className="office-section-number">DESK 03</span><h3>Add person</h3></div></div>
             <form className="office-add office-add--person" onSubmit={submitPerson}>
               <label><span>Public ID</span><input aria-label="Public ID" value={publicId}
-                aria-invalid={Boolean(addPersonError)} aria-describedby={addPersonError ? "add-person-error" : undefined}
+                aria-invalid={addPersonError?.field === "publicId"}
+                aria-describedby={addPersonError?.field === "publicId" ? "add-person-public-id-error" : undefined}
                 onChange={(event) => {
                   setPublicId(event.target.value);
-                  setAddPersonError("");
+                  if (addPersonError?.field === "publicId") setAddPersonError(null);
                 }} placeholder="pk_…" spellCheck={false} autoComplete="off" /></label>
               <label><span>Email <small>optional</small></span><input aria-label="Email" type="email" value={email}
-                onChange={(event) => setEmail(event.target.value)} placeholder="tester@example.com" autoComplete="off" /></label>
+                aria-invalid={addPersonError?.field === "email"}
+                aria-describedby={addPersonError?.field === "email" ? "add-person-email-error" : undefined}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  if (addPersonError?.field === "email") setAddPersonError(null);
+                }} placeholder="tester@example.com" autoComplete="off" /></label>
               <label><span>Cohort</span><select aria-label="Cohort" value={cohortId} onChange={(event) => setCohortId(event.target.value)}>
                 {overview.cohorts.map((cohort) => <option key={cohort.id} value={cohort.id}>{cohort.name}</option>)}
               </select></label>
               <button type="submit" disabled={!publicId.trim() || saving}>Add person</button>
-              {addPersonError && <p id="add-person-error" className="office-add__error" role="alert">{addPersonError}</p>}
+              {addPersonError && <p id={`add-person-${addPersonError.field === "publicId" ? "public-id" : "email"}-error`}
+                className="office-add__error" role="alert">{addPersonError.message}</p>}
               {notice && <p className="office-add__success" role="status">{notice}</p>}
             </form>
             <details className="office-bulk-import">

--- a/extension/website/admin/style.scss
+++ b/extension/website/admin/style.scss
@@ -220,11 +220,19 @@ a {
     min-height: 38px;
   }
 
+  .office-add__error,
   .office-add__success {
     grid-column: 1 / -1;
     margin: 0;
-    color: #236859;
     font: 12px/1.4 "Lora", serif;
+  }
+
+  .office-add__error {
+    color: #9b4228;
+  }
+
+  .office-add__success {
+    color: #236859;
   }
 }
 


### PR DESCRIPTION
## Summary

- Show malformed public ID errors inside the Add person form.
- Mark the public ID field invalid and connect it to the alert for assistive technology.
- Cover the form behavior and confirm invalid input does not call the Worker mutation endpoint.

## Verification

- `vitest run --config extension/website/vite.config.ts extension/website/admin/admin.test.tsx extension/website/admin/accessControlApi.test.ts`
- `bun run check:extension-website`
- `bun run build-extension:website`
- Loaded the real local `/admin/` route in a browser, entered `pk_short`, and confirmed the inline alert and invalid-field state.

## Release notes

No `extension/PENDING.md` entry. This is an internal operator-console fix.

See the PR Evidence comment for the verified UI state.
