### PR TITLE
react: fix usePresence().myIdentity freezing at sync completion

### DIFF
--- a/.changeset/fix-use-presence-identity.md
+++ b/.changeset/fix-use-presence-identity.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/react": patch
+---
+
+Fix `usePresence().myIdentity` freezing at sync completion and never reflecting a later identity change (e.g. the "we were online" extension injecting identity post-sync). It now updates reactively, mirroring `usePlayerIdentity`.

--- a/packages/react/src/__tests__/hooks.test.tsx
+++ b/packages/react/src/__tests__/hooks.test.tsx
@@ -26,6 +26,12 @@ const mockedPlayhtml = (globalThis as any).MOCKED_PLAYHTML as {
   resolveReady: () => void;
   createPresenceRoom: ReturnType<typeof vi.fn>;
   presence: unknown;
+  setMockPlayerIdentity: (next: {
+    publicKey?: string;
+    name?: string;
+    playerStyle?: { colorPalette: string[]; cursorStyle?: string };
+    createdAt?: number;
+  }) => void;
 };
 
 describe("usePresence", () => {
@@ -102,6 +108,35 @@ describe("usePresence", () => {
       });
     });
     expect(captured!.presences.get("me")).not.toHaveProperty("x");
+  });
+
+  it("re-derives myIdentity on a later identity change instead of freezing at sync completion", async () => {
+    let captured: ReturnType<typeof usePresence<"selection">> | null = null;
+
+    function TestComponent() {
+      captured = usePresence("selection");
+      return <div />;
+    }
+
+    render(
+      <PlayProvider>
+        <TestComponent />
+      </PlayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(captured!.myIdentity).not.toBeNull();
+    });
+    expect(captured!.myIdentity?.publicKey).toBe("me");
+
+    // Simulates the "we were online" extension injecting identity post-sync.
+    act(() => {
+      mockedPlayhtml.setMockPlayerIdentity({ publicKey: "injected-pid" });
+    });
+
+    await waitFor(() => {
+      expect(captured!.myIdentity?.publicKey).toBe("injected-pid");
+    });
   });
 });
 

--- a/packages/react/src/__tests__/setup.ts
+++ b/packages/react/src/__tests__/setup.ts
@@ -31,6 +31,18 @@ function notifyUsersChange() {
   for (const cb of usersChangeListeners) cb(snapshot);
 }
 
+// Mutable so tests can simulate an identity change (e.g. the extension
+// injecting identity post-sync) and assert usePresence().myIdentity updates.
+const mockPlayerIdentity = {
+  publicKey: "me",
+  name: "Me" as string | undefined,
+  playerStyle: {
+    colorPalette: ["#fff"] as string[],
+    cursorStyle: undefined as string | undefined,
+  },
+  createdAt: undefined as number | undefined,
+};
+
 function mockGetAllUsers(): Array<Record<string, unknown>> {
   return [
     {
@@ -155,9 +167,18 @@ const mockedPlayhtml = {
         return () => set!.delete(callback);
       },
     ),
-    getMyIdentity: vi.fn(() => ({ stableId: "me", name: "Me", color: "#fff" })),
+    getMyIdentity: vi.fn(() => ({
+      publicKey: mockPlayerIdentity.publicKey,
+      name: mockPlayerIdentity.name,
+      playerStyle: { ...mockPlayerIdentity.playerStyle },
+      createdAt: mockPlayerIdentity.createdAt,
+    })),
   },
   users: mockUsers,
+  setMockPlayerIdentity: (next: Partial<typeof mockPlayerIdentity>) => {
+    Object.assign(mockPlayerIdentity, next);
+    notifyUsersChange();
+  },
   createPageData: vi.fn((_name: string, defaultValue: unknown) => {
     let data = defaultValue;
     const listeners = new Set<(d: unknown) => void>();

--- a/packages/react/src/hooks.ts
+++ b/packages/react/src/hooks.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Custom React hooks for playhtml functionality
 // ABOUTME: Cursor, presence, page-data, and presence-room hooks that safely no-op pre-sync
 
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import type * as React from "react";
 import { PlayContext } from "./PlayProvider";
 import playhtml from "./playhtml-singleton";
@@ -44,6 +44,24 @@ function usePlayhtmlSubscription<T>(
   }, [isLoading, ...dependencies]);
 
   return value;
+}
+
+function identityEquals(
+  a: PlayerIdentity | null,
+  b: PlayerIdentity | null,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.publicKey === b.publicKey &&
+    a.name === b.name &&
+    a.createdAt === b.createdAt &&
+    a.playerStyle.cursorStyle === b.playerStyle.cursorStyle &&
+    a.playerStyle.colorPalette.length === b.playerStyle.colorPalette.length &&
+    a.playerStyle.colorPalette.every(
+      (color, i) => color === b.playerStyle.colorPalette[i],
+    )
+  );
 }
 
 function isPresenceRoomNotReadyError(error: unknown): boolean {
@@ -140,10 +158,24 @@ export function usePresence<
     [isLoading, channel],
   );
 
-  const myIdentity = useMemo(
-    () => (isLoading ? null : playhtml.presence.getMyIdentity()),
-    [isLoading],
-  );
+  // Re-derived on every identity change (not just once at sync completion) —
+  // e.g. the "we were online" extension can inject identity post-sync via the
+  // `playhtml:configure-identity` event. `users.onChange` fires on every
+  // presence tick, so dedupe by value to avoid re-rendering consumers when the
+  // identity itself hasn't changed.
+  const [myIdentity, setMyIdentity] = useState<PlayerIdentity | null>(null);
+  useEffect(() => {
+    if (isLoading) {
+      setMyIdentity(null);
+      return;
+    }
+    const readIdentity = () => {
+      const next = playhtml.presence.getMyIdentity();
+      setMyIdentity((prev) => (identityEquals(prev, next) ? prev : next));
+    };
+    readIdentity();
+    return playhtml.users.onChange(readIdentity);
+  }, [isLoading]);
 
   return { presences, setMyPresence, myIdentity };
 }


### PR DESCRIPTION
## Summary

`usePresence().myIdentity` (`packages/react/src/hooks.ts`) was a `useMemo` keyed only on `isLoading`, which transitions false→true exactly once — so `myIdentity` was computed the instant sync finished and never re-derived afterward. The sibling `usePlayerIdentity` hook's own docstring explicitly calls out that the "we were online" extension can inject identity post-sync via a `playhtml:configure-identity` event, and correctly re-subscribes to `playhtml.users.onChange` to catch it — `usePresence`'s `myIdentity` did not, so a component reading it could show a stale/wrong player color or pid indefinitely after such a change.

Fix: subscribe to `playhtml.users.onChange` the same way `usePlayerIdentity` does, re-reading `playhtml.presence.getMyIdentity()` on each notification with a value-equality check (dedupe) so consumers don't re-render on every presence tick.

## Verification

- `bun run check:react` — clean
- `bun run test` in `packages/react` — 57/57 pass, including a new regression test that simulates a post-sync identity change and asserts `myIdentity` updates instead of staying frozen (also extended the test mock's `getMyIdentity` to return a well-formed `PlayerIdentity` shape with a `setMockPlayerIdentity` helper for tests to trigger a change)
- Added a changeset (`@playhtml/react` patch)

Found via a scheduled read-only codebase audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_