### PR TITLE
partykit: fail closed on missing ADMIN_TOKEN

### DIFF
--- a/partykit/__tests__/adminAuth.test.ts
+++ b/partykit/__tests__/adminAuth.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Tests the shared admin-token gate used by PartyKit and Worker admin routes.
+// ABOUTME: A missing ADMIN_TOKEN must fail closed, not silently authorize every request.
+import { describe, expect, it } from "bun:test";
+import { getAdminAuthError } from "../adminAuth";
+
+function request(url: string, headers: Record<string, string> = {}): Request {
+  return new Request(url, { headers });
+}
+
+describe("getAdminAuthError", () => {
+  it("rejects with 500 when ADMIN_TOKEN is unset, rather than authorizing the request", () => {
+    const res = getAdminAuthError(request("https://api.example.com/admin/hard-reset"), undefined);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(500);
+  });
+
+  it("rejects with 500 when ADMIN_TOKEN is an empty string", () => {
+    const res = getAdminAuthError(request("https://api.example.com/admin/hard-reset"), "");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(500);
+  });
+
+  it("rejects requests with no token when ADMIN_TOKEN is configured", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset"),
+      "secret",
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("rejects requests with the wrong token", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset?token=wrong"),
+      "secret",
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("authorizes a request with the correct token via query param", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset?token=secret"),
+      "secret",
+    );
+    expect(res).toBeNull();
+  });
+
+  it("authorizes a request with the correct token via Authorization header", () => {
+    const res = getAdminAuthError(
+      request("https://api.example.com/admin/hard-reset", {
+        Authorization: "Bearer secret",
+      }),
+      "secret",
+    );
+    expect(res).toBeNull();
+  });
+});

--- a/partykit/__tests__/quarantineLoad.test.ts
+++ b/partykit/__tests__/quarantineLoad.test.ts
@@ -42,12 +42,18 @@ const quarantineKvStub = {
   },
 };
 
