### PR TITLE
react: fix function-form defaultData crash on initial render

### DIFF
--- a/.changeset/fix-react-default-data-crash.md
+++ b/.changeset/fix-react-default-data-crash.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Fix function-form `defaultData`/`myDefaultAwareness` (e.g. `(el) => ({ text: el.id })`) being resolved against `null` during the initial render instead of the real element, crashing on mount. It now resolves once the element is attached.

--- a/packages/react/src/__tests__/elements.test.tsx
+++ b/packages/react/src/__tests__/elements.test.tsx
@@ -128,6 +128,56 @@ describe("CanPlayElement with built-in capabilities", () => {
     expect((element as any).onDrag).toBe(capabilityOnDrag);
   });
 
+  it("resolves function-form defaultData against the real element instead of null", async () => {
+    // Regression test: resolving this synchronously during render (before
+    // ref.current is attached) throws `Cannot read properties of null`.
+    const { container } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanMove]}
+        defaultData={(el: HTMLElement) => ({ tag: el.tagName })}
+        defaultLocalData={{ startMouseX: 0, startMouseY: 0 }}
+        updateElement={() => {}}
+        resetShortcut="shiftKey"
+      >
+        {({ data }) => <div id="fn-default-data-child">{JSON.stringify(data)}</div>}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-move]") as HTMLElement;
+    expect(element).toBeTruthy();
+
+    await act(async () => {});
+
+    const child = container.querySelector("#fn-default-data-child") as HTMLElement;
+    expect(child.textContent).toBe(JSON.stringify({ tag: element.tagName }));
+  });
+
+  it("resolves function-form myDefaultAwareness against the real element instead of null", async () => {
+    const { container } = render(
+      <CanPlayElement
+        // @ts-ignore
+        tagInfo={[TagType.CanHover]}
+        defaultData={{}}
+        myDefaultAwareness={(el: HTMLElement) => ({ tag: el.tagName })}
+        updateElement={() => {}}
+        updateElementAwareness={() => {}}
+      >
+        {({ myAwareness }) => (
+          <div id="fn-default-awareness-child">{JSON.stringify(myAwareness)}</div>
+        )}
+      </CanPlayElement>,
+    );
+
+    const element = container.querySelector("[can-hover]") as HTMLElement;
+    expect(element).toBeTruthy();
+
+    await act(async () => {});
+
+    const child = container.querySelector("#fn-default-awareness-child") as HTMLElement;
+    expect(child.textContent).toBe(JSON.stringify({ tag: element.tagName }));
+  });
+
   it("does not remove the element when synced data updates React state", () => {
     const setupSpy = vi
       .spyOn(playhtml, "setupPlayElement")

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -273,14 +273,20 @@ export function CanPlayElement<T extends object, V = any>({
         (fnOrValue as (el: HTMLElement) => V)(ref.current as HTMLElement)
       : fnOrValue;
 
+  // Function-form defaultData/myDefaultAwareness receive the real element, but
+  // `ref.current` is still null during this first render (React hasn't attached
+  // the ref yet) — resolving them here would call the consumer's function with
+  // null and crash. Seed with a plain value only; resolve the function form in
+  // a layout effect below, once ref.current is populated.
   const [data, setData] = useState<T | undefined>(
-    defaultData !== undefined
-      ? resolveDefaultData(defaultData as T | ((el: HTMLElement) => T))
+    defaultData !== undefined && typeof defaultData !== "function"
+      ? (defaultData as T)
       : undefined,
   );
-  const initialAwareness = resolveDefaultAwareness(
-    myDefaultAwareness as V | ((el: HTMLElement) => V) | undefined,
-  );
+  const initialAwareness =
+    typeof myDefaultAwareness === "function"
+      ? undefined
+      : (myDefaultAwareness as V | undefined);
   const [awareness, setAwareness] = useState<V[]>(
     initialAwareness ? [initialAwareness] : [],
   );
@@ -290,6 +296,28 @@ export function CanPlayElement<T extends object, V = any>({
   const [myAwareness, setMyAwareness] = useState<V | undefined>(
     initialAwareness,
   );
+
+  useElementRegistrationEffect(() => {
+    if (typeof defaultData === "function") {
+      setData((prev) =>
+        prev === undefined
+          ? resolveDefaultData(defaultData as T | ((el: HTMLElement) => T))
+          : prev,
+      );
+    }
+    if (typeof myDefaultAwareness === "function") {
+      const resolved = resolveDefaultAwareness(
+        myDefaultAwareness as (el: HTMLElement) => V,
+      );
+      if (resolved !== undefined) {
+        setMyAwareness((prev) => (prev === undefined ? resolved : prev));
+        setAwareness((prev) => (prev.length === 0 ? [resolved] : prev));
+      }
+    }
+    // Resolve function-form defaults exactly once, right after the element
+    // mounts — not on every re-render of this effect's inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Capture the capability's original updateElement/updateElementAwareness so we can
   // compose them with the React state updater below. These come from the built-in


### PR DESCRIPTION
## Summary

`packages/react/src/index.tsx` resolved function-form `defaultData`/`myDefaultAwareness` (e.g. `(el) => ({ text: el.id })` — the documented pattern shown in `apps/docs/src/content/docs/custom-elements.mdx`) synchronously during the initial render, calling the consumer's function with `ref.current` while it's still `null` (React hasn't attached the ref yet at that point). Any consumer passing the function form crashes on first render.

The vanilla core library already resolves this correctly against the real element (`packages/playhtml/src/elements.ts`), so only the React wrapper's own local `data`/`myAwareness` state was affected — not the persisted value once sync catches up.

Fix: seed React's initial state with `undefined` when `defaultData`/`myDefaultAwareness` is a function, and resolve it in a layout effect (`useElementRegistrationEffect`, already used elsewhere in this file) once `ref.current` is populated.

## Verification

- `bun run check:react` — clean
- `bun run test` in `packages/react` — 58/58 pass, including two new regression tests that render `CanPlayElement` with function-form `defaultData`/`myDefaultAwareness` and assert against the real element instead of crashing
- Added a changeset (`@playhtml/react` patch)

Found via a scheduled read-only codebase audit. A prior attempt at this exact fix exists on branch `cx/fix-react-function-defaults`, but that branch reverts its own change, so the bug is still live on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_