### PR TITLE
partykit: stop silently dropping a due autosave retry

### DIFF
--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -2864,7 +2864,7 @@ describe("quarantine data safety", () => {
     expect(persistedRow.document).toBe(candidate.base64);
   });
 
-  test("an unavailable room consumes an expired save retry", async () => {
+  test("an unavailable room reschedules (does not drop) an expired save retry", async () => {
     const { room, storage } = createRoom();
     room.documentLoadCompleted = true;
     room.persistenceMode = {
@@ -2876,7 +2876,13 @@ describe("quarantine data safety", () => {
 
     await room.onAlarm();
 
-    expect(storage.values.has("documentSaveRetry")).toBe(false);
+    // The room can't persist while transient, but the retry must survive so a
+    // later alarm can try again once persistence recovers — dropping it here
+    // would silently lose the pending save if no further edit ever occurs.
+    expect(storage.values.has("documentSaveRetry")).toBe(true);
+    expect(
+      (storage.values.get("documentSaveRetry") as { retryAt: number }).retryAt
+    ).toBeGreaterThan(Date.now());
     expect(upsertCalls).toEqual([]);
   });
 

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -195,6 +195,34 @@ describe("alarm entry point", () => {
     expect(storage.alarm).toBe(loadRetryAfter);
   });
 
+  test("a due save retry is kept (not dropped) when the room is mid-maintenance instead of ready", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    // Simulate a concurrent admin operation (restoreFromSnapshot/hard-reset)
+    // holding the write lock when the retry's alarm fires.
+    (server as any).documentMaintenanceInProgress = true;
+
+    await server.alarm();
+
+    // The retry marker must survive so the next alarm tries again — clearing
+    // it here would silently drop the save forever if no further edit occurs.
+    expect(storage.values.has("documentSaveRetry")).toBe(true);
+    expect((storage.values.get("documentSaveRetry") as { retryAt: number }).retryAt).toBeGreaterThan(
+      Date.now()
+    );
+    expect(storage.alarm).not.toBeNull();
+  });
+
+  test("a due save retry is cleared and the document persisted once the room is ready", async () => {
+    const { server, storage } = createServer();
+    storage.values.set("documentSaveRetry", { retryAt: Date.now() - 1 });
+
+    await server.alarm();
+
+    expect(storage.values.has("documentSaveRetry")).toBe(false);
+  });
+
   test("a KV-quarantined room does not hydrate when its alarm fires", async () => {
     const { server } = createServer();
     kvStore.set("quarantine:example-room", "operator stop");

--- a/partykit/party.ts
+++ b/partykit/party.ts
@@ -3099,14 +3099,21 @@ export class PartyServer extends YServer {
         documentSaveRetry !== null &&
         documentSaveRetry.retryAt <= Date.now()
       ) {
-        await this.clearDocumentSaveRetry();
         if (this.roomState() === "ready") {
+          await this.clearDocumentSaveRetry();
           try {
             await this.persistLiveDocument({ allowCompaction: false });
           } catch (error) {
             await this.scheduleDocumentSaveRetry();
             throw error;
           }
+        } else {
+          // Room isn't ready yet (e.g. a concurrent admin operation such as
+          // restoreFromSnapshot/hard-reset holds the write lock). Keep the
+          // retry marker and try again on the next alarm instead of clearing
+          // it here — clearing unconditionally would silently drop this save
+          // forever if no further edit ever re-triggers persistence.
+          await this.scheduleDocumentSaveRetry();
         }
       }
 


### PR DESCRIPTION
## Summary

`onAlarm`'s document-save retry (`partykit/party.ts`) cleared its retry marker (`clearDocumentSaveRetry()`) *before* checking whether the room was actually `roomState() === "ready"`. If a concurrent admin operation held the write lock (`documentMaintenanceInProgress`, e.g. `restoreFromSnapshot`/hard-reset in flight) or persistence was transient (Supabase unreachable) when the retry fired, the save attempt was skipped entirely — but the marker was already gone, so the save was silently dropped forever unless some later edit happened to re-trigger a fresh autosave cycle.

The sibling empty-room-compaction retry three lines below already gets this right: it only clears its own marker once the operation actually ran or is confirmed no longer applicable. This PR applies the same pattern to the document-save retry — the marker is now cleared only once the save is attempted; otherwise it's rescheduled for the next alarm.

## Verification

- `bun run check:partykit` — clean
- `bun test` in `partykit/` — 291/291 pass, including two new regression tests (one exercising the "mid-maintenance" case via `onAlarm()` directly, one via the platform `alarm()` entry point) plus an updated existing test that previously asserted the buggy drop-on-transient-persistence behavior as expected
- Verified the tests actually catch the regression: temporarily reverted the fix, confirmed all three fail, then restored and confirmed green

This fix is fully independent of `ADMIN_TOKEN`/admin-route auth — `onAlarm` is the platform's timer callback, not an HTTP route, so none of the new/updated tests need any admin token.

Found via a scheduled read-only codebase audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_