### PR TITLE
Fix large WWO data exports

### DIFF
--- a/extension/src/entrypoints/background.ts
+++ b/extension/src/entrypoints/background.ts
@@ -24,7 +24,7 @@ import {
 } from '../storage/playerIdentity'
 import { syncStoredPlayerColor } from '../storage/playerColor'
 import { VERBOSE } from '../config'
-import { gzipString, gunzipToString } from '../utils/dataTransfer'
+import { gzipEventExport, gunzipToString } from '../utils/dataTransfer'
 import { normalizeUrl, extractDomain } from '../utils/urlNormalization'
 import {
   loadState,
@@ -1009,13 +1009,11 @@ export default defineBackground(() => {
         try {
           const events = await store.getAllEvents()
           const identity = await getPublicPlayerIdentity()
-          const payload = JSON.stringify({
-            version: 1,
-            exportedAt: Date.now(),
+          const compressed = await gzipEventExport(
             events,
             identity,
-          })
-          const compressed = await gzipString(payload)
+            Date.now(),
+          )
           reply({ success: true, data: Array.from(compressed) })
         } catch (e) {
           console.error('[Background] EXPORT_EVENTS error:', e)

--- a/extension/src/utils/dataTransfer.test.ts
+++ b/extension/src/utils/dataTransfer.test.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Verifies extension data export compression and JSON reconstruction.
+// ABOUTME: Protects large exports from requiring one full-size JSON string.
+
+import { describe, expect, it, vi } from "vitest";
+import type { CollectionEvent } from "@playhtml/extension-types";
+import { gunzipToString, gzipEventExport } from "./dataTransfer";
+
+describe("gzipEventExport", () => {
+  it("serializes each event separately while preserving the export format", async () => {
+    const events = [
+      { id: "event-1", type: "cursor", ts: 1, data: { x: 10, y: 20 } },
+      { id: "event-2", type: "click", ts: 2, data: { x: 30, y: 40 } },
+    ] as CollectionEvent[];
+    const identity = {
+      publicKey: "pk_test",
+      playerStyle: { colorPalette: ["#4a9a8a"] },
+    };
+    const stringify = vi.spyOn(JSON, "stringify");
+
+    const compressed = await gzipEventExport(events, identity, 123);
+    const parsed = JSON.parse(await gunzipToString(compressed));
+
+    expect(parsed).toEqual({ version: 1, exportedAt: 123, events, identity });
+    expect(stringify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ events }),
+    );
+    expect(stringify).toHaveBeenCalledWith(events[0]);
+    expect(stringify).toHaveBeenCalledWith(events[1]);
+  });
+});

--- a/extension/src/utils/dataTransfer.ts
+++ b/extension/src/utils/dataTransfer.ts
@@ -1,32 +1,46 @@
 // ABOUTME: Gzip compression/decompression helpers using the browser's built-in CompressionStream API
 // ABOUTME: Used for export/import of local event data as compact .json.gz files
 
-export async function gzipString(str: string): Promise<Uint8Array> {
+import type { PlayerIdentity } from "@playhtml/common";
+import type { CollectionEvent } from "@playhtml/extension-types";
+
+async function gzipChunks(chunks: Iterable<string>): Promise<Uint8Array> {
   const encoder = new TextEncoder();
-  const input = encoder.encode(str);
-  const cs = new CompressionStream('gzip');
+  const cs = new CompressionStream("gzip");
+  const compressed = new Response(cs.readable).arrayBuffer();
   const writer = cs.writable.getWriter();
-  writer.write(input);
-  writer.close();
-  const chunks: Uint8Array[] = [];
-  const reader = cs.readable.getReader();
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-  }
-  const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
-  const result = new Uint8Array(totalLength);
-  let offset = 0;
+
   for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
+    await writer.write(encoder.encode(chunk));
   }
-  return result;
+  await writer.close();
+
+  return new Uint8Array(await compressed);
+}
+
+export async function gzipString(str: string): Promise<Uint8Array> {
+  return gzipChunks([str]);
+}
+
+export async function gzipEventExport(
+  events: CollectionEvent[],
+  identity: PlayerIdentity | null,
+  exportedAt: number,
+): Promise<Uint8Array> {
+  function* jsonChunks(): Generator<string> {
+    yield `{"version":1,"exportedAt":${exportedAt},"events":[`;
+    for (let index = 0; index < events.length; index++) {
+      if (index > 0) yield ",";
+      yield JSON.stringify(events[index]);
+    }
+    yield `],"identity":${JSON.stringify(identity)}}`;
+  }
+
+  return gzipChunks(jsonChunks());
 }
 
 export async function gunzipToString(data: Uint8Array): Promise<string> {
-  const ds = new DecompressionStream('gzip');
+  const ds = new DecompressionStream("gzip");
   const writer = ds.writable.getWriter();
   const input = new Uint8Array(data.length);
   input.set(data);


### PR DESCRIPTION
## Summary

- Stream each event into gzip instead of building one full-size JSON string.
- Preserve the existing version 1 export format.
- Add regression coverage for incremental serialization and round-trip decompression.

## Why

Large local archives could exceed V8's maximum string length during `JSON.stringify`, before compression started. Arc then reported `RangeError: Invalid string length` and the export failed.

## Verification

- `bun run check:extension`
- `bun run test:extension` (141 files, 904 tests)
- Development extension build with the loopback Worker configuration
- Isolated Chromium loaded the built MV3 extension and seeded 2,000 events through the background worker. Exporting from Options → Your data downloaded a 16.5 MB gzip that decompressed to 22.5 MB of valid version 1 JSON with all event IDs present in order.

Visual evidence is attached in the PR Evidence comment.

## Documentation

No docs, starter template, changeset, or permission updates are needed. This changes the extension's internal export implementation without changing its file format or public API.
