### PR TITLE
common: fix can-grow leaking document keydown/keyup listeners

### DIFF
--- a/.changeset/fix-can-grow-listener-leak.md
+++ b/.changeset/fix-can-grow-listener-leak.md
@@ -1,0 +1,5 @@
+---
+"@playhtml/common": patch
+---
+
+Fix a `can-grow` element leaking document-level keydown/keyup listeners when it's removed from the DOM while hovered (e.g. an SPA route change or React unmount that doesn't fire `mouseleave` first). The listeners are now cleaned up on unmount regardless of hover state.

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -692,6 +692,17 @@ export const TagTypeToElement: DefaultTagInitializers = {
 
       element.addEventListener("mouseenter", onMouseEnter);
       element.addEventListener("mouseleave", onMouseLeave);
+
+      // The mouseenter/mouseleave listeners die with the element, but the
+      // document-level keydown/keyup listeners don't — if the element is
+      // removed while hovered (SPA navigation, React unmount), mouseleave
+      // never fires and they'd otherwise leak for the life of the page.
+      return () => {
+        element.removeEventListener("mouseenter", onMouseEnter);
+        element.removeEventListener("mouseleave", onMouseLeave);
+        document.removeEventListener("keydown", onKeyDownUp);
+        document.removeEventListener("keyup", onKeyDownUp);
+      };
     },
     resetShortcut: "shiftKey",
   },

--- a/packages/playhtml/src/__tests__/elements.test.ts
+++ b/packages/playhtml/src/__tests__/elements.test.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies handler-level write semantics used by playhtml capabilities.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ElementHandler } from "../elements";
+import { TagType, TagTypeToElement } from "@playhtml/common";
 import type {
   ElementAwarenessEventHandlerData,
   ElementData,
@@ -374,5 +375,71 @@ describe("ElementHandler", () => {
     handler.setMyAwareness({ me: "X" } as any);
     expect(onAwarenessChange).toHaveBeenCalledWith({ me: "X" });
     expect(triggerAwarenessUpdate).toHaveBeenCalled();
+  });
+});
+
+describe("CanGrow onMount cleanup", () => {
+  let element: HTMLElement;
+
+  beforeEach(() => {
+    element = document.createElement("div");
+    document.body.appendChild(element);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("removes the document-level keydown/keyup listeners on destroy, even without a preceding mouseleave", () => {
+    const canGrow = TagTypeToElement[TagType.CanGrow];
+    const handler = new ElementHandler({
+      element,
+      defaultData: canGrow.defaultData,
+      defaultLocalData: canGrow.defaultLocalData,
+      updateElement: canGrow.updateElement,
+      onMount: canGrow.onMount,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: () => {},
+    } as unknown as ElementData);
+
+    // Hover without a mouseleave — the failure scenario from a SPA
+    // navigation/React unmount that removes the element mid-hover.
+    element.dispatchEvent(new MouseEvent("mouseenter"));
+
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    handler.destroy();
+
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("keyup", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("does not leave a live keydown listener reacting after destroy", () => {
+    const canGrow = TagTypeToElement[TagType.CanGrow];
+    const handler = new ElementHandler({
+      element,
+      defaultData: canGrow.defaultData,
+      defaultLocalData: canGrow.defaultLocalData,
+      updateElement: canGrow.updateElement,
+      onMount: canGrow.onMount,
+      onChange: vi.fn(),
+      onAwarenessChange: vi.fn(),
+      triggerAwarenessUpdate: () => {},
+    } as unknown as ElementData);
+
+    // mouseenter arms the document keydown/keyup listeners AND sets the
+    // cursor once (no altKey held yet, scale 1 < maxScale 2 -> grow cursor).
+    element.dispatchEvent(new MouseEvent("mouseenter"));
+    const cursorAfterMouseEnter = element.style.cursor;
+    expect(cursorAfterMouseEnter).not.toBe("");
+
+    // No mouseleave — destroy the handler while still "hovering".
+    handler.destroy();
+
+    // A leaked document keydown listener would flip the cursor to the
+    // alt/cut style here; a cleaned-up one leaves it untouched.
+    document.dispatchEvent(new KeyboardEvent("keydown", { altKey: true }));
+    expect(element.style.cursor).toBe(cursorAfterMouseEnter);
   });
 });


### PR DESCRIPTION
## Summary

`can-grow`'s `onMount` (`packages/common/src/index.ts`) adds `document`-level `keydown`/`keyup` listeners on `mouseenter`, but only removes them on `mouseleave`. `onMount` returned no cleanup function, so `ElementHandler.destroy()` had no path to remove them. If a hovered `can-grow` element is removed from the DOM without a preceding `mouseleave` — an SPA route change, a React unmount, any dynamic removal, since `mouseleave` doesn't fire on programmatic removal — the document listeners persist for the life of the page, firing `canGrowCursorHandler` against the orphaned handler on every keystroke thereafter.

Fix: return a cleanup function from `onMount` (the type already supports this — `ElementHandler` already wires up `onUnmount` when `onMount` returns one) that removes the listeners unconditionally.

## Verification

- `bun run check:common`, `check:playhtml` — clean
- `bun run test` in `packages/playhtml` — 16/16 pass in the affected test file, including two new regression tests
- Verified the tests actually catch the regression: temporarily reverted the fix, confirmed both new tests fail (`removeEventListener` not called; a leaked `keydown` listener changes the cursor after destroy), then restored the fix and confirmed green
- Added a changeset (`@playhtml/common` patch — `playhtml` picks this up automatically via `updateInternalDependencies`)

Found via a scheduled read-only codebase audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_