### PR TITLE
Prevent options page storage stats crash

### DIFF
--- a/extension/src/__tests__/Collections.test.tsx
+++ b/extension/src/__tests__/Collections.test.tsx
@@ -131,6 +131,36 @@ describe("Collections", () => {
     }
   });
 
+  it("renders storage stats from a background worker without per-type sizes", async () => {
+    vi.mocked(browser.runtime.sendMessage).mockImplementation(async (message) => {
+      if (message?.type === "GET_STORAGE_STATS") {
+        return {
+          success: true,
+          stats: {
+            totalEvents: 12,
+            estimatedSizeBytes: 1536,
+            localUsageBytes: 2048,
+            oldestEvent: Date.now(),
+            countsByType: { cursor: 12 },
+          },
+        };
+      }
+      return { success: true };
+    });
+
+    const { container, root } = await renderCollections();
+
+    try {
+      const text = container.textContent ?? "";
+
+      expect(text).toContain("12events");
+      expect(text).toContain("1.5 KBevent data");
+      expect(text).not.toContain("internet scraps");
+    } finally {
+      cleanupRoot(root, container);
+    }
+  });
+
   it("hides local storage stats when all collectors are off", async () => {
     vi.mocked(browser.storage.local.get).mockImplementation(async (keys) => {
       if (

--- a/extension/src/components/Collections.tsx
+++ b/extension/src/components/Collections.tsx
@@ -35,7 +35,7 @@ const DEV_MODE_KEY = "dev_mode";
 interface StorageStats {
   totalEvents: number;
   estimatedSizeBytes: number;
-  estimatedSizeBytesByType: Record<string, number>;
+  estimatedSizeBytesByType?: Record<string, number>;
   localUsageBytes: number | null;
   oldestEvent: number;
   newestEvent?: number;
@@ -725,7 +725,7 @@ export function Collections({
   const eventTypeCounts = storageStats
     ? getEventTypeCounts(storageStats.countsByType)
     : [];
-  const scrapSizeBytes = storageStats?.estimatedSizeBytesByType.element;
+  const scrapSizeBytes = storageStats?.estimatedSizeBytesByType?.element;
   const hasActiveCollection = Object.values(modes).some(
     (mode) => mode !== "off",
   );


### PR DESCRIPTION
## Summary

- tolerate storage stats responses without per-type size estimates
- keep rendering the available totals while omitting the Internet Scraps size
- cover the previous background worker response shape with a regression test

## Root cause

The options page could load updated UI code while the previous MV3 background worker was still active. That worker returned storage stats without estimatedSizeBytesByType, and the options page read .element from the missing map during render.

## Verification

- bun run test:extension (144 files, 915 tests)
- bun run check:extension
- bun run build-extension
- bun run smoke:extension
- loaded the built MV3 options page in isolated Chromium with the previous stats response shape; Your data rendered with zero uncaught errors

This is a narrow extension UI fix. It does not change permissions, collection behavior, or public release notes.