### PR TITLE
Add cross-computer live installation playback

### DIFF
--- a/extension/website/installation/live/index.html
+++ b/extension/website/installation/live/index.html
@@ -1,0 +1,34 @@
+<!-- ABOUTME: Hosts the cross-computer live installation field and follower screens. -->
+<!-- ABOUTME: Loads a bare hybrid archive/live canvas with no public portrait chrome. -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="we were online — live installation" />
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,200..900;1,200..900&family=Martian+Mono:wght@100..800&family=Lora:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>live installation — we were online</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background: #faf9f6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./live.tsx"></script>
+  </body>
+</html>

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Renders the dedicated WWO live installation field or deterministic follower view.
-// ABOUTME: Inserts dense live chapters between progressively older archive chapters.
+// ABOUTME: Uses live-forward chapters for movement and rotating reservoirs for typing and scrolling.
 
 import "../../shared/portrait-styles.scss";
 import React, { useEffect, useMemo, useState } from "react";
@@ -56,7 +56,8 @@ const LiveInstallation = () => {
     document.body.dataset.installationView = screen.view;
     document.body.dataset.installationSlot = String(screen.slot);
     document.body.dataset.installationSource = hybrid.source;
-  }, [hybrid.source, screen.slot, screen.view]);
+    document.body.dataset.installationPlaybackKey = hybrid.playbackKey;
+  }, [hybrid.playbackKey, hybrid.source, screen.slot, screen.view]);
 
   return (
     <>

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -1,0 +1,80 @@
+// ABOUTME: Renders the dedicated WWO live installation field or deterministic follower view.
+// ABOUTME: Inserts dense live chapters between progressively older archive chapters.
+
+import "../../shared/portrait-styles.scss";
+import React, { useEffect, useMemo, useState } from "react";
+import ReactDOM from "react-dom/client";
+import { MovementCanvas } from "../../shared/components/MovementCanvas";
+import { LiveIndicator } from "../../shared/components/LiveIndicator";
+import {
+  parseDayFromUrl,
+  parseTimeOfDayFromUrl,
+  parseVizFromUrl,
+} from "../../shared/config";
+import { useHybridInstallationEvents } from "../../shared/hooks/useHybridInstallationEvents";
+import { summarizeActiveLocations } from "../../shared/utils/eventUtils";
+import {
+  LIVE_INSTALLATION_VISUALIZATIONS,
+  parseLiveInstallationScreen,
+} from "../../shared/utils/liveInstallation";
+
+const LiveInstallation = () => {
+  const screen = useMemo(() => parseLiveInstallationScreen(), []);
+  const selectedDay = parseDayFromUrl() ?? null;
+  const timeOfDay = parseTimeOfDayFromUrl() ?? null;
+  const [activeVisualizations] = useState<string[]>(() => {
+    const requested = parseVizFromUrl();
+    if (requested === undefined) return [...LIVE_INSTALLATION_VISUALIZATIONS];
+    const allowed = requested.filter((id) =>
+      LIVE_INSTALLATION_VISUALIZATIONS.includes(
+        id as (typeof LIVE_INSTALLATION_VISUALIZATIONS)[number],
+      ),
+    );
+    return allowed.length > 0 ? allowed : [...LIVE_INSTALLATION_VISUALIZATIONS];
+  });
+  const hybrid = useHybridInstallationEvents({
+    selectedDay,
+    timeOfDay,
+    serverDomain: "",
+    activeVisualizations,
+    screen,
+  });
+  const activity = useMemo(
+    () => summarizeActiveLocations(hybrid.liveEvents),
+    [hybrid.liveEvents],
+  );
+
+  useEffect(() => {
+    document.body.dataset.installationView = screen.view;
+    document.body.dataset.installationSlot = String(screen.slot);
+    document.body.dataset.installationSource = hybrid.source;
+  }, [hybrid.source, screen.slot, screen.view]);
+
+  return (
+    <>
+      <MovementCanvas
+        events={hybrid.events}
+        loading={hybrid.loading}
+        error={hybrid.error}
+        fetchEvents={hybrid.refresh}
+        activeVisualizations={activeVisualizations}
+        onSetActiveVisualizations={() => {}}
+        minimumCleanLevel={2}
+        playbackKey={hybrid.playbackKey}
+        playbackContextKey={hybrid.playbackContextKey}
+        onPlaybackCycleComplete={hybrid.finishChapter}
+      />
+      {screen.view === "field" && (
+        <LiveIndicator
+          connected={hybrid.connected}
+          peopleCount={activity.people}
+          style={{ position: "absolute", bottom: 20, left: 20, zIndex: 100 }}
+        />
+      )}
+    </>
+  );
+};
+
+ReactDOM.createRoot(
+  document.getElementById("reactContent") as HTMLElement,
+).render(<LiveInstallation />);

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -14,9 +14,24 @@ import {
 import { useHybridInstallationEvents } from "../../shared/hooks/useHybridInstallationEvents";
 import { summarizeActiveLocations } from "../../shared/utils/eventUtils";
 import {
+  LIVE_INSTALLATION_VISUALIZATIONS,
   parseLiveInstallationScreen,
   resolveLiveInstallationVisualizations,
 } from "../../shared/utils/liveInstallation";
+
+const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
+  scrollSpeed: 1,
+  backgroundOpacity: 0.8,
+  maxConcurrentScrolls: 30,
+  windowScale: 0.5,
+  showPagePreview: false,
+  showTitleBar: true,
+  allowOverlap: true,
+  windowBleed: 0.45,
+  showScrollEvents: true,
+  showResizeEvents: true,
+  showZoomEvents: true,
+};
 
 const LiveInstallation = () => {
   const screen = useMemo(() => parseLiveInstallationScreen(), []);
@@ -52,6 +67,8 @@ const LiveInstallation = () => {
         fetchEvents={hybrid.refresh}
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
+        availableVisualizations={LIVE_INSTALLATION_VISUALIZATIONS}
+        defaultSettings={LIVE_INSTALLATION_SETTINGS_DEFAULTS}
         minimumCleanLevel={2}
         playbackKey={hybrid.playbackKey}
         playbackContextKey={hybrid.playbackContextKey}

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -71,6 +71,7 @@ const LiveInstallation = () => {
         defaultSettings={LIVE_INSTALLATION_SETTINGS_DEFAULTS}
         minimumCleanLevel={2}
         playbackKey={hybrid.playbackKey}
+        playbackSource={hybrid.source}
         playbackContextKey={hybrid.playbackContextKey}
         onPlaybackCycleComplete={hybrid.finishChapter}
       />

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -22,7 +22,7 @@ const LiveInstallation = () => {
   const screen = useMemo(() => parseLiveInstallationScreen(), []);
   const selectedDay = parseDayFromUrl() ?? null;
   const timeOfDay = parseTimeOfDayFromUrl() ?? null;
-  const [activeVisualizations] = useState<string[]>(() =>
+  const [activeVisualizations, setActiveVisualizations] = useState<string[]>(() =>
     resolveLiveInstallationVisualizations(parseVizFromUrl()),
   );
   const hybrid = useHybridInstallationEvents({
@@ -51,7 +51,7 @@ const LiveInstallation = () => {
         error={hybrid.error}
         fetchEvents={hybrid.refresh}
         activeVisualizations={activeVisualizations}
-        onSetActiveVisualizations={() => {}}
+        onSetActiveVisualizations={setActiveVisualizations}
         minimumCleanLevel={2}
         playbackKey={hybrid.playbackKey}
         playbackContextKey={hybrid.playbackContextKey}

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -14,24 +14,17 @@ import {
 import { useHybridInstallationEvents } from "../../shared/hooks/useHybridInstallationEvents";
 import { summarizeActiveLocations } from "../../shared/utils/eventUtils";
 import {
-  LIVE_INSTALLATION_VISUALIZATIONS,
   parseLiveInstallationScreen,
+  resolveLiveInstallationVisualizations,
 } from "../../shared/utils/liveInstallation";
 
 const LiveInstallation = () => {
   const screen = useMemo(() => parseLiveInstallationScreen(), []);
   const selectedDay = parseDayFromUrl() ?? null;
   const timeOfDay = parseTimeOfDayFromUrl() ?? null;
-  const [activeVisualizations] = useState<string[]>(() => {
-    const requested = parseVizFromUrl();
-    if (requested === undefined) return [...LIVE_INSTALLATION_VISUALIZATIONS];
-    const allowed = requested.filter((id) =>
-      LIVE_INSTALLATION_VISUALIZATIONS.includes(
-        id as (typeof LIVE_INSTALLATION_VISUALIZATIONS)[number],
-      ),
-    );
-    return allowed.length > 0 ? allowed : [...LIVE_INSTALLATION_VISUALIZATIONS];
-  });
+  const [activeVisualizations] = useState<string[]>(() =>
+    resolveLiveInstallationVisualizations(parseVizFromUrl()),
+  );
   const hybrid = useHybridInstallationEvents({
     selectedDay,
     timeOfDay,

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -18,6 +18,7 @@ import {
   LIVE_INSTALLATION_VISUALIZATIONS,
   parseLiveInstallationScreen,
   resolveLiveInstallationVisualizations,
+  showsInstallationPeopleCount,
 } from "../../shared/utils/liveInstallation";
 
 const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
@@ -78,7 +79,7 @@ const LiveInstallation = () => {
         playbackContextKey={hybrid.playbackContextKey}
         onPlaybackCycleComplete={hybrid.finishChapter}
       />
-      {screen.view === "field" && (
+      {showsInstallationPeopleCount(screen, activeVisualizations) && (
         <LiveIndicator
           connected={hybrid.connected}
           peopleCount={activity.people}

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -20,6 +20,7 @@ import {
   resolveLiveInstallationVisualizations,
   showsInstallationPeopleCount,
 } from "../../shared/utils/liveInstallation";
+import { resolveLiveInstallationProfile } from "../../shared/utils/liveInstallationProfiles";
 
 const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
   scrollSpeed: 1,
@@ -37,11 +38,33 @@ const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
 
 const LiveInstallation = () => {
   useDailyPageReload();
-  const screen = useMemo(() => parseLiveInstallationScreen(), []);
+  const profile = useMemo(() => resolveLiveInstallationProfile(), []);
+  const screen = useMemo(
+    () =>
+      parseLiveInstallationScreen(
+        window.location.search,
+        profile?.screen ?? {
+          view: "field",
+          slot: 0,
+          slots: 4,
+        },
+      ),
+    [profile],
+  );
+  const settingsDefaults = useMemo(
+    () => ({
+      ...LIVE_INSTALLATION_SETTINGS_DEFAULTS,
+      ...(profile?.settings ?? {}),
+    }),
+    [profile],
+  );
   const selectedDay = parseDayFromUrl() ?? null;
   const timeOfDay = parseTimeOfDayFromUrl() ?? null;
-  const [activeVisualizations, setActiveVisualizations] = useState<string[]>(() =>
-    resolveLiveInstallationVisualizations(parseVizFromUrl()),
+  const [activeVisualizations, setActiveVisualizations] = useState<string[]>(
+    () =>
+      resolveLiveInstallationVisualizations(
+        parseVizFromUrl() ?? profile?.visualizations,
+      ),
   );
   const hybrid = useHybridInstallationEvents({
     selectedDay,
@@ -72,7 +95,12 @@ const LiveInstallation = () => {
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
         availableVisualizations={LIVE_INSTALLATION_VISUALIZATIONS}
-        defaultSettings={LIVE_INSTALLATION_SETTINGS_DEFAULTS}
+        defaultSettings={settingsDefaults}
+        useStoredSettings={profile === null}
+        syncSettingsToUrl={profile === null}
+        defaultCinematic={profile?.cinematic}
+        installationRole={profile?.role}
+        installationFollowerId={profile?.followerId}
         minimumCleanLevel={2}
         playbackKey={hybrid.playbackKey}
         playbackSource={hybrid.source}

--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -12,6 +12,7 @@ import {
   parseVizFromUrl,
 } from "../../shared/config";
 import { useHybridInstallationEvents } from "../../shared/hooks/useHybridInstallationEvents";
+import { useDailyPageReload } from "../../shared/hooks/useDailyPageReload";
 import { summarizeActiveLocations } from "../../shared/utils/eventUtils";
 import {
   LIVE_INSTALLATION_VISUALIZATIONS,
@@ -34,6 +35,7 @@ const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
 };
 
 const LiveInstallation = () => {
+  useDailyPageReload();
   const screen = useMemo(() => parseLiveInstallationScreen(), []);
   const selectedDay = parseDayFromUrl() ?? null;
   const timeOfDay = parseTimeOfDayFromUrl() ?? null;

--- a/extension/website/installation/live/setup/index.html
+++ b/extension/website/installation/live/setup/index.html
@@ -1,0 +1,28 @@
+<!-- ABOUTME: Hosts the setup utility for generating cross-computer live installation URLs. -->
+<!-- ABOUTME: Provides copy and open actions for one field and its follower screens. -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>live installation setup — we were online</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        min-height: 100%;
+        background: #faf9f6;
+        color: #3d3833;
+      }
+
+      button,
+      input {
+        font: inherit;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="reactContent"></div>
+    <script type="module" src="./setup.tsx"></script>
+  </body>
+</html>

--- a/extension/website/installation/live/setup/setup.tsx
+++ b/extension/website/installation/live/setup/setup.tsx
@@ -1,0 +1,147 @@
+// ABOUTME: Generates and operates the field and follower links for a live installation.
+// ABOUTME: Keeps the screen count explicit while participant assignment remains automatic.
+
+import React, { useMemo, useState } from "react";
+import ReactDOM from "react-dom/client";
+import { buildLiveInstallationScreens } from "../../../shared/utils/installationUrls";
+
+const buttonStyle: React.CSSProperties = {
+  border: "1px solid rgba(61, 56, 51, 0.2)",
+  borderRadius: 4,
+  padding: "6px 10px",
+  background: "#fdfcf9",
+  color: "#3d3833",
+  cursor: "pointer",
+};
+
+const LiveInstallationSetup = () => {
+  const [followerCount, setFollowerCount] = useState(4);
+  const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
+  const screens = useMemo(
+    () => buildLiveInstallationScreens(window.location.origin, followerCount),
+    [followerCount],
+  );
+
+  const copy = async (url: string) => {
+    await navigator.clipboard.writeText(url);
+    setCopiedUrl(url);
+    window.setTimeout(
+      () => setCopiedUrl((current) => (current === url ? null : current)),
+      1500,
+    );
+  };
+
+  return (
+    <main
+      style={{
+        width: "min(920px, calc(100% - 40px))",
+        margin: "0 auto",
+        padding: "56px 0",
+        fontFamily: "'Source Serif 4', Georgia, serif",
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: 38, fontStyle: "italic", fontWeight: 300 }}>
+        live installation setup
+      </h1>
+      <p style={{ maxWidth: 620, color: "#726b64", lineHeight: 1.5 }}>
+        Open the field on the main screen and one numbered follower on each close-up
+        screen. Each follower owns a different set of people automatically.
+      </p>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          margin: "28px 0 18px",
+          fontFamily: "'Martian Mono', monospace",
+          fontSize: 12,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+        }}
+      >
+        <span>Follower screens</span>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => setFollowerCount((count) => Math.max(1, count - 1))}
+          aria-label="Remove one follower screen"
+        >
+          −
+        </button>
+        <strong style={{ minWidth: 20, textAlign: "center" }}>{followerCount}</strong>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => setFollowerCount((count) => Math.min(32, count + 1))}
+          aria-label="Add one follower screen"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          style={{ ...buttonStyle, marginLeft: "auto" }}
+          onClick={() => screens.forEach((screen) => window.open(screen.url, "_blank"))}
+        >
+          open all
+        </button>
+      </div>
+
+      <ol style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {screens.map((screen) => (
+          <li
+            key={screen.label}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "110px minmax(0, 1fr) auto auto",
+              alignItems: "center",
+              gap: 10,
+              padding: "10px 0",
+              borderTop: "1px solid rgba(61, 56, 51, 0.1)",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: "'Martian Mono', monospace",
+                fontSize: 11,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                color: screen.role === "master" ? "#c4724e" : "#4a9a8a",
+              }}
+            >
+              {screen.label}
+            </span>
+            <code
+              title={screen.url}
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                padding: "7px 9px",
+                borderRadius: 4,
+                background: "#f5f0e8",
+                color: "#5b8db8",
+              }}
+            >
+              {screen.url}
+            </code>
+            <button type="button" style={buttonStyle} onClick={() => copy(screen.url)}>
+              {copiedUrl === screen.url ? "copied" : "copy"}
+            </button>
+            <button
+              type="button"
+              style={buttonStyle}
+              onClick={() => window.open(screen.url, "_blank", "noopener")}
+            >
+              open
+            </button>
+          </li>
+        ))}
+      </ol>
+    </main>
+  );
+};
+
+ReactDOM.createRoot(
+  document.getElementById("reactContent") as HTMLElement,
+).render(<LiveInstallationSetup />);

--- a/extension/website/installation/live/setup/setup.tsx
+++ b/extension/website/installation/live/setup/setup.tsx
@@ -15,11 +15,10 @@ const buttonStyle: React.CSSProperties = {
 };
 
 const LiveInstallationSetup = () => {
-  const [followerCount, setFollowerCount] = useState(4);
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const screens = useMemo(
-    () => buildLiveInstallationScreens(window.location.origin, followerCount),
-    [followerCount],
+    () => buildLiveInstallationScreens(window.location.origin),
+    [],
   );
 
   const copy = async (url: string) => {
@@ -45,8 +44,8 @@ const LiveInstallationSetup = () => {
       </h1>
       <p style={{ maxWidth: 620, color: "#726b64", lineHeight: 1.5 }}>
         Open one link on each display: four event views, the cursor field, and
-        one cursor follower per close-up screen. Each follower owns a different
-        set of people automatically.
+        four cursor followers. Each follower owns a different set of people
+        automatically.
       </p>
 
       <div
@@ -61,24 +60,7 @@ const LiveInstallationSetup = () => {
           letterSpacing: "0.05em",
         }}
       >
-        <span>Cursor follower screens</span>
-        <button
-          type="button"
-          style={buttonStyle}
-          onClick={() => setFollowerCount((count) => Math.max(1, count - 1))}
-          aria-label="Remove one follower screen"
-        >
-          −
-        </button>
-        <strong style={{ minWidth: 20, textAlign: "center" }}>{followerCount}</strong>
-        <button
-          type="button"
-          style={buttonStyle}
-          onClick={() => setFollowerCount((count) => Math.min(32, count + 1))}
-          aria-label="Add one follower screen"
-        >
-          +
-        </button>
+        <span>Nine named installation screens</span>
         <button
           type="button"
           style={{ ...buttonStyle, marginLeft: "auto" }}

--- a/extension/website/installation/live/setup/setup.tsx
+++ b/extension/website/installation/live/setup/setup.tsx
@@ -44,8 +44,9 @@ const LiveInstallationSetup = () => {
         live installation setup
       </h1>
       <p style={{ maxWidth: 620, color: "#726b64", lineHeight: 1.5 }}>
-        Open the field on the main screen and one numbered follower on each close-up
-        screen. Each follower owns a different set of people automatically.
+        Open one link on each display: four event views, the cursor field, and
+        one cursor follower per close-up screen. Each follower owns a different
+        set of people automatically.
       </p>
 
       <div
@@ -60,7 +61,7 @@ const LiveInstallationSetup = () => {
           letterSpacing: "0.05em",
         }}
       >
-        <span>Follower screens</span>
+        <span>Cursor follower screens</span>
         <button
           type="button"
           style={buttonStyle}

--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -21,8 +21,6 @@ export interface ScheduledClick {
 
 export const MAX_VISIBLE_CLICK_EFFECTS = 4000;
 
-const RECENT_COMPLETED_CLICK_EFFECTS = 1000;
-const COMPLETED_RESIDUE_OPACITY = 0.5;
 const MINIMUM_RESIDUE_OPACITY = 0.03;
 
 export function getClickResidueOpacity(
@@ -33,23 +31,11 @@ export function getClickResidueOpacity(
   if (!completed) return 1;
 
   const distanceFromNewest = total - index - 1;
-  if (distanceFromNewest < RECENT_COMPLETED_CLICK_EFFECTS) {
-    return COMPLETED_RESIDUE_OPACITY;
-  }
-
-  const fadedCapacity =
-    MAX_VISIBLE_CLICK_EFFECTS - RECENT_COMPLETED_CLICK_EFFECTS;
   const fadeProgress = Math.min(
     1,
-    (distanceFromNewest - RECENT_COMPLETED_CLICK_EFFECTS) /
-      Math.max(1, fadedCapacity - 1),
+    distanceFromNewest / Math.max(1, MAX_VISIBLE_CLICK_EFFECTS - 1),
   );
-  return (
-    COMPLETED_RESIDUE_OPACITY -
-    (COMPLETED_RESIDUE_OPACITY - MINIMUM_RESIDUE_OPACITY) *
-      fadeProgress *
-      fadeProgress
-  );
+  return 1 - (1 - MINIMUM_RESIDUE_OPACITY) * fadeProgress;
 }
 
 export type VisibleClickEffect = ClickEffect & {
@@ -280,7 +266,7 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
               activeClickEffects.length,
               effect.completed,
             )}
-            style={{ transition: "opacity 3000ms ease-out" }}
+            style={{ transition: "opacity 200ms linear" }}
           >
             <RippleEffect
               effect={effect}

--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -19,7 +19,25 @@ export interface ScheduledClick {
   holdDuration?: number;
 }
 
-export const MAX_VISIBLE_CLICK_EFFECTS = 2000;
+export const MAX_VISIBLE_CLICK_EFFECTS = 4000;
+
+const FULL_OPACITY_RESIDUE_FRACTION = 0.25;
+const MINIMUM_RESIDUE_OPACITY = 0.03;
+
+export function getClickResidueOpacity(index: number, total: number): number {
+  if (total <= 1) return 1;
+
+  const fadedCount = Math.floor(
+    total * (1 - FULL_OPACITY_RESIDUE_FRACTION),
+  );
+  if (index >= fadedCount) return 1;
+
+  const fadeProgress = index / Math.max(1, fadedCount);
+  return (
+    MINIMUM_RESIDUE_OPACITY +
+    (1 - MINIMUM_RESIDUE_OPACITY) * fadeProgress * fadeProgress
+  );
+}
 
 export type VisibleClickEffect = ClickEffect & {
   sourceId: string;
@@ -238,13 +256,21 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
           pointerEvents: "none",
         }}
       >
-        {activeClickEffects.map((effect) => (
-          <RippleEffect
+        {activeClickEffects.map((effect, index) => (
+          <g
             key={effect.id}
-            effect={effect}
-            settings={rippleSettings}
-            onComplete={handleClickComplete}
-          />
+            opacity={getClickResidueOpacity(
+              index,
+              activeClickEffects.length,
+            )}
+            style={{ transition: "opacity 200ms linear" }}
+          >
+            <RippleEffect
+              effect={effect}
+              settings={rippleSettings}
+              onComplete={handleClickComplete}
+            />
+          </g>
         ))}
       </svg>
     );

--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -21,37 +21,47 @@ export interface ScheduledClick {
 
 export const MAX_VISIBLE_CLICK_EFFECTS = 4000;
 
-const FULL_OPACITY_RESIDUE_FRACTION = 0.25;
+const RECENT_COMPLETED_CLICK_EFFECTS = 1000;
+const COMPLETED_RESIDUE_OPACITY = 0.5;
 const MINIMUM_RESIDUE_OPACITY = 0.03;
 
-export function getClickResidueOpacity(index: number, total: number): number {
-  if (total <= 1) return 1;
+export function getClickResidueOpacity(
+  index: number,
+  total: number,
+  completed: boolean,
+): number {
+  if (!completed) return 1;
 
-  const fadedCount = Math.floor(
-    total * (1 - FULL_OPACITY_RESIDUE_FRACTION),
+  const distanceFromNewest = total - index - 1;
+  if (distanceFromNewest < RECENT_COMPLETED_CLICK_EFFECTS) {
+    return COMPLETED_RESIDUE_OPACITY;
+  }
+
+  const fadedCapacity =
+    MAX_VISIBLE_CLICK_EFFECTS - RECENT_COMPLETED_CLICK_EFFECTS;
+  const fadeProgress = Math.min(
+    1,
+    (distanceFromNewest - RECENT_COMPLETED_CLICK_EFFECTS) /
+      Math.max(1, fadedCapacity - 1),
   );
-  if (index >= fadedCount) return 1;
-
-  const fadeProgress = index / Math.max(1, fadedCount);
   return (
-    MINIMUM_RESIDUE_OPACITY +
-    (1 - MINIMUM_RESIDUE_OPACITY) * fadeProgress * fadeProgress
+    COMPLETED_RESIDUE_OPACITY -
+    (COMPLETED_RESIDUE_OPACITY - MINIMUM_RESIDUE_OPACITY) *
+      fadeProgress *
+      fadeProgress
   );
 }
 
 export type VisibleClickEffect = ClickEffect & {
   sourceId: string;
+  completed: boolean;
 };
 
 export function mergeClickEffects(
   current: VisibleClickEffect[],
   incoming: VisibleClickEffect[],
 ): VisibleClickEffect[] {
-  const incomingSourceIds = new Set(incoming.map((effect) => effect.sourceId));
-  return [
-    ...current.filter((effect) => !incomingSourceIds.has(effect.sourceId)),
-    ...incoming,
-  ].slice(-MAX_VISIBLE_CLICK_EFFECTS);
+  return [...current, ...incoming].slice(-MAX_VISIBLE_CLICK_EFFECTS);
 }
 
 interface AnimatedClicksProps {
@@ -91,6 +101,11 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       if (currentCycleEffectIdsRef.current.has(id)) {
         completedCycleEffectIdsRef.current.add(id);
       }
+      setActiveClickEffects((effects) =>
+        effects.map((effect) =>
+          effect.id === id ? { ...effect, completed: true } : effect,
+        ),
+      );
     }, []);
 
     // Microtask-batched commits so multiple per-frame spawns don't each cause
@@ -188,6 +203,7 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
               startTime: Date.now(),
               trailIndex: 0,
               holdDuration: sc.holdDuration,
+              completed: false,
             });
           }
         }
@@ -262,8 +278,9 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
             opacity={getClickResidueOpacity(
               index,
               activeClickEffects.length,
+              effect.completed,
             )}
-            style={{ transition: "opacity 200ms linear" }}
+            style={{ transition: "opacity 3000ms ease-out" }}
           >
             <RippleEffect
               effect={effect}

--- a/extension/website/shared/components/AnimatedTyping.tsx
+++ b/extension/website/shared/components/AnimatedTyping.tsx
@@ -33,10 +33,20 @@ interface AnimatedTypingProps {
   typingStates: TypingState[];
   timeRange: { min: number; max: number; duration: number };
   settings: TypingSettings;
+  repeatAnimations?: boolean;
 }
 
 export const COMPLETED_TYPING_VISIBLE_COUNT = 50;
 const HIDDEN_TAB_TICK_MS = 100;
+
+export function getTypingPlaybackElapsed(
+  elapsedMs: number,
+  durationMs: number,
+  repeat: boolean,
+): number {
+  if (durationMs <= 0) return 0;
+  return repeat ? elapsedMs % durationMs : Math.min(elapsedMs, durationMs);
+}
 
 interface TypingTrackAction extends TypingAction {
   endTimestamp: number;
@@ -484,7 +494,7 @@ const TypingBox = memo(
 );
 
 export const AnimatedTyping: React.FC<AnimatedTypingProps> = memo(
-  ({ typingStates, timeRange, settings }) => {
+  ({ typingStates, timeRange, settings, repeatAnimations = true }) => {
     const [activeTypings, setActiveTypings] = useState<ActiveTyping[]>([]);
     const animationRef = useRef<number | undefined>(undefined);
     const timeoutRef = useRef<number | undefined>(undefined);
@@ -583,9 +593,13 @@ export const AnimatedTyping: React.FC<AnimatedTypingProps> = memo(
 
         const realElapsed = timestamp - startTime;
         const scaledElapsed = realElapsed * settingsRef.current.animationSpeed;
-        const loopedElapsed = scaledElapsed % timeRange.duration;
+        const loopedElapsed = getTypingPlaybackElapsed(
+          scaledElapsed,
+          timeRange.duration,
+          repeatAnimations,
+        );
 
-        if (loopedElapsed < prevElapsedRef.current) {
+        if (repeatAnimations && loopedElapsed < prevElapsedRef.current) {
           resetPlaybackTrackers();
         }
         prevElapsedRef.current = loopedElapsed;
@@ -744,7 +758,7 @@ export const AnimatedTyping: React.FC<AnimatedTypingProps> = memo(
       scheduleNextFrame();
 
       return clearScheduledFrame;
-    }, [schedule, timeRange.duration, typingStates.length]);
+    }, [repeatAnimations, schedule, timeRange.duration, typingStates.length]);
 
     const tracksById = useMemo(() => {
       const m = new Map<string, TypingTrack>();

--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -42,7 +42,7 @@ export function getRippleLifecycle(
     rippleSettings.clickRingDelayMs;
   const completedAt =
     effect.startTime +
-    Math.min(effectTotalDuration, outerRingStartDelay + expansionDuration);
+    Math.max(effectTotalDuration, outerRingStartDelay + expansionDuration);
 
   return {
     holdMultiplier,

--- a/extension/website/shared/components/Controls.tsx
+++ b/extension/website/shared/components/Controls.tsx
@@ -47,6 +47,7 @@ interface ControlsProps {
   timeRange: { min: number; max: number; duration: number };
   activeVisualizations: string[];
   onSetActiveVisualizations: (vizIds: string[]) => void;
+  availableVisualizations?: readonly string[];
   /** When non-null, the canvas is scoped to this absolute-time window. */
   selectedTimeRange?: { startMs: number; endMs: number } | null;
   /** Set/clear the canvas time-range filter from the Hotspots panel. */
@@ -724,6 +725,7 @@ export const Controls: React.FC<ControlsProps> = memo(
     timeRange,
     activeVisualizations,
     onSetActiveVisualizations,
+    availableVisualizations,
     selectedTimeRange,
     onSelectTimeRange,
   }) => {
@@ -934,7 +936,11 @@ export const Controls: React.FC<ControlsProps> = memo(
                 marginTop: "4px",
               }}
             >
-              {VISUALIZATIONS.map((viz) => {
+              {VISUALIZATIONS.filter(
+                (viz) =>
+                  availableVisualizations === undefined ||
+                  availableVisualizations.includes(viz.id),
+              ).map((viz) => {
                 const isActive = activeVisualizations.includes(viz.id);
                 return (
                   <React.Fragment key={viz.id}>

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1661,6 +1661,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             typingStates={typingStates}
             timeRange={timeRange}
             settings={typingSettings}
+            repeatAnimations={onPlaybackCycleComplete === undefined}
           />
         )}
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -369,6 +369,8 @@ interface MovementCanvasProps {
   getInstallationElapsedMs?: (animationSpeed: number) => number | null;
   /** Restarts finite archive playback when the parent swaps event batches. */
   playbackKey?: string;
+  /** Labels the developer-console playhead for hybrid archive/live playback. */
+  playbackSource?: "archive" | "live";
   /** Identifies playback batches that belong to the same archive query. */
   playbackContextKey?: string;
   /** Called when finite archive playback reaches the end of its batch. */
@@ -397,6 +399,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   connected = false,
   getInstallationElapsedMs,
   playbackKey = "fixed",
+  playbackSource,
   playbackContextKey = playbackKey,
   onPlaybackCycleComplete,
 }) => {
@@ -1362,8 +1365,11 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
           events={events}
           filteredEventCount={filteredEvents.length}
           trailCount={trails.length}
-          cycleDurationMs={timeRange.duration}
+          cycleDurationMs={playbackCycleDuration}
           animationSpeed={settings.animationSpeed}
+          frozen={paused}
+          playbackKey={playbackKey}
+          playbackSource={playbackSource}
           leftOffset={controlsVisible ? 340 : 16}
           loading={loading}
           error={error}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -350,6 +350,8 @@ interface MovementCanvasProps {
   onSetFilters?: (filters: FilterChip[]) => void;
   activeVisualizations: string[];
   onSetActiveVisualizations: (vizIds: string[]) => void;
+  /** Route-specific visualization ids shown in the developer controls. */
+  availableVisualizations?: readonly string[];
   /** Initial sound-on state. The AudioContext will still start suspended
    * until the user's first gesture (browser autoplay policy). */
   defaultSoundEnabled?: boolean;
@@ -387,6 +389,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   onSetFilters,
   activeVisualizations,
   onSetActiveVisualizations,
+  availableVisualizations,
   defaultSoundEnabled = false,
   defaultSettings,
   minimumCleanLevel = 0,
@@ -1346,6 +1349,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
         timeRange={timeRange}
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={onSetActiveVisualizations}
+        availableVisualizations={availableVisualizations}
         selectedTimeRange={selectedTimeRange}
         onSelectTimeRange={setSelectedTimeRange}
       />

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -355,6 +355,8 @@ interface MovementCanvasProps {
   defaultSoundEnabled?: boolean;
   /** Route-specific defaults applied before stored settings and URL overrides. */
   defaultSettings?: Partial<MovementSettings>;
+  /** Route-enforced presentation floor. URL clean levels can still raise it. */
+  minimumCleanLevel?: 0 | 1 | 2;
   live?: boolean;
   /** Live-stream connection status, gates the people-count readout. */
   connected?: boolean;
@@ -387,6 +389,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   onSetActiveVisualizations,
   defaultSoundEnabled = false,
   defaultSettings,
+  minimumCleanLevel = 0,
   live = false,
   connected = false,
   getInstallationElapsedMs,
@@ -472,6 +475,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   const [captureCleanOverride, setCaptureCleanOverride] = useState(false);
   const cleanLevel = Math.max(
     cleanFromUrl,
+    minimumCleanLevel,
     captureCleanOverride ? 1 : 0,
   ) as 0 | 1 | 2;
   const cleanMode = cleanLevel >= 1; // level 1+: hides sound + readouts

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1149,7 +1149,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     showTyping,
   ]);
 
-  usePlaybackCycle({
+  const getPlaybackElapsedMs = usePlaybackCycle({
     enabled:
       !live &&
       !scrollingControlsPlayback &&
@@ -1370,6 +1370,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
           frozen={paused}
           playbackKey={playbackKey}
           playbackSource={playbackSource}
+          getPlaybackElapsedMs={getPlaybackElapsedMs}
           leftOffset={controlsVisible ? 340 : 16}
           loading={loading}
           error={error}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -56,7 +56,7 @@ import {
   type TimeOfDayFilter,
 } from "../config";
 import type { DayCounts } from "../types";
-import { DEFAULT_SETTINGS } from "./settingsDefaults";
+import { DEFAULT_SETTINGS, type MovementSettings } from "./settingsDefaults";
 import {
   DEFAULT_CINEMATIC_CONFIG,
   type CinematicConfig,
@@ -298,16 +298,17 @@ function playShutterSound() {
 // only persist when the user explicitly modifies a control.
 const SETTINGS_STORAGE_KEY = "internet-movement-settings-v2";
 
-type MovementSettings = typeof DEFAULT_SETTINGS;
-
 const loadSettings = (
   defaultSettings: Partial<MovementSettings> = {},
+  useStoredSettings = true,
 ): MovementSettings => {
   const defaults = { ...DEFAULT_SETTINGS, ...defaultSettings };
   const urlOverrides = parseSettingsFromUrl();
 
   try {
-    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    const stored = useStoredSettings
+      ? localStorage.getItem(SETTINGS_STORAGE_KEY)
+      : null;
     if (stored) {
       const parsed = JSON.parse(stored);
       return {
@@ -357,6 +358,14 @@ interface MovementCanvasProps {
   defaultSoundEnabled?: boolean;
   /** Route-specific defaults applied before stored settings and URL overrides. */
   defaultSettings?: Partial<MovementSettings>;
+  /** Whether this route should use personal defaults saved in this browser. */
+  useStoredSettings?: boolean;
+  /** Whether settings changes should be mirrored into the current URL. */
+  syncSettingsToUrl?: boolean;
+  /** Named-installation defaults; explicit URL parameters still take precedence. */
+  defaultCinematic?: CinematicConfig | null;
+  installationRole?: "master" | "follower" | null;
+  installationFollowerId?: string | null;
   /** Route-enforced presentation floor. URL clean levels can still raise it. */
   minimumCleanLevel?: 0 | 1 | 2;
   live?: boolean;
@@ -394,6 +403,11 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   availableVisualizations,
   defaultSoundEnabled = false,
   defaultSettings,
+  useStoredSettings = true,
+  syncSettingsToUrl = true,
+  defaultCinematic = null,
+  installationRole = null,
+  installationFollowerId = null,
   minimumCleanLevel = 0,
   live = false,
   connected = false,
@@ -407,10 +421,12 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     () => ({ ...DEFAULT_SETTINGS, ...defaultSettings }),
     [defaultSettings],
   );
-  const [settings, setSettings] = useState(() => loadSettings(defaultSettings));
+  const [settings, setSettings] = useState(() =>
+    loadSettings(defaultSettings, useStoredSettings),
+  );
   const [controlsVisible, setControlsVisible] = useState(false);
   const [cinematic, setCinematic] = useState<CinematicConfig | null>(() =>
-    parseCinematicFromUrl(),
+    parseCinematicFromUrl(defaultCinematic),
   );
   // Bumped by the N key to ask the cinematic camera to swap subjects now.
   const [cinematicNextSignal, setCinematicNextSignal] = useState(0);
@@ -419,7 +435,10 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   // filters out cursors other followers are riding so no two screens follow the
   // same cursor. Inert (identity-stable lowest-progress selector, no channel)
   // for every other window. Injected into the cinematic config below.
-  const { isFollower, pickSubject } = useFollowerCoordination();
+  const { isFollower, pickSubject } = useFollowerCoordination({
+    role: installationRole,
+    followerId: installationFollowerId,
+  });
 
   // Merge the coordination selector into the cinematic config in FOLLOW mode
   // only. The camera gives `forcedSubjectIndex` (the `?follow=N` escape hatch)
@@ -641,7 +660,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   // history entry. `replaceState` is cheap, but skipping calls until input
   // settles keeps the URL bar visually quiet during interaction.
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || !syncSettingsToUrl) return;
     const timer = window.setTimeout(() => {
       try {
         const next = buildShareUrl({
@@ -662,7 +681,13 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       }
     }, 200);
     return () => window.clearTimeout(timer);
-  }, [settings, settingsDefaults, activeVisualizations, selectedTimeRange]);
+  }, [
+    settings,
+    settingsDefaults,
+    activeVisualizations,
+    selectedTimeRange,
+    syncSettingsToUrl,
+  ]);
 
   // Keyboard shortcuts:
   //   double-tap D — toggle controls panel

--- a/extension/website/shared/components/StatsConsole.tsx
+++ b/extension/website/shared/components/StatsConsole.tsx
@@ -4,6 +4,7 @@
 import React, { useEffect, useMemo, useRef } from "react";
 import { CollectionEvent } from "../types";
 import { extractDomain } from "../utils/eventUtils";
+import { formatCompactTimeSpan } from "../utils/timeFormat";
 
 interface StatsConsoleProps {
   events: CollectionEvent[];
@@ -167,19 +168,6 @@ function relativeTime(ts: number): string {
     month: "short",
     day: "numeric",
   });
-}
-
-/** Compact duration for the dataset's actual time bounds. The tile tooltip
- * carries the exact start and end timestamps. */
-export function formatCompactTimeSpan(minTs: number, maxTs: number): string {
-  if (!minTs || !maxTs || maxTs <= minTs) return "—";
-  const durationMs = maxTs - minTs;
-  if (durationMs < 60_000) return "<1m";
-  if (durationMs < 60 * 60_000) return `${Math.round(durationMs / 60_000)}m`;
-  if (durationMs < 24 * 60 * 60_000) {
-    return `${(durationMs / (60 * 60_000)).toFixed(1)}h`;
-  }
-  return `${(durationMs / (24 * 60 * 60_000)).toFixed(1)}d`;
 }
 
 function formatPlaybackTimestamp(timestampMs: number, includeDate: boolean): string {

--- a/extension/website/shared/components/StatsConsole.tsx
+++ b/extension/website/shared/components/StatsConsole.tsx
@@ -255,7 +255,9 @@ const PlaybackTimeValue: React.FC<{
       }
 
       if (timestamp - lastRenderedAt >= 200) {
-        const progress = (elapsedMs % cycleDurationMs) / cycleDurationMs;
+        const progress = elapsedGetterRef.current
+          ? Math.min(elapsedMs / cycleDurationMs, 1)
+          : (elapsedMs % cycleDurationMs) / cycleDurationMs;
         const playbackTimestamp = minTs + (maxTs - minTs) * progress;
         if (textRef.current) {
           textRef.current.textContent = formatPlaybackTimestamp(
@@ -280,7 +282,9 @@ const PlaybackTimeValue: React.FC<{
   const initialElapsedMs = getPlaybackElapsedMs?.() ?? 0;
   const initialProgress =
     cycleDurationMs > 0
-      ? (initialElapsedMs % cycleDurationMs) / cycleDurationMs
+      ? getPlaybackElapsedMs
+        ? Math.min(initialElapsedMs / cycleDurationMs, 1)
+        : (initialElapsedMs % cycleDurationMs) / cycleDurationMs
       : 0;
   const initialTimestamp = minTs + (maxTs - minTs) * initialProgress;
 

--- a/extension/website/shared/components/StatsConsole.tsx
+++ b/extension/website/shared/components/StatsConsole.tsx
@@ -17,6 +17,7 @@ interface StatsConsoleProps {
   frozen?: boolean;
   playbackKey?: string;
   playbackSource?: "archive" | "live";
+  getPlaybackElapsedMs?: () => number;
   /** Pixels to leave on the left so the console doesn't overlap the dev
    * panel (which is `position: fixed; left: 0` at 320px wide). */
   leftOffset: number;
@@ -191,6 +192,7 @@ const PlaybackTimeValue: React.FC<{
   animationSpeed: number;
   frozen: boolean;
   playbackKey: string;
+  getPlaybackElapsedMs?: () => number;
 }> = ({
   minTs,
   maxTs,
@@ -198,10 +200,12 @@ const PlaybackTimeValue: React.FC<{
   animationSpeed,
   frozen,
   playbackKey,
+  getPlaybackElapsedMs,
 }) => {
   const textRef = useRef<HTMLSpanElement>(null);
   const speedRef = useRef(animationSpeed);
   const frozenRef = useRef(frozen);
+  const elapsedGetterRef = useRef(getPlaybackElapsedMs);
 
   useEffect(() => {
     speedRef.current = animationSpeed;
@@ -209,6 +213,9 @@ const PlaybackTimeValue: React.FC<{
   useEffect(() => {
     frozenRef.current = frozen;
   }, [frozen]);
+  useEffect(() => {
+    elapsedGetterRef.current = getPlaybackElapsedMs;
+  }, [getPlaybackElapsedMs]);
 
   useEffect(() => {
     if (!minTs || !maxTs || cycleDurationMs <= 0) return;
@@ -240,7 +247,12 @@ const PlaybackTimeValue: React.FC<{
       if (previousTimestamp === null) previousTimestamp = timestamp;
       const frameDelta = Math.min(250, timestamp - previousTimestamp);
       previousTimestamp = timestamp;
-      if (!frozenRef.current) elapsedMs += frameDelta * speedRef.current;
+      const playbackElapsedMs = elapsedGetterRef.current?.();
+      if (playbackElapsedMs !== undefined) {
+        elapsedMs = playbackElapsedMs;
+      } else if (!frozenRef.current) {
+        elapsedMs += frameDelta * speedRef.current;
+      }
 
       if (timestamp - lastRenderedAt >= 200) {
         const progress = (elapsedMs % cycleDurationMs) / cycleDurationMs;
@@ -265,9 +277,16 @@ const PlaybackTimeValue: React.FC<{
     };
   }, [cycleDurationMs, maxTs, minTs, playbackKey]);
 
+  const initialElapsedMs = getPlaybackElapsedMs?.() ?? 0;
+  const initialProgress =
+    cycleDurationMs > 0
+      ? (initialElapsedMs % cycleDurationMs) / cycleDurationMs
+      : 0;
+  const initialTimestamp = minTs + (maxTs - minTs) * initialProgress;
+
   return (
     <span ref={textRef} data-testid="playback-current-time">
-      {formatPlaybackTimestamp(minTs, false)}
+      {formatPlaybackTimestamp(initialTimestamp, false)}
     </span>
   );
 };
@@ -297,6 +316,7 @@ export const StatsConsole: React.FC<StatsConsoleProps> = ({
   frozen = false,
   playbackKey = "fixed",
   playbackSource,
+  getPlaybackElapsedMs,
   leftOffset,
   loading,
   error,
@@ -436,6 +456,7 @@ export const StatsConsole: React.FC<StatsConsoleProps> = ({
                   animationSpeed={animationSpeed}
                   frozen={frozen}
                   playbackKey={playbackKey}
+                  getPlaybackElapsedMs={getPlaybackElapsedMs}
                 />
               }
               titleAttr={`Current ${playbackSource} chapter time`}

--- a/extension/website/shared/components/StatsConsole.tsx
+++ b/extension/website/shared/components/StatsConsole.tsx
@@ -1,7 +1,7 @@
-// ABOUTME: Top-of-canvas instrument console showing dataset scale at a glance
-// ABOUTME: Mirrors the ActivityStrip's bottom-of-screen role with totals + breakdowns
+// ABOUTME: Top-of-canvas instrument console showing dataset scale and playback time.
+// ABOUTME: Mirrors the ActivityStrip with compact totals, timing, and event breakdowns.
 
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { CollectionEvent } from "../types";
 import { extractDomain } from "../utils/eventUtils";
 
@@ -13,6 +13,9 @@ interface StatsConsoleProps {
   trailCount: number;
   cycleDurationMs: number;
   animationSpeed: number;
+  frozen?: boolean;
+  playbackKey?: string;
+  playbackSource?: "archive" | "live";
   /** Pixels to leave on the left so the console doesn't overlap the dev
    * panel (which is `position: fixed; left: 0` at 320px wide). */
   leftOffset: number;
@@ -31,7 +34,7 @@ const LABEL_FONT = "'Martian Mono', 'Space Mono', monospace";
  * uppercase label below. Stack horizontally to form the console. */
 const Tile: React.FC<{
   label: string;
-  value: string;
+  value: React.ReactNode;
   /** Smaller subtitle/unit shown after the value (e.g. "min" on cycle). */
   unit?: string;
   /** Optional accent color for the value — used to color-code event
@@ -166,33 +169,120 @@ function relativeTime(ts: number): string {
   });
 }
 
-/** Compact start→end date range for the dataset's actual time bounds.
- *
- *   Same day: "May 11 9:14 AM → 5:42 PM"
- *   Multi-day: "Apr 27 → May 11"
- *   Hover/title carries the exact unrounded timestamps.
- *
- * We previously rendered just a duration ("14 days") which left the user
- * guessing which 14 days. The absolute range is much more informative for
- * picking out art-piece moments. */
-function formatTimeSpan(minTs: number, maxTs: number): string {
+/** Compact duration for the dataset's actual time bounds. The tile tooltip
+ * carries the exact start and end timestamps. */
+export function formatCompactTimeSpan(minTs: number, maxTs: number): string {
   if (!minTs || !maxTs || maxTs <= minTs) return "—";
-  const start = new Date(minTs);
-  const end = new Date(maxTs);
-  const sameDay = start.toDateString() === end.toDateString();
-  const dateFmt: Intl.DateTimeFormatOptions = {
+  const durationMs = maxTs - minTs;
+  if (durationMs < 60_000) return "<1m";
+  if (durationMs < 60 * 60_000) return `${Math.round(durationMs / 60_000)}m`;
+  if (durationMs < 24 * 60 * 60_000) {
+    return `${(durationMs / (60 * 60_000)).toFixed(1)}h`;
+  }
+  return `${(durationMs / (24 * 60 * 60_000)).toFixed(1)}d`;
+}
+
+function formatPlaybackTimestamp(timestampMs: number, includeDate: boolean): string {
+  const date = new Date(timestampMs);
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  if (!includeDate) return time;
+  return `${date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
-  };
-  if (sameDay) {
-    const timeFmt: Intl.DateTimeFormatOptions = {
-      hour: "numeric",
-      minute: "2-digit",
-    };
-    return `${start.toLocaleDateString(undefined, dateFmt)} ${start.toLocaleTimeString(undefined, timeFmt)} → ${end.toLocaleTimeString(undefined, timeFmt)}`;
-  }
-  return `${start.toLocaleDateString(undefined, dateFmt)} → ${end.toLocaleDateString(undefined, dateFmt)}`;
+  })} ${time}`;
 }
+
+const PlaybackTimeValue: React.FC<{
+  minTs: number;
+  maxTs: number;
+  cycleDurationMs: number;
+  animationSpeed: number;
+  frozen: boolean;
+  playbackKey: string;
+}> = ({
+  minTs,
+  maxTs,
+  cycleDurationMs,
+  animationSpeed,
+  frozen,
+  playbackKey,
+}) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const speedRef = useRef(animationSpeed);
+  const frozenRef = useRef(frozen);
+
+  useEffect(() => {
+    speedRef.current = animationSpeed;
+  }, [animationSpeed]);
+  useEffect(() => {
+    frozenRef.current = frozen;
+  }, [frozen]);
+
+  useEffect(() => {
+    if (!minTs || !maxTs || cycleDurationMs <= 0) return;
+    let frame: number | undefined;
+    let timeout: number | undefined;
+    let previousTimestamp: number | null = null;
+    let elapsedMs = 0;
+    let lastRenderedAt = -Infinity;
+    const includeDate =
+      new Date(minTs).toDateString() !== new Date(maxTs).toDateString();
+
+    const clearScheduledTick = () => {
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      if (timeout !== undefined) window.clearTimeout(timeout);
+      frame = undefined;
+      timeout = undefined;
+    };
+
+    const schedule = () => {
+      clearScheduledTick();
+      if (document.visibilityState === "hidden") {
+        timeout = window.setTimeout(() => tick(performance.now()), 100);
+      } else {
+        frame = requestAnimationFrame(tick);
+      }
+    };
+
+    const tick = (timestamp: number) => {
+      if (previousTimestamp === null) previousTimestamp = timestamp;
+      const frameDelta = Math.min(250, timestamp - previousTimestamp);
+      previousTimestamp = timestamp;
+      if (!frozenRef.current) elapsedMs += frameDelta * speedRef.current;
+
+      if (timestamp - lastRenderedAt >= 200) {
+        const progress = (elapsedMs % cycleDurationMs) / cycleDurationMs;
+        const playbackTimestamp = minTs + (maxTs - minTs) * progress;
+        if (textRef.current) {
+          textRef.current.textContent = formatPlaybackTimestamp(
+            playbackTimestamp,
+            includeDate,
+          );
+        }
+        lastRenderedAt = timestamp;
+      }
+      schedule();
+    };
+
+    const handleVisibilityChange = () => schedule();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    schedule();
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      clearScheduledTick();
+    };
+  }, [cycleDurationMs, maxTs, minTs, playbackKey]);
+
+  return (
+    <span ref={textRef} data-testid="playback-current-time">
+      {formatPlaybackTimestamp(minTs, false)}
+    </span>
+  );
+};
 
 /** Top-level event-type labels — these mirror the registry but stay
  * separate so we can keep the console rendering independent of viz IDs. */
@@ -216,6 +306,9 @@ export const StatsConsole: React.FC<StatsConsoleProps> = ({
   trailCount,
   cycleDurationMs,
   animationSpeed,
+  frozen = false,
+  playbackKey = "fixed",
+  playbackSource,
   leftOffset,
   loading,
   error,
@@ -226,7 +319,7 @@ export const StatsConsole: React.FC<StatsConsoleProps> = ({
     filteredEventCount !== events.length;
 
   const cycleMin = cycleDurationMs > 0 ? cycleDurationMs / 60000 : 0;
-  const timeSpan = formatTimeSpan(stats.minTs, stats.maxTs);
+  const timeSpan = formatCompactTimeSpan(stats.minTs, stats.maxTs);
   const lastSeen = relativeTime(stats.maxTs);
 
   // High-level event-type tiles: only render the types that have data.
@@ -344,7 +437,26 @@ export const StatsConsole: React.FC<StatsConsoleProps> = ({
             />
           )}
 
-          {lastSeen && (
+          {playbackSource && stats.minTs > 0 && stats.maxTs > stats.minTs && (
+            <Tile
+              label={playbackSource}
+              value={
+                <PlaybackTimeValue
+                  minTs={stats.minTs}
+                  maxTs={stats.maxTs}
+                  cycleDurationMs={cycleDurationMs}
+                  animationSpeed={animationSpeed}
+                  frozen={frozen}
+                  playbackKey={playbackKey}
+                />
+              }
+              titleAttr={`Current ${playbackSource} chapter time`}
+              accent={playbackSource === "live" ? ACCENTS.rust : ACCENTS.blue}
+              minWidth={104}
+            />
+          )}
+
+          {!playbackSource && lastSeen && (
             <Tile
               label="Last Seen"
               value={lastSeen}

--- a/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
@@ -19,26 +19,45 @@ function makeEffect(sourceId: string, startTime: number): VisibleClickEffect {
     durationFactor: 0.5,
     startTime,
     trailIndex: 0,
+    completed: true,
   };
 }
 
 describe("AnimatedClicks residue", () => {
-  it("fades older residue while keeping recent clicks at full opacity", () => {
-    expect(getClickResidueOpacity(0, 100)).toBeCloseTo(0.03);
-    expect(getClickResidueOpacity(49, 100)).toBeGreaterThan(0.03);
-    expect(getClickResidueOpacity(75, 100)).toBe(1);
-    expect(getClickResidueOpacity(99, 100)).toBe(1);
+  it("keeps active ripples fully opaque", () => {
+    expect(getClickResidueOpacity(0, MAX_VISIBLE_CLICK_EFFECTS, false)).toBe(1);
+  });
+
+  it("settles sparse completed ripples to half opacity", () => {
+    expect(getClickResidueOpacity(0, 100, true)).toBe(0.5);
+    expect(getClickResidueOpacity(0, 1000, true)).toBe(0.5);
+    expect(getClickResidueOpacity(3000, MAX_VISIBLE_CLICK_EFFECTS, true)).toBe(
+      0.5,
+    );
+  });
+
+  it("fades retained completed ripples toward transparency near the cap", () => {
+    expect(
+      getClickResidueOpacity(0, MAX_VISIBLE_CLICK_EFFECTS, true),
+    ).toBeCloseTo(0.03);
+    expect(
+      getClickResidueOpacity(1500, MAX_VISIBLE_CLICK_EFFECTS, true),
+    ).toBeGreaterThan(0.03);
+    expect(
+      getClickResidueOpacity(1500, MAX_VISIBLE_CLICK_EFFECTS, true),
+    ).toBeLessThan(0.5);
   });
 
   it("keeps substantially more completed ripples before eviction", () => {
     expect(MAX_VISIBLE_CLICK_EFFECTS).toBeGreaterThanOrEqual(4000);
   });
 
-  it("replaces a replayed click without clearing unrelated marks", () => {
+  it("retains earlier generations when a click is replayed", () => {
     const current = [makeEffect("click-a", 1), makeEffect("click-b", 1)];
     const next = mergeClickEffects(current, [makeEffect("click-a", 2)]);
 
     expect(next.map((effect) => effect.id)).toEqual([
+      "click-a-1",
       "click-b-1",
       "click-a-2",
     ]);

--- a/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import type { VisibleClickEffect } from "../AnimatedClicks";
 import {
+  getClickResidueOpacity,
   MAX_VISIBLE_CLICK_EFFECTS,
   mergeClickEffects,
 } from "../AnimatedClicks";
@@ -22,6 +23,17 @@ function makeEffect(sourceId: string, startTime: number): VisibleClickEffect {
 }
 
 describe("AnimatedClicks residue", () => {
+  it("fades older residue while keeping recent clicks at full opacity", () => {
+    expect(getClickResidueOpacity(0, 100)).toBeCloseTo(0.03);
+    expect(getClickResidueOpacity(49, 100)).toBeGreaterThan(0.03);
+    expect(getClickResidueOpacity(75, 100)).toBe(1);
+    expect(getClickResidueOpacity(99, 100)).toBe(1);
+  });
+
+  it("keeps substantially more completed ripples before eviction", () => {
+    expect(MAX_VISIBLE_CLICK_EFFECTS).toBeGreaterThanOrEqual(4000);
+  });
+
   it("replaces a replayed click without clearing unrelated marks", () => {
     const current = [makeEffect("click-a", 1), makeEffect("click-b", 1)];
     const next = mergeClickEffects(current, [makeEffect("click-a", 2)]);

--- a/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
+++ b/extension/website/shared/components/__tests__/AnimatedClicks.test.ts
@@ -28,24 +28,34 @@ describe("AnimatedClicks residue", () => {
     expect(getClickResidueOpacity(0, MAX_VISIBLE_CLICK_EFFECTS, false)).toBe(1);
   });
 
-  it("settles sparse completed ripples to half opacity", () => {
-    expect(getClickResidueOpacity(0, 100, true)).toBe(0.5);
-    expect(getClickResidueOpacity(0, 1000, true)).toBe(0.5);
-    expect(getClickResidueOpacity(3000, MAX_VISIBLE_CLICK_EFFECTS, true)).toBe(
-      0.5,
+  it("keeps the newest completed ripple fully opaque", () => {
+    expect(getClickResidueOpacity(99, 100, true)).toBe(1);
+    expect(
+      getClickResidueOpacity(
+        MAX_VISIBLE_CLICK_EFFECTS - 1,
+        MAX_VISIBLE_CLICK_EFFECTS,
+        true,
+      ),
+    ).toBe(1);
+  });
+
+  it("uses fixed distance from newest rather than current list size", () => {
+    expect(getClickResidueOpacity(0, 100, true)).toBeCloseTo(
+      getClickResidueOpacity(3900, MAX_VISIBLE_CLICK_EFFECTS, true),
     );
   });
 
-  it("fades retained completed ripples toward transparency near the cap", () => {
+  it("linearly fades completed ripples toward transparency at the cap", () => {
     expect(
       getClickResidueOpacity(0, MAX_VISIBLE_CLICK_EFFECTS, true),
     ).toBeCloseTo(0.03);
-    expect(
-      getClickResidueOpacity(1500, MAX_VISIBLE_CLICK_EFFECTS, true),
-    ).toBeGreaterThan(0.03);
-    expect(
-      getClickResidueOpacity(1500, MAX_VISIBLE_CLICK_EFFECTS, true),
-    ).toBeLessThan(0.5);
+    const midpointOpacity = getClickResidueOpacity(
+      2000,
+      MAX_VISIBLE_CLICK_EFFECTS,
+      true,
+    );
+    expect(midpointOpacity).toBeGreaterThan(0.5);
+    expect(midpointOpacity).toBeLessThan(0.52);
   });
 
   it("keeps substantially more completed ripples before eviction", () => {

--- a/extension/website/shared/components/__tests__/AnimatedTyping.test.tsx
+++ b/extension/website/shared/components/__tests__/AnimatedTyping.test.tsx
@@ -6,6 +6,7 @@ import {
   COMPLETED_TYPING_VISIBLE_COUNT,
   buildTypingPlaybackSchedule,
   getRecentCompletedTypingTracks,
+  getTypingPlaybackElapsed,
   getTypingTextAtTime,
 } from "../AnimatedTyping";
 
@@ -41,6 +42,11 @@ function makeTypingState(index: number, sequence: TypingAction[]): TypingState {
 }
 
 describe("AnimatedTyping playback", () => {
+  it("holds finite playback at the end instead of wrapping", () => {
+    expect(getTypingPlaybackElapsed(12_000, 10_000, false)).toBe(10_000);
+    expect(getTypingPlaybackElapsed(12_000, 10_000, true)).toBe(2_000);
+  });
+
   it("keeps completed typing tracks bounded to recent history", () => {
     const states = Array.from({ length: 500 }, (_, index) =>
       makeTypingState(index, [

--- a/extension/website/shared/components/__tests__/ClickRipple.test.ts
+++ b/extension/website/shared/components/__tests__/ClickRipple.test.ts
@@ -6,6 +6,39 @@ import { getRippleLifecycle } from "../ClickRipple";
 import { CLICK_DEFAULTS } from "../clickDefaults";
 
 describe("getRippleLifecycle", () => {
+  it("waits for the final ring to settle before completing", () => {
+    const effect = {
+      id: "six-ring-click",
+      x: 0,
+      y: 0,
+      color: "#000",
+      radiusFactor: 0.5,
+      durationFactor: 0,
+      startTime: 1000,
+      trailIndex: 0,
+    };
+    const settings = {
+      ...CLICK_DEFAULTS,
+      clickNumRings: 6,
+    };
+    const settledAt =
+      effect.startTime +
+      (settings.clickNumRings - 1) * settings.clickRingDelayMs +
+      settings.clickExpansionDuration;
+
+    expect(
+      getRippleLifecycle(
+        effect,
+        settings,
+        effect.startTime + settings.clickMinDuration,
+      ).complete,
+    ).toBe(false);
+    expect(getRippleLifecycle(effect, settings, settledAt - 1).complete).toBe(
+      false,
+    );
+    expect(getRippleLifecycle(effect, settings, settledAt).complete).toBe(true);
+  });
+
   it("caps very long holds at three times the normal size and duration", () => {
     const lifecycle = getRippleLifecycle(
       {

--- a/extension/website/shared/components/__tests__/StatsConsole.test.ts
+++ b/extension/website/shared/components/__tests__/StatsConsole.test.ts
@@ -31,7 +31,10 @@ describe("StatsConsole playback time", () => {
       IS_REACT_ACT_ENVIRONMENT?: boolean;
     };
     testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
-    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
     vi.stubGlobal("cancelAnimationFrame", vi.fn());
     const start = 1_700_000_000_000;
     const end = start + 10 * 60_000;
@@ -62,6 +65,57 @@ describe("StatsConsole playback time", () => {
       undefined,
       { hour: "numeric", minute: "2-digit", second: "2-digit" },
     );
+    expect(
+      container.querySelector('[data-testid="playback-current-time"]')
+        ?.textContent,
+    ).toBe(expected);
+
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("holds at the end of finite playback instead of wrapping backward", async () => {
+    const testGlobal = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 1),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const start = 1_700_000_000_000;
+    const end = start + 10 * 60_000;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(StatsConsole, {
+          events: [
+            { type: "keyboard", ts: start },
+            { type: "keyboard", ts: end },
+          ] as CollectionEvent[],
+          trailCount: 0,
+          cycleDurationMs: 10_000,
+          animationSpeed: 1,
+          playbackSource: "live",
+          getPlaybackElapsedMs: () => 10_000,
+          leftOffset: 0,
+          loading: false,
+          error: null,
+        }),
+      );
+    });
+
+    const expected = new Date(end).toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      second: "2-digit",
+    });
     expect(
       container.querySelector('[data-testid="playback-current-time"]')
         ?.textContent,

--- a/extension/website/shared/components/__tests__/StatsConsole.test.ts
+++ b/extension/website/shared/components/__tests__/StatsConsole.test.ts
@@ -1,8 +1,13 @@
 // ABOUTME: Tests compact time-span formatting for the developer playback console.
 // ABOUTME: Keeps long archive ranges from crowding the top instrumentation bar.
+// @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { CollectionEvent } from "../../types";
 import { formatCompactTimeSpan } from "../../utils/timeFormat";
+import { StatsConsole } from "../StatsConsole";
 
 describe("formatCompactTimeSpan", () => {
   it("keeps minute, hour, and day spans compact", () => {
@@ -17,5 +22,54 @@ describe("formatCompactTimeSpan", () => {
   it("omits empty and reversed ranges", () => {
     expect(formatCompactTimeSpan(0, 0)).toBe("—");
     expect(formatCompactTimeSpan(200, 100)).toBe("—");
+  });
+});
+
+describe("StatsConsole playback time", () => {
+  it("opens at the current playback position", async () => {
+    const testGlobal = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    const start = 1_700_000_000_000;
+    const end = start + 10 * 60_000;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(StatsConsole, {
+          events: [
+            { type: "cursor", ts: start },
+            { type: "cursor", ts: end },
+          ] as CollectionEvent[],
+          trailCount: 1,
+          cycleDurationMs: 10_000,
+          animationSpeed: 1,
+          playbackSource: "archive",
+          getPlaybackElapsedMs: () => 5_000,
+          leftOffset: 0,
+          loading: false,
+          error: null,
+        }),
+      );
+    });
+
+    const expected = new Date(start + 5 * 60_000).toLocaleTimeString(
+      undefined,
+      { hour: "numeric", minute: "2-digit", second: "2-digit" },
+    );
+    expect(
+      container.querySelector('[data-testid="playback-current-time"]')
+        ?.textContent,
+    ).toBe(expected);
+
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
   });
 });

--- a/extension/website/shared/components/__tests__/StatsConsole.test.ts
+++ b/extension/website/shared/components/__tests__/StatsConsole.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Keeps long archive ranges from crowding the top instrumentation bar.
 
 import { describe, expect, it } from "vitest";
-import { formatCompactTimeSpan } from "../StatsConsole";
+import { formatCompactTimeSpan } from "../../utils/timeFormat";
 
 describe("formatCompactTimeSpan", () => {
   it("keeps minute, hour, and day spans compact", () => {

--- a/extension/website/shared/components/__tests__/StatsConsole.test.ts
+++ b/extension/website/shared/components/__tests__/StatsConsole.test.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Tests compact time-span formatting for the developer playback console.
+// ABOUTME: Keeps long archive ranges from crowding the top instrumentation bar.
+
+import { describe, expect, it } from "vitest";
+import { formatCompactTimeSpan } from "../StatsConsole";
+
+describe("formatCompactTimeSpan", () => {
+  it("keeps minute, hour, and day spans compact", () => {
+    const start = 1_700_000_000_000;
+
+    expect(formatCompactTimeSpan(start, start + 30_000)).toBe("<1m");
+    expect(formatCompactTimeSpan(start, start + 12 * 60_000)).toBe("12m");
+    expect(formatCompactTimeSpan(start, start + 90 * 60_000)).toBe("1.5h");
+    expect(formatCompactTimeSpan(start, start + 36 * 60 * 60_000)).toBe("1.5d");
+  });
+
+  it("omits empty and reversed ranges", () => {
+    expect(formatCompactTimeSpan(0, 0)).toBe("—");
+    expect(formatCompactTimeSpan(200, 100)).toBe("—");
+  });
+});

--- a/extension/website/shared/components/settingsDefaults.ts
+++ b/extension/website/shared/components/settingsDefaults.ts
@@ -110,3 +110,5 @@ export const DEFAULT_SETTINGS = {
   // setting you'd want baked into a saved/shared URL.
   debugMode: false,
 };
+
+export type MovementSettings = typeof DEFAULT_SETTINGS;

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -18,7 +18,7 @@ export const COMMUTE_TRAIN_BOARD_URL = `${WORKER_URL}/commute/trains/board`;
 export const DAILY_COUNTS_URL = `${WORKER_URL}/events/daily-counts`;
 export const PAGE_META_URL = `${WORKER_URL}/page-meta`;
 
-/** WebSocket endpoint for the live cursor-event stream. Derived from
+/** WebSocket endpoint for the live movement-event stream. Derived from
  * WORKER_URL by swapping the http(s) scheme for ws(s). */
 export const STREAM_URL = `${WORKER_URL.replace(/^http/, "ws")}/stream`;
 

--- a/extension/website/shared/config.ts
+++ b/extension/website/shared/config.ts
@@ -214,12 +214,14 @@ export function parseTimeOfDayFromUrl(): TimeOfDayFilter | undefined {
  * epoch; `follower` additionally participates in cinematic follow coordination.
  * Returns null when the param is absent (a standalone window drives its own
  * clock). */
-export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
-  if (typeof window === "undefined") return null;
+export function parseInstallationRoleFromUrl(
+  defaultRole: "master" | "follower" | null = null,
+): "master" | "follower" | null {
+  if (typeof window === "undefined") return defaultRole;
   const raw = new URLSearchParams(window.location.search).get("role");
   if (raw === "master") return "master";
   if (raw === "follower") return "follower";
-  return null;
+  return defaultRole;
 }
 
 /** `?follower=<id>` is the stable id a follower window uses to claim cursors in
@@ -227,10 +229,12 @@ export function parseInstallationRoleFromUrl(): "master" | "follower" | null {
  * cursor). Any non-empty string works (e.g. `a`, `b`, `1`, `2`). Returns null
  * when absent — the coordination hook then falls back to a per-window random id
  * so it still participates without a URL-set id. */
-export function parseFollowerIdFromUrl(): string | null {
-  if (typeof window === "undefined") return null;
+export function parseFollowerIdFromUrl(
+  defaultFollowerId: string | null = null,
+): string | null {
+  if (typeof window === "undefined") return defaultFollowerId;
   const raw = new URLSearchParams(window.location.search).get("follower");
-  if (raw === null) return null;
+  if (raw === null) return defaultFollowerId;
   const trimmed = raw.trim();
   return trimmed === "" ? null : trimmed;
 }
@@ -246,12 +250,17 @@ export function parseFollowerIdFromUrl(): string | null {
  *   ?follow=5               follow: lock onto trail index 5 (only takes effect
  *                           in follow mode; ignored by reveal)
  * Returns null when cinematic mode is not requested. */
-export function parseCinematicFromUrl(): CinematicConfig | null {
-  if (typeof window === "undefined") return null;
+export function parseCinematicFromUrl(
+  defaultConfig: CinematicConfig | null = null,
+): CinematicConfig | null {
+  if (typeof window === "undefined") return defaultConfig;
   const params = new URLSearchParams(window.location.search);
   const raw = params.get("cinematic");
+  if (raw === null) return defaultConfig;
   const on = raw !== null && raw !== "" && parseBool(raw) !== false;
   if (!on) return null;
+
+  const baseConfig = defaultConfig ?? DEFAULT_CINEMATIC_CONFIG;
 
   const mode = raw === "reveal" ? "reveal" : "follow";
   const zoom = parseNumber(params.get("cinemaZoom"));
@@ -267,29 +276,29 @@ export function parseCinematicFromUrl(): CinematicConfig | null {
       : null;
 
   return {
-    ...DEFAULT_CINEMATIC_CONFIG,
+    ...baseConfig,
     mode,
-    zoom: zoom !== undefined && zoom > 0 ? zoom : DEFAULT_CINEMATIC_CONFIG.zoom,
+    zoom: zoom !== undefined && zoom > 0 ? zoom : baseConfig.zoom,
     transitionMs:
       transitionS !== undefined && transitionS > 0
         ? transitionS * 1000
-        : DEFAULT_CINEMATIC_CONFIG.transitionMs,
+        : baseConfig.transitionMs,
     centerLerp:
       lerp !== undefined && lerp >= 0
         ? lerp
-        : DEFAULT_CINEMATIC_CONFIG.centerLerp,
+        : baseConfig.centerLerp,
     velocityZoomOut:
       velZoom !== undefined && velZoom >= 0
         ? velZoom
-        : DEFAULT_CINEMATIC_CONFIG.velocityZoomOut,
+        : baseConfig.velocityZoomOut,
     revealMs:
       revealS !== undefined && revealS > 0
         ? revealS * 1000
-        : DEFAULT_CINEMATIC_CONFIG.revealMs,
+        : baseConfig.revealMs,
     revealStartZoom:
       startZoom !== undefined && startZoom > 0
         ? startZoom
-        : DEFAULT_CINEMATIC_CONFIG.revealStartZoom,
+        : baseConfig.revealStartZoom,
     forcedSubjectIndex,
   };
 }

--- a/extension/website/shared/hooks/__tests__/useDailyPageReload.test.ts
+++ b/extension/website/shared/hooks/__tests__/useDailyPageReload.test.ts
@@ -1,0 +1,102 @@
+// ABOUTME: Tests local-day rollover for unattended installation pages.
+// ABOUTME: Covers midnight timers, repeated boundaries, sleeping tabs, and cleanup.
+
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  localDateKey,
+  millisecondsUntilNextLocalDay,
+  useDailyPageReload,
+} from "../useDailyPageReload";
+
+async function renderDailyReload(reloadPage: () => void, now: () => Date) {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  function HookHarness() {
+    useDailyPageReload(reloadPage, now);
+    return null;
+  }
+
+  await act(async () => root.render(createElement(HookHarness)));
+  return async () => act(async () => root.unmount());
+}
+
+function setVisibility(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("daily page reload timing", () => {
+  let now: Date;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    now = new Date(2026, 0, 15, 23, 59, 50);
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calculates the next boundary from the local calendar", () => {
+    const now = new Date(2026, 2, 8, 22, 30, 0);
+    const nextDay = new Date(
+      now.getTime() + millisecondsUntilNextLocalDay(now),
+    );
+
+    expect(localDateKey(nextDay)).toBe(localDateKey(new Date(2026, 2, 9)));
+    expect(nextDay.getHours()).toBe(0);
+    expect(nextDay.getMinutes()).toBe(0);
+  });
+
+  it("reloads at midnight and recalculates the following boundary", async () => {
+    const reloadPage = vi.fn();
+    const unmount = await renderDailyReload(reloadPage, () => now);
+
+    now = new Date(2026, 0, 16, 0, 0, 0);
+    await act(async () => vi.advanceTimersByTime(10_000));
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+
+    now = new Date(2026, 0, 17, 0, 0, 0);
+    await act(async () => vi.advanceTimersByTime(24 * 60 * 60 * 1000));
+    expect(reloadPage).toHaveBeenCalledTimes(2);
+
+    await unmount();
+  });
+
+  it("reloads when a sleeping page becomes visible on another day", async () => {
+    const reloadPage = vi.fn();
+    const unmount = await renderDailyReload(reloadPage, () => now);
+
+    setVisibility("hidden");
+    now = new Date(2026, 0, 16, 8, 0, 0);
+    setVisibility("visible");
+
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+    setVisibility("visible");
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+
+    await unmount();
+  });
+
+  it("cancels the scheduled reload when the page unmounts", async () => {
+    const reloadPage = vi.fn();
+    const unmount = await renderDailyReload(reloadPage, () => now);
+
+    await unmount();
+    await act(async () => vi.advanceTimersByTime(10_000));
+
+    expect(reloadPage).not.toHaveBeenCalled();
+  });
+});

--- a/extension/website/shared/hooks/useArchiveEvents.ts
+++ b/extension/website/shared/hooks/useArchiveEvents.ts
@@ -129,6 +129,7 @@ export function useArchiveEvents(params: {
   const [prefetchRetryVersion, setPrefetchRetryVersion] = useState(0);
   const batchQueueRef = useRef(batchQueue);
   const batchGenerationRef = useRef(0);
+  const fixedFetchGenerationRef = useRef(0);
   const batchSequenceRef = useRef(0);
   const prefetchRequestRef = useRef("");
 
@@ -136,6 +137,13 @@ export function useArchiveEvents(params: {
   const fetchedTypesRef = useRef<Set<string>>(new Set());
   // Track the last domain+day combo we fetched for so we know when to force refresh
   const lastFetchKeyRef = useRef<string>("");
+
+  useEffect(() => {
+    fixedFetchGenerationRef.current++;
+    batchGenerationRef.current++;
+    fetchedTypesRef.current = new Set();
+    lastFetchKeyRef.current = "";
+  }, [batchPlayback]);
 
   // Fetch daily counts for the heatmap calendar
   useEffect(() => {
@@ -192,6 +200,7 @@ export function useArchiveEvents(params: {
 
       setLoading(true);
       setError(null);
+      const requestGeneration = ++fixedFetchGenerationRef.current;
 
       try {
         // Retry with exponential backoff so a transient network hiccup or a 5xx
@@ -258,6 +267,8 @@ export function useArchiveEvents(params: {
           fetched = results.flat();
         }
 
+        if (requestGeneration !== fixedFetchGenerationRef.current) return;
+
         // Track what we've fetched
         for (const t of typesToFetch) {
           fetchedTypesRef.current.add(t);
@@ -269,10 +280,13 @@ export function useArchiveEvents(params: {
           setEvents((prev) => [...prev, ...fetched]);
         }
       } catch (err) {
+        if (requestGeneration !== fixedFetchGenerationRef.current) return;
         setError(err instanceof Error ? err.message : "Failed to fetch events");
         console.error("Error fetching events:", err);
       } finally {
-        setLoading(false);
+        if (requestGeneration === fixedFetchGenerationRef.current) {
+          setLoading(false);
+        }
       }
     },
     [],

--- a/extension/website/shared/hooks/useDailyPageReload.ts
+++ b/extension/website/shared/hooks/useDailyPageReload.ts
@@ -1,0 +1,65 @@
+// ABOUTME: Reloads long-running installation pages when their local calendar day changes.
+// ABOUTME: Recalculates each midnight boundary so daylight-saving transitions stay correct.
+
+import { useEffect } from "react";
+
+const reloadCurrentPage = () => window.location.reload();
+const currentDate = () => new Date();
+
+export function localDateKey(date: Date): string {
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+
+export function millisecondsUntilNextLocalDay(now: Date): number {
+  const nextDay = new Date(now);
+  nextDay.setHours(24, 0, 0, 0);
+  return Math.max(1, nextDay.getTime() - now.getTime());
+}
+
+export function useDailyPageReload(
+  reloadPage: () => void = reloadCurrentPage,
+  now: () => Date = currentDate,
+): void {
+  useEffect(() => {
+    let active = true;
+    let timer: number | undefined;
+    let currentDateKey = localDateKey(now());
+
+    const scheduleNextDay = () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+      const currentTime = now();
+      timer = window.setTimeout(
+        handleDayBoundary,
+        millisecondsUntilNextLocalDay(currentTime),
+      );
+    };
+
+    const reloadIfDayChanged = () => {
+      const nextDate = localDateKey(now());
+      if (nextDate === currentDateKey) return;
+      currentDateKey = nextDate;
+      reloadPage();
+    };
+
+    function handleDayBoundary() {
+      if (!active) return;
+      reloadIfDayChanged();
+      scheduleNextDay();
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      reloadIfDayChanged();
+      scheduleNextDay();
+    };
+
+    scheduleNextDay();
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      active = false;
+      if (timer !== undefined) window.clearTimeout(timer);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [now, reloadPage]);
+}

--- a/extension/website/shared/hooks/useFollowerCoordination.ts
+++ b/extension/website/shared/hooks/useFollowerCoordination.ts
@@ -51,6 +51,11 @@ export interface FollowerCoordination {
   pickSubject: PickSubject;
 }
 
+interface FollowerCoordinationDefaults {
+  role?: "master" | "follower" | null;
+  followerId?: string | null;
+}
+
 /** Lowest-progress pick — prefer a trail early in its draw so the camera rides
  * most of it. Matches the camera's built-in default; used when this window
  * isn't coordinating. */
@@ -74,14 +79,16 @@ function pickLowestProgress(
 /** Wires the claims BroadcastChannel keyed off `?role=follower`. Inert for any
  * other window: `pickSubject` just does lowest-progress and no channel opens, so
  * the archive/portrait pages and a single-window auto-pick are unaffected. */
-export function useFollowerCoordination(): FollowerCoordination {
-  const roleRef = useRef(parseInstallationRoleFromUrl());
+export function useFollowerCoordination(
+  defaults: FollowerCoordinationDefaults = {},
+): FollowerCoordination {
+  const roleRef = useRef(parseInstallationRoleFromUrl(defaults.role));
   const isFollower = roleRef.current === "follower";
 
   // Stable window id: the URL-set follower id, or a random one generated once
   // so an id-less follower still participates (and two id-less windows diverge).
   const idRef = useRef<string>(
-    parseFollowerIdFromUrl() ??
+    parseFollowerIdFromUrl(defaults.followerId) ??
       `f-${Math.random().toString(36).slice(2, 8)}`,
   );
 

--- a/extension/website/shared/hooks/useHybridInstallationEvents.ts
+++ b/extension/website/shared/hooks/useHybridInstallationEvents.ts
@@ -1,16 +1,28 @@
-// ABOUTME: Alternates archive playback with sufficiently dense chapters accumulated from the live stream.
-// ABOUTME: Advances archive history before each live chapter so playback resumes farther back in time.
+// ABOUTME: Supplies finite installation chapters from archive and live browsing events.
+// ABOUTME: Rotates typing and scrolling reservoirs while other views move toward live playback.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CollectionEvent } from "../types";
 import { useArchiveEvents } from "./useArchiveEvents";
 import { useLiveEvents } from "./useLiveEvents";
+import { deriveRequiredEventTypes } from "../components/registry";
 import {
   eventsForInstallationScreen,
+  installationChapterAction,
   liveChapterIsReady,
   type LiveInstallationScreenConfig,
   unconsumedLiveEvents,
 } from "../utils/liveInstallation";
+import {
+  addTypingReservoirEvents,
+  createTypingReservoir,
+  takeTypingReservoirChapter,
+} from "../utils/typingInstallationReservoir";
+import {
+  addScrollReservoirEvents,
+  createScrollReservoir,
+  takeScrollReservoirChapter,
+} from "../utils/scrollInstallationReservoir";
 import type { parseTimeOfDayFromUrl } from "../config";
 
 type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
@@ -36,46 +48,151 @@ export function useHybridInstallationEvents(params: {
   activeVisualizations: string[];
   screen: LiveInstallationScreenConfig;
 }): HybridInstallationEventsState {
-  const {
-    selectedDay,
-    timeOfDay,
-    serverDomain,
-    activeVisualizations,
-    screen,
-  } = params;
+  const { selectedDay, timeOfDay, serverDomain, activeVisualizations, screen } =
+    params;
+  const typingOnly =
+    activeVisualizations.length === 1 && activeVisualizations[0] === "typing";
+  const scrollingOnly =
+    activeVisualizations.length === 1 &&
+    activeVisualizations[0] === "scrolling";
+  const reservoirOnly = typingOnly || scrollingOnly;
   const archive = useArchiveEvents({
     selectedDay,
     timeOfDay,
     serverDomain,
     activeVisualizations,
-    batchPlayback: true,
+    batchPlayback: !reservoirOnly,
   });
   const live = useLiveEvents({ maxEvents: 5000 });
   const [source, setSource] = useState<ChapterSource>("archive");
   const [liveChapter, setLiveChapter] = useState<CollectionEvent[]>([]);
   const [liveSequence, setLiveSequence] = useState(0);
+  const [typingChapter, setTypingChapter] = useState<CollectionEvent[]>([]);
+  const [typingSequence, setTypingSequence] = useState(0);
+  const [typingRotation, setTypingRotation] = useState(0);
+  const [scrollChapter, setScrollChapter] = useState<CollectionEvent[]>([]);
+  const [scrollSequence, setScrollSequence] = useState(0);
+  const [scrollRotation, setScrollRotation] = useState(0);
   const sourceRef = useRef<ChapterSource>(source);
   const liveEventsRef = useRef(live.events);
   const activeVisualizationsRef = useRef(activeVisualizations);
   const consumedIdsRef = useRef<Set<string>>(new Set());
   const seededInitialArchiveRef = useRef(false);
+  const lastLiveTimestampRef = useRef(-Infinity);
+  const typingChapterRef = useRef<CollectionEvent[]>([]);
+  const typingReservoirRef = useRef(createTypingReservoir());
+  const scrollChapterRef = useRef<CollectionEvent[]>([]);
+  const scrollReservoirRef = useRef(createScrollReservoir());
+  const typingContextKey = [
+    selectedDay ?? "recent",
+    `${timeOfDay?.centerMinutes ?? "all"}:${timeOfDay?.radiusMinutes ?? "all"}`,
+    serverDomain,
+    `${screen.view}:${screen.slot}:${screen.slots}`,
+  ].join("|");
+  const hybridContextKey = `${typingContextKey}|${activeVisualizations.join(",")}`;
 
   liveEventsRef.current = live.events;
   activeVisualizationsRef.current = activeVisualizations;
 
   useEffect(() => {
+    typingReservoirRef.current = createTypingReservoir();
+    typingChapterRef.current = [];
+    setTypingChapter([]);
+    setTypingSequence(0);
+    setTypingRotation(0);
+  }, [typingContextKey, typingOnly]);
+
+  useEffect(() => {
+    scrollReservoirRef.current = createScrollReservoir();
+    scrollChapterRef.current = [];
+    setScrollChapter([]);
+    setScrollSequence(0);
+    setScrollRotation(0);
+  }, [typingContextKey, scrollingOnly]);
+
+  useEffect(() => {
+    if (reservoirOnly) return;
+    sourceRef.current = "archive";
+    setSource("archive");
+    setLiveChapter([]);
+    setLiveSequence(0);
+    consumedIdsRef.current = new Set();
+    seededInitialArchiveRef.current = false;
+    lastLiveTimestampRef.current = -Infinity;
+  }, [hybridContextKey, reservoirOnly]);
+
+  useEffect(() => {
+    if (reservoirOnly) return;
     if (seededInitialArchiveRef.current || archive.events.length === 0) return;
     for (const event of archive.events) consumedIdsRef.current.add(event.id);
     seededInitialArchiveRef.current = true;
-  }, [archive.events]);
+  }, [archive.events, reservoirOnly]);
 
-  const finishChapter = useCallback((): boolean => {
-    if (sourceRef.current === "live") {
+  const takeNextTypingChapter = useCallback((): boolean => {
+    let reservoir = addTypingReservoirEvents(
+      typingReservoirRef.current,
+      eventsForInstallationScreen(archive.events, screen),
+      "archive",
+      Date.now(),
+    );
+    reservoir = addTypingReservoirEvents(
+      reservoir,
+      eventsForInstallationScreen(liveEventsRef.current, screen),
+      "live",
+      Date.now(),
+    );
+    const next = takeTypingReservoirChapter(reservoir);
+    typingReservoirRef.current = next.state;
+    if (next.events.length === 0) return false;
+
+    typingChapterRef.current = next.events;
+    setTypingChapter(next.events);
+    setTypingRotation(next.rotation);
+    setTypingSequence((sequence) => sequence + 1);
       sourceRef.current = "archive";
       setSource("archive");
       return true;
-    }
+  }, [archive.events, screen]);
 
+  useEffect(() => {
+    if (!typingOnly || typingChapterRef.current.length > 0) return;
+    takeNextTypingChapter();
+  }, [archive.events, live.events, takeNextTypingChapter, typingOnly]);
+
+  const takeNextScrollChapter = useCallback((): boolean => {
+    let reservoir = addScrollReservoirEvents(
+      scrollReservoirRef.current,
+      eventsForInstallationScreen(archive.events, screen),
+      "archive",
+      Date.now(),
+    );
+    reservoir = addScrollReservoirEvents(
+      reservoir,
+      eventsForInstallationScreen(liveEventsRef.current, screen),
+      "live",
+      Date.now(),
+    );
+    const next = takeScrollReservoirChapter(reservoir);
+    scrollReservoirRef.current = next.state;
+    if (next.events.length === 0) return false;
+
+    scrollChapterRef.current = next.events;
+    setScrollChapter(next.events);
+    setScrollRotation(next.rotation);
+    setScrollSequence((sequence) => sequence + 1);
+    sourceRef.current = "archive";
+    setSource("archive");
+    return true;
+  }, [archive.events, screen]);
+
+  useEffect(() => {
+    if (!scrollingOnly || scrollChapterRef.current.length > 0) return;
+    takeNextScrollChapter();
+    const retry = window.setInterval(takeNextScrollChapter, 1000);
+    return () => window.clearInterval(retry);
+  }, [archive.events, live.events, scrollingOnly, takeNextScrollChapter]);
+
+  const startReadyLiveChapter = useCallback((): boolean => {
     if (liveEventsRef.current.length > 0) {
       consumedIdsRef.current = new Set(
         liveEventsRef.current
@@ -84,30 +201,61 @@ export function useHybridInstallationEvents(params: {
       );
     }
 
-    const candidate = eventsForInstallationScreen(
+    const requiredTypes = deriveRequiredEventTypes(
+      activeVisualizationsRef.current,
+    );
+    const screenEvents = eventsForInstallationScreen(
       unconsumedLiveEvents(liveEventsRef.current, consumedIdsRef.current),
       screen,
+    ).filter((event) => event.ts > lastLiveTimestampRef.current);
+    if (!liveChapterIsReady(screenEvents, activeVisualizationsRef.current)) {
+      return false;
+    }
+    const candidate = screenEvents.filter((event) =>
+      requiredTypes.has(event.type),
     );
-    if (
-      liveChapterIsReady(candidate, activeVisualizationsRef.current) &&
-      archive.advanceBatch()
-    ) {
-      for (const event of candidate) consumedIdsRef.current.add(event.id);
+
+    for (const event of screenEvents) consumedIdsRef.current.add(event.id);
+    lastLiveTimestampRef.current =
+      candidate.at(-1)?.ts ?? lastLiveTimestampRef.current;
       setLiveChapter(candidate);
       setLiveSequence((sequence) => sequence + 1);
       sourceRef.current = "live";
       setSource("live");
       return true;
-    }
+  }, [screen]);
+
+  const finishChapter = useCallback((): boolean => {
+    if (typingOnly) return takeNextTypingChapter();
+    if (scrollingOnly) return takeNextScrollChapter();
+
+    const action = installationChapterAction(
+      sourceRef.current,
+      startReadyLiveChapter(),
+    );
+    if (action === "show-live") return true;
+    if (action === "wait-live") return false;
 
     return archive.advanceBatch();
-  }, [archive.advanceBatch, screen]);
+  }, [
+    archive.advanceBatch,
+    startReadyLiveChapter,
+    takeNextScrollChapter,
+    takeNextTypingChapter,
+    scrollingOnly,
+    typingOnly,
+  ]);
 
   const chapterEvents = source === "live" ? liveChapter : archive.events;
-  const events = useMemo(
+  const hybridEvents = useMemo(
     () => eventsForInstallationScreen(chapterEvents, screen),
     [chapterEvents, screen],
   );
+  const events = typingOnly
+    ? typingChapter
+    : scrollingOnly
+      ? scrollChapter
+      : hybridEvents;
 
   return {
     events,
@@ -116,10 +264,19 @@ export function useHybridInstallationEvents(params: {
     loading: archive.loading,
     error: archive.error,
     refresh: archive.refresh,
-    playbackKey:
-      source === "live" ? `live:${liveSequence}` : `archive:${archive.batchKey}`,
-    playbackContextKey: `hybrid:${archive.batchContextKey}`,
+    playbackKey: typingOnly
+      ? `typing:${typingRotation}:${typingSequence}`
+      : scrollingOnly
+        ? `scrolling:${scrollRotation}:${scrollSequence}`
+        : source === "live"
+          ? `live:${liveSequence}`
+          : `archive:${archive.batchKey}`,
+    playbackContextKey: typingOnly
+      ? `typing:${typingContextKey}`
+      : scrollingOnly
+        ? `scrolling:${typingContextKey}`
+        : `hybrid:${archive.batchContextKey}`,
     finishChapter,
-    source,
+    source: reservoirOnly ? "archive" : source,
   };
 }

--- a/extension/website/shared/hooks/useHybridInstallationEvents.ts
+++ b/extension/website/shared/hooks/useHybridInstallationEvents.ts
@@ -1,0 +1,125 @@
+// ABOUTME: Alternates archive playback with sufficiently dense chapters accumulated from the live stream.
+// ABOUTME: Advances archive history before each live chapter so playback resumes farther back in time.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CollectionEvent } from "../types";
+import { useArchiveEvents } from "./useArchiveEvents";
+import { useLiveEvents } from "./useLiveEvents";
+import {
+  eventsForInstallationScreen,
+  liveChapterIsReady,
+  type LiveInstallationScreenConfig,
+  unconsumedLiveEvents,
+} from "../utils/liveInstallation";
+import type { parseTimeOfDayFromUrl } from "../config";
+
+type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
+type ChapterSource = "archive" | "live";
+
+export interface HybridInstallationEventsState {
+  events: CollectionEvent[];
+  liveEvents: CollectionEvent[];
+  connected: boolean;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+  playbackKey: string;
+  playbackContextKey: string;
+  finishChapter: () => boolean;
+  source: ChapterSource;
+}
+
+export function useHybridInstallationEvents(params: {
+  selectedDay: string | null;
+  timeOfDay: TimeOfDay;
+  serverDomain: string;
+  activeVisualizations: string[];
+  screen: LiveInstallationScreenConfig;
+}): HybridInstallationEventsState {
+  const {
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+    screen,
+  } = params;
+  const archive = useArchiveEvents({
+    selectedDay,
+    timeOfDay,
+    serverDomain,
+    activeVisualizations,
+    batchPlayback: true,
+  });
+  const live = useLiveEvents({ maxEvents: 5000 });
+  const [source, setSource] = useState<ChapterSource>("archive");
+  const [liveChapter, setLiveChapter] = useState<CollectionEvent[]>([]);
+  const [liveSequence, setLiveSequence] = useState(0);
+  const sourceRef = useRef<ChapterSource>(source);
+  const liveEventsRef = useRef(live.events);
+  const activeVisualizationsRef = useRef(activeVisualizations);
+  const consumedIdsRef = useRef<Set<string>>(new Set());
+  const seededInitialArchiveRef = useRef(false);
+
+  liveEventsRef.current = live.events;
+  activeVisualizationsRef.current = activeVisualizations;
+
+  useEffect(() => {
+    if (seededInitialArchiveRef.current || archive.events.length === 0) return;
+    for (const event of archive.events) consumedIdsRef.current.add(event.id);
+    seededInitialArchiveRef.current = true;
+  }, [archive.events]);
+
+  const finishChapter = useCallback((): boolean => {
+    if (sourceRef.current === "live") {
+      sourceRef.current = "archive";
+      setSource("archive");
+      return true;
+    }
+
+    if (liveEventsRef.current.length > 0) {
+      consumedIdsRef.current = new Set(
+        liveEventsRef.current
+          .filter((event) => consumedIdsRef.current.has(event.id))
+          .map((event) => event.id),
+      );
+    }
+
+    const candidate = eventsForInstallationScreen(
+      unconsumedLiveEvents(liveEventsRef.current, consumedIdsRef.current),
+      screen,
+    );
+    if (
+      liveChapterIsReady(candidate, activeVisualizationsRef.current) &&
+      archive.advanceBatch()
+    ) {
+      for (const event of candidate) consumedIdsRef.current.add(event.id);
+      setLiveChapter(candidate);
+      setLiveSequence((sequence) => sequence + 1);
+      sourceRef.current = "live";
+      setSource("live");
+      return true;
+    }
+
+    return archive.advanceBatch();
+  }, [archive.advanceBatch, screen]);
+
+  const chapterEvents = source === "live" ? liveChapter : archive.events;
+  const events = useMemo(
+    () => eventsForInstallationScreen(chapterEvents, screen),
+    [chapterEvents, screen],
+  );
+
+  return {
+    events,
+    liveEvents: live.events,
+    connected: live.connected,
+    loading: archive.loading,
+    error: archive.error,
+    refresh: archive.refresh,
+    playbackKey:
+      source === "live" ? `live:${liveSequence}` : `archive:${archive.batchKey}`,
+    playbackContextKey: `hybrid:${archive.batchContextKey}`,
+    finishChapter,
+    source,
+  };
+}

--- a/extension/website/shared/hooks/useKeyboardTyping.ts
+++ b/extension/website/shared/hooks/useKeyboardTyping.ts
@@ -14,6 +14,7 @@ import {
   eventMatchesAnyFilter,
   type FilterChip,
 } from "../utils/eventUtils";
+import { groupTypingEvents } from "../utils/typingEventGroups";
 
 // Settings interface for keyboard typing
 export interface KeyboardTypingSettings {
@@ -55,9 +56,6 @@ export interface UseKeyboardTypingResult {
    * shared animation loop. */
   cycleDuration: number;
 }
-
-// Merge threshold for combining fragmented typing sequences
-const MERGE_THRESHOLD_MS = 35000;
 
 /**
  * Calculate typing duration from a sequence of actions
@@ -101,124 +99,63 @@ export function useKeyboardTyping(
       return [];
     }
 
-    // Apply URL-scope chips and pid filter.
-    let filteredKeyboardEvents = keyboardEvents;
+    // Build the same stable typing-box groups used by installation reservoirs,
+    // then apply URL-scope chips and pid filtering to those groups.
+    let typingEventGroups = groupTypingEvents(keyboardEvents);
     const hasFilters = (settings.filters?.length ?? 0) > 0;
     if (hasFilters || settings.pidFilter) {
-      filteredKeyboardEvents = keyboardEvents.filter((e) => {
-        if (settings.pidFilter && e.meta?.pid !== settings.pidFilter) return false;
-        return eventMatchesAnyFilter(e.meta.url || "", settings.filters);
+      typingEventGroups = typingEventGroups.filter((group) => {
+        const event = group.events[0];
+        if (settings.pidFilter && event.meta?.pid !== settings.pidFilter) {
+          return false;
+        }
+        return eventMatchesAnyFilter(event.meta.url || "", settings.filters);
       });
     }
 
-    // Filter out test data (e.g., "elizabeth" test entries)
-    filteredKeyboardEvents = filteredKeyboardEvents.filter((e) => {
-      const data = e.data as any;
-      return (
-        !data.sequence ||
-        data.sequence.reduce((acc: string, s: any) => acc + (s.text || ""), "") !==
-          "elizabeth"
-      );
-    });
-
-    // Group by participant + session + URL + element selector to merge fragmented typing events
-    const eventsByInputField = new Map<string, CollectionEvent[]>();
-
-    filteredKeyboardEvents.forEach((event) => {
-      const data = event.data as any as KeyboardEventData;
-
-      // Skip events without sequence or ID
-      if (!data.sequence || data.sequence.length === 0 || !event.id) {
-        return;
-      }
-
-      const pid = event.meta.pid;
-      const sid = event.meta.sid;
-      const url = event.meta.url || "";
-      const selector = data.t || "unknown";
-      const key = `${pid}|${sid}|${url}|${selector}`;
-
-      if (!eventsByInputField.has(key)) {
-        eventsByInputField.set(key, []);
-      }
-      eventsByInputField.get(key)!.push(event);
-    });
-
     const animations: TypingAnimation[] = [];
 
-    // Merge fragmented sequences that belong to the same input field
-    eventsByInputField.forEach((groupEvents) => {
-      groupEvents.sort((a, b) => a.ts - b.ts);
+    typingEventGroups.forEach(({ events: group }) => {
+      const firstEvent = group[0];
+      const firstData = firstEvent.data as any as KeyboardEventData;
 
-      // Merge sequences that are close in time
-      const mergedGroups: CollectionEvent[][] = [];
-      let currentGroup: CollectionEvent[] = [];
+      // Merge all sequences from the group
+      const mergedSequence: TypingAction[] = [];
+      let timeOffset = 0;
 
-      groupEvents.forEach((event) => {
-        if (currentGroup.length === 0) {
-          currentGroup.push(event);
-        } else {
-          const lastEvent = currentGroup[currentGroup.length - 1];
-          const timeDiff = event.ts - lastEvent.ts;
+      group.forEach((event, index) => {
+        const data = event.data as any as KeyboardEventData;
+        if (!data.sequence) return;
 
-          if (timeDiff <= MERGE_THRESHOLD_MS) {
-            // Close enough to merge
-            currentGroup.push(event);
-          } else {
-            // Start new group
-            mergedGroups.push(currentGroup);
-            currentGroup = [event];
-          }
+        // Adjust timestamps for continuity
+        const sequenceTimeOffset = index === 0 ? 0 : timeOffset;
+
+        data.sequence.forEach((action) => {
+          mergedSequence.push({
+            ...action,
+            timestamp: action.timestamp + sequenceTimeOffset,
+          });
+        });
+
+        // Update offset for next sequence
+        if (data.sequence.length > 0) {
+          const lastTimestamp =
+            data.sequence[data.sequence.length - 1].timestamp;
+          timeOffset += lastTimestamp + 500; // Add 500ms gap between merged sequences
         }
       });
 
-      if (currentGroup.length > 0) {
-        mergedGroups.push(currentGroup);
-      }
+      // Use first event's position and metadata
+      const x = firstData.x * viewportSize.width;
+      const y = firstData.y * viewportSize.height;
 
-      // Create one animation per merged group
-      mergedGroups.forEach((group) => {
-        const firstEvent = group[0];
-        const firstData = firstEvent.data as any as KeyboardEventData;
-
-        // Merge all sequences from the group
-        const mergedSequence: TypingAction[] = [];
-        let timeOffset = 0;
-
-        group.forEach((event, index) => {
-          const data = event.data as any as KeyboardEventData;
-          if (!data.sequence) return;
-
-          // Adjust timestamps for continuity
-          const sequenceTimeOffset = index === 0 ? 0 : timeOffset;
-
-          data.sequence.forEach((action) => {
-            mergedSequence.push({
-              ...action,
-              timestamp: action.timestamp + sequenceTimeOffset,
-            });
-          });
-
-          // Update offset for next sequence
-          if (data.sequence.length > 0) {
-            const lastTimestamp =
-              data.sequence[data.sequence.length - 1].timestamp;
-            timeOffset += lastTimestamp + 500; // Add 500ms gap between merged sequences
-          }
-        });
-
-        // Use first event's position and metadata
-        const x = firstData.x * viewportSize.width;
-        const y = firstData.y * viewportSize.height;
-
-        animations.push({
-          event: firstEvent,
-          x,
-          y,
-          color: getColorForEvent(firstEvent),
-          startTime: firstEvent.ts,
-          sequence: mergedSequence,
-        });
+      animations.push({
+        event: firstEvent,
+        x,
+        y,
+        color: getColorForEvent(firstEvent),
+        startTime: firstEvent.ts,
+        sequence: mergedSequence,
       });
     });
 

--- a/extension/website/shared/hooks/useNavigationTimeline.ts
+++ b/extension/website/shared/hooks/useNavigationTimeline.ts
@@ -12,6 +12,7 @@ import {
 import {
   RISO_COLORS,
   eventMatchesAnyFilter,
+  extractDomain,
   type FilterChip,
 } from "../utils/eventUtils";
 

--- a/extension/website/shared/hooks/usePlaybackCycle.ts
+++ b/extension/website/shared/hooks/usePlaybackCycle.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Drives one finite archive playback cycle independently of its visuals.
 // ABOUTME: Advances only when the next event batch is ready, then restarts by key.
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 const HIDDEN_TAB_TICK_MS = 100;
 const EMPTY_PLAYBACK_DURATION_MS = 60000;
@@ -22,12 +22,13 @@ export function usePlaybackCycle(params: {
   animationSpeed: number;
   frozen: boolean;
   onComplete?: () => boolean;
-}): void {
+}): () => number {
   const { enabled, cycleKey, durationMs, animationSpeed, frozen, onComplete } =
     params;
   const animationSpeedRef = useRef(animationSpeed);
   const frozenRef = useRef(frozen);
   const onCompleteRef = useRef(onComplete);
+  const elapsedMsRef = useRef(0);
 
   useEffect(() => {
     animationSpeedRef.current = animationSpeed;
@@ -40,12 +41,12 @@ export function usePlaybackCycle(params: {
   }, [onComplete]);
 
   useEffect(() => {
+    elapsedMsRef.current = 0;
     if (!enabled || durationMs <= 0) return;
 
     let animationFrame: number | undefined;
     let timeout: number | undefined;
     let previousTimestamp: number | null = null;
-    let elapsedMs = 0;
 
     const clearScheduledFrame = () => {
       if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
@@ -72,12 +73,12 @@ export function usePlaybackCycle(params: {
       previousTimestamp = timestamp;
 
       if (!frozenRef.current) {
-        elapsedMs += frameDelta * animationSpeedRef.current;
+        elapsedMsRef.current += frameDelta * animationSpeedRef.current;
       }
 
-      if (elapsedMs >= durationMs) {
+      if (elapsedMsRef.current >= durationMs) {
         if (onCompleteRef.current?.()) return;
-        elapsedMs %= durationMs;
+        elapsedMsRef.current %= durationMs;
       }
 
       scheduleNextFrame();
@@ -90,5 +91,7 @@ export function usePlaybackCycle(params: {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       clearScheduledFrame();
     };
-  }, [enabled, cycleKey, durationMs, frozen]);
+  }, [enabled, cycleKey, durationMs]);
+
+  return useCallback(() => elapsedMsRef.current, []);
 }

--- a/extension/website/shared/hooks/usePlaybackCycle.ts
+++ b/extension/website/shared/hooks/usePlaybackCycle.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef } from "react";
 
 const HIDDEN_TAB_TICK_MS = 100;
 const EMPTY_PLAYBACK_DURATION_MS = 60000;
+const COMPLETION_RETRY_MS = 500;
 
 export function getPlaybackCycleDuration(
   durations: readonly number[],
@@ -47,6 +48,7 @@ export function usePlaybackCycle(params: {
     let animationFrame: number | undefined;
     let timeout: number | undefined;
     let previousTimestamp: number | null = null;
+    let lastCompletionAttempt = -Infinity;
 
     const clearScheduledFrame = () => {
       if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
@@ -77,8 +79,15 @@ export function usePlaybackCycle(params: {
       }
 
       if (elapsedMsRef.current >= durationMs) {
-        if (onCompleteRef.current?.()) return;
-        elapsedMsRef.current %= durationMs;
+        if (!onCompleteRef.current) {
+          elapsedMsRef.current %= durationMs;
+        } else {
+          elapsedMsRef.current = durationMs;
+          if (timestamp - lastCompletionAttempt >= COMPLETION_RETRY_MS) {
+            lastCompletionAttempt = timestamp;
+            if (onCompleteRef.current()) return;
+          }
+        }
       }
 
       scheduleNextFrame();

--- a/extension/website/shared/hooks/useViewportScroll.ts
+++ b/extension/website/shared/hooks/useViewportScroll.ts
@@ -6,11 +6,11 @@ import { CollectionEvent, ScrollAnimation } from "../types";
 import {
   getColorForEvent,
   eventMatchesAnyFilter,
-  SCROLL_SESSION_THRESHOLD,
   SCROLL_TIME_COMPRESSION,
   MAX_VIEWPORT_ANIMATION_DURATION,
   type FilterChip,
 } from "../utils/eventUtils";
+import { groupScrollEvents } from "../utils/scrollEventGroups";
 
 // Settings interface for viewport scroll
 export interface ViewportScrollSettings {
@@ -107,48 +107,25 @@ export function useViewportScroll(
       return { animations: [], timeBounds: { min: 0, max: 0 } };
     }
 
-    // Group viewport events by session (pid + sid + url) with time windows
-    const scrollsBySession = new Map<string, CollectionEvent[]>();
-
-    filteredEvents.forEach((event) => {
-      const key = `${event.meta.pid}|${event.meta.sid}|${event.meta.url}`;
-      if (!scrollsBySession.has(key)) {
-        scrollsBySession.set(key, []);
+    const groupsBySession = new Map<
+      string,
+      ReturnType<typeof groupScrollEvents>
+    >();
+    for (const group of groupScrollEvents(filteredEvents)) {
+      const sessionGroups = groupsBySession.get(group.sessionId);
+      if (sessionGroups) {
+        sessionGroups.push(group);
+      } else {
+        groupsBySession.set(group.sessionId, [group]);
       }
-      scrollsBySession.get(key)!.push(event);
-    });
+    }
 
-    // Create ScrollAnimation objects by merging events within time windows
+    // Create ScrollAnimation objects from the shared session boundaries.
     const scrollAnimations: ScrollAnimation[] = [];
     let totalMergedSessions = 0;
 
-    scrollsBySession.forEach((sessionEvents) => {
-      sessionEvents.sort((a, b) => a.ts - b.ts);
-
-      // Merge events within SCROLL_SESSION_THRESHOLD
-      const mergedSessions: CollectionEvent[][] = [];
-      let currentSession: CollectionEvent[] = [];
-
-      sessionEvents.forEach((event) => {
-        if (currentSession.length === 0) {
-          currentSession.push(event);
-        } else {
-          const lastEvent = currentSession[currentSession.length - 1];
-          const timeDiff = event.ts - lastEvent.ts;
-
-          if (timeDiff <= SCROLL_SESSION_THRESHOLD) {
-            currentSession.push(event);
-          } else {
-            // Start new session
-            mergedSessions.push(currentSession);
-            currentSession = [event];
-          }
-        }
-      });
-
-      if (currentSession.length > 0) {
-        mergedSessions.push(currentSession);
-      }
+    groupsBySession.forEach((sessionGroups) => {
+      const mergedSessions = sessionGroups.map((group) => group.events);
 
       totalMergedSessions += mergedSessions.length;
 

--- a/extension/website/shared/utils/__tests__/installationUrls.test.ts
+++ b/extension/website/shared/utils/__tests__/installationUrls.test.ts
@@ -1,0 +1,40 @@
+// ABOUTME: Tests generated URL contracts for archive and live multi-screen installations.
+// ABOUTME: Ensures each cross-computer follower receives one stable participant slot.
+
+import { describe, expect, it } from "vitest";
+import { buildLiveInstallationScreens } from "../installationUrls";
+
+describe("buildLiveInstallationScreens", () => {
+  it("builds one field and four disjoint follower URLs by default", () => {
+    const screens = buildLiveInstallationScreens("https://wewere.online");
+
+    expect(screens).toHaveLength(5);
+    expect(new URL(screens[0].url).searchParams.get("view")).toBe("field");
+    expect(
+      screens.slice(1).map((screen) => {
+        const url = new URL(screen.url);
+        return {
+          path: url.pathname,
+          view: url.searchParams.get("view"),
+          slot: url.searchParams.get("slot"),
+          slots: url.searchParams.get("slots"),
+          cinematic: url.searchParams.get("cinematic"),
+        };
+      }),
+    ).toEqual(
+      ["0", "1", "2", "3"].map((slot) => ({
+        path: "/installation/live/",
+        view: "follow",
+        slot,
+        slots: "4",
+        cinematic: "follow",
+      })),
+    );
+  });
+
+  it("caps generated followers at the runtime slot limit", () => {
+    expect(
+      buildLiveInstallationScreens("https://wewere.online", 40),
+    ).toHaveLength(33);
+  });
+});

--- a/extension/website/shared/utils/__tests__/installationUrls.test.ts
+++ b/extension/website/shared/utils/__tests__/installationUrls.test.ts
@@ -5,36 +5,88 @@ import { describe, expect, it } from "vitest";
 import { buildLiveInstallationScreens } from "../installationUrls";
 
 describe("buildLiveInstallationScreens", () => {
-  it("builds one field and four disjoint follower URLs by default", () => {
+  it("builds the exact nine-screen installation set by default", () => {
     const screens = buildLiveInstallationScreens("https://wewere.online");
 
-    expect(screens).toHaveLength(5);
-    expect(new URL(screens[0].url).searchParams.get("view")).toBe("field");
+    expect(screens).toHaveLength(9);
+    expect(screens.map((screen) => screen.label)).toEqual([
+      "scrolling",
+      "keypresses",
+      "touches",
+      "clicks",
+      "cursor field",
+      "cursor follower 1",
+      "cursor follower 2",
+      "cursor follower 3",
+      "cursor follower 4",
+    ]);
+
     expect(
-      screens.slice(1).map((screen) => {
+      screens.slice(0, 5).map((screen) => {
         const url = new URL(screen.url);
         return {
           path: url.pathname,
+          viz: url.searchParams.get("viz"),
+          view: url.searchParams.get("view"),
+          clean: url.searchParams.get("clean"),
+        };
+      }),
+    ).toEqual([
+      {
+        path: "/installation/live/",
+        viz: "scrolling",
+        view: "field",
+        clean: "2",
+      },
+      { path: "/installation/live/", viz: "typing", view: "field", clean: "2" },
+      { path: "/touches/", viz: null, view: null, clean: "2" },
+      { path: "/installation/live/", viz: "clicks", view: "field", clean: "2" },
+      { path: "/installation/live/", viz: "trails", view: "field", clean: "2" },
+    ]);
+
+    expect(
+      screens.slice(5).map((screen) => {
+        const url = new URL(screen.url);
+        return {
+          path: url.pathname,
+          viz: url.searchParams.get("viz"),
           view: url.searchParams.get("view"),
           slot: url.searchParams.get("slot"),
           slots: url.searchParams.get("slots"),
           cinematic: url.searchParams.get("cinematic"),
+          clean: url.searchParams.get("clean"),
         };
       }),
     ).toEqual(
       ["0", "1", "2", "3"].map((slot) => ({
         path: "/installation/live/",
+        viz: "trails",
         view: "follow",
         slot,
         slots: "4",
         cinematic: "follow",
+        clean: "2",
       })),
     );
+  });
+
+  it("updates the follower partition across every cursor URL", () => {
+    const screens = buildLiveInstallationScreens("https://wewere.online", 2);
+
+    expect(screens).toHaveLength(7);
+    expect(
+      screens.map((screen) => new URL(screen.url).searchParams.get("slots")),
+    ).toEqual(["2", "2", null, "2", "2", "2", "2"]);
+    expect(
+      screens
+        .slice(5)
+        .map((screen) => new URL(screen.url).searchParams.get("slot")),
+    ).toEqual(["0", "1"]);
   });
 
   it("caps generated followers at the runtime slot limit", () => {
     expect(
       buildLiveInstallationScreens("https://wewere.online", 40),
-    ).toHaveLength(33);
+    ).toHaveLength(37);
   });
 });

--- a/extension/website/shared/utils/__tests__/installationUrls.test.ts
+++ b/extension/website/shared/utils/__tests__/installationUrls.test.ts
@@ -26,22 +26,20 @@ describe("buildLiveInstallationScreens", () => {
         const url = new URL(screen.url);
         return {
           path: url.pathname,
-          viz: url.searchParams.get("viz"),
-          view: url.searchParams.get("view"),
+          screen: url.searchParams.get("screen"),
           clean: url.searchParams.get("clean"),
         };
       }),
     ).toEqual([
       {
         path: "/installation/live/",
-        viz: "scrolling",
-        view: "field",
+        screen: "scrolling",
         clean: "2",
       },
-      { path: "/installation/live/", viz: "typing", view: "field", clean: "2" },
-      { path: "/touches/", viz: null, view: null, clean: "2" },
-      { path: "/installation/live/", viz: "clicks", view: "field", clean: "2" },
-      { path: "/installation/live/", viz: "trails", view: "field", clean: "2" },
+      { path: "/installation/live/", screen: "typing", clean: "2" },
+      { path: "/touches/", screen: "touches", clean: "2" },
+      { path: "/installation/live/", screen: "clicks", clean: "2" },
+      { path: "/installation/live/", screen: "cursors", clean: "2" },
     ]);
 
     expect(
@@ -49,44 +47,16 @@ describe("buildLiveInstallationScreens", () => {
         const url = new URL(screen.url);
         return {
           path: url.pathname,
-          viz: url.searchParams.get("viz"),
-          view: url.searchParams.get("view"),
-          slot: url.searchParams.get("slot"),
-          slots: url.searchParams.get("slots"),
-          cinematic: url.searchParams.get("cinematic"),
+          screen: url.searchParams.get("screen"),
           clean: url.searchParams.get("clean"),
         };
       }),
     ).toEqual(
-      ["0", "1", "2", "3"].map((slot) => ({
+      ["a", "b", "c", "d"].map((follower) => ({
         path: "/installation/live/",
-        viz: "trails",
-        view: "follow",
-        slot,
-        slots: "4",
-        cinematic: "follow",
+        screen: `follower-${follower}`,
         clean: "2",
       })),
     );
-  });
-
-  it("updates the follower partition across every cursor URL", () => {
-    const screens = buildLiveInstallationScreens("https://wewere.online", 2);
-
-    expect(screens).toHaveLength(7);
-    expect(
-      screens.map((screen) => new URL(screen.url).searchParams.get("slots")),
-    ).toEqual(["2", "2", null, "2", "2", "2", "2"]);
-    expect(
-      screens
-        .slice(5)
-        .map((screen) => new URL(screen.url).searchParams.get("slot")),
-    ).toEqual(["0", "1"]);
-  });
-
-  it("caps generated followers at the runtime slot limit", () => {
-    expect(
-      buildLiveInstallationScreens("https://wewere.online", 40),
-    ).toHaveLength(37);
   });
 });

--- a/extension/website/shared/utils/__tests__/liveInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallation.test.ts
@@ -57,8 +57,9 @@ describe("live installation visualizations", () => {
     expect(resolveLiveInstallationVisualizations(["scrolling"])).toEqual([
       "scrolling",
     ]);
-    expect(resolveLiveInstallationVisualizations(["navigation"])).toEqual([
-      "navigation",
+    expect(resolveLiveInstallationVisualizations(["navigation"])).toEqual([]);
+    expect(resolveLiveInstallationVisualizations(["typing"])).toEqual([
+      "typing",
     ]);
   });
 
@@ -144,13 +145,12 @@ describe("live chapter selection", () => {
     expect(liveChapterIsReady(events, ["trails"])).toBe(true);
   });
 
-  it("accepts navigation once one session forms a three-step path", () => {
+  it("accepts a chapter with multiple keyboard events", () => {
     const events = [
       event("start", "cursor", 0, "a"),
-      event("n1", "navigation", 30_000, "a", "focus", "journey"),
-      event("n2", "navigation", 31_000, "a", "popstate", "journey"),
-      event("n3", "navigation", 32_000, "a", "beforeunload", "journey"),
+      event("k1", "keyboard", 30_000, "a", "move", "typing"),
+      event("k2", "keyboard", 31_000, "a", "move", "typing"),
     ];
-    expect(liveChapterIsReady(events, ["navigation"])).toBe(true);
+    expect(liveChapterIsReady(events, ["typing"])).toBe(true);
   });
 });

--- a/extension/website/shared/utils/__tests__/liveInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallation.test.ts
@@ -8,6 +8,7 @@ import {
   liveChapterIsReady,
   parseLiveInstallationScreen,
   participantInstallationSlot,
+  resolveLiveInstallationVisualizations,
   unconsumedLiveEvents,
 } from "../liveInstallation";
 
@@ -43,6 +44,33 @@ describe("live installation screen config", () => {
       slot: 3,
       slots: 4,
     });
+  });
+});
+
+describe("live installation visualizations", () => {
+  it("shows cursor trails only when the viz query parameter is absent", () => {
+    expect(resolveLiveInstallationVisualizations(undefined)).toEqual(["trails"]);
+  });
+
+  it("allows each additional visualization to be selected explicitly", () => {
+    expect(resolveLiveInstallationVisualizations(["clicks"])).toEqual(["clicks"]);
+    expect(resolveLiveInstallationVisualizations(["scrolling"])).toEqual([
+      "scrolling",
+    ]);
+    expect(resolveLiveInstallationVisualizations(["navigation"])).toEqual([
+      "navigation",
+    ]);
+  });
+
+  it("allows explicit combinations without enabling unrequested visualizations", () => {
+    expect(
+      resolveLiveInstallationVisualizations(["trails", "clicks", "unknown"]),
+    ).toEqual(["trails", "clicks"]);
+  });
+
+  it("keeps an explicitly empty or invalid selection empty", () => {
+    expect(resolveLiveInstallationVisualizations([])).toEqual([]);
+    expect(resolveLiveInstallationVisualizations(["unknown"])).toEqual([]);
   });
 });
 

--- a/extension/website/shared/utils/__tests__/liveInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { CollectionEvent } from "../../types";
 import {
   eventsForInstallationScreen,
+  installationChapterAction,
   liveChapterIsReady,
   parseLiveInstallationScreen,
   participantInstallationSlot,
@@ -49,11 +50,15 @@ describe("live installation screen config", () => {
 
 describe("live installation visualizations", () => {
   it("shows cursor trails only when the viz query parameter is absent", () => {
-    expect(resolveLiveInstallationVisualizations(undefined)).toEqual(["trails"]);
+    expect(resolveLiveInstallationVisualizations(undefined)).toEqual([
+      "trails",
+    ]);
   });
 
   it("allows each additional visualization to be selected explicitly", () => {
-    expect(resolveLiveInstallationVisualizations(["clicks"])).toEqual(["clicks"]);
+    expect(resolveLiveInstallationVisualizations(["clicks"])).toEqual([
+      "clicks",
+    ]);
     expect(resolveLiveInstallationVisualizations(["scrolling"])).toEqual([
       "scrolling",
     ]);
@@ -109,14 +114,21 @@ describe("participant ownership", () => {
 });
 
 describe("live chapter selection", () => {
+  it("stays at the live edge after live playback begins", () => {
+    expect(installationChapterAction("archive", false)).toBe("advance-archive");
+    expect(installationChapterAction("archive", true)).toBe("show-live");
+    expect(installationChapterAction("live", false)).toBe("wait-live");
+    expect(installationChapterAction("live", true)).toBe("show-live");
+  });
+
   it("excludes events already represented by the archive or an earlier chapter", () => {
     const events = [
       event("newer", "cursor", 2, "a"),
       event("used", "cursor", 1, "a"),
     ];
-    expect(unconsumedLiveEvents(events, new Set(["used"])).map((item) => item.id)).toEqual([
-      "newer",
-    ]);
+    expect(
+      unconsumedLiveEvents(events, new Set(["used"])).map((item) => item.id),
+    ).toEqual(["newer"]);
   });
 
   it("accepts a 30-second cursor chapter with enough movement from two people", () => {

--- a/extension/website/shared/utils/__tests__/liveInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallation.test.ts
@@ -1,0 +1,128 @@
+// ABOUTME: Tests deterministic installation screen ownership and live-chapter thresholds.
+// ABOUTME: Protects cross-computer follower exclusivity and sparse-stream fallback behavior.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  eventsForInstallationScreen,
+  liveChapterIsReady,
+  parseLiveInstallationScreen,
+  participantInstallationSlot,
+  unconsumedLiveEvents,
+} from "../liveInstallation";
+
+function event(
+  id: string,
+  type: string,
+  ts: number,
+  pid: string,
+  dataEvent = "move",
+  sid = "session",
+): CollectionEvent {
+  return {
+    id,
+    type,
+    ts,
+    data: { x: 0.5, y: 0.5, event: dataEvent },
+    meta: { pid, sid, url: "https://example.com", vw: 100, vh: 100, tz: "UTC" },
+  } as CollectionEvent;
+}
+
+describe("live installation screen config", () => {
+  it("uses a four-follower field view by default", () => {
+    expect(parseLiveInstallationScreen("")).toEqual({
+      view: "field",
+      slot: 0,
+      slots: 4,
+    });
+  });
+
+  it("clamps an invalid follower slot into the configured range", () => {
+    expect(parseLiveInstallationScreen("?view=follow&slot=9&slots=4")).toEqual({
+      view: "follow",
+      slot: 3,
+      slots: 4,
+    });
+  });
+});
+
+describe("participant ownership", () => {
+  it("assigns every participant to exactly one stable slot", () => {
+    const pids = ["alice", "bob", "charlie", "dana", "erin"];
+    for (const pid of pids) {
+      const slot = participantInstallationSlot(pid, 4);
+      expect(slot).toBeGreaterThanOrEqual(0);
+      expect(slot).toBeLessThan(4);
+      expect(participantInstallationSlot(pid, 4)).toBe(slot);
+    }
+  });
+
+  it("returns disjoint event sets for follower screens", () => {
+    const events = Array.from({ length: 20 }, (_, index) =>
+      event(String(index), "cursor", index, `person-${index}`),
+    );
+    const assignedIds = new Set<string>();
+
+    for (let slot = 0; slot < 4; slot++) {
+      const screenEvents = eventsForInstallationScreen(events, {
+        view: "follow",
+        slot,
+        slots: 4,
+      });
+      for (const item of screenEvents) {
+        expect(assignedIds.has(item.id)).toBe(false);
+        assignedIds.add(item.id);
+      }
+    }
+
+    expect(assignedIds.size).toBe(events.length);
+  });
+});
+
+describe("live chapter selection", () => {
+  it("excludes events already represented by the archive or an earlier chapter", () => {
+    const events = [
+      event("newer", "cursor", 2, "a"),
+      event("used", "cursor", 1, "a"),
+    ];
+    expect(unconsumedLiveEvents(events, new Set(["used"])).map((item) => item.id)).toEqual([
+      "newer",
+    ]);
+  });
+
+  it("accepts a 30-second cursor chapter with enough movement from two people", () => {
+    const events = Array.from({ length: 24 }, (_, index) =>
+      event(
+        String(index),
+        "cursor",
+        Math.round((index / 23) * 30_000),
+        index % 2 === 0 ? "a" : "b",
+      ),
+    );
+    expect(liveChapterIsReady(events, ["trails"])).toBe(true);
+  });
+
+  it("keeps sparse or single-participant cursor activity in the buffer", () => {
+    const events = Array.from({ length: 24 }, (_, index) =>
+      event(String(index), "cursor", Math.round((index / 23) * 30_000), "a"),
+    );
+    expect(liveChapterIsReady(events, ["trails"])).toBe(false);
+  });
+
+  it("does not require 30 seconds when a high-volume stream fills a dense chapter", () => {
+    const events = Array.from({ length: 1000 }, (_, index) =>
+      event(String(index), "cursor", index * 5, index % 4 === 0 ? "a" : "b"),
+    );
+    expect(liveChapterIsReady(events, ["trails"])).toBe(true);
+  });
+
+  it("accepts navigation once one session forms a three-step path", () => {
+    const events = [
+      event("start", "cursor", 0, "a"),
+      event("n1", "navigation", 30_000, "a", "focus", "journey"),
+      event("n2", "navigation", 31_000, "a", "popstate", "journey"),
+      event("n3", "navigation", 32_000, "a", "beforeunload", "journey"),
+    ];
+    expect(liveChapterIsReady(events, ["navigation"])).toBe(true);
+  });
+});

--- a/extension/website/shared/utils/__tests__/liveInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallation.test.ts
@@ -10,6 +10,7 @@ import {
   parseLiveInstallationScreen,
   participantInstallationSlot,
   resolveLiveInstallationVisualizations,
+  showsInstallationPeopleCount,
   unconsumedLiveEvents,
 } from "../liveInstallation";
 
@@ -77,6 +78,26 @@ describe("live installation visualizations", () => {
   it("keeps an explicitly empty or invalid selection empty", () => {
     expect(resolveLiveInstallationVisualizations([])).toEqual([]);
     expect(resolveLiveInstallationVisualizations(["unknown"])).toEqual([]);
+  });
+});
+
+describe("live installation people count", () => {
+  it("shows only on the cursor field", () => {
+    const field = { view: "field", slot: 0, slots: 4 } as const;
+    expect(
+      showsInstallationPeopleCount(field, ["trails"]),
+    ).toBe(true);
+
+    for (const visualization of ["clicks", "typing", "scrolling"]) {
+      expect(showsInstallationPeopleCount(field, [visualization])).toBe(false);
+    }
+
+    expect(
+      showsInstallationPeopleCount(
+        { view: "follow", slot: 0, slots: 4 },
+        ["trails"],
+      ),
+    ).toBe(false);
   });
 });
 

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Tests named live-installation profile resolution and current machine settings.
+// ABOUTME: Protects stable screen identities while allowing explicit URL overrides elsewhere.
+
+import { describe, expect, it } from "vitest";
+import {
+  parseCinematicFromUrl,
+  parseFollowerIdFromUrl,
+  parseInstallationRoleFromUrl,
+} from "../../config";
+import { parseLiveInstallationScreen } from "../liveInstallation";
+import {
+  LIVE_INSTALLATION_PROFILES,
+  resolveLiveInstallationProfile,
+} from "../liveInstallationProfiles";
+
+describe("live installation profiles", () => {
+  it("resolves every named machine profile", () => {
+    for (const [name, profile] of Object.entries(LIVE_INSTALLATION_PROFILES)) {
+      expect(resolveLiveInstallationProfile(`?screen=${name}`)).toBe(profile);
+    }
+    expect(resolveLiveInstallationProfile("?screen=unknown")).toBeNull();
+    expect(resolveLiveInstallationProfile("")).toBeNull();
+  });
+
+  it("keeps the current installation settings in centrally deployed profiles", () => {
+    expect(LIVE_INSTALLATION_PROFILES.scrolling.settings.scrollSpeed).toBe(1);
+    expect(
+      LIVE_INSTALLATION_PROFILES.scrolling.settings.maxConcurrentScrolls,
+    ).toBe(42);
+    expect(LIVE_INSTALLATION_PROFILES.typing.settings).toMatchObject({
+      textboxOpacity: 0.85,
+      keyboardAnimationSpeed: 0.4,
+      maxConcurrentTyping: 50,
+    });
+    expect(LIVE_INSTALLATION_PROFILES.clicks.settings).toMatchObject({
+      clickMaxRadius: 55,
+      clickNumRings: 6,
+      clickMaxGapMs: 850,
+    });
+    expect(LIVE_INSTALLATION_PROFILES.cursors.settings).toMatchObject({
+      trailAnimationMode: "natural",
+      strokeWidth: 6,
+      trailOpacity: 0.9,
+      maxConcurrentTrails: 24,
+    });
+  });
+
+  it("uses explicit follower query parameters over profile defaults", () => {
+    const profile = LIVE_INSTALLATION_PROFILES["follower-c"];
+    expect(parseLiveInstallationScreen("", profile.screen)).toEqual({
+      view: "follow",
+      slot: 2,
+      slots: 4,
+    });
+    expect(
+      parseLiveInstallationScreen("?view=field&slot=0&slots=2", profile.screen),
+    ).toEqual({ view: "field", slot: 0, slots: 2 });
+  });
+
+  it("provides a complete follower runtime without redundant query parameters", () => {
+    const profile = LIVE_INSTALLATION_PROFILES["follower-c"];
+
+    expect(profile.screen).toEqual({ view: "follow", slot: 2, slots: 4 });
+    expect(profile.role).toBe("follower");
+    expect(profile.followerId).toBe("c");
+    expect(profile.cinematic?.mode).toBe("follow");
+  });
+
+  it("lets explicit runtime query parameters override follower defaults", () => {
+    const originalUrl = window.location.href;
+    const profile = LIVE_INSTALLATION_PROFILES["follower-c"];
+    window.history.replaceState(
+      null,
+      "",
+      "/installation/live/?screen=follower-c&role=master&follower=z&cinematic=reveal&cinemaZoom=0.5",
+    );
+
+    try {
+      expect(parseInstallationRoleFromUrl(profile.role)).toBe("master");
+      expect(parseFollowerIdFromUrl(profile.followerId)).toBe("z");
+      expect(parseCinematicFromUrl(profile.cinematic)).toMatchObject({
+        mode: "reveal",
+        zoom: 0.5,
+      });
+    } finally {
+      window.history.replaceState(null, "", originalUrl);
+    }
+  });
+});

--- a/extension/website/shared/utils/__tests__/scrollEventGroups.test.ts
+++ b/extension/website/shared/utils/__tests__/scrollEventGroups.test.ts
@@ -1,0 +1,144 @@
+// ABOUTME: Tests logical scroll-window grouping with real viewport event shapes.
+// ABOUTME: Covers session identity, inactivity boundaries, ordering, and visible activity.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import { SCROLL_SESSION_THRESHOLD } from "../eventUtils";
+import {
+  groupScrollEvents,
+  scrollEventGroupHasActivity,
+  scrollEventGroupHasVisibleActivity,
+} from "../scrollEventGroups";
+
+function viewportEvent(
+  id: string,
+  ts: number,
+  options: {
+    pid?: string;
+    sid?: string;
+    url?: string;
+    event?: "scroll" | "resize" | "zoom";
+    scrollX?: number;
+    scrollY?: number;
+    width?: number;
+    height?: number;
+    zoom?: number;
+  } = {},
+): CollectionEvent {
+  return {
+    id,
+    type: "viewport",
+    ts,
+    data: {
+      event: options.event ?? "scroll",
+      scrollX: options.scrollX ?? 0,
+      scrollY: options.scrollY ?? 0,
+      width: options.width,
+      height: options.height,
+      zoom: options.zoom,
+    },
+    meta: {
+      pid: options.pid ?? "person",
+      sid: options.sid ?? "session",
+      url: options.url ?? "https://example.com/page",
+      vw: 1280,
+      vh: 720,
+      tz: "UTC",
+    },
+  };
+}
+
+describe("groupScrollEvents", () => {
+  it("groups one participant, browser session, and URL within 15 minutes", () => {
+    const groups = groupScrollEvents([
+      viewportEvent("later", SCROLL_SESSION_THRESHOLD, { scrollY: 0.8 }),
+      viewportEvent("earlier", 0, { scrollY: 0.1 }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events.map(({ id }) => id)).toEqual(["earlier", "later"]);
+  });
+
+  it("splits after the renderer inactivity boundary", () => {
+    const groups = groupScrollEvents([
+      viewportEvent("first", 0),
+      viewportEvent("second", SCROLL_SESSION_THRESHOLD + 1),
+    ]);
+
+    expect(groups.map((group) => group.events.map(({ id }) => id))).toEqual([
+      ["first"],
+      ["second"],
+    ]);
+  });
+
+  it("keeps participant, browser session, and URL identities separate", () => {
+    const groups = groupScrollEvents([
+      viewportEvent("base", 0),
+      viewportEvent("pid", 1, { pid: "other" }),
+      viewportEvent("sid", 2, { sid: "other" }),
+      viewportEvent("url", 3, { url: "https://example.org" }),
+    ]);
+
+    expect(groups).toHaveLength(4);
+  });
+
+  it("recognizes visible scroll, resize, and zoom changes", () => {
+    const visibleScroll = groupScrollEvents([
+      viewportEvent("scroll-a", 0, { scrollY: 0.1 }),
+      viewportEvent("scroll-b", 1, { scrollY: 0.2 }),
+    ])[0];
+    const visibleResize = groupScrollEvents([
+      viewportEvent("resize-a", 0, { event: "resize", width: 800 }),
+      viewportEvent("resize-b", 1, { event: "resize", width: 1000 }),
+    ])[0];
+    const visibleZoom = groupScrollEvents([
+      viewportEvent("zoom-a", 0, { event: "zoom", zoom: 1 }),
+      viewportEvent("zoom-b", 1, { event: "zoom", zoom: 1.25 }),
+    ])[0];
+    const invisible = groupScrollEvents([
+      viewportEvent("small-a", 0, { scrollY: 0.1 }),
+      viewportEvent("small-b", 1, { scrollY: 0.11 }),
+    ])[0];
+
+    expect(scrollEventGroupHasVisibleActivity(visibleScroll)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(visibleResize)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(visibleZoom)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(invisible)).toBe(false);
+  });
+
+  it("matches the renderer's activity fallback without treating horizontal scroll as visible", () => {
+    const horizontal = groupScrollEvents([
+      viewportEvent("horizontal-a", 0, { scrollX: 0.1 }),
+      viewportEvent("horizontal-b", 1, { scrollX: 0.3 }),
+    ])[0];
+    const oneResize = groupScrollEvents([
+      viewportEvent("resize", 0, { event: "resize", width: 800 }),
+    ])[0];
+
+    expect(scrollEventGroupHasActivity(horizontal)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(horizontal)).toBe(false);
+    expect(scrollEventGroupHasActivity(oneResize)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(oneResize)).toBe(false);
+  });
+
+  it("evaluates visibility after timeline compression and the 30-second cap", () => {
+    const capped = groupScrollEvents([
+      viewportEvent("early", 0, { scrollY: 0.1 }),
+      viewportEvent("late", 6 * 60_000, { scrollY: 0.4 }),
+    ])[0];
+
+    expect(scrollEventGroupHasActivity(capped)).toBe(true);
+    expect(scrollEventGroupHasVisibleActivity(capped)).toBe(false);
+  });
+
+  it("omits non-viewport and unidentified events", () => {
+    const viewport = viewportEvent("visible", 0);
+    expect(
+      groupScrollEvents([
+        { ...viewport, id: "", ts: 1 },
+        { ...viewport, id: "cursor", type: "cursor", ts: 2 },
+        viewport,
+      ]).flatMap((group) => group.events.map(({ id }) => id)),
+    ).toEqual(["visible"]);
+  });
+});

--- a/extension/website/shared/utils/__tests__/scrollInstallationReservoir.test.ts
+++ b/extension/website/shared/utils/__tests__/scrollInstallationReservoir.test.ts
@@ -1,0 +1,190 @@
+// ABOUTME: Tests finite scrolling chapter selection from live and archive reservoirs.
+// ABOUTME: Verifies quiet completion, whole-window rotation, deduplication, and exhaustion.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  DEFAULT_SCROLL_INSTALLATION_CHAPTER_GROUPS,
+  SCROLL_INSTALLATION_QUIET_MS,
+  addScrollReservoirEvents,
+  createScrollReservoir,
+  takeScrollReservoirChapter,
+} from "../scrollInstallationReservoir";
+
+function scrollWindow(
+  id: string,
+  ts: number,
+  options: { pid?: string; sid?: string; startY?: number } = {},
+): CollectionEvent[] {
+  const event = (suffix: string, offset: number, scrollY: number) => ({
+    id: `${id}-${suffix}`,
+    type: "viewport" as const,
+    ts: ts + offset,
+    data: { event: "scroll", scrollX: 0, scrollY },
+    meta: {
+      pid: options.pid ?? "person",
+      sid: options.sid ?? id,
+      url: "https://example.com/page",
+      vw: 1280,
+      vh: 720,
+      tz: "UTC",
+    },
+  });
+  const startY = options.startY ?? 0;
+  return [event("a", 0, startY), event("b", 1_000, startY + 0.2)];
+}
+
+describe("scroll installation reservoir", () => {
+  it("uses a named 1000-window chapter default", () => {
+    expect(DEFAULT_SCROLL_INSTALLATION_CHAPTER_GROUPS).toBe(1000);
+  });
+
+  it("prioritizes completed live windows and fills from archive", () => {
+    let state = createScrollReservoir();
+    state = addScrollReservoirEvents(
+      state,
+      scrollWindow("archive", 0),
+      "archive",
+      100_000,
+    );
+    state = addScrollReservoirEvents(
+      state,
+      scrollWindow("live", 10_000),
+      "live",
+      100_000,
+    );
+
+    const chapter = takeScrollReservoirChapter(state, 2);
+    expect(chapter.events.map(({ id }) => id)).toEqual([
+      "live-a",
+      "live-b",
+      "archive-a",
+      "archive-b",
+    ]);
+    expect(chapter.hasLive).toBe(true);
+  });
+
+  it("keeps live activity pending until its quiet period closes", () => {
+    let state = addScrollReservoirEvents(
+      createScrollReservoir(),
+      scrollWindow("live", 10_000),
+      "live",
+      11_000 + SCROLL_INSTALLATION_QUIET_MS - 1,
+    );
+
+    expect(takeScrollReservoirChapter(state).events).toEqual([]);
+
+    state = addScrollReservoirEvents(
+      state,
+      [],
+      "live",
+      11_000 + SCROLL_INSTALLATION_QUIET_MS,
+    );
+    expect(
+      takeScrollReservoirChapter(state).events.map(({ id }) => id),
+    ).toEqual(["live-a", "live-b"]);
+  });
+
+  it("shows later unseen activity from a previously displayed session", () => {
+    let state = addScrollReservoirEvents(
+      createScrollReservoir(),
+      scrollWindow("first", 0, { sid: "shared" }),
+      "archive",
+      100_000,
+    );
+    const first = takeScrollReservoirChapter(state, 1);
+
+    state = addScrollReservoirEvents(
+      first.state,
+      scrollWindow("later", 60_000, { sid: "shared", startY: 0.3 }),
+      "live",
+      100_000,
+    );
+    const later = takeScrollReservoirChapter(state, 1);
+
+    expect(later.events.map(({ id }) => id)).toEqual(["later-a", "later-b"]);
+    expect(later.repeated).toBe(false);
+  });
+
+  it("rotates whole windows without repeating events until exhaustion", () => {
+    let state = addScrollReservoirEvents(
+      createScrollReservoir(),
+      [
+        ...scrollWindow("a", 0),
+        ...scrollWindow("b", 60_000),
+        ...scrollWindow("c", 120_000),
+      ],
+      "archive",
+      200_000,
+    );
+
+    const first = takeScrollReservoirChapter(state, 2);
+    const second = takeScrollReservoirChapter(first.state, 2);
+    const third = takeScrollReservoirChapter(second.state, 2);
+
+    expect(first.events.map(({ id }) => id)).toEqual([
+      "c-a",
+      "c-b",
+      "b-a",
+      "b-b",
+    ]);
+    expect(second.events.map(({ id }) => id)).toEqual(["a-a", "a-b"]);
+    expect(second.repeated).toBe(false);
+    expect(third.events.map(({ id }) => id)).toEqual(
+      first.events.map(({ id }) => id),
+    );
+    expect(third.repeated).toBe(true);
+    expect(third.rotation).toBe(1);
+  });
+
+  it("deduplicates raw event IDs", () => {
+    const events = scrollWindow("shared", 0);
+    let state = addScrollReservoirEvents(
+      createScrollReservoir(),
+      [...events, ...events],
+      "archive",
+      100_000,
+    );
+    state = addScrollReservoirEvents(state, events, "live", 100_000);
+
+    const chapter = takeScrollReservoirChapter(state);
+    expect(chapter.events.map(({ id }) => id)).toEqual([
+      "shared-a",
+      "shared-b",
+    ]);
+  });
+
+  it("uses renderer fallback activity only when no visible windows remain", () => {
+    const resize: CollectionEvent = {
+      id: "resize",
+      type: "viewport",
+      ts: 0,
+      data: { event: "resize", width: 800, height: 600 },
+      meta: {
+        pid: "person",
+        sid: "resize",
+        url: "https://example.com/resize",
+        vw: 800,
+        vh: 600,
+        tz: "UTC",
+      },
+    };
+    let state = addScrollReservoirEvents(
+      createScrollReservoir(),
+      [resize, ...scrollWindow("visible", 10_000)],
+      "archive",
+      100_000,
+    );
+
+    const visible = takeScrollReservoirChapter(state, 1);
+    expect(visible.events.map(({ id }) => id)).toEqual([
+      "visible-a",
+      "visible-b",
+    ]);
+
+    state = visible.state;
+    const fallback = takeScrollReservoirChapter(state, 1);
+    expect(fallback.events.map(({ id }) => id)).toEqual(["resize"]);
+    expect(fallback.repeated).toBe(false);
+  });
+});

--- a/extension/website/shared/utils/__tests__/shareUrl.test.ts
+++ b/extension/website/shared/utils/__tests__/shareUrl.test.ts
@@ -33,4 +33,28 @@ describe("buildShareUrl", () => {
 
     expect(new URL(url).searchParams.has("s")).toBe(true);
   });
+
+  it("preserves live installation screen identity across URL rewrites", () => {
+    const originalUrl = window.location.href;
+    window.history.replaceState(
+      null,
+      "",
+      "/installation/live/?view=follow&slot=2&slots=4",
+    );
+
+    try {
+      const url = new URL(
+        buildShareUrl({
+          settings: DEFAULT_SETTINGS,
+          activeVisualizations: DEFAULT_ACTIVE_VISUALIZATIONS,
+          selectedTimeRange: null,
+        }),
+      );
+      expect(url.searchParams.get("view")).toBe("follow");
+      expect(url.searchParams.get("slot")).toBe("2");
+      expect(url.searchParams.get("slots")).toBe("4");
+    } finally {
+      window.history.replaceState(null, "", originalUrl);
+    }
+  });
 });

--- a/extension/website/shared/utils/__tests__/shareUrl.test.ts
+++ b/extension/website/shared/utils/__tests__/shareUrl.test.ts
@@ -39,7 +39,7 @@ describe("buildShareUrl", () => {
     window.history.replaceState(
       null,
       "",
-      "/installation/live/?view=follow&slot=2&slots=4",
+      "/installation/live/?screen=follower-c&view=follow&slot=2&slots=4",
     );
 
     try {
@@ -53,6 +53,7 @@ describe("buildShareUrl", () => {
       expect(url.searchParams.get("view")).toBe("follow");
       expect(url.searchParams.get("slot")).toBe("2");
       expect(url.searchParams.get("slots")).toBe("4");
+      expect(url.searchParams.get("screen")).toBe("follower-c");
     } finally {
       window.history.replaceState(null, "", originalUrl);
     }

--- a/extension/website/shared/utils/__tests__/typingEventGroups.test.ts
+++ b/extension/website/shared/utils/__tests__/typingEventGroups.test.ts
@@ -1,0 +1,131 @@
+// ABOUTME: Tests logical typing-box grouping with real keyboard event shapes.
+// ABOUTME: Covers input identity, inactivity boundaries, ordering, and eligibility.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent, TypingAction } from "../../types";
+import {
+  groupTypingEvents,
+  TYPING_EVENT_MERGE_THRESHOLD_MS,
+} from "../typingEventGroups";
+
+function keyboardEvent(
+  id: string,
+  ts: number,
+  options: {
+    pid?: string;
+    sid?: string;
+    url?: string;
+    selector?: string;
+    sequence?: TypingAction[] | null;
+  } = {},
+): CollectionEvent {
+  return {
+    id,
+    type: "keyboard",
+    ts,
+    data: {
+      event: "type",
+      x: 0.25,
+      y: 0.75,
+      t: options.selector ?? "#message",
+      sequence:
+        options.sequence === undefined
+          ? [{ action: "type", text: id, timestamp: 0 }]
+          : options.sequence,
+    },
+    meta: {
+      pid: options.pid ?? "person",
+      sid: options.sid ?? "session",
+      url: options.url ?? "https://example.com/chat",
+      vw: 1280,
+      vh: 720,
+      tz: "UTC",
+    },
+  };
+}
+
+describe("groupTypingEvents", () => {
+  it("merges adjacent fragments for one visible input and sorts their events", () => {
+    const later = keyboardEvent("later", TYPING_EVENT_MERGE_THRESHOLD_MS);
+    const earlier = keyboardEvent("earlier", 0);
+
+    const groups = groupTypingEvents([later, earlier]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events.map(({ id }) => id)).toEqual(["earlier", "later"]);
+    expect(groups[0]).toMatchObject({ startTs: 0, endTs: 35_000 });
+    expect(groups[0].id).toContain("earlier");
+  });
+
+  it("starts a new visible box after more than 35 seconds of inactivity", () => {
+    const groups = groupTypingEvents([
+      keyboardEvent("first", 0),
+      keyboardEvent("second", TYPING_EVENT_MERGE_THRESHOLD_MS + 1),
+    ]);
+
+    expect(groups.map((group) => group.events.map(({ id }) => id))).toEqual([
+      ["first"],
+      ["second"],
+    ]);
+    expect(new Set(groups.map(({ id }) => id)).size).toBe(2);
+  });
+
+  it("keeps participant, browser session, URL, and selector identities separate", () => {
+    const groups = groupTypingEvents([
+      keyboardEvent("base", 0),
+      keyboardEvent("pid", 1, { pid: "other" }),
+      keyboardEvent("sid", 2, { sid: "other" }),
+      keyboardEvent("url", 3, { url: "https://example.org" }),
+      keyboardEvent("selector", 4, { selector: "#search" }),
+    ]);
+
+    expect(groups).toHaveLength(5);
+    expect(groups.map((group) => group.events[0].id)).toEqual([
+      "base",
+      "pid",
+      "sid",
+      "url",
+      "selector",
+    ]);
+  });
+
+  it("returns the same chronological group order for shuffled input", () => {
+    const earliest = keyboardEvent("earliest", 100, { selector: "#first" });
+    const sameTimeA = keyboardEvent("a", 200, { selector: "#a" });
+    const sameTimeB = keyboardEvent("b", 200, { selector: "#b" });
+
+    const orderedIds = (events: CollectionEvent[]) =>
+      groupTypingEvents(events).map(({ id }) => id);
+
+    expect(orderedIds([sameTimeB, earliest, sameTimeA])).toEqual(
+      orderedIds([sameTimeA, sameTimeB, earliest]),
+    );
+    expect(
+      groupTypingEvents([sameTimeB, earliest, sameTimeA]).map(
+        (group) => group.events[0].id,
+      ),
+    ).toEqual(["earliest", "a", "b"]);
+  });
+
+  it("omits non-keyboard, empty, unidentified, and collection-test events", () => {
+    const nonKeyboard = { ...keyboardEvent("cursor", 0), type: "cursor" };
+    const unidentified = { ...keyboardEvent("missing-id", 1), id: "" };
+
+    const groups = groupTypingEvents([
+      nonKeyboard,
+      unidentified,
+      keyboardEvent("empty", 2, { sequence: [] }),
+      keyboardEvent("null", 3, { sequence: null }),
+      keyboardEvent("test", 4, {
+        sequence: [
+          { action: "type", text: "eliza", timestamp: 0 },
+          { action: "type", text: "beth", timestamp: 100 },
+        ],
+      }),
+      keyboardEvent("visible", 5),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].events.map(({ id }) => id)).toEqual(["visible"]);
+  });
+});

--- a/extension/website/shared/utils/__tests__/typingEventGroups.test.ts
+++ b/extension/website/shared/utils/__tests__/typingEventGroups.test.ts
@@ -15,7 +15,9 @@ function keyboardEvent(
     pid?: string;
     sid?: string;
     url?: string;
-    selector?: string;
+    selector?: string | null;
+    x?: number;
+    y?: number;
     sequence?: TypingAction[] | null;
   } = {},
 ): CollectionEvent {
@@ -25,9 +27,11 @@ function keyboardEvent(
     ts,
     data: {
       event: "type",
-      x: 0.25,
-      y: 0.75,
-      t: options.selector ?? "#message",
+      x: options.x ?? 0.25,
+      y: options.y ?? 0.75,
+      ...(options.selector === null
+        ? {}
+        : { t: options.selector ?? "#message" }),
       sequence:
         options.sequence === undefined
           ? [{ action: "type", text: id, timestamp: 0 }]
@@ -86,6 +90,18 @@ describe("groupTypingEvents", () => {
       "sid",
       "url",
       "selector",
+    ]);
+  });
+
+  it("uses geometry to keep redacted live inputs separate", () => {
+    const groups = groupTypingEvents([
+      keyboardEvent("first", 0, { selector: null, x: 0.1, y: 0.2 }),
+      keyboardEvent("second", 1, { selector: null, x: 0.7, y: 0.8 }),
+    ]);
+
+    expect(groups.map((group) => group.events[0].id)).toEqual([
+      "first",
+      "second",
     ]);
   });
 

--- a/extension/website/shared/utils/__tests__/typingInstallationReservoir.test.ts
+++ b/extension/website/shared/utils/__tests__/typingInstallationReservoir.test.ts
@@ -1,0 +1,196 @@
+// ABOUTME: Tests finite typing chapter selection from live and archive reservoirs.
+// ABOUTME: Verifies completion, whole-group rotation, deduplication, and exhaustion.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  DEFAULT_TYPING_INSTALLATION_CHAPTER_GROUPS,
+  addTypingReservoirEvents,
+  createTypingReservoir,
+  takeTypingReservoirChapter,
+} from "../typingInstallationReservoir";
+
+function keyboardEvent(
+  id: string,
+  ts: number,
+  options: {
+    pid?: string;
+    sid?: string;
+    selector?: string;
+    text?: string;
+  } = {},
+): CollectionEvent {
+  return {
+    id,
+    type: "keyboard",
+    ts,
+    data: {
+      event: "type",
+      x: 0.4,
+      y: 0.6,
+      t: options.selector ?? `#${id}`,
+      sequence: [{ action: "type", text: options.text ?? id, timestamp: 0 }],
+    },
+    meta: {
+      pid: options.pid ?? "person",
+      sid: options.sid ?? "session",
+      url: "https://example.com/write",
+      vw: 1440,
+      vh: 900,
+      tz: "UTC",
+    },
+  };
+}
+
+describe("typing installation reservoir", () => {
+  it("uses a named 1000-group chapter default", () => {
+    expect(DEFAULT_TYPING_INSTALLATION_CHAPTER_GROUPS).toBe(1000);
+  });
+
+  it("prioritizes completed live groups and fills the chapter from archive", () => {
+    let state = createTypingReservoir();
+    state = addTypingReservoirEvents(
+      state,
+      [keyboardEvent("archive", 10_000)],
+      "archive",
+      40_000,
+    );
+    state = addTypingReservoirEvents(
+      state,
+      [keyboardEvent("live", 20_000)],
+      "live",
+      55_000,
+    );
+
+    const chapter = takeTypingReservoirChapter(state, 2);
+
+    expect(chapter.events.map(({ id }) => id)).toEqual(["live", "archive"]);
+    expect(chapter.hasLive).toBe(true);
+    expect(chapter.repeated).toBe(false);
+    expect(chapter.rotation).toBe(0);
+  });
+
+  it("keeps an incomplete live group pending until its inactivity window closes", () => {
+    let state = createTypingReservoir();
+    state = addTypingReservoirEvents(
+      state,
+      [keyboardEvent("archive", 0)],
+      "archive",
+      20_000,
+    );
+    state = addTypingReservoirEvents(
+      state,
+      [keyboardEvent("live", 10_000)],
+      "live",
+      20_000,
+    );
+
+    const pending = takeTypingReservoirChapter(state, 2);
+    expect(pending.events.map(({ id }) => id)).toEqual(["archive"]);
+    expect(pending.hasLive).toBe(false);
+
+    state = addTypingReservoirEvents(pending.state, [], "live", 45_000);
+    const completed = takeTypingReservoirChapter(state, 2);
+    expect(completed.events.map(({ id }) => id)).toEqual(["live"]);
+    expect(completed.hasLive).toBe(true);
+  });
+
+  it("merges archive and live fragments for one input and waits for live completion", () => {
+    const archiveFragment = keyboardEvent("archive-fragment", 0, {
+      selector: "#shared",
+    });
+    const liveFragment = keyboardEvent("live-fragment", 10_000, {
+      selector: "#shared",
+    });
+    let state = createTypingReservoir();
+    state = addTypingReservoirEvents(
+      state,
+      [archiveFragment],
+      "archive",
+      20_000,
+    );
+    state = addTypingReservoirEvents(state, [liveFragment], "live", 20_000);
+
+    const pending = takeTypingReservoirChapter(state, 1);
+    expect(pending.events).toEqual([]);
+
+    state = addTypingReservoirEvents(state, [], "live", 45_000);
+    const completed = takeTypingReservoirChapter(state, 1);
+    expect(completed.events.map(({ id }) => id)).toEqual([
+      "archive-fragment",
+      "live-fragment",
+    ]);
+    expect(completed.hasLive).toBe(true);
+  });
+
+  it("rotates whole groups without repeating until every available group is seen", () => {
+    let state = createTypingReservoir();
+    state = addTypingReservoirEvents(
+      state,
+      [
+        keyboardEvent("a-1", 0, { selector: "#a" }),
+        keyboardEvent("a-2", 1_000, { selector: "#a" }),
+        keyboardEvent("b", 50_000, { selector: "#b" }),
+        keyboardEvent("c", 100_000, { selector: "#c" }),
+      ],
+      "archive",
+      200_000,
+    );
+
+    const first = takeTypingReservoirChapter(state, 2);
+    expect(first.events.map(({ id }) => id)).toEqual(["c", "b"]);
+    expect(first.repeated).toBe(false);
+    expect(first.rotation).toBe(0);
+
+    const second = takeTypingReservoirChapter(first.state, 2);
+    expect(second.events.map(({ id }) => id)).toEqual(["a-1", "a-2"]);
+    expect(second.repeated).toBe(false);
+    expect(second.rotation).toBe(0);
+
+    const third = takeTypingReservoirChapter(second.state, 2);
+    expect(third.events.map(({ id }) => id)).toEqual(["c", "b"]);
+    expect(third.repeated).toBe(true);
+    expect(third.rotation).toBe(1);
+  });
+
+  it("deduplicates event IDs while keeping an overlapping group whole", () => {
+    const shared = keyboardEvent("shared", 0, { selector: "#shared" });
+    const archiveCompanion = keyboardEvent("archive-companion", 1_000, {
+      selector: "#shared",
+    });
+    let state = createTypingReservoir();
+    state = addTypingReservoirEvents(
+      state,
+      [shared, shared, archiveCompanion],
+      "archive",
+      40_000,
+    );
+    state = addTypingReservoirEvents(state, [shared], "live", 40_000);
+
+    const chapter = takeTypingReservoirChapter(state, 2);
+
+    expect(chapter.events.map(({ id }) => id)).toEqual([
+      "shared",
+      "archive-companion",
+    ]);
+    expect(new Set(chapter.events.map(({ id }) => id)).size).toBe(
+      chapter.events.length,
+    );
+    expect(chapter.hasLive).toBe(true);
+  });
+
+  it("does not mutate the state passed to add or take", () => {
+    const initial = createTypingReservoir();
+    const populated = addTypingReservoirEvents(
+      initial,
+      [keyboardEvent("archive", 0)],
+      "archive",
+      40_000,
+    );
+    const chapter = takeTypingReservoirChapter(populated, 1);
+
+    expect(initial.archiveEvents).toEqual([]);
+    expect(populated.seenEventIds.size).toBe(0);
+    expect(chapter.state.seenEventIds).not.toBe(populated.seenEventIds);
+  });
+});

--- a/extension/website/shared/utils/installationUrls.ts
+++ b/extension/website/shared/utils/installationUrls.ts
@@ -83,3 +83,50 @@ export function buildInstallationScreens(
 
   return screens;
 }
+
+/** Build the independent cross-computer URLs for the hybrid live installation.
+ * Participant ownership is encoded by numeric slot, so every follower can
+ * reconstruct the same disjoint assignment without a shared browser channel. */
+export function buildLiveInstallationScreens(
+  origin: string,
+  followerCount: number = 4,
+): InstallationScreen[] {
+  if (!Number.isFinite(followerCount)) {
+    throw new Error("Installation follower count must be finite");
+  }
+  const count = Math.min(32, Math.max(1, Math.floor(followerCount)));
+  const base = new URL("/installation/live/", origin);
+  base.searchParams.set("clean", "2");
+  base.searchParams.set("slots", String(count));
+
+  const withParams = (params: Record<string, string>): string => {
+    const url = new URL(base.toString());
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.set(key, value);
+    }
+    return url.toString();
+  };
+
+  const screens: InstallationScreen[] = [
+    {
+      label: "field",
+      role: "master",
+      url: withParams({ view: "field" }),
+    },
+  ];
+
+  for (let slot = 0; slot < count; slot++) {
+    screens.push({
+      label: `follower ${slot + 1}`,
+      role: "follower",
+      followerId: String(slot),
+      url: withParams({
+        view: "follow",
+        slot: String(slot),
+        cinematic: "follow",
+      }),
+    });
+  }
+
+  return screens;
+}

--- a/extension/website/shared/utils/installationUrls.ts
+++ b/extension/website/shared/utils/installationUrls.ts
@@ -1,6 +1,11 @@
 // ABOUTME: Turns a saved archive/share URL into a matched set of installation
 // ABOUTME: screen URLs — one master + N coordinated followers — for multi-screen.
 
+import {
+  LIVE_INSTALLATION_PROFILES,
+  LIVE_INSTALLATION_PROFILE_NAMES,
+} from "./liveInstallationProfiles";
+
 /** One screen in a generated installation set. */
 export interface InstallationScreen {
   /** "master" (full field, drives the clock) or "follower N" (zoomed). */
@@ -84,88 +89,20 @@ export function buildInstallationScreens(
   return screens;
 }
 
-/** Build the independent cross-computer URLs for the live installation.
- * The set includes four dedicated event views, a cursor field, and one cursor
- * follower per slot. Participant ownership is encoded by numeric slot, so every
- * follower can reconstruct the same disjoint assignment without coordination. */
+/** Build stable named URLs for the nine-screen live installation. */
 export function buildLiveInstallationScreens(
   origin: string,
-  followerCount: number = 4,
 ): InstallationScreen[] {
-  if (!Number.isFinite(followerCount)) {
-    throw new Error("Installation follower count must be finite");
-  }
-  const count = Math.min(32, Math.max(1, Math.floor(followerCount)));
-  const withParams = (
-    pathname: string,
-    params: Record<string, string> = {},
-  ): string => {
-    const url = new URL(pathname, origin);
+  return LIVE_INSTALLATION_PROFILE_NAMES.map((name) => {
+    const profile = LIVE_INSTALLATION_PROFILES[name];
+    const url = new URL(profile.pathname, origin);
     url.searchParams.set("clean", "2");
-    for (const [key, value] of Object.entries(params)) {
-      url.searchParams.set(key, value);
-    }
-    return url.toString();
-  };
-
-  const screens: InstallationScreen[] = [
-    {
-      label: "scrolling",
-      role: "master",
-      url: withParams("/installation/live/", {
-        viz: "scrolling",
-        view: "field",
-        slots: String(count),
-      }),
-    },
-    {
-      label: "keypresses",
-      role: "master",
-      url: withParams("/installation/live/", {
-        viz: "typing",
-        view: "field",
-        slots: String(count),
-      }),
-    },
-    {
-      label: "touches",
-      role: "master",
-      url: withParams("/touches/"),
-    },
-    {
-      label: "clicks",
-      role: "master",
-      url: withParams("/installation/live/", {
-        viz: "clicks",
-        view: "field",
-        slots: String(count),
-      }),
-    },
-    {
-      label: "cursor field",
-      role: "master",
-      url: withParams("/installation/live/", {
-        viz: "trails",
-        view: "field",
-        slots: String(count),
-      }),
-    },
-  ];
-
-  for (let slot = 0; slot < count; slot++) {
-    screens.push({
-      label: `cursor follower ${slot + 1}`,
-      role: "follower",
-      followerId: String(slot),
-      url: withParams("/installation/live/", {
-        viz: "trails",
-        view: "follow",
-        slot: String(slot),
-        slots: String(count),
-        cinematic: "follow",
-      }),
-    });
-  }
-
-  return screens;
+    url.searchParams.set("screen", name);
+    return {
+      label: profile.label,
+      role: profile.role,
+      followerId: profile.role === "follower" ? name : undefined,
+      url: url.toString(),
+    };
+  });
 }

--- a/extension/website/shared/utils/installationUrls.ts
+++ b/extension/website/shared/utils/installationUrls.ts
@@ -84,9 +84,10 @@ export function buildInstallationScreens(
   return screens;
 }
 
-/** Build the independent cross-computer URLs for the hybrid live installation.
- * Participant ownership is encoded by numeric slot, so every follower can
- * reconstruct the same disjoint assignment without a shared browser channel. */
+/** Build the independent cross-computer URLs for the live installation.
+ * The set includes four dedicated event views, a cursor field, and one cursor
+ * follower per slot. Participant ownership is encoded by numeric slot, so every
+ * follower can reconstruct the same disjoint assignment without coordination. */
 export function buildLiveInstallationScreens(
   origin: string,
   followerCount: number = 4,
@@ -95,12 +96,12 @@ export function buildLiveInstallationScreens(
     throw new Error("Installation follower count must be finite");
   }
   const count = Math.min(32, Math.max(1, Math.floor(followerCount)));
-  const base = new URL("/installation/live/", origin);
-  base.searchParams.set("clean", "2");
-  base.searchParams.set("slots", String(count));
-
-  const withParams = (params: Record<string, string>): string => {
-    const url = new URL(base.toString());
+  const withParams = (
+    pathname: string,
+    params: Record<string, string> = {},
+  ): string => {
+    const url = new URL(pathname, origin);
+    url.searchParams.set("clean", "2");
     for (const [key, value] of Object.entries(params)) {
       url.searchParams.set(key, value);
     }
@@ -109,20 +110,58 @@ export function buildLiveInstallationScreens(
 
   const screens: InstallationScreen[] = [
     {
-      label: "field",
+      label: "scrolling",
       role: "master",
-      url: withParams({ view: "field" }),
+      url: withParams("/installation/live/", {
+        viz: "scrolling",
+        view: "field",
+        slots: String(count),
+      }),
+    },
+    {
+      label: "keypresses",
+      role: "master",
+      url: withParams("/installation/live/", {
+        viz: "typing",
+        view: "field",
+        slots: String(count),
+      }),
+    },
+    {
+      label: "touches",
+      role: "master",
+      url: withParams("/touches/"),
+    },
+    {
+      label: "clicks",
+      role: "master",
+      url: withParams("/installation/live/", {
+        viz: "clicks",
+        view: "field",
+        slots: String(count),
+      }),
+    },
+    {
+      label: "cursor field",
+      role: "master",
+      url: withParams("/installation/live/", {
+        viz: "trails",
+        view: "field",
+        slots: String(count),
+      }),
     },
   ];
 
   for (let slot = 0; slot < count; slot++) {
     screens.push({
-      label: `follower ${slot + 1}`,
+      label: `cursor follower ${slot + 1}`,
       role: "follower",
       followerId: String(slot),
-      url: withParams({
+      url: withParams("/installation/live/", {
+        viz: "trails",
         view: "follow",
         slot: String(slot),
+        slots: String(count),
         cinematic: "follow",
       }),
     });

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -11,12 +11,27 @@ export const LIVE_INSTALLATION_VISUALIZATIONS = [
   "navigation",
 ] as const;
 
+export const DEFAULT_LIVE_INSTALLATION_VISUALIZATIONS = ["trails"] as const;
+
 export type LiveInstallationView = "field" | "follow";
 
 export interface LiveInstallationScreenConfig {
   view: LiveInstallationView;
   slot: number;
   slots: number;
+}
+
+export function resolveLiveInstallationVisualizations(
+  requested: string[] | undefined,
+): string[] {
+  if (requested === undefined) {
+    return [...DEFAULT_LIVE_INSTALLATION_VISUALIZATIONS];
+  }
+  return requested.filter((id) =>
+    LIVE_INSTALLATION_VISUALIZATIONS.includes(
+      id as (typeof LIVE_INSTALLATION_VISUALIZATIONS)[number],
+    ),
+  );
 }
 
 const DEFAULT_FOLLOWER_COUNT = 4;

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -7,8 +7,8 @@ import { hashString } from "./styleUtils";
 export const LIVE_INSTALLATION_VISUALIZATIONS = [
   "trails",
   "clicks",
+  "typing",
   "scrolling",
-  "navigation",
 ] as const;
 
 export const DEFAULT_LIVE_INSTALLATION_VISUALIZATIONS = ["trails"] as const;
@@ -143,16 +143,8 @@ export function liveChapterIsReady(
     return true;
   }
 
-  const navigationSessions = new Map<string, number>();
-  if (enabled.has("navigation")) {
-    for (const event of events) {
-      if (event.type !== "navigation") continue;
-      const key = `${event.meta.pid}|${event.meta.sid}`;
-      const count = (navigationSessions.get(key) ?? 0) + 1;
-      if (count >= 3) return true;
-      navigationSessions.set(key, count);
-    }
-  }
+  const keyboardEvents = events.filter((event) => event.type === "keyboard");
+  if (enabled.has("typing") && keyboardEvents.length >= 2) return true;
 
   return false;
 }

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -1,0 +1,143 @@
+// ABOUTME: Defines deterministic screen ownership and live-chapter readiness for installations.
+// ABOUTME: Keeps cross-computer followers disjoint without runtime coordination.
+
+import type { CollectionEvent } from "../types";
+import { hashString } from "./styleUtils";
+
+export const LIVE_INSTALLATION_VISUALIZATIONS = [
+  "trails",
+  "clicks",
+  "scrolling",
+  "navigation",
+] as const;
+
+export type LiveInstallationView = "field" | "follow";
+
+export interface LiveInstallationScreenConfig {
+  view: LiveInstallationView;
+  slot: number;
+  slots: number;
+}
+
+const DEFAULT_FOLLOWER_COUNT = 4;
+const MAX_FOLLOWER_COUNT = 32;
+const MIN_LIVE_SPAN_MS = 30_000;
+const DENSE_LIVE_EVENT_COUNT = 1000;
+
+function parseInteger(value: string | null): number | null {
+  if (value === null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+export function parseLiveInstallationScreen(
+  search: string = window.location.search,
+): LiveInstallationScreenConfig {
+  const params = new URLSearchParams(search);
+  const view = params.get("view") === "follow" ? "follow" : "field";
+  const requestedSlots = parseInteger(params.get("slots"));
+  const slots = Math.min(
+    MAX_FOLLOWER_COUNT,
+    Math.max(1, requestedSlots ?? DEFAULT_FOLLOWER_COUNT),
+  );
+  const requestedSlot = parseInteger(params.get("slot"));
+  const slot = Math.min(slots - 1, requestedSlot ?? 0);
+
+  return { view, slot, slots };
+}
+
+export function participantInstallationSlot(pid: string, slots: number): number {
+  if (!Number.isInteger(slots) || slots < 1) {
+    throw new Error("Installation follower count must be a positive integer");
+  }
+  return hashString(pid) % slots;
+}
+
+export function eventsForInstallationScreen(
+  events: CollectionEvent[],
+  screen: LiveInstallationScreenConfig,
+): CollectionEvent[] {
+  if (screen.view === "field") return events;
+  return events.filter(
+    (event) =>
+      participantInstallationSlot(event.meta.pid, screen.slots) === screen.slot,
+  );
+}
+
+export function unconsumedLiveEvents(
+  events: CollectionEvent[],
+  consumedIds: ReadonlySet<string>,
+): CollectionEvent[] {
+  return events
+    .filter((event) => !consumedIds.has(event.id))
+    .sort((a, b) => a.ts - b.ts);
+}
+
+function distinctParticipants(events: CollectionEvent[]): number {
+  return new Set(events.map((event) => event.meta.pid)).size;
+}
+
+function distinctSessions(events: CollectionEvent[]): number {
+  return new Set(events.map((event) => `${event.meta.pid}|${event.meta.sid}`))
+    .size;
+}
+
+export function liveChapterIsReady(
+  events: CollectionEvent[],
+  activeVisualizations: readonly string[],
+): boolean {
+  if (events.length === 0) return false;
+  let oldestTs = Infinity;
+  let newestTs = -Infinity;
+  for (const event of events) {
+    oldestTs = Math.min(oldestTs, event.ts);
+    newestTs = Math.max(newestTs, event.ts);
+  }
+  const spanMs = newestTs - oldestTs;
+  if (spanMs < MIN_LIVE_SPAN_MS && events.length < DENSE_LIVE_EVENT_COUNT) {
+    return false;
+  }
+
+  const enabled = new Set(activeVisualizations);
+  const cursorMoves = events.filter(
+    (event) => event.type === "cursor" && event.data.event === "move",
+  );
+  if (
+    enabled.has("trails") &&
+    cursorMoves.length >= 24 &&
+    distinctParticipants(cursorMoves) >= 2
+  ) {
+    return true;
+  }
+
+  const clicks = events.filter(
+    (event) =>
+      event.type === "cursor" &&
+      (event.data.event === "click" || event.data.event === "hold"),
+  );
+  if (enabled.has("clicks") && clicks.length >= 3) return true;
+
+  const scrolls = events.filter(
+    (event) => event.type === "viewport" && event.data.event === "scroll",
+  );
+  if (
+    enabled.has("scrolling") &&
+    scrolls.length >= 6 &&
+    distinctSessions(scrolls) >= 2
+  ) {
+    return true;
+  }
+
+  const navigationSessions = new Map<string, number>();
+  if (enabled.has("navigation")) {
+    for (const event of events) {
+      if (event.type !== "navigation") continue;
+      const key = `${event.meta.pid}|${event.meta.sid}`;
+      const count = (navigationSessions.get(key) ?? 0) + 1;
+      if (count >= 3) return true;
+      navigationSessions.set(key, count);
+    }
+  }
+
+  return false;
+}

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -14,11 +14,24 @@ export const LIVE_INSTALLATION_VISUALIZATIONS = [
 export const DEFAULT_LIVE_INSTALLATION_VISUALIZATIONS = ["trails"] as const;
 
 export type LiveInstallationView = "field" | "follow";
+export type InstallationChapterSource = "archive" | "live";
+export type InstallationChapterAction =
+  | "advance-archive"
+  | "show-live"
+  | "wait-live";
 
 export interface LiveInstallationScreenConfig {
   view: LiveInstallationView;
   slot: number;
   slots: number;
+}
+
+export function installationChapterAction(
+  source: InstallationChapterSource,
+  liveChapterReady: boolean,
+): InstallationChapterAction {
+  if (liveChapterReady) return "show-live";
+  return source === "live" ? "wait-live" : "advance-archive";
 }
 
 export function resolveLiveInstallationVisualizations(
@@ -61,7 +74,10 @@ export function parseLiveInstallationScreen(
   return { view, slot, slots };
 }
 
-export function participantInstallationSlot(pid: string, slots: number): number {
+export function participantInstallationSlot(
+  pid: string,
+  slots: number,
+): number {
   if (!Number.isInteger(slots) || slots < 1) {
     throw new Error("Installation follower count must be a positive integer");
   }

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -95,6 +95,13 @@ export function eventsForInstallationScreen(
   );
 }
 
+export function showsInstallationPeopleCount(
+  screen: LiveInstallationScreenConfig,
+  activeVisualizations: readonly string[],
+): boolean {
+  return screen.view === "field" && activeVisualizations.includes("trails");
+}
+
 export function unconsumedLiveEvents(
   events: CollectionEvent[],
   consumedIds: ReadonlySet<string>,

--- a/extension/website/shared/utils/liveInstallation.ts
+++ b/extension/website/shared/utils/liveInstallation.ts
@@ -60,16 +60,23 @@ function parseInteger(value: string | null): number | null {
 
 export function parseLiveInstallationScreen(
   search: string = window.location.search,
+  defaults: LiveInstallationScreenConfig = {
+    view: "field",
+    slot: 0,
+    slots: DEFAULT_FOLLOWER_COUNT,
+  },
 ): LiveInstallationScreenConfig {
   const params = new URLSearchParams(search);
-  const view = params.get("view") === "follow" ? "follow" : "field";
+  const rawView = params.get("view");
+  const view =
+    rawView === "follow" || rawView === "field" ? rawView : defaults.view;
   const requestedSlots = parseInteger(params.get("slots"));
   const slots = Math.min(
     MAX_FOLLOWER_COUNT,
-    Math.max(1, requestedSlots ?? DEFAULT_FOLLOWER_COUNT),
+    Math.max(1, requestedSlots ?? defaults.slots),
   );
   const requestedSlot = parseInteger(params.get("slot"));
-  const slot = Math.min(slots - 1, requestedSlot ?? 0);
+  const slot = Math.min(slots - 1, requestedSlot ?? defaults.slot);
 
   return { view, slot, slots };
 }

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -1,0 +1,240 @@
+// ABOUTME: Defines the named screen profiles used by the live WWO installation.
+// ABOUTME: Keeps stable machine URLs separate from centrally deployed visual settings.
+
+import type { LiveInstallationScreenConfig } from "./liveInstallation";
+import type { MovementSettings } from "../components/settingsDefaults";
+import {
+  DEFAULT_CINEMATIC_CONFIG,
+  type CinematicConfig,
+} from "./cinematicCamera";
+
+export const LIVE_INSTALLATION_PROFILE_NAMES = [
+  "scrolling",
+  "typing",
+  "touches",
+  "clicks",
+  "cursors",
+  "follower-a",
+  "follower-b",
+  "follower-c",
+  "follower-d",
+] as const;
+
+export type LiveInstallationProfileName =
+  (typeof LIVE_INSTALLATION_PROFILE_NAMES)[number];
+
+interface TouchesProfileSettings {
+  touchRadius: number;
+  speed: number;
+  showCursors: boolean;
+  samePersonOk: boolean;
+  night: boolean;
+  renderer: "glsl" | "nebula" | "pinwheel";
+  markStyle: "hands" | "fingerprint" | "blot" | "wear" | "stitch" | "nebula";
+}
+
+export interface LiveInstallationProfile {
+  label: string;
+  pathname: "/installation/live/" | "/touches/";
+  role: "master" | "follower";
+  followerId?: string;
+  cinematic: CinematicConfig | null;
+  visualizations: string[];
+  screen?: LiveInstallationScreenConfig;
+  settings: Partial<MovementSettings>;
+  touchesSettings?: TouchesProfileSettings;
+}
+
+const CURSOR_SETTINGS = {
+  trailAnimationMode: "natural",
+  strokeWidth: 6,
+  trailOpacity: 0.9,
+  maxConcurrentTrails: 24,
+  clickOpacity: 0.3,
+  textboxOpacity: 0.2,
+} satisfies Partial<MovementSettings>;
+
+const SCROLLING_SETTINGS = {
+  trailOpacity: 0.9,
+  strokeWidth: 6.5,
+  animationSpeed: 3,
+  maxConcurrentTrails: 16,
+  clickMaxGapMs: 850,
+  scrollSpeed: 1,
+  backgroundOpacity: 0.9,
+  maxConcurrentScrolls: 42,
+  allowOverlap: true,
+  windowBleed: 0.25,
+  windowScale: 0.7,
+  textboxOpacity: 0.2,
+  keyboardRandomizeOrder: true,
+} satisfies Partial<MovementSettings>;
+
+const TYPING_SETTINGS = {
+  trailOpacity: 0.9,
+  strokeWidth: 6.5,
+  animationSpeed: 3,
+  maxConcurrentTrails: 16,
+  clickMaxGapMs: 850,
+  scrollSpeed: 0.2,
+  backgroundOpacity: 1,
+  maxConcurrentScrolls: 42,
+  allowOverlap: true,
+  windowBleed: 0.25,
+  windowScale: 0.7,
+  textboxOpacity: 0.85,
+  keyboardMinFontSize: 8,
+  keyboardMaxFontSize: 16,
+  keyboardAnimationSpeed: 0.4,
+  keyboardPositionRandomness: 0.8,
+  keyboardRandomizeOrder: true,
+  maxConcurrentTyping: 50,
+  keyboardSizeCap: 0.3,
+  keyboardMaxAspect: 2.5,
+} satisfies Partial<MovementSettings>;
+
+const CLICK_SETTINGS = {
+  trailOpacity: 0.9,
+  strokeWidth: 6.5,
+  animationSpeed: 3,
+  maxConcurrentTrails: 16,
+  clickMaxRadius: 55,
+  clickNumRings: 6,
+  clickMaxGapMs: 850,
+  scrollSpeed: 0.2,
+  backgroundOpacity: 0.9,
+  maxConcurrentScrolls: 42,
+  allowOverlap: true,
+  windowBleed: 0.25,
+  windowScale: 0.7,
+  textboxOpacity: 0.2,
+  keyboardRandomizeOrder: true,
+} satisfies Partial<MovementSettings>;
+
+const TOUCHES_SETTINGS: TouchesProfileSettings = {
+  touchRadius: 20,
+  speed: 1,
+  showCursors: true,
+  samePersonOk: false,
+  night: false,
+  renderer: "nebula",
+  markStyle: "hands",
+};
+
+const field = (): LiveInstallationScreenConfig => ({
+  view: "field",
+  slot: 0,
+  slots: 4,
+});
+
+const follower = (slot: number): LiveInstallationScreenConfig => ({
+  view: "follow",
+  slot,
+  slots: 4,
+});
+
+export const LIVE_INSTALLATION_PROFILES: Record<
+  LiveInstallationProfileName,
+  LiveInstallationProfile
+> = {
+  scrolling: {
+    label: "scrolling",
+    pathname: "/installation/live/",
+    role: "master",
+    cinematic: null,
+    visualizations: ["scrolling"],
+    screen: field(),
+    settings: SCROLLING_SETTINGS,
+  },
+  typing: {
+    label: "keypresses",
+    pathname: "/installation/live/",
+    role: "master",
+    cinematic: null,
+    visualizations: ["typing"],
+    screen: field(),
+    settings: TYPING_SETTINGS,
+  },
+  touches: {
+    label: "touches",
+    pathname: "/touches/",
+    role: "master",
+    cinematic: null,
+    visualizations: [],
+    settings: {},
+    touchesSettings: TOUCHES_SETTINGS,
+  },
+  clicks: {
+    label: "clicks",
+    pathname: "/installation/live/",
+    role: "master",
+    cinematic: null,
+    visualizations: ["clicks"],
+    screen: field(),
+    settings: CLICK_SETTINGS,
+  },
+  cursors: {
+    label: "cursor field",
+    pathname: "/installation/live/",
+    role: "master",
+    cinematic: null,
+    visualizations: ["trails"],
+    screen: field(),
+    settings: CURSOR_SETTINGS,
+  },
+  "follower-a": {
+    label: "cursor follower 1",
+    pathname: "/installation/live/",
+    role: "follower",
+    followerId: "a",
+    cinematic: DEFAULT_CINEMATIC_CONFIG,
+    visualizations: ["trails"],
+    screen: follower(0),
+    settings: CURSOR_SETTINGS,
+  },
+  "follower-b": {
+    label: "cursor follower 2",
+    pathname: "/installation/live/",
+    role: "follower",
+    followerId: "b",
+    cinematic: DEFAULT_CINEMATIC_CONFIG,
+    visualizations: ["trails"],
+    screen: follower(1),
+    settings: CURSOR_SETTINGS,
+  },
+  "follower-c": {
+    label: "cursor follower 3",
+    pathname: "/installation/live/",
+    role: "follower",
+    followerId: "c",
+    cinematic: DEFAULT_CINEMATIC_CONFIG,
+    visualizations: ["trails"],
+    screen: follower(2),
+    settings: CURSOR_SETTINGS,
+  },
+  "follower-d": {
+    label: "cursor follower 4",
+    pathname: "/installation/live/",
+    role: "follower",
+    followerId: "d",
+    cinematic: DEFAULT_CINEMATIC_CONFIG,
+    visualizations: ["trails"],
+    screen: follower(3),
+    settings: CURSOR_SETTINGS,
+  },
+};
+
+export function resolveLiveInstallationProfile(
+  search: string = window.location.search,
+): LiveInstallationProfile | null {
+  const name = new URLSearchParams(search).get("screen");
+  if (
+    !name ||
+    !LIVE_INSTALLATION_PROFILE_NAMES.includes(
+      name as LiveInstallationProfileName,
+    )
+  ) {
+    return null;
+  }
+  return LIVE_INSTALLATION_PROFILES[name as LiveInstallationProfileName];
+}

--- a/extension/website/shared/utils/scrollEventGroups.ts
+++ b/extension/website/shared/utils/scrollEventGroups.ts
@@ -1,0 +1,188 @@
+// ABOUTME: Groups viewport collection events into stable scroll-window sessions.
+// ABOUTME: Shares the renderer's participant, browser session, URL, and inactivity boundaries.
+
+import type { CollectionEvent } from "../types";
+import {
+  MAX_VIEWPORT_ANIMATION_DURATION,
+  SCROLL_SESSION_THRESHOLD,
+  SCROLL_TIME_COMPRESSION,
+} from "./eventUtils";
+
+export interface ScrollEventGroup {
+  id: string;
+  sessionId: string;
+  events: CollectionEvent[];
+  startTs: number;
+  endTs: number;
+}
+
+function scrollSessionId(event: CollectionEvent): string {
+  return JSON.stringify([event.meta.pid, event.meta.sid, event.meta.url || ""]);
+}
+
+function createScrollEventGroup(
+  sessionId: string,
+  events: CollectionEvent[],
+): ScrollEventGroup {
+  const first = events[0];
+  const last = events.at(-1) ?? first;
+  return {
+    id: `${sessionId}:${first.id}`,
+    sessionId,
+    events,
+    startTs: first.ts,
+    endTs: last.ts,
+  };
+}
+
+export function scrollEventGroupHasVisibleActivity(
+  group: ScrollEventGroup,
+): boolean {
+  const rawScrollEvents = group.events.filter(
+    (event) => (event.data as { event?: string })?.event === "scroll",
+  );
+  const resizeEvents = group.events.filter(
+    (event) => (event.data as { event?: string })?.event === "resize",
+  );
+  const zoomEvents = group.events.filter(
+    (event) => (event.data as { event?: string })?.event === "zoom",
+  );
+  const baseStartTime =
+    rawScrollEvents[0]?.ts ??
+    resizeEvents[0]?.ts ??
+    zoomEvents[0]?.ts ??
+    group.startTs;
+  const scrollEvents = rawScrollEvents.map((event, index) => {
+    if (index === 0) return event;
+    const previous = rawScrollEvents[index - 1];
+    return {
+      ...event,
+      ts: previous.ts + (event.ts - previous.ts) * SCROLL_TIME_COMPRESSION,
+    };
+  });
+  const compressedResizeEvents = resizeEvents.map((event) => ({
+    ...event,
+    ts: baseStartTime + (event.ts - baseStartTime) * SCROLL_TIME_COMPRESSION,
+  }));
+  const compressedZoomEvents = zoomEvents.map((event) => ({
+    ...event,
+    ts: baseStartTime + (event.ts - baseStartTime) * SCROLL_TIME_COMPRESSION,
+  }));
+  const startTime = Math.min(
+    ...[
+      ...scrollEvents,
+      ...compressedResizeEvents,
+      ...compressedZoomEvents,
+    ].map((event) => event.ts),
+  );
+  const cappedEndTime = startTime + MAX_VIEWPORT_ANIMATION_DURATION;
+  const cappedScrollEvents = scrollEvents.filter(
+    (event) => event.ts <= cappedEndTime,
+  );
+  const cappedResizeEvents = compressedResizeEvents.filter(
+    (event) => event.ts <= cappedEndTime,
+  );
+  const cappedZoomEvents = compressedZoomEvents.filter(
+    (event) => event.ts <= cappedEndTime,
+  );
+
+  if (cappedScrollEvents.length >= 2) {
+    const scrollY = cappedScrollEvents.map(
+      (event) => (event.data as { scrollY?: number }).scrollY ?? 0,
+    );
+    if (Math.max(...scrollY) - Math.min(...scrollY) >= 0.05) {
+      return true;
+    }
+  }
+
+  if (cappedResizeEvents.length >= 2) {
+    const widths = cappedResizeEvents.map(
+      (event) => (event.data as { width?: number }).width ?? event.meta.vw,
+    );
+    const heights = cappedResizeEvents.map(
+      (event) => (event.data as { height?: number }).height ?? event.meta.vh,
+    );
+    if (
+      Math.max(...widths) - Math.min(...widths) >= 100 ||
+      Math.max(...heights) - Math.min(...heights) >= 100
+    ) {
+      return true;
+    }
+  }
+
+  if (cappedZoomEvents.length >= 2) {
+    const zooms = cappedZoomEvents.map(
+      (event) => (event.data as { zoom?: number }).zoom ?? 1,
+    );
+    if (Math.max(...zooms) - Math.min(...zooms) >= 0.1) return true;
+  }
+
+  return false;
+}
+
+export function scrollEventGroupHasActivity(group: ScrollEventGroup): boolean {
+  const scrollEvents = group.events.filter(
+    (event) => (event.data as { event?: string })?.event === "scroll",
+  );
+  const hasScroll = scrollEvents.some((event, index) => {
+    if (index === 0) return false;
+    const previous = scrollEvents[index - 1];
+    const data = event.data as { scrollX?: number; scrollY?: number };
+    const previousData = previous.data as {
+      scrollX?: number;
+      scrollY?: number;
+    };
+    return (
+      Math.abs((data.scrollX ?? 0) - (previousData.scrollX ?? 0)) > 0.000001 ||
+      Math.abs((data.scrollY ?? 0) - (previousData.scrollY ?? 0)) > 0.000001
+    );
+  });
+  if (hasScroll) return true;
+
+  return group.events.some((event) => {
+    const eventType = (event.data as { event?: string })?.event;
+    return eventType === "resize" || eventType === "zoom";
+  });
+}
+
+export function groupScrollEvents(
+  events: readonly CollectionEvent[],
+): ScrollEventGroup[] {
+  const eventsBySession = new Map<string, CollectionEvent[]>();
+
+  for (const event of events) {
+    if (event.type !== "viewport" || !event.id) continue;
+    const sessionId = scrollSessionId(event);
+    const sessionEvents = eventsBySession.get(sessionId);
+    if (sessionEvents) {
+      sessionEvents.push(event);
+    } else {
+      eventsBySession.set(sessionId, [event]);
+    }
+  }
+
+  const groups: ScrollEventGroup[] = [];
+  for (const [sessionId, sessionEvents] of eventsBySession) {
+    const chronological = [...sessionEvents].sort(
+      (a, b) => a.ts - b.ts || a.id.localeCompare(b.id),
+    );
+    let current: CollectionEvent[] = [];
+
+    for (const event of chronological) {
+      const previous = current.at(-1);
+      if (previous && event.ts - previous.ts > SCROLL_SESSION_THRESHOLD) {
+        groups.push(createScrollEventGroup(sessionId, current));
+        current = [];
+      }
+      current.push(event);
+    }
+
+    if (current.length > 0) {
+      groups.push(createScrollEventGroup(sessionId, current));
+    }
+  }
+
+  return groups.sort(
+    (a, b) => a.startTs - b.startTs || a.id.localeCompare(b.id),
+  );
+}

--- a/extension/website/shared/utils/scrollInstallationReservoir.ts
+++ b/extension/website/shared/utils/scrollInstallationReservoir.ts
@@ -1,0 +1,175 @@
+// ABOUTME: Builds finite scrolling chapters from completed live and archived viewport sessions.
+// ABOUTME: Keeps visible windows whole, prioritizes live work, and delays event repeats until exhaustion.
+
+import type { CollectionEvent } from "../types";
+import {
+  groupScrollEvents,
+  scrollEventGroupHasActivity,
+  scrollEventGroupHasVisibleActivity,
+  type ScrollEventGroup,
+} from "./scrollEventGroups";
+
+export const DEFAULT_SCROLL_INSTALLATION_CHAPTER_GROUPS = 1000;
+export const SCROLL_INSTALLATION_QUIET_MS = 35_000;
+
+export type ScrollReservoirOrigin = "archive" | "live";
+
+export interface ScrollReservoirState {
+  archiveEvents: readonly CollectionEvent[];
+  liveEvents: readonly CollectionEvent[];
+  seenEventIds: ReadonlySet<string>;
+  nowMs: number;
+  rotation: number;
+}
+
+export interface ScrollReservoirChapter {
+  state: ScrollReservoirState;
+  events: CollectionEvent[];
+  rotation: number;
+  repeated: boolean;
+  hasLive: boolean;
+}
+
+export function createScrollReservoir(): ScrollReservoirState {
+  return {
+    archiveEvents: [],
+    liveEvents: [],
+    seenEventIds: new Set(),
+    nowMs: 0,
+    rotation: 0,
+  };
+}
+
+function mergeUniqueEvents(
+  existing: readonly CollectionEvent[],
+  incoming: readonly CollectionEvent[],
+): CollectionEvent[] {
+  const byId = new Map(existing.map((event) => [event.id, event]));
+  for (const event of incoming) {
+    if (!byId.has(event.id)) byId.set(event.id, event);
+  }
+  return [...byId.values()];
+}
+
+export function addScrollReservoirEvents(
+  state: ScrollReservoirState,
+  events: readonly CollectionEvent[],
+  origin: ScrollReservoirOrigin,
+  nowMs: number,
+): ScrollReservoirState {
+  if (!Number.isFinite(nowMs)) {
+    throw new Error("Scroll reservoir time must be finite");
+  }
+
+  return {
+    ...state,
+    archiveEvents:
+      origin === "archive"
+        ? mergeUniqueEvents(state.archiveEvents, events)
+        : state.archiveEvents,
+    liveEvents:
+      origin === "live"
+        ? mergeUniqueEvents(state.liveEvents, events)
+        : state.liveEvents,
+    nowMs: Math.max(state.nowMs, nowMs),
+  };
+}
+
+function availableGroups(
+  state: ScrollReservoirState,
+  seenEventIds: ReadonlySet<string>,
+): { live: ScrollEventGroup[]; archive: ScrollEventGroup[] } {
+  const unseenEvents = mergeUniqueEvents(
+    state.archiveEvents,
+    state.liveEvents,
+  ).filter((event) => !seenEventIds.has(event.id));
+  const liveEventIds = new Set(state.liveEvents.map((event) => event.id));
+  const completionCutoff = state.nowMs - SCROLL_INSTALLATION_QUIET_MS;
+  const completedLive: ScrollEventGroup[] = [];
+  const archived: ScrollEventGroup[] = [];
+
+  for (const group of groupScrollEvents(unseenEvents)) {
+    if (!scrollEventGroupHasActivity(group)) continue;
+    const containsLiveEvent = group.events.some((event) =>
+      liveEventIds.has(event.id),
+    );
+    if (!containsLiveEvent) {
+      archived.push(group);
+    } else if (group.endTs <= completionCutoff) {
+      completedLive.push(group);
+    }
+  }
+
+  const completedGroups = [...completedLive, ...archived];
+  const hasVisibleGroup = completedGroups.some(
+    scrollEventGroupHasVisibleActivity,
+  );
+  const eligible = (groups: ScrollEventGroup[]) =>
+    hasVisibleGroup
+      ? groups.filter(scrollEventGroupHasVisibleActivity)
+      : groups;
+  const live = eligible(completedLive);
+  const archive = eligible(archived);
+  live.sort((a, b) => a.startTs - b.startTs || a.id.localeCompare(b.id));
+  archive.sort((a, b) => b.startTs - a.startTs || a.id.localeCompare(b.id));
+  return { live, archive };
+}
+
+function selectGroups(
+  groups: { live: ScrollEventGroup[]; archive: ScrollEventGroup[] },
+  maxGroups: number,
+): { selected: ScrollEventGroup[]; liveIds: Set<string> } {
+  const selected: ScrollEventGroup[] = [];
+  const liveIds = new Set<string>();
+  for (const group of [...groups.live, ...groups.archive]) {
+    if (selected.length >= maxGroups) break;
+    selected.push(group);
+    if (groups.live.includes(group)) liveIds.add(group.id);
+  }
+  return { selected, liveIds };
+}
+
+export function takeScrollReservoirChapter(
+  state: ScrollReservoirState,
+  maxGroups: number = DEFAULT_SCROLL_INSTALLATION_CHAPTER_GROUPS,
+): ScrollReservoirChapter {
+  if (!Number.isInteger(maxGroups) || maxGroups < 1) {
+    throw new Error("Scroll reservoir chapter size must be a positive integer");
+  }
+
+  let seenEventIds = state.seenEventIds;
+  let groups = availableGroups(state, seenEventIds);
+  let selection = selectGroups(groups, maxGroups);
+  let repeated = false;
+
+  if (selection.selected.length === 0) {
+    const resetGroups = availableGroups(state, new Set());
+    const resetSelection = selectGroups(resetGroups, maxGroups);
+    if (resetSelection.selected.length > 0) {
+      seenEventIds = new Set();
+      groups = resetGroups;
+      selection = resetSelection;
+      repeated = true;
+    }
+  }
+
+  const nextSeenEventIds = new Set(seenEventIds);
+  for (const group of selection.selected) {
+    for (const event of group.events) nextSeenEventIds.add(event.id);
+  }
+
+  const rotation = repeated ? state.rotation + 1 : state.rotation;
+  return {
+    state: {
+      ...state,
+      seenEventIds: nextSeenEventIds,
+      rotation,
+    },
+    events: selection.selected.flatMap((group) => group.events),
+    rotation,
+    repeated,
+    hasLive: selection.selected.some((group) =>
+      selection.liveIds.has(group.id),
+    ),
+  };
+}

--- a/extension/website/shared/utils/shareUrl.ts
+++ b/extension/website/shared/utils/shareUrl.ts
@@ -102,6 +102,9 @@ export function buildShareUrl({
       "cinemaStartZoom",
       "role",
       "follower",
+      "view",
+      "slot",
+      "slots",
     ];
     for (const key of PRESERVE) {
       const val = current.get(key);

--- a/extension/website/shared/utils/shareUrl.ts
+++ b/extension/website/shared/utils/shareUrl.ts
@@ -105,6 +105,7 @@ export function buildShareUrl({
       "view",
       "slot",
       "slots",
+      "screen",
     ];
     for (const key of PRESERVE) {
       const val = current.get(key);

--- a/extension/website/shared/utils/timeFormat.ts
+++ b/extension/website/shared/utils/timeFormat.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Formats time ranges for compact visualization readouts.
+// ABOUTME: Keeps minute, hour, and day spans short enough for instrumentation bars.
+
+/** Compact duration for a dataset's actual time bounds. */
+export function formatCompactTimeSpan(minTs: number, maxTs: number): string {
+  if (!minTs || !maxTs || maxTs <= minTs) return "—";
+  const durationMs = maxTs - minTs;
+  if (durationMs < 60_000) return "<1m";
+  if (durationMs < 60 * 60_000) return `${Math.round(durationMs / 60_000)}m`;
+  if (durationMs < 24 * 60 * 60_000) {
+    return `${(durationMs / (60 * 60_000)).toFixed(1)}h`;
+  }
+  return `${(durationMs / (24 * 60 * 60_000)).toFixed(1)}d`;
+}

--- a/extension/website/shared/utils/typingEventGroups.ts
+++ b/extension/website/shared/utils/typingEventGroups.ts
@@ -14,7 +14,7 @@ export interface TypingEventGroup {
 }
 
 function typingEventText(event: CollectionEvent): string {
-  const data = event.data as KeyboardEventData;
+  const data = event.data as unknown as KeyboardEventData;
   return (data.sequence ?? []).reduce(
     (text, action) => text + (action.text ?? ""),
     "",
@@ -23,13 +23,13 @@ function typingEventText(event: CollectionEvent): string {
 
 function isVisibleTypingEvent(event: CollectionEvent): boolean {
   if (event.type !== "keyboard" || !event.id) return false;
-  const data = event.data as KeyboardEventData;
+  const data = event.data as unknown as KeyboardEventData;
   if (!data.sequence || data.sequence.length === 0) return false;
   return typingEventText(event) !== "elizabeth";
 }
 
 function typingInputId(event: CollectionEvent): string {
-  const data = event.data as KeyboardEventData;
+  const data = event.data as unknown as KeyboardEventData;
   return JSON.stringify([
     event.meta.pid,
     event.meta.sid,

--- a/extension/website/shared/utils/typingEventGroups.ts
+++ b/extension/website/shared/utils/typingEventGroups.ts
@@ -1,0 +1,104 @@
+// ABOUTME: Groups keyboard collection events into stable visible typing-box sessions.
+// ABOUTME: Shares the renderer's input identity, merge window, and event eligibility rules.
+
+import type { CollectionEvent, KeyboardEventData } from "../types";
+
+export const TYPING_EVENT_MERGE_THRESHOLD_MS = 35_000;
+
+export interface TypingEventGroup {
+  id: string;
+  inputId: string;
+  events: CollectionEvent[];
+  startTs: number;
+  endTs: number;
+}
+
+function typingEventText(event: CollectionEvent): string {
+  const data = event.data as KeyboardEventData;
+  return (data.sequence ?? []).reduce(
+    (text, action) => text + (action.text ?? ""),
+    "",
+  );
+}
+
+function isVisibleTypingEvent(event: CollectionEvent): boolean {
+  if (event.type !== "keyboard" || !event.id) return false;
+  const data = event.data as KeyboardEventData;
+  if (!data.sequence || data.sequence.length === 0) return false;
+  return typingEventText(event) !== "elizabeth";
+}
+
+function typingInputId(event: CollectionEvent): string {
+  const data = event.data as KeyboardEventData;
+  return JSON.stringify([
+    event.meta.pid,
+    event.meta.sid,
+    event.meta.url || "",
+    data.t || "unknown",
+  ]);
+}
+
+function createTypingEventGroup(
+  inputId: string,
+  events: CollectionEvent[],
+): TypingEventGroup {
+  const first = events[0];
+  const last = events.at(-1) ?? first;
+  return {
+    id: `${inputId}:${first.id}`,
+    inputId,
+    events,
+    startTs: first.ts,
+    endTs: last.ts,
+  };
+}
+
+/**
+ * Returns visible typing-box groups in chronological order. Events within each
+ * group are chronological, and fragmented captures merge when adjacent rows
+ * for the same input are no more than 35 seconds apart.
+ */
+export function groupTypingEvents(
+  events: readonly CollectionEvent[],
+): TypingEventGroup[] {
+  const eventsByInput = new Map<string, CollectionEvent[]>();
+
+  for (const event of events) {
+    if (!isVisibleTypingEvent(event)) continue;
+    const inputId = typingInputId(event);
+    const inputEvents = eventsByInput.get(inputId);
+    if (inputEvents) {
+      inputEvents.push(event);
+    } else {
+      eventsByInput.set(inputId, [event]);
+    }
+  }
+
+  const groups: TypingEventGroup[] = [];
+  for (const [inputId, inputEvents] of eventsByInput) {
+    const chronological = [...inputEvents].sort(
+      (a, b) => a.ts - b.ts || a.id.localeCompare(b.id),
+    );
+    let current: CollectionEvent[] = [];
+
+    for (const event of chronological) {
+      const previous = current.at(-1);
+      if (
+        previous &&
+        event.ts - previous.ts > TYPING_EVENT_MERGE_THRESHOLD_MS
+      ) {
+        groups.push(createTypingEventGroup(inputId, current));
+        current = [];
+      }
+      current.push(event);
+    }
+
+    if (current.length > 0) {
+      groups.push(createTypingEventGroup(inputId, current));
+    }
+  }
+
+  return groups.sort(
+    (a, b) => a.startTs - b.startTs || a.id.localeCompare(b.id),
+  );
+}

--- a/extension/website/shared/utils/typingEventGroups.ts
+++ b/extension/website/shared/utils/typingEventGroups.ts
@@ -34,7 +34,7 @@ function typingInputId(event: CollectionEvent): string {
     event.meta.pid,
     event.meta.sid,
     event.meta.url || "",
-    data.t || "unknown",
+    data.t || `${data.x}:${data.y}`,
   ]);
 }
 

--- a/extension/website/shared/utils/typingInstallationReservoir.ts
+++ b/extension/website/shared/utils/typingInstallationReservoir.ts
@@ -1,0 +1,202 @@
+// ABOUTME: Builds finite typing chapters from completed live and archived input sessions.
+// ABOUTME: Keeps groups whole, prioritizes live work, and delays repeats until exhaustion.
+
+import type { CollectionEvent } from "../types";
+import {
+  groupTypingEvents,
+  TYPING_EVENT_MERGE_THRESHOLD_MS,
+  type TypingEventGroup,
+} from "./typingEventGroups";
+
+export const DEFAULT_TYPING_INSTALLATION_CHAPTER_GROUPS = 1000;
+
+export type TypingReservoirOrigin = "archive" | "live";
+
+export interface TypingReservoirState {
+  archiveEvents: readonly CollectionEvent[];
+  liveEvents: readonly CollectionEvent[];
+  seenEventIds: ReadonlySet<string>;
+  seenGroupIds: ReadonlySet<string>;
+  nowMs: number;
+  rotation: number;
+}
+
+export interface TypingReservoirChapter {
+  state: TypingReservoirState;
+  events: CollectionEvent[];
+  rotation: number;
+  repeated: boolean;
+  hasLive: boolean;
+}
+
+export function createTypingReservoir(): TypingReservoirState {
+  return {
+    archiveEvents: [],
+    liveEvents: [],
+    seenEventIds: new Set(),
+    seenGroupIds: new Set(),
+    nowMs: 0,
+    rotation: 0,
+  };
+}
+
+function mergeUniqueEvents(
+  existing: readonly CollectionEvent[],
+  incoming: readonly CollectionEvent[],
+): CollectionEvent[] {
+  const byId = new Map(existing.map((event) => [event.id, event]));
+  for (const event of incoming) {
+    if (!byId.has(event.id)) byId.set(event.id, event);
+  }
+  return [...byId.values()];
+}
+
+export function addTypingReservoirEvents(
+  state: TypingReservoirState,
+  events: readonly CollectionEvent[],
+  origin: TypingReservoirOrigin,
+  nowMs: number,
+): TypingReservoirState {
+  if (!Number.isFinite(nowMs)) {
+    throw new Error("Typing reservoir time must be finite");
+  }
+
+  return {
+    ...state,
+    archiveEvents:
+      origin === "archive"
+        ? mergeUniqueEvents(state.archiveEvents, events)
+        : state.archiveEvents,
+    liveEvents:
+      origin === "live"
+        ? mergeUniqueEvents(state.liveEvents, events)
+        : state.liveEvents,
+    nowMs: Math.max(state.nowMs, nowMs),
+  };
+}
+
+function reservoirGroups(state: TypingReservoirState): {
+  live: TypingEventGroup[];
+  archive: TypingEventGroup[];
+} {
+  const completionCutoff = state.nowMs - TYPING_EVENT_MERGE_THRESHOLD_MS;
+  const liveEventIds = new Set(state.liveEvents.map((event) => event.id));
+  const allEvents = mergeUniqueEvents(state.archiveEvents, state.liveEvents);
+  const live: TypingEventGroup[] = [];
+  const archive: TypingEventGroup[] = [];
+
+  for (const group of groupTypingEvents(allEvents)) {
+    const containsLiveEvent = group.events.some((event) =>
+      liveEventIds.has(event.id),
+    );
+    if (!containsLiveEvent) {
+      archive.push(group);
+    } else if (group.endTs <= completionCutoff) {
+      live.push(group);
+    }
+  }
+
+  live.sort((a, b) => a.startTs - b.startTs || a.id.localeCompare(b.id));
+  archive.sort((a, b) => b.startTs - a.startTs || a.id.localeCompare(b.id));
+  return { live, archive };
+}
+
+function groupIsUnseen(
+  group: TypingEventGroup,
+  seenGroupIds: ReadonlySet<string>,
+  seenEventIds: ReadonlySet<string>,
+): boolean {
+  return (
+    !seenGroupIds.has(group.id) &&
+    group.events.every((event) => !seenEventIds.has(event.id))
+  );
+}
+
+function selectChapterGroups(
+  liveGroups: readonly TypingEventGroup[],
+  archivedGroups: readonly TypingEventGroup[],
+  seenGroupIds: ReadonlySet<string>,
+  seenEventIds: ReadonlySet<string>,
+  maxGroups: number,
+): { groups: TypingEventGroup[]; liveGroupIds: Set<string> } {
+  const groups: TypingEventGroup[] = [];
+  const liveGroupIds = new Set<string>();
+  const selectedGroupIds = new Set(seenGroupIds);
+  const selectedEventIds = new Set(seenEventIds);
+
+  const append = (group: TypingEventGroup, live: boolean) => {
+    if (groups.length >= maxGroups) return;
+    if (!groupIsUnseen(group, selectedGroupIds, selectedEventIds)) return;
+    groups.push(group);
+    selectedGroupIds.add(group.id);
+    for (const event of group.events) selectedEventIds.add(event.id);
+    if (live) liveGroupIds.add(group.id);
+  };
+
+  for (const group of liveGroups) append(group, true);
+  for (const group of archivedGroups) append(group, false);
+
+  return { groups, liveGroupIds };
+}
+
+export function takeTypingReservoirChapter(
+  state: TypingReservoirState,
+  maxGroups: number = DEFAULT_TYPING_INSTALLATION_CHAPTER_GROUPS,
+): TypingReservoirChapter {
+  if (!Number.isInteger(maxGroups) || maxGroups < 1) {
+    throw new Error("Typing reservoir chapter size must be a positive integer");
+  }
+
+  const { live: liveGroups, archive: archivedGroups } = reservoirGroups(state);
+  let repeated = false;
+  let seenGroupIds = state.seenGroupIds;
+  let seenEventIds = state.seenEventIds;
+  let selection = selectChapterGroups(
+    liveGroups,
+    archivedGroups,
+    seenGroupIds,
+    seenEventIds,
+    maxGroups,
+  );
+
+  if (
+    selection.groups.length === 0 &&
+    (liveGroups.length > 0 || archivedGroups.length > 0)
+  ) {
+    repeated = true;
+    seenGroupIds = new Set();
+    seenEventIds = new Set();
+    selection = selectChapterGroups(
+      liveGroups,
+      archivedGroups,
+      seenGroupIds,
+      seenEventIds,
+      maxGroups,
+    );
+  }
+
+  const nextSeenGroupIds = new Set(seenGroupIds);
+  const nextSeenEventIds = new Set(seenEventIds);
+  for (const group of selection.groups) {
+    nextSeenGroupIds.add(group.id);
+    for (const event of group.events) nextSeenEventIds.add(event.id);
+  }
+
+  const rotation = repeated ? state.rotation + 1 : state.rotation;
+  const nextState: TypingReservoirState = {
+    ...state,
+    seenGroupIds: nextSeenGroupIds,
+    seenEventIds: nextSeenEventIds,
+    rotation,
+  };
+
+  return {
+    state: nextState,
+    events: selection.groups.flatMap((group) => group.events),
+    rotation,
+    repeated,
+    hasLive: selection.groups.some((group) =>
+      selection.liveGroupIds.has(group.id),
+    ),
+  };
+}

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -8,6 +8,7 @@ import {
 } from "../shared/hooks/useCursorTrails";
 import { useCursorEventPool } from "../shared/hooks/useCursorEventPool";
 import { useChromeToggle } from "../shared/hooks/useChromeToggle";
+import { useDailyPageReload } from "../shared/hooks/useDailyPageReload";
 import { detectTouches, buildCoPresenceTimeline } from "./detect";
 import { createTouchesSketch, MarkStyle, SketchSettings } from "./sketch";
 import { createTouchesSketchGlsl } from "./sketchGlsl";
@@ -83,6 +84,7 @@ const styles = {
 };
 
 const CursorTouches = () => {
+  useDailyPageReload();
   const chromeHidden = useChromeToggle(true);
   const { events, loading, deepening, error } = useCursorEventPool(
     "",

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -10,6 +10,7 @@ import { useCursorEventPool } from "../shared/hooks/useCursorEventPool";
 import { useChromeToggle } from "../shared/hooks/useChromeToggle";
 import { useDailyPageReload } from "../shared/hooks/useDailyPageReload";
 import { parseCleanFromUrl } from "../shared/config";
+import { resolveLiveInstallationProfile } from "../shared/utils/liveInstallationProfiles";
 import { detectTouches, buildCoPresenceTimeline } from "./detect";
 import { createTouchesSketch, MarkStyle, SketchSettings } from "./sketch";
 import { createTouchesSketchGlsl } from "./sketchGlsl";
@@ -88,18 +89,32 @@ const CursorTouches = () => {
   useDailyPageReload();
   const chromeHidden = useChromeToggle(true);
   const cleanMode = useMemo(() => parseCleanFromUrl() >= 1, []);
+  const profileSettings = useMemo(
+    () => resolveLiveInstallationProfile()?.touchesSettings,
+    [],
+  );
   const { events, loading, deepening, error } = useCursorEventPool(
     "",
     MAX_POOL_EVENTS,
   );
 
-  const [touchRadius, setTouchRadius] = useState(20);
-  const [speed, setSpeed] = useState(1);
-  const [showCursors, setShowCursors] = useState(true);
-  const [samePersonOk, setSamePersonOk] = useState(false);
-  const [night, setNight] = useState(false);
-  const [renderer, setRenderer] = useState<Renderer>("nebula");
-  const [markStyle, setMarkStyle] = useState<MarkStyle>("hands");
+  const [touchRadius, setTouchRadius] = useState(
+    profileSettings?.touchRadius ?? 20,
+  );
+  const [speed, setSpeed] = useState(profileSettings?.speed ?? 1);
+  const [showCursors, setShowCursors] = useState(
+    profileSettings?.showCursors ?? true,
+  );
+  const [samePersonOk, setSamePersonOk] = useState(
+    profileSettings?.samePersonOk ?? false,
+  );
+  const [night, setNight] = useState(profileSettings?.night ?? false);
+  const [renderer, setRenderer] = useState<Renderer>(
+    profileSettings?.renderer ?? "nebula",
+  );
+  const [markStyle, setMarkStyle] = useState<MarkStyle>(
+    profileSettings?.markStyle ?? "hands",
+  );
 
   const [viewportSize, setViewportSize] = useState(() => ({
     width: window.innerWidth,
@@ -225,9 +240,7 @@ const CursorTouches = () => {
     <div style={{ ...styles.page, background: night ? "#100d13" : "#faf7f2" }}>
       <div ref={hostRef} style={styles.canvasHost} />
       {!chromeHidden && (
-        <div
-          style={{ ...styles.title, color: night ? "#e8e2d8" : "#3d3833" }}
-        >
+        <div style={{ ...styles.title, color: night ? "#e8e2d8" : "#3d3833" }}>
           cursor touches
         </div>
       )}

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -9,6 +9,7 @@ import {
 import { useCursorEventPool } from "../shared/hooks/useCursorEventPool";
 import { useChromeToggle } from "../shared/hooks/useChromeToggle";
 import { useDailyPageReload } from "../shared/hooks/useDailyPageReload";
+import { parseCleanFromUrl } from "../shared/config";
 import { detectTouches, buildCoPresenceTimeline } from "./detect";
 import { createTouchesSketch, MarkStyle, SketchSettings } from "./sketch";
 import { createTouchesSketchGlsl } from "./sketchGlsl";
@@ -86,6 +87,7 @@ const styles = {
 const CursorTouches = () => {
   useDailyPageReload();
   const chromeHidden = useChromeToggle(true);
+  const cleanMode = useMemo(() => parseCleanFromUrl() >= 1, []);
   const { events, loading, deepening, error } = useCursorEventPool(
     "",
     MAX_POOL_EVENTS,
@@ -230,19 +232,21 @@ const CursorTouches = () => {
         </div>
       )}
       {!chromeHidden && <div style={styles.status}>{statusText}</div>}
-      <div
-        ref={timeReadoutRef}
-        style={{
-          position: "fixed",
-          bottom: 16,
-          left: 20,
-          fontFamily: "'Martian Mono', monospace",
-          fontSize: "10px",
-          color: "#8a8279",
-          zIndex: 10,
-          pointerEvents: "none",
-        }}
-      />
+      {!cleanMode && (
+        <div
+          ref={timeReadoutRef}
+          style={{
+            position: "fixed",
+            bottom: 16,
+            left: 20,
+            fontFamily: "'Martian Mono', monospace",
+            fontSize: "10px",
+            color: "#8a8279",
+            zIndex: 10,
+            pointerEvents: "none",
+          }}
+        />
+      )}
 
       {!chromeHidden && (
         <div style={styles.panel}>

--- a/extension/worker/src/__tests__/broadcast.test.ts
+++ b/extension/worker/src/__tests__/broadcast.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the ingest→DO broadcast forwarder.
-// ABOUTME: Verifies cursor-only forwarding, cursor-color enrichment, and that failures never throw.
+// ABOUTME: Verifies renderable event forwarding, cursor-color enrichment, and failure isolation.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -48,7 +48,7 @@ describe('broadcastLiveEvents', () => {
     mockColorRows.length = 0;
   });
 
-  it('forwards only cursor events to the DO', async () => {
+  it('forwards cursor, viewport, and navigation events to the DO', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
     const pid = uniquePid();
@@ -56,14 +56,19 @@ describe('broadcastLiveEvents', () => {
     await broadcastLiveEvents(
       ns,
       ENV,
-      [ev('a', 'cursor', pid), ev('b', 'navigation', pid), ev('c', 'cursor', pid)],
+      [
+        ev('a', 'cursor', pid),
+        ev('b', 'navigation', pid),
+        ev('c', 'viewport', pid),
+        ev('d', 'keyboard', pid),
+      ],
       1000,
     );
 
     expect(stubFetch).toHaveBeenCalledTimes(1);
     const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
     const body = (await sentReq.json()) as { events: CollectionEvent[] };
-    expect(body.events.map((e) => e.id)).toEqual(['a', 'c']);
+    expect(body.events.map((e) => e.id)).toEqual(['a', 'b', 'c']);
   });
 
   it('enriches forwarded events with the participant cursor color', async () => {
@@ -91,10 +96,10 @@ describe('broadcastLiveEvents', () => {
     expect(body.events[0].meta.cursor_color).toBeUndefined();
   });
 
-  it('does nothing when there are no cursor events', async () => {
+  it('does nothing when there are no renderable live events', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
-    await broadcastLiveEvents(ns, ENV, [ev('b', 'navigation')], 1000);
+    await broadcastLiveEvents(ns, ENV, [ev('b', 'keyboard')], 1000);
     expect(stubFetch).not.toHaveBeenCalled();
   });
 

--- a/extension/worker/src/__tests__/broadcast.test.ts
+++ b/extension/worker/src/__tests__/broadcast.test.ts
@@ -48,7 +48,7 @@ describe('broadcastLiveEvents', () => {
     mockColorRows.length = 0;
   });
 
-  it('forwards cursor, viewport, and navigation events to the DO', async () => {
+  it('forwards cursor, viewport, and keyboard events to the DO', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
     const pid = uniquePid();
@@ -68,7 +68,7 @@ describe('broadcastLiveEvents', () => {
     expect(stubFetch).toHaveBeenCalledTimes(1);
     const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
     const body = (await sentReq.json()) as { events: CollectionEvent[] };
-    expect(body.events.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+    expect(body.events.map((e) => e.id)).toEqual(['a', 'c', 'd']);
   });
 
   it('enriches forwarded events with the participant cursor color', async () => {
@@ -99,7 +99,7 @@ describe('broadcastLiveEvents', () => {
   it('does nothing when there are no renderable live events', async () => {
     const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
     const ns = fakeNamespace(stubFetch);
-    await broadcastLiveEvents(ns, ENV, [ev('b', 'keyboard')], 1000);
+    await broadcastLiveEvents(ns, ENV, [ev('b', 'navigation')], 1000);
     expect(stubFetch).not.toHaveBeenCalled();
   });
 

--- a/extension/worker/src/__tests__/broadcast.test.ts
+++ b/extension/worker/src/__tests__/broadcast.test.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for the ingest→DO broadcast forwarder.
-// ABOUTME: Verifies renderable event forwarding, cursor-color enrichment, and failure isolation.
+// ABOUTME: Verifies live payload privacy, cursor-color enrichment, and failure isolation.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -24,8 +24,25 @@ const ENV = {
   SUPABASE_SECRET_KEY: 'k',
 } as unknown as Env;
 
-function ev(id: string, type: CollectionEvent['type'], pid = 'p'): CollectionEvent {
-  return { id, type, ts: 1, data: {}, meta: { pid, sid: 's' } } as CollectionEvent;
+function ev(
+  id: string,
+  type: CollectionEvent['type'],
+  pid = 'p',
+): CollectionEvent {
+  return {
+    id,
+    type,
+    ts: 1,
+    data: {},
+    meta: {
+      pid,
+      sid: 's',
+      url: 'https://example.com/page',
+      vw: 1440,
+      vh: 900,
+      tz: 'America/New_York',
+    },
+  } as CollectionEvent;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -69,6 +86,199 @@ describe('broadcastLiveEvents', () => {
     const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
     const body = (await sentReq.json()) as { events: CollectionEvent[] };
     expect(body.events.map((e) => e.id)).toEqual(['a', 'c', 'd']);
+  });
+
+  it('projects keyboard events to redacted live-only payloads', async () => {
+    const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const ns = fakeNamespace(stubFetch);
+    const pid = uniquePid();
+    const keyboardEvent = {
+      ...ev('keyboard', 'keyboard', pid),
+      data: {
+        x: 0.25,
+        y: 0.75,
+        t: '#private-message',
+        event: 'type',
+        sequence: [
+          {
+            action: 'type',
+            text: 'secret',
+            timestamp: 0,
+            unexpected: 'another secret',
+          },
+          { action: 'backspace', deletedCount: 2, timestamp: 140 },
+          { action: 'type', text: 'o🙂', timestamp: 220 },
+        ],
+        style: { w: 320, h: 48, br: 8, bg: 0.9, bs: 1, font: 'private' },
+        ce: true,
+        unexpected: 'top-level secret',
+      },
+    } as CollectionEvent;
+
+    await broadcastLiveEvents(ns, ENV, [keyboardEvent], 1000);
+
+    const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
+    const bodyText = await sentReq.text();
+    const body = JSON.parse(bodyText) as { events: CollectionEvent[] };
+    expect(bodyText).not.toContain('secret');
+    expect(bodyText).not.toContain('#private-message');
+    expect(bodyText).not.toContain('private');
+    expect(body.events[0].data).toEqual({
+      x: 0.25,
+      y: 0.75,
+      event: 'type',
+      sequence: [
+        {
+          action: 'type',
+          text: '\u2588\u2588\u2588\u2588\u2588\u2588',
+          timestamp: 0,
+        },
+        { action: 'backspace', deletedCount: 2, timestamp: 140 },
+        { action: 'type', text: '\u2588\u2588', timestamp: 220 },
+      ],
+      style: { w: 320, h: 48, br: 8, bg: 0.9, bs: 1 },
+    });
+  });
+
+  it('preserves null keyboard sequences without copying other keyboard data', async () => {
+    const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const ns = fakeNamespace(stubFetch);
+    const keyboardEvent = {
+      ...ev('keyboard', 'keyboard', uniquePid()),
+      data: {
+        x: 0.1,
+        y: 0.2,
+        event: 'type',
+        sequence: null,
+        text: 'must not leave ingest',
+      },
+    } as CollectionEvent;
+
+    await broadcastLiveEvents(ns, ENV, [keyboardEvent], 1000);
+
+    const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
+    const body = (await sentReq.json()) as { events: CollectionEvent[] };
+    expect(body.events[0].data).toEqual({
+      x: 0.1,
+      y: 0.2,
+      event: 'type',
+      sequence: null,
+    });
+  });
+
+  it('projects cursor and viewport events to renderer-only payloads', async () => {
+    const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const ns = fakeNamespace(stubFetch);
+    const pid = uniquePid();
+    const cursor = {
+      ...ev('cursor', 'cursor', pid),
+      data: {
+        x: 0.3,
+        y: 0.4,
+        scrollX: 12,
+        scrollY: 34,
+        t: '#private-account',
+        event: 'move',
+        cursor: 'pointer',
+        unexpected: 'cursor secret',
+      },
+      topLevelSecret: 'top-level secret',
+    } as CollectionEvent;
+    const viewport = {
+      ...ev('viewport', 'viewport', pid),
+      data: {
+        event: 'scroll',
+        scrollX: 0.1,
+        scrollY: 0.8,
+        scrollDistancePx: 200,
+        unexpected: 'viewport secret',
+      },
+      meta: {
+        ...ev('viewport', 'viewport', pid).meta,
+        unexpected: 'meta secret',
+      },
+    } as CollectionEvent;
+
+    await broadcastLiveEvents(ns, ENV, [cursor, viewport], 1000);
+
+    const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
+    const bodyText = await sentReq.text();
+    const body = JSON.parse(bodyText) as { events: CollectionEvent[] };
+    expect(bodyText).not.toContain('secret');
+    expect(bodyText).not.toContain('#private-account');
+    expect(body.events.map((event) => event.data)).toEqual([
+      {
+        x: 0.3,
+        y: 0.4,
+        scrollX: 12,
+        scrollY: 34,
+        event: 'move',
+        cursor: 'pointer',
+      },
+      {
+        event: 'scroll',
+        scrollX: 0.1,
+        scrollY: 0.8,
+        scrollDistancePx: 200,
+      },
+    ]);
+  });
+
+  it('removes private URL components from every forwarded event', async () => {
+    const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const ns = fakeNamespace(stubFetch);
+    const pid = uniquePid();
+    const events = (['cursor', 'viewport', 'keyboard'] as const).map(
+      (type, index) => ({
+        ...ev(String(index), type, pid),
+        normalizedUrl:
+          'https://example.com/private/path?normalized=secret#part',
+        meta: {
+          ...ev(String(index), type, pid).meta,
+          url: 'https://person:password@example.com/private/path?token=secret#part',
+        },
+      }),
+    );
+
+    await broadcastLiveEvents(ns, ENV, events, 1000);
+
+    const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
+    const bodyText = await sentReq.text();
+    const body = JSON.parse(bodyText) as { events: CollectionEvent[] };
+    expect(bodyText).not.toContain('secret');
+    expect(bodyText).not.toContain('password');
+    expect(body.events.map((event) => event.meta.url)).toEqual([
+      'https://example.com/private/path',
+      'https://example.com/private/path',
+      'https://example.com/private/path',
+    ]);
+    expect(body.events.map((event) => event.normalizedUrl)).toEqual([
+      'https://example.com/private/path',
+      'https://example.com/private/path',
+      'https://example.com/private/path',
+    ]);
+  });
+
+  it('does not forward malformed URLs raw', async () => {
+    const stubFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const ns = fakeNamespace(stubFetch);
+    const event = {
+      ...ev('cursor', 'cursor', uniquePid()),
+      normalizedUrl: 'not a URL?secret=value',
+      meta: {
+        ...ev('cursor', 'cursor').meta,
+        url: 'not a URL?token=secret',
+      },
+    };
+
+    await broadcastLiveEvents(ns, ENV, [event], 1000);
+
+    const sentReq = (stubFetch.mock.calls[0] as unknown[])[0] as Request;
+    const bodyText = await sentReq.text();
+    const body = JSON.parse(bodyText) as { events: CollectionEvent[] };
+    expect(bodyText).not.toContain('secret');
+    expect(body.events[0].meta.url).toBe('');
+    expect(body.events[0].normalizedUrl).toBeUndefined();
   });
 
   it('enriches forwarded events with the participant cursor color', async () => {

--- a/extension/worker/src/__tests__/ingest.test.ts
+++ b/extension/worker/src/__tests__/ingest.test.ts
@@ -19,6 +19,11 @@ const pageMetadataHistory = {
   single: vi.fn(),
 };
 
+const participants = {
+  select: vi.fn(),
+  in: vi.fn(),
+};
+
 vi.mock('../lib/supabase', () => ({
   createSupabaseClient: vi.fn(() => ({
     from: vi.fn((table: string) => {
@@ -27,6 +32,9 @@ vi.mock('../lib/supabase', () => ({
       }
       if (table === 'page_metadata_history') {
         return pageMetadataHistory;
+      }
+      if (table === 'participants') {
+        return participants;
       }
       throw new Error(`Unexpected table: ${table}`);
     }),
@@ -41,7 +49,12 @@ const ENV: Env = {
   ADMIN_KEY: 'a',
   RESEND_API_KEY: 'r',
   CODA_API_TOKEN: 'c',
-  LIVE_EVENTS_HUB: {} as DurableObjectNamespace,
+  LIVE_EVENTS_HUB: {
+    idFromName: () => ({}) as DurableObjectId,
+    get: () => ({
+      fetch: async () => new Response(null, { status: 204 }),
+    }),
+  } as unknown as DurableObjectNamespace,
   COMMUTE_TRAIN_DISPATCHER: {} as DurableObjectNamespace,
   COMMUTE_BOARD_RATE_LIMITER: {
     limit: async () => ({ success: true }),
@@ -95,6 +108,8 @@ describe('handleIngest', () => {
     pageMetadataHistory.eq.mockReset();
     pageMetadataHistory.insert.mockReset();
     pageMetadataHistory.single.mockReset();
+    participants.select.mockReset();
+    participants.in.mockReset();
     waitUntil.mockReset();
 
     collectionEvents.upsert.mockReturnValue({
@@ -116,6 +131,8 @@ describe('handleIngest', () => {
       },
       error: null,
     });
+    participants.select.mockReturnValue(participants);
+    participants.in.mockResolvedValue({ data: [] });
   });
 
   it('accepts event upserts without selecting inserted row ids', async () => {

--- a/extension/worker/src/live/LiveEventsHub.ts
+++ b/extension/worker/src/live/LiveEventsHub.ts
@@ -1,5 +1,5 @@
 // ABOUTME: Durable Object that holds website WebSocket connections and a ring buffer.
-// ABOUTME: Replays recent cursor events on connect, then broadcasts live events from ingest.
+// ABOUTME: Replays recent renderable events on connect, then broadcasts new events from ingest.
 
 import type { Env } from '../lib/supabase';
 import type { CollectionEvent } from '@playhtml/extension-types';
@@ -10,8 +10,7 @@ import type { CollectionEvent } from '@playhtml/extension-types';
 const MAX_AGE_MS = 2 * 60_000;
 
 // Hard cap on buffered events as a memory backstop for traffic spikes, applied
-// on top of the time window. At ~10 events per trail this is roughly one
-// canvas-worth (~60 trails); a viral burst is trimmed to the most recent.
+// on top of the time window. A traffic burst is trimmed to the most recent.
 const MAX_BUFFER = 600;
 
 interface BroadcastBody {

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -1,4 +1,4 @@
-// ABOUTME: Forwards newly ingested cursor events to the LiveEventsHub durable object.
+// ABOUTME: Forwards renderable movement events to the LiveEventsHub durable object.
 // ABOUTME: Enriches events with participant cursor colors; fire-and-forget, never fails ingest.
 
 import type { CollectionEvent } from '@playhtml/extension-types';
@@ -12,6 +12,7 @@ import { HUB_NAME } from './constants';
  */
 const COLOR_TTL_MS = 5 * 60 * 1000;
 const colorCache = new Map<string, { color: string | null; at: number }>();
+const LIVE_EVENT_TYPES = new Set(['cursor', 'viewport', 'navigation']);
 
 /** Fetch cursor colors for pids not in the cache (or whose cache entry expired),
  * then return a pid -> color map covering all requested pids. Best-effort: on
@@ -71,14 +72,14 @@ export async function broadcastLiveEvents(
   events: CollectionEvent[],
   nowMs: number,
 ): Promise<void> {
-  const cursorEvents = events.filter((e) => e.type === 'cursor');
-  if (cursorEvents.length === 0) return;
+  const liveEvents = events.filter((event) => LIVE_EVENT_TYPES.has(event.type));
+  if (liveEvents.length === 0) return;
 
   try {
-    const pids = [...new Set(cursorEvents.map((e) => e.meta.pid))];
+    const pids = [...new Set(liveEvents.map((event) => event.meta.pid))];
     const colors = await resolveCursorColors(env, pids, nowMs);
 
-    const enriched = cursorEvents.map((e) => {
+    const enriched = liveEvents.map((e) => {
       const color = colors.get(e.meta.pid);
       if (!color) return e;
       return { ...e, meta: { ...e.meta, cursor_color: color } };

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -12,7 +12,7 @@ import { HUB_NAME } from './constants';
  */
 const COLOR_TTL_MS = 5 * 60 * 1000;
 const colorCache = new Map<string, { color: string | null; at: number }>();
-const LIVE_EVENT_TYPES = new Set(['cursor', 'viewport', 'navigation']);
+const LIVE_EVENT_TYPES = new Set(['cursor', 'viewport', 'keyboard']);
 
 /** Fetch cursor colors for pids not in the cache (or whose cache entry expired),
  * then return a pid -> color map covering all requested pids. Best-effort: on

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -13,6 +13,161 @@ import { HUB_NAME } from './constants';
 const COLOR_TTL_MS = 5 * 60 * 1000;
 const colorCache = new Map<string, { color: string | null; at: number }>();
 const LIVE_EVENT_TYPES = new Set(['cursor', 'viewport', 'keyboard']);
+const REDACTED_GLYPH = '\u2588';
+
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function sanitizeLiveUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function projectKeyboardStyle(value: unknown): UnknownRecord | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const style: UnknownRecord = {};
+  for (const key of ['w', 'h', 'br', 'bg', 'bs']) {
+    if (typeof value[key] === 'number') style[key] = value[key];
+  }
+  return Object.keys(style).length > 0 ? style : undefined;
+}
+
+function projectKeyboardSequence(
+  value: unknown,
+): UnknownRecord[] | null | undefined {
+  if (value === null) return null;
+  if (!Array.isArray(value)) return undefined;
+
+  return value.filter(isRecord).map((action) => {
+    const projected: UnknownRecord = {};
+    if (action.action === 'type' || action.action === 'backspace') {
+      projected.action = action.action;
+    }
+    if (typeof action.timestamp === 'number') {
+      projected.timestamp = action.timestamp;
+    }
+    if (typeof action.deletedCount === 'number') {
+      projected.deletedCount = action.deletedCount;
+    }
+    if (typeof action.text === 'string') {
+      projected.text = REDACTED_GLYPH.repeat([...action.text].length);
+    }
+    return projected;
+  });
+}
+
+function projectKeyboardEvent(event: CollectionEvent): CollectionEvent {
+  const source = isRecord(event.data) ? event.data : {};
+  const data: UnknownRecord = {};
+
+  if (typeof source.x === 'number') data.x = source.x;
+  if (typeof source.y === 'number') data.y = source.y;
+  if (source.event === 'type') data.event = source.event;
+
+  const sequence = projectKeyboardSequence(source.sequence);
+  if (sequence !== undefined) data.sequence = sequence;
+
+  const style = projectKeyboardStyle(source.style);
+  if (style) data.style = style;
+
+  return { ...event, data };
+}
+
+function projectCursorEvent(event: CollectionEvent): CollectionEvent {
+  const source = isRecord(event.data) ? event.data : {};
+  const data: UnknownRecord = {};
+
+  for (const key of [
+    'x',
+    'y',
+    'scrollX',
+    'scrollY',
+    'button',
+    'duration',
+    'quantity',
+  ]) {
+    if (typeof source[key] === 'number') data[key] = source[key];
+  }
+  if (typeof source.cursor === 'string') data.cursor = source.cursor;
+  if (
+    source.event === 'move' ||
+    source.event === 'click' ||
+    source.event === 'hold' ||
+    source.event === 'cursor_change'
+  ) {
+    data.event = source.event;
+  }
+
+  return { ...event, data };
+}
+
+function projectViewportEvent(event: CollectionEvent): CollectionEvent {
+  const source = isRecord(event.data) ? event.data : {};
+  const data: UnknownRecord = {};
+
+  for (const key of [
+    'scrollX',
+    'scrollY',
+    'scrollDistancePx',
+    'width',
+    'height',
+    'zoom',
+    'previous_zoom',
+    'quantity',
+  ]) {
+    if (typeof source[key] === 'number') data[key] = source[key];
+  }
+  if (
+    source.event === 'scroll' ||
+    source.event === 'resize' ||
+    source.event === 'zoom'
+  ) {
+    data.event = source.event;
+  }
+
+  return { ...event, data };
+}
+
+function projectLiveEvent(event: CollectionEvent): CollectionEvent {
+  const projected =
+    event.type === 'keyboard'
+      ? projectKeyboardEvent(event)
+      : event.type === 'cursor'
+        ? projectCursorEvent(event)
+        : projectViewportEvent(event);
+  const normalizedUrl = sanitizeLiveUrl(projected.normalizedUrl);
+  return {
+    id: projected.id,
+    type: projected.type,
+    ts: projected.ts,
+    data: projected.data,
+    meta: {
+      pid: projected.meta.pid,
+      sid: projected.meta.sid,
+      url: sanitizeLiveUrl(projected.meta.url) ?? '',
+      vw: projected.meta.vw,
+      vh: projected.meta.vh,
+      tz: projected.meta.tz,
+      cursor_color: projected.meta.cursor_color,
+    },
+    domain: projected.domain,
+    normalizedUrl,
+  };
+}
 
 /** Fetch cursor colors for pids not in the cache (or whose cache entry expired),
  * then return a pid -> color map covering all requested pids. Best-effort: on
@@ -79,7 +234,7 @@ export async function broadcastLiveEvents(
     const pids = [...new Set(liveEvents.map((event) => event.meta.pid))];
     const colors = await resolveCursorColors(env, pids, nowMs);
 
-    const enriched = liveEvents.map((e) => {
+    const enriched = liveEvents.map(projectLiveEvent).map((e) => {
       const color = colors.get(e.meta.pid);
       if (!color) return e;
       return { ...e, meta: { ...e.meta, cursor_color: color } };

--- a/extension/worker/src/routes/ingest.ts
+++ b/extension/worker/src/routes/ingest.ts
@@ -337,10 +337,9 @@ export async function handleIngest(
       console.log(`[Ingest] Inserted ${inserted} new events, ${duplicates} duplicates ignored`);
     }
     
-    // Fan out cursor events to the live stream. Fire-and-forget — must never
-    // affect the ingest result. The cast is sound for cursor events: the live
-    // consumers read cursor position from `data`, and tolerate the optional
-    // `meta` fields (url/vw/vh/tz) being absent.
+    // Fan out renderable movement events to the live stream. Fire-and-forget
+    // must never affect the ingest result. Live consumers tolerate optional
+    // metadata fields being absent.
     ctx.waitUntil(
       broadcastLiveEvents(
         env.LIVE_EVENTS_HUB,


### PR DESCRIPTION
## Summary

- Add nine named installation profiles for scrolling, keypresses, touches, clicks, the cursor field, and four coordinated cursor followers.
- Keep each machine URL stable while profile settings remain in a checked-in registry that can change with later website deployments.
- Show cursor trails by default and keep clicks, keypresses, scrolling, and touches on independent installation screens.
- Keep cursor and click views live-forward while keypresses and scrolling consume recent archive reservoirs, then incorporate completed live activity into later chapters.
- Retain completed click ripples across archive replays. Completed marks fade continuously as newer marks move them toward 3% opacity at the 4,000-mark eviction edge.
- Reload unattended live installation and touches pages at the next local midnight. A screen that slept through midnight reloads when it becomes visible again.
- Sanitize the public live stream with explicit payload allowlists. Keyboard text is replaced with block characters, DOM selectors and unknown fields are removed, and URLs lose credentials, queries, and fragments. Navigation remains excluded.
- Keep the public portrait page unchanged.

## Rationale

The installation hardware uses independent computers. Each named follower profile provides its own follow camera, stable coordination identity, and one of four participant slots.

The named profiles prevent browser-saved settings from changing an installation screen. Explicit query parameters remain available as temporary test overrides. Unprofiled live URLs retain their existing browser-saved settings behavior.

Keypress and scrolling activity is too sparse for a consistently active pure-live screen. Reservoir playback preserves density, consumes each item once per reservoir, and admits completed live sessions without a manual refresh. The daily reload gives long-running screens a clean day boundary while retaining that same-day flow.

## Installation links

- Setup: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/setup/
- Scrolling: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=scrolling
- Keypresses: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=typing
- Touches: https://cx-live-installation.we-were-online-website.pages.dev/touches/?clean=2&screen=touches
- Clicks: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=clicks
- Cursor field: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=cursors
- Cursor follower 1: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=follower-a
- Cursor follower 2: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=follower-b
- Cursor follower 3: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=follower-c
- Cursor follower 4: https://cx-live-installation.we-were-online-website.pages.dev/installation/live/?clean=2&screen=follower-d

Replace the preview host with `https://wewere.online` after this PR merges and the production website deploys. The paths and screen names do not change.

## Verification

- `bun run test:extension`: 152 files, 968 tests passed before the final rebase
- Named-profile suite: 4 files, 24 tests passed
- Click lifecycle suite: 2 files, 8 tests passed
- `bun run lint`
- `bun run check:extension-website`
- `bun run check:extension-worker`
- Website production build: 756 modules transformed
- The full Worker suite printed all 18 files as passing but did not exit. The process was interrupted after the existing Vitest shutdown hang. Focused tests and type-checking exit cleanly.

## Real-browser and production verification

- Confirmed the deployed setup page generates exactly nine named URLs.
- Confirmed the deployed clicks profile selects only click ripples and retains completed generations across a replay.
- Confirmed active ripples remain fully opaque, complete their eased expansion, and then fade continuously by retained position without an opacity step.
- Confirmed the deployed follower-c profile resolves slot 2, follower coordination, and a 320 by 180 camera view inside a 1280 by 720 display.
- Confirmed the deployed touches profile renders its canvas without installation chrome.
- Confirmed named profile URLs remain stable and do not rewrite themselves with serialized settings.
- Deployed `playhtml-game-api` with repo-pinned Wrangler `4.81.1`.
- Active production Worker version: `541ac0a4-8061-48b2-9544-548830e1482b`.
- Confirmed the production WebSocket accepts the website origin and live keyboard text is block-redacted.

## Release notes and documentation

- No changeset or starter update: this does not change a published package API.
- No public developer documentation update: this is an installation-only website surface.
- No extension release-note entry: this is not part of the regular extension user workflow.