+// getAdminAuthError now fails closed on a missing ADMIN_TOKEN, so every admin
+// route exercised below needs both a configured token and a matching one on
+// the request (see the `?token=` suffix on each admin URL below).
+const ADMIN_TOKEN = "test-admin-token";
+
 const workerEnv: Record<string, unknown> = {
   QUARANTINE_CONTROL: quarantineKvStub,
   SUPABASE_LOAD_ATTEMPTS: "3",
   SUPABASE_LOAD_RETRY_DELAY_MS: "1",
   SUPABASE_RECOVERY_RETRY_DELAY_MS: "1",
   SUPABASE_RECOVERY_RETRY_MAX_DELAY_MS: "5",
+  ADMIN_TOKEN,
 };
 
 mock.module("cloudflare:workers", () => ({
@@ -249,7 +255,7 @@ function adminPost(
 ): Promise<Response> {
   return room.adminHandler.handleRequest(
     new Request(
-      `https://example.com/parties/main/example-room/admin/${endpoint}`,
+      `https://example.com/parties/main/example-room/admin/${endpoint}?token=${ADMIN_TOKEN}`,
       {
         method: "POST",
         body: JSON.stringify(body),
@@ -334,7 +340,7 @@ describe("admin mutations use the authoritative live document", () => {
 
     const responsePromise = room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -367,7 +373,7 @@ describe("admin mutations use the authoritative live document", () => {
     try {
       response = await room.onRequest(
         new Request(
-          "https://example.com/parties/main/example-room/admin/force-save-live",
+          `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
           { method: "POST" }
         )
       );
@@ -779,7 +785,7 @@ describe("hydration write guards", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -804,7 +810,7 @@ describe("hydration write guards", () => {
     });
     const adminResponse = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -1026,7 +1032,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -1045,7 +1051,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -1064,7 +1070,7 @@ describe("load path", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        `https://example.com/parties/main/example-room/admin/quarantine-set?token=${ADMIN_TOKEN}`,
         {
           method: "POST",
           body: JSON.stringify({ reason: "operator intervention" }),
@@ -1984,8 +1990,9 @@ describe("hardening", () => {
 
 describe("admin quarantine endpoints", () => {
   function adminRequest(path: string, init?: RequestInit) {
+    const separator = path.includes("?") ? "&" : "?";
     return new Request(
-      `https://example.com/parties/main/example-room/admin/${path}`,
+      `https://example.com/parties/main/example-room/admin/${path}${separator}token=${ADMIN_TOKEN}`,
       init
     );
   }
@@ -2893,7 +2900,7 @@ describe("quarantine data safety", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/force-save-live",
+        `https://example.com/parties/main/example-room/admin/force-save-live?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -3052,7 +3059,7 @@ describe("quarantine data safety", () => {
 
     const response = await room.onRequest(
       new Request(
-        "https://example.com/parties/main/example-room/admin/hard-reset",
+        `https://example.com/parties/main/example-room/admin/hard-reset?token=${ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );

--- a/partykit/__tests__/quarantinePlatformEntry.test.ts
+++ b/partykit/__tests__/quarantinePlatformEntry.test.ts
@@ -33,8 +33,10 @@ const quarantineKvStub = {
   },
 };
 
+const TEST_ADMIN_TOKEN = "test-admin-token";
+
 mock.module("cloudflare:workers", () => ({
-  env: { QUARANTINE_CONTROL: quarantineKvStub },
+  env: { QUARANTINE_CONTROL: quarantineKvStub, ADMIN_TOKEN: TEST_ADMIN_TOKEN },
   DurableObject: class {
     constructor(
       public ctx: unknown,
@@ -243,7 +245,7 @@ describe("alarm entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -320,7 +322,7 @@ describe("persistence recovery admission", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -339,7 +341,7 @@ describe("persistence recovery admission", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -517,7 +519,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -535,7 +537,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -543,7 +545,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -565,7 +567,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -573,7 +575,7 @@ describe("fetch entry point", () => {
 
     const response = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-set",
+        `https://example.com/parties/main/example-room/admin/quarantine-set?token=${TEST_ADMIN_TOKEN}`,
         {
           method: "POST",
           body: JSON.stringify({ reason: "operator stop" }),
@@ -594,7 +596,7 @@ describe("fetch entry point", () => {
 
     await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );
@@ -603,7 +605,7 @@ describe("fetch entry point", () => {
 
     const cleared = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-clear",
+        `https://example.com/parties/main/example-room/admin/quarantine-clear?token=${TEST_ADMIN_TOKEN}`,
         { method: "POST" }
       )
     );
@@ -615,7 +617,7 @@ describe("fetch entry point", () => {
 
     const status = await server.fetch(
       new Request(
-        "https://example.com/parties/main/example-room/admin/quarantine-status",
+        `https://example.com/parties/main/example-room/admin/quarantine-status?token=${TEST_ADMIN_TOKEN}`,
         { method: "GET" }
       )
     );

--- a/partykit/adminAuth.ts
+++ b/partykit/adminAuth.ts
@@ -4,7 +4,21 @@ export function getAdminAuthError(
   request: Request,
   adminToken: string | undefined
 ): Response | null {
-  if (!adminToken) return null;
+  // Fail closed: a missing ADMIN_TOKEN (unset secret, misconfigured
+  // deployment) must not silently authorize every admin request — these
+  // routes can overwrite or destroy live room data.
+  if (!adminToken) {
+    return new Response(
+      JSON.stringify({ error: "Admin endpoint misconfigured: ADMIN_TOKEN is not set" }),
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        },
+      }
+    );
+  }
 
   const url = new URL(request.url);
   const token =


### PR DESCRIPTION
## Summary

`getAdminAuthError` (`partykit/adminAuth.ts`) returned `null` (authorized) whenever `adminToken` was falsy: `if (!adminToken) return null;`. If `ADMIN_TOKEN` is ever unset for a deployment — a misconfigured secret, a new preview/staging environment spun up without it — every admin route becomes open with no authentication, including hard-reset and raw-snapshot-restore, both of which can overwrite or destroy live room data. This is a fail-*open* default rather than fail-closed.

Fix: treat a missing token as a 500 config error rather than an authorization pass.

## Verification

- `bun run check:partykit` — clean
- `bun test` in `partykit/` — 295/295 pass, including a new dedicated `adminAuth.test.ts` (6 tests covering the missing-token, empty-token, wrong-token, and correct-token-via-query-param/header cases)
- This change makes every admin-route test that previously ran with no token now need one — updated `quarantineLoad.test.ts` and `quarantinePlatformEntry.test.ts` to configure an `ADMIN_TOKEN` in their mocked env and pass a matching `?token=` on each admin request they exercise, so those tests keep asserting the actual route behavior they were written for rather than incidentally hitting a new 500

Found via a scheduled read-only codebase audit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ebz8Lu77mpaaAGPSfY6Fxk)_