### PR TITLE
Fix Internet Commute train assignment

### DIFF
--- a/extension/PENDING.md
+++ b/extension/PENDING.md
@@ -3,6 +3,7 @@
 - Slow Mode commute rides now connect reliably when the hosted route loads before the extension.
 - Internet Commute now stops counting riders after they leave and always shows the train pull-up and cursor boarding intro for Slow Mode rides.
 - Internet Commute now starts a fresh route after returning to home station.
+- Internet Commute now keeps active riders together and gives each new train different stops.
 
 <!--
 Add a bullet here in any PR that touches extension/**. The release-prep workflow

--- a/extension/src/entrypoints/commute/commute.tsx
+++ b/extension/src/entrypoints/commute/commute.tsx
@@ -305,6 +305,7 @@ function useCommuteTrain(
           refreshTimer = window.setTimeout(() => void board(), 3_000);
         } else {
           setConnection((current) => ({ ...current, status: "error" }));
+          refreshTimer = window.setTimeout(() => void board(), 3_000);
         }
       }
     };

--- a/extension/src/entrypoints/commute/commuteTrain.test.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.test.ts
@@ -60,20 +60,25 @@ describe("commute train client", () => {
     expect(getCommuteRiderToken(null)).toBe(nextToken);
   });
 
-  it("refreshes open trains and reboards riders after completion", () => {
+  it("refreshes active rider leases and reboards riders after completion", () => {
     expect(getCommuteTrainNextAction(assignment)).toEqual({
       kind: "refresh",
-      delayMs: 3_000,
+      delayMs: 5_000,
     });
     expect(
-      getCommuteTrainNextAction(
-        { ...assignment, joinable: false, serverNow: 75_000 },
-      ),
-    ).toEqual({ kind: "reboard", delayMs: 5_000 });
+      getCommuteTrainNextAction({
+        ...assignment,
+        joinable: false,
+        serverNow: 75_000,
+      }),
+    ).toEqual({ kind: "refresh", delayMs: 5_000 });
     expect(
-      getCommuteTrainNextAction(
-        { ...assignment, joinable: false, serverNow: 85_000, phase: "complete" },
-      ),
+      getCommuteTrainNextAction({
+        ...assignment,
+        joinable: false,
+        serverNow: 85_000,
+        phase: "complete",
+      }),
     ).toEqual({ kind: "reboard", delayMs: 0 });
   });
 

--- a/extension/src/entrypoints/commute/commuteTrain.ts
+++ b/extension/src/entrypoints/commute/commuteTrain.ts
@@ -11,7 +11,7 @@ import type { HostedSlowModeRide } from "../../features/slowMode/slowModeHostedB
 import type { CommuteStop } from "./commuteStops";
 
 const COMMUTE_RIDER_TOKEN_KEY = "wwo-commute-rider-token";
-const COMMUTE_TRAIN_REFRESH_MS = 3_000;
+const COMMUTE_TRAIN_REFRESH_MS = 5_000;
 
 export type CommuteTrainNextAction =
   | { kind: "refresh"; delayMs: number }
@@ -93,7 +93,7 @@ export function rotateCommuteRiderToken(): string {
 export function getCommuteTrainNextAction(
   assignment: CommuteTrainAssignment,
 ): CommuteTrainNextAction {
-  if (assignment.joinable) {
+  if (assignment.phase !== "complete") {
     return { kind: "refresh", delayMs: COMMUTE_TRAIN_REFRESH_MS };
   }
   return {

--- a/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
+++ b/extension/worker/src/__tests__/commuteTrainDispatcher.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   CommuteTrainDispatcher,
   CommuteTrainCapacityError,
+  COMMUTE_TRAIN_RIDER_LEASE_MS,
   EMPTY_COMMUTE_TRAIN_DISPATCHER_STATE,
   MAX_RETAINED_COMMUTE_TRAINS,
 } from '../commuteTrainDispatcher';
@@ -35,15 +36,10 @@ const COMMUNAL_STOPS: CommuteTrainCommunalStop[] = [
   },
 ];
 
-function rider(
-  riderToken: string,
-  domain?: string,
-): CommuteTrainBoardRequest {
+function rider(riderToken: string, domain?: string): CommuteTrainBoardRequest {
   return {
     riderToken,
-    requestedStop: domain
-      ? { kind: 'domain', domain }
-      : { kind: 'none' },
+    requestedStop: domain ? { kind: 'domain', domain } : { kind: 'none' },
   };
 }
 
@@ -62,18 +58,99 @@ describe('CommuteTrainDispatcher', () => {
       subject.board(rider(`rider-${index}`), COMMUNAL_STOPS, NOW),
     );
 
-    expect(new Set(assignments.map((assignment) => assignment.trainId)).size).toBe(25);
-    expect(Math.max(...assignments.map((assignment) => assignment.riderCount))).toBe(4);
+    expect(
+      new Set(assignments.map((assignment) => assignment.trainId)).size,
+    ).toBe(25);
+    expect(
+      Math.max(...assignments.map((assignment) => assignment.riderCount)),
+    ).toBe(4);
   });
 
   it('returns the same assignment for an idempotent rider request', () => {
     const subject = dispatcher();
-    const first = subject.board(rider('rider-a', 'example.com'), COMMUNAL_STOPS, NOW);
-    const repeated = subject.board(rider('rider-a', 'other.example'), [], NOW + 10_000);
+    const first = subject.board(
+      rider('rider-a', 'example.com'),
+      COMMUNAL_STOPS,
+      NOW,
+    );
+    const repeated = subject.board(
+      rider('rider-a', 'other.example'),
+      [],
+      NOW + 10_000,
+    );
 
     expect(repeated.trainId).toBe(first.trainId);
     expect(repeated.routeVersion).toBe(first.routeVersion);
     expect(repeated.stops).toEqual(first.stops);
+  });
+
+  it('reuses capacity after disconnected rider leases expire', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+    subject.board(rider('rider-b'), [], NOW);
+    subject.board(rider('rider-c'), [], NOW);
+    subject.board(rider('rider-d'), [], NOW);
+
+    const replacement = subject.board(
+      rider('rider-e'),
+      [],
+      NOW + COMMUTE_TRAIN_RIDER_LEASE_MS + 1,
+    );
+
+    expect(replacement.trainId).toBe(first.trainId);
+    expect(replacement.riderCount).toBe(1);
+  });
+
+  it('keeps refreshed rider leases active', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+
+    subject.board(rider('rider-a'), [], NOW + COMMUTE_TRAIN_RIDER_LEASE_MS - 1);
+    const joined = subject.board(
+      rider('rider-b'),
+      [],
+      NOW + COMMUTE_TRAIN_RIDER_LEASE_MS + 1,
+    );
+
+    expect(joined.trainId).toBe(first.trainId);
+    expect(joined.riderCount).toBe(2);
+  });
+
+  it('moves an expired rider when replacement riders fill their train', () => {
+    const subject = dispatcher();
+    const first = subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+    subject.board(rider('rider-b'), [], NOW);
+    subject.board(rider('rider-c'), [], NOW);
+    subject.board(rider('rider-d'), [], NOW);
+    const replacementsAt = NOW + COMMUTE_TRAIN_RIDER_LEASE_MS + 1;
+    subject.board(rider('rider-e'), [], replacementsAt);
+    subject.board(rider('rider-f'), [], replacementsAt);
+    subject.board(rider('rider-g'), [], replacementsAt);
+    subject.board(rider('rider-h'), [], replacementsAt);
+
+    expect(subject.needsCommunalStops('rider-a', replacementsAt + 1)).toBe(
+      true,
+    );
+    const moved = subject.board(
+      rider('rider-a'),
+      COMMUNAL_STOPS,
+      replacementsAt + 1,
+    );
+
+    expect(moved.trainId).not.toBe(first.trainId);
+    expect(moved.riderCount).toBe(1);
+  });
+
+  it('treats deployed rider records without leases as active', () => {
+    const subject = dispatcher();
+    subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+    const state = subject.snapshot();
+    delete state.trains[0].riders['rider-a'].activeUntil;
+
+    const restored = new CommuteTrainDispatcher(state, () => 'restored-id');
+    const joined = restored.board(rider('rider-b'), [], NOW + 20_000);
+
+    expect(joined.riderCount).toBe(2);
   });
 
   it('boards the same rider onto a fresh train after their route completes', () => {
@@ -91,8 +168,16 @@ describe('CommuteTrainDispatcher', () => {
 
   it('appends new domains without reordering existing stops', () => {
     const subject = dispatcher();
-    const first = subject.board(rider('rider-a', 'a.example'), COMMUNAL_STOPS, NOW);
-    const second = subject.board(rider('rider-b', 'b.example'), [], NOW + 20_000);
+    const first = subject.board(
+      rider('rider-a', 'a.example'),
+      COMMUNAL_STOPS,
+      NOW,
+    );
+    const second = subject.board(
+      rider('rider-b', 'b.example'),
+      [],
+      NOW + 20_000,
+    );
 
     expect(second.trainId).toBe(first.trainId);
     expect(second.stops.map((stop) => stop.domain)).toEqual([
@@ -128,6 +213,15 @@ describe('CommuteTrainDispatcher', () => {
     expect(later.trainId).not.toBe(first.trainId);
   });
 
+  it('reports communal domains used by retained trains', () => {
+    const subject = dispatcher();
+    subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
+
+    expect(subject.getRecentCommunalDomains(NOW)).toEqual(
+      new Set(['html.energy', 'special.fish']),
+    );
+  });
+
   it('deletes completed trains after the retention window', () => {
     const subject = dispatcher();
     subject.board(rider('rider-a'), COMMUNAL_STOPS, NOW);
@@ -148,9 +242,9 @@ describe('CommuteTrainDispatcher', () => {
     expect(() =>
       subject.board(rider('rider-over-capacity'), COMMUNAL_STOPS, NOW),
     ).toThrow(CommuteTrainCapacityError);
-    expect(
-      subject.board(rider('rider-0'), [], NOW + 1).trainId,
-    ).toBe(assignments[0].trainId);
+    expect(subject.board(rider('rider-0'), [], NOW + 1).trainId).toBe(
+      assignments[0].trainId,
+    );
     expect(subject.snapshot().trains).toHaveLength(MAX_RETAINED_COMMUTE_TRAINS);
   });
 });

--- a/extension/worker/src/__tests__/commuteTrainDispatcherObject.test.ts
+++ b/extension/worker/src/__tests__/commuteTrainDispatcherObject.test.ts
@@ -1,9 +1,21 @@
 // ABOUTME: Verifies new Internet Commute trains avoid recently used communal stops.
 // ABOUTME: Keeps fallback routes from silently repeating an active train's domains.
 
-import { describe, expect, it } from 'vitest';
-import type { CommuteDestination } from '@playhtml/extension-types';
-import { selectCommuteTrainCommunalStops } from '../commuteTrainDispatcherObject';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  CommuteDestination,
+  CommuteTrainAssignment,
+} from '@playhtml/extension-types';
+import type { Env } from '../lib/supabase';
+
+const getCommuteResponse = vi.hoisted(() => vi.fn());
+
+vi.mock('../routes/commute', () => ({ getCommuteResponse }));
+
+import {
+  CommuteTrainDispatcherObject,
+  selectCommuteTrainCommunalStops,
+} from '../commuteTrainDispatcherObject';
 
 function destination(domain: string): CommuteDestination {
   return {
@@ -43,5 +55,67 @@ describe('selectCommuteTrainCommunalStops', () => {
     );
 
     expect(stops).toEqual([]);
+  });
+
+  it('revalidates routes after concurrent destination loads', async () => {
+    const destinations = [
+      destination('first-one.example'),
+      destination('first-two.example'),
+      destination('second-one.example'),
+      destination('second-two.example'),
+    ];
+    getCommuteResponse.mockImplementation(async () => {
+      await Promise.resolve();
+      return { destinations };
+    });
+    const storage = {
+      get: vi.fn().mockResolvedValue(undefined),
+      put: vi.fn().mockResolvedValue(undefined),
+      setAlarm: vi.fn().mockResolvedValue(undefined),
+      deleteAlarm: vi.fn().mockResolvedValue(undefined),
+    };
+    const state = {
+      storage,
+      blockConcurrencyWhile: <T>(callback: () => Promise<T>) => callback(),
+    } as unknown as DurableObjectState;
+    const dispatcher = new CommuteTrainDispatcherObject(state, {} as Env);
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, (_, index) =>
+        dispatcher.fetch(
+          new Request('https://dispatcher.internal/board', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              riderToken: `commute-rider-0${index}`,
+              requestedStop: { kind: 'none' },
+            }),
+          }),
+        ),
+      ),
+    );
+    const assignments = (await Promise.all(
+      responses.map((response) => response.json()),
+    )) as CommuteTrainAssignment[];
+
+    expect(responses.map(({ status }) => status)).toEqual([
+      200,
+      200,
+      200,
+      200,
+      200,
+    ]);
+    expect(new Set(assignments.slice(0, 4).map(({ trainId }) => trainId))).toEqual(
+      new Set([assignments[0].trainId]),
+    );
+    expect(assignments[4].trainId).not.toBe(assignments[0].trainId);
+    expect(assignments[0].stops.map(({ domain }) => domain)).toEqual([
+      'first-one.example',
+      'first-two.example',
+    ]);
+    expect(assignments[4].stops.map(({ domain }) => domain)).toEqual([
+      'second-one.example',
+      'second-two.example',
+    ]);
   });
 });

--- a/extension/worker/src/__tests__/commuteTrainDispatcherObject.test.ts
+++ b/extension/worker/src/__tests__/commuteTrainDispatcherObject.test.ts
@@ -1,0 +1,47 @@
+// ABOUTME: Verifies new Internet Commute trains avoid recently used communal stops.
+// ABOUTME: Keeps fallback routes from silently repeating an active train's domains.
+
+import { describe, expect, it } from 'vitest';
+import type { CommuteDestination } from '@playhtml/extension-types';
+import { selectCommuteTrainCommunalStops } from '../commuteTrainDispatcherObject';
+
+function destination(domain: string): CommuteDestination {
+  return {
+    id: `https://${domain}/page`,
+    domain,
+    url: `https://${domain}/page`,
+    title: domain,
+    visitedAt: 1_000,
+    hue: '#4a9a8a',
+  };
+}
+
+describe('selectCommuteTrainCommunalStops', () => {
+  it('skips domains already used by retained trains', () => {
+    const stops = selectCommuteTrainCommunalStops(
+      [
+        destination('love2d.org'),
+        destination('jessicabickling.com'),
+        destination('fresh-one.example'),
+        destination('fresh-two.example'),
+      ],
+      new Set(['love2d.org', 'jessicabickling.com']),
+      2_000,
+    );
+
+    expect(stops.map((stop) => stop.domain)).toEqual([
+      'fresh-one.example',
+      'fresh-two.example',
+    ]);
+  });
+
+  it('does not reuse fallback domains from retained trains', () => {
+    const stops = selectCommuteTrainCommunalStops(
+      [],
+      new Set(['html.energy', 'special.fish']),
+      2_000,
+    );
+
+    expect(stops).toEqual([]);
+  });
+});

--- a/extension/worker/src/commuteTrainDispatcher.ts
+++ b/extension/worker/src/commuteTrainDispatcher.ts
@@ -18,6 +18,7 @@ import {
 } from '@playhtml/extension-types';
 
 const COMPLETED_TRAIN_RETENTION_MS = 60_000;
+export const COMMUTE_TRAIN_RIDER_LEASE_MS = 20_000;
 export const MAX_RETAINED_COMMUTE_TRAINS = 64;
 
 export class CommuteTrainCapacityError extends Error {
@@ -29,6 +30,7 @@ export class CommuteTrainCapacityError extends Error {
 
 interface CommuteTrainRider {
   requestedStop: CommuteTrainStopRequest;
+  activeUntil?: number;
 }
 
 interface StoredDomainStop extends CommuteTrainDomainStop {
@@ -71,8 +73,25 @@ function getJoinableUntil(train: CommuteTrainRecord): number {
 
 function isTrainJoinable(train: CommuteTrainRecord, now: number): boolean {
   return (
-    Object.keys(train.riders).length < COMMUTE_TRAIN_CAPACITY &&
+    getActiveRiderCount(train, now) < COMMUTE_TRAIN_CAPACITY &&
     now < getJoinableUntil(train)
+  );
+}
+
+function getActiveRiderCount(train: CommuteTrainRecord, now: number): number {
+  return Object.values(train.riders).filter((rider) =>
+    isRiderActive(train, rider, now),
+  ).length;
+}
+
+function isRiderActive(
+  train: CommuteTrainRecord,
+  rider: CommuteTrainRider,
+  now: number,
+): boolean {
+  return (
+    (rider.activeUntil ??
+      getCommuteTrainRouteEndsAt(train.createdAt, train.stops.length)) > now
   );
 }
 
@@ -102,7 +121,7 @@ function assignmentFor(
       train.stops.length,
     ),
     routeVersion: train.routeVersion,
-    riderCount: Object.keys(train.riders).length,
+    riderCount: getActiveRiderCount(train, now),
     capacity: COMMUTE_TRAIN_CAPACITY,
     joinable: isTrainJoinable(train, now),
     phase: getTrainPhase(train, now),
@@ -149,9 +168,27 @@ export class CommuteTrainDispatcher {
     this.state.trains = retainedTrains.slice(-MAX_RETAINED_COMMUTE_TRAINS);
   }
 
+  getRecentCommunalDomains(now: number): Set<string> {
+    this.cleanup(now);
+    const domains = new Set<string>();
+    for (const train of this.state.trains) {
+      for (const stop of train.stops) {
+        if (stop.kind === 'communal') domains.add(stop.domain);
+      }
+    }
+    return domains;
+  }
+
   needsCommunalStops(riderToken: string, now: number): boolean {
     this.cleanup(now);
-    if (this.findActiveRiderTrain(riderToken, now)) return false;
+    const currentTrain = this.findCurrentRiderTrain(riderToken, now);
+    if (
+      currentTrain &&
+      (isRiderActive(currentTrain, currentTrain.riders[riderToken], now) ||
+        isTrainJoinable(currentTrain, now))
+    ) {
+      return false;
+    }
     if (this.state.trains.some((train) => isTrainJoinable(train, now))) {
       return false;
     }
@@ -168,8 +205,21 @@ export class CommuteTrainDispatcher {
   ): CommuteTrainAssignment {
     this.cleanup(now);
 
-    const existingTrain = this.findActiveRiderTrain(request.riderToken, now);
-    if (existingTrain) return assignmentFor(existingTrain, now);
+    const existingTrain = this.findCurrentRiderTrain(request.riderToken, now);
+    if (
+      existingTrain &&
+      (isRiderActive(
+        existingTrain,
+        existingTrain.riders[request.riderToken],
+        now,
+      ) ||
+        isTrainJoinable(existingTrain, now))
+    ) {
+      existingTrain.riders[request.riderToken].activeUntil =
+        now + COMMUTE_TRAIN_RIDER_LEASE_MS;
+      return assignmentFor(existingTrain, now);
+    }
+    if (existingTrain) delete existingTrain.riders[request.riderToken];
 
     let train = [...this.state.trains]
       .sort((left, right) => left.createdAt - right.createdAt)
@@ -195,6 +245,7 @@ export class CommuteTrainDispatcher {
 
     train.riders[request.riderToken] = {
       requestedStop: request.requestedStop,
+      activeUntil: now + COMMUTE_TRAIN_RIDER_LEASE_MS,
     };
     this.addRequestedStop(train, request.riderToken, request.requestedStop, now);
     train.routeVersion += 1;
@@ -213,7 +264,7 @@ export class CommuteTrainDispatcher {
     return cleanupAt;
   }
 
-  private findActiveRiderTrain(
+  private findCurrentRiderTrain(
     riderToken: string,
     now: number,
   ): CommuteTrainRecord | null {

--- a/extension/worker/src/commuteTrainDispatcherObject.ts
+++ b/extension/worker/src/commuteTrainDispatcherObject.ts
@@ -100,19 +100,27 @@ export class CommuteTrainDispatcherObject {
     const parsed = await readBoardRequest(request);
     if (!parsed) return jsonResponse(400, { error: 'Invalid boarding request' });
 
-    const now = Date.now();
+    let now = Date.now();
     const dispatcher = await this.ready;
     let assignment: CommuteTrainAssignment;
     try {
-      const communalStops = dispatcher.needsCommunalStops(
-        parsed.riderToken,
-        now,
-      )
-        ? await this.loadCommunalStops(
-            now,
-            dispatcher.getRecentCommunalDomains(now),
-          )
-        : [];
+      let destinations: CommuteDestination[] = [];
+      if (dispatcher.needsCommunalStops(parsed.riderToken, now)) {
+        destinations = await this.loadCommunalDestinations(now);
+        now = Date.now();
+      }
+
+      let communalStops: CommuteTrainCommunalStop[] = [];
+      if (dispatcher.needsCommunalStops(parsed.riderToken, now)) {
+        communalStops = selectCommuteTrainCommunalStops(
+          destinations,
+          dispatcher.getRecentCommunalDomains(now),
+          now,
+        );
+        if (communalStops.length < 2) {
+          throw new Error('Internet Commute requires two unseen communal stops');
+        }
+      }
       assignment = dispatcher.board(parsed, communalStops, now);
     } catch (error) {
       if (!(error instanceof CommuteTrainCapacityError)) throw error;
@@ -133,10 +141,9 @@ export class CommuteTrainDispatcherObject {
     await this.scheduleCleanup(dispatcher);
   }
 
-  private async loadCommunalStops(
+  private async loadCommunalDestinations(
     now: number,
-    recentDomains: Set<string>,
-  ): Promise<CommuteTrainCommunalStop[]> {
+  ): Promise<CommuteDestination[]> {
     let destinations: CommuteDestination[] = [];
     try {
       const response = await getCommuteResponse(
@@ -149,15 +156,7 @@ export class CommuteTrainDispatcherObject {
       console.warn('[commute trains] communal route unavailable:', error);
     }
 
-    const stops = selectCommuteTrainCommunalStops(
-      destinations,
-      recentDomains,
-      now,
-    );
-    if (stops.length < 2) {
-      throw new Error('Internet Commute requires two unseen communal stops');
-    }
-    return stops;
+    return destinations;
   }
 
   private async scheduleCleanup(

--- a/extension/worker/src/commuteTrainDispatcherObject.ts
+++ b/extension/worker/src/commuteTrainDispatcherObject.ts
@@ -2,6 +2,7 @@
 // ABOUTME: Loads communal routes only when a new bounded train must be created.
 
 import type {
+  CommuteDestination,
   CommuteTrainAssignment,
   CommuteTrainBoardRequest,
   CommuteTrainCommunalStop,
@@ -39,6 +40,39 @@ const FALLBACK_COMMUNAL_STOPS: CommuteTrainCommunalStop[] = [
   },
 ];
 
+export function selectCommuteTrainCommunalStops(
+  destinations: CommuteDestination[],
+  recentDomains: Set<string>,
+  now: number,
+): CommuteTrainCommunalStop[] {
+  const stops: CommuteTrainCommunalStop[] = [];
+  const selectedDomains = new Set<string>();
+  for (const destination of destinations) {
+    if (
+      recentDomains.has(destination.domain) ||
+      selectedDomains.has(destination.domain)
+    ) {
+      continue;
+    }
+    stops.push({ kind: 'communal', ...destination });
+    selectedDomains.add(destination.domain);
+    if (stops.length === 2) return stops;
+  }
+
+  for (const fallback of FALLBACK_COMMUNAL_STOPS) {
+    if (
+      recentDomains.has(fallback.domain) ||
+      selectedDomains.has(fallback.domain)
+    ) {
+      continue;
+    }
+    stops.push({ ...fallback, visitedAt: now });
+    selectedDomains.add(fallback.domain);
+    if (stops.length === 2) return stops;
+  }
+  return stops;
+}
+
 export class CommuteTrainDispatcherObject {
   private readonly ready: Promise<CommuteTrainDispatcher>;
 
@@ -74,7 +108,10 @@ export class CommuteTrainDispatcherObject {
         parsed.riderToken,
         now,
       )
-        ? await this.loadCommunalStops(now)
+        ? await this.loadCommunalStops(
+            now,
+            dispatcher.getRecentCommunalDomains(now),
+          )
         : [];
       assignment = dispatcher.board(parsed, communalStops, now);
     } catch (error) {
@@ -98,35 +135,29 @@ export class CommuteTrainDispatcherObject {
 
   private async loadCommunalStops(
     now: number,
+    recentDomains: Set<string>,
   ): Promise<CommuteTrainCommunalStop[]> {
-    let destinations: CommuteTrainCommunalStop[] = [];
+    let destinations: CommuteDestination[] = [];
     try {
       const response = await getCommuteResponse(
         new Request('https://dispatcher.internal/commute/recent'),
         this.env,
         now,
       );
-      destinations = response.destinations.slice(0, 2).map((destination) => ({
-        kind: 'communal',
-        id: destination.id,
-        domain: destination.domain,
-        url: destination.url,
-        title: destination.title,
-        visitedAt: destination.visitedAt,
-        hue: destination.hue,
-      }));
+      destinations = response.destinations;
     } catch (error) {
       console.warn('[commute trains] communal route unavailable:', error);
     }
 
-    const domains = new Set(destinations.map((stop) => stop.domain));
-    for (const fallback of FALLBACK_COMMUNAL_STOPS) {
-      if (destinations.length === 2) break;
-      if (domains.has(fallback.domain)) continue;
-      destinations.push({ ...fallback, visitedAt: now });
-      domains.add(fallback.domain);
+    const stops = selectCommuteTrainCommunalStops(
+      destinations,
+      recentDomains,
+      now,
+    );
+    if (stops.length < 2) {
+      throw new Error('Internet Commute requires two unseen communal stops');
     }
-    return destinations;
+    return stops;
   }
 
   private async scheduleCleanup(


### PR DESCRIPTION
## Summary

- count only riders with an active boarding lease when assigning train capacity
- keep rider leases alive throughout the route and retry transient initial boarding failures
- exclude communal destinations used by retained trains when creating a route

## Why

Disconnected rider tokens stayed in dispatcher state for the entire route, so they occupied seats after their browser left. That split four live riders across two train IDs even though each UI correctly showed only its two connected riders. The dispatcher also selected the first two recent destinations for every new train, which made those split trains run identical routes.

## Verification

- `bun run test:extension-worker` — 18 files passed
- `bun run test:extension` — 140 files, 903 tests passed
- `bun run check:extension-worker`
- `bun run check:extension`
- `bun run check:extension-website`
- `WRANGLER_LOG_PATH=/private/tmp/commute-train-wrangler.log bun run smoke:extension-worker`
- automated real-browser flow on the actual Internet Commute page with the production dispatcher and route-selection modules:
  - four simultaneous sessions joined one train
  - after two sessions closed and their leases expired, two replacements reused the open seats on that train
  - a fifth active session created a second train whose two communal stops differed from the first train

Local PlayHTML cursor-presence transport could not connect because this checkout has no PartyKit/Supabase development secrets; the browser verification covers the changed dispatcher admission and route behavior directly.

No package behavior, public core API, manifest permissions, or starter-template usage changed.