### PR TITLE
extension: strip query strings/fragments from uploaded event URLs

### DIFF
--- a/extension/src/__tests__/sync.test.ts
+++ b/extension/src/__tests__/sync.test.ts
@@ -1,0 +1,56 @@
+// ABOUTME: Tests that event upload strips query strings/fragments from meta.url
+// ABOUTME: before events leave the device, without touching the caller's objects.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uploadEvents } from "../storage/sync";
+import type { CollectionEvent } from "../collectors/types";
+
+function makeEvent(url: string): CollectionEvent {
+  return {
+    id: "01TESTULID",
+    type: "cursor",
+    ts: Date.now(),
+    data: { x: 0.5, y: 0.5 },
+    meta: {
+      pid: "pk_test",
+      sid: "sid_test",
+      url,
+      vw: 1024,
+      vh: 768,
+      tz: "UTC",
+    },
+  } as CollectionEvent;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("uploadEvents", () => {
+  it("strips query string and hash from meta.url for every event type, not just navigation", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ inserted: 1, duplicates: 0 }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const event = makeEvent("https://example.com/search?q=sensitive+query&session=abc123#results");
+    await uploadEvents([event]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string);
+    expect(body.events[0].meta.url).toBe("https://example.com/search");
+  });
+
+  it("does not mutate the original event object passed in", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(JSON.stringify({ inserted: 1, duplicates: 0 }), { status: 200 }))
+    );
+
+    const event = makeEvent("https://example.com/page?token=secret");
+    await uploadEvents([event]);
+
+    expect(event.meta.url).toBe("https://example.com/page?token=secret");
+  });
+});

--- a/extension/src/storage/sync.ts
+++ b/extension/src/storage/sync.ts
@@ -4,6 +4,22 @@
 import browser from 'webextension-polyfill';
 import type { CollectionEvent } from '../collectors/types';
 import { VERBOSE } from '../config';
+import { stripQueryAndFragment } from '../utils/urlNormalization';
+
+/**
+ * Query strings and hash fragments can carry sensitive content (search
+ * terms, order IDs, auth tokens) regardless of event type — not just
+ * navigation events. Strip them from the outgoing payload only; the local
+ * IndexedDB copy (used for the user's own history/visualization features)
+ * keeps the full URL.
+ */
+function sanitizeForUpload(events: CollectionEvent[]): CollectionEvent[] {
+  return events.map((event) =>
+    event.meta?.url
+      ? { ...event, meta: { ...event.meta, url: stripQueryAndFragment(event.meta.url) } }
+      : event
+  );
+}
 
 const STORAGE_KEYS = {
   WORKER_URL: 'collection_worker_url',
@@ -76,14 +92,15 @@ export async function uploadEvents(events: CollectionEvent[]): Promise<void> {
   }
   
   const workerUrl = await getWorkerUrl();
-  
+  const sanitizedEvents = sanitizeForUpload(events);
+
   try {
     const response = await fetch(`${workerUrl}/events`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ events }),
+      body: JSON.stringify({ events: sanitizedEvents }),
     });
     
     if (!response.ok) {

--- a/extension/src/utils/urlNormalization.ts
+++ b/extension/src/utils/urlNormalization.ts
@@ -37,6 +37,24 @@ export function normalizeUrl(url: string): string {
 }
 
 /**
+ * Strip the query string and hash fragment from a URL before it leaves the
+ * device (e.g. upload to the shared worker). Unlike `normalizeUrl`, this
+ * preserves protocol/host/path casing exactly — it exists purely to drop
+ * potentially sensitive query params (search terms, order IDs, tokens) and
+ * fragments, not to canonicalize for matching.
+ */
+export function stripQueryAndFragment(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Extract domain from URL, removing www prefix
  *
  * Examples:


### PR DESCRIPTION
## Summary

`meta.url` was uploaded to the shared worker unmodified for *every* event type (cursor, viewport, keyboard — not just navigation), leaking search queries, tokens, and other sensitive query-string content through a publicly-served endpoint (`GET /events/recent`). The only gate on that endpoint is a client-spoofable Origin/Referer check, documented in `originAllowlist.ts` as "a casual-scraping deterrent, not a security boundary."

Fix: strip the query string and hash fragment from `meta.url` right before upload in `extension/src/storage/sync.ts`, leaving the local IndexedDB copy (used for the user's own history/visualization features) untouched with the full URL.

## Verification

- `bun run check:extension` — clean
- `bun run test -- src/__tests__/sync.test.ts` — 2/2 pass (verifies query/hash stripped for a non-navigation event type, and that the original event object passed in isn't mutated)

Found via a scheduled read-only codebase audit.

## Extension feature real-browser verification

Not applicable — no new extension feature is added; this modifies an existing upload path under unit test coverage, not a new user-facing capability.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_