### PR TITLE
Avoid redundant document connections for domain-wide cursors

### DIFF
--- a/.changeset/calm-cursors-connect.md
+++ b/.changeset/calm-cursors-connect.md
@@ -1,0 +1,5 @@
+---
+"playhtml": patch
+---
+
+Avoid opening a redundant collaborative-document connection when cursors use a dedicated presence room, preventing repeated reconnections and unnecessary request load.

--- a/packages/playhtml/src/__tests__/presence-transport-sharing.test.ts
+++ b/packages/playhtml/src/__tests__/presence-transport-sharing.test.ts
@@ -60,6 +60,36 @@ describe("presence transport sharing", () => {
     expect(openRooms).toHaveLength(2);
   });
 
+  it("does not open a Yjs provider for a separate cursor presence room", async () => {
+    const providers = (globalThis as any).PLAYHTML_TEST_PROVIDERS as Array<{
+      roomname: string;
+    }>;
+
+    await playhtml.init({ cursors: { enabled: true, room: "domain" } });
+
+    expect(providers.map((provider) => provider.roomname)).toEqual([
+      playhtml.roomId,
+    ]);
+  });
+
+  it("uses a separate cursor Yjs provider when presence transport is unavailable", async () => {
+    const providers = (globalThis as any).PLAYHTML_TEST_PROVIDERS as Array<{
+      roomname: string;
+    }>;
+    const originalWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = undefined;
+
+    try {
+      await playhtml.init({ cursors: { enabled: true, room: "domain" } });
+
+      expect(providers.map((provider) => provider.roomname)).toHaveLength(2);
+      expect(providers[0]?.roomname).toBe(playhtml.roomId);
+      expect(providers[1]?.roomname).not.toBe(playhtml.roomId);
+    } finally {
+      (globalThis as any).WebSocket = originalWebSocket;
+    }
+  });
+
   it("opens the page-room socket even when cursors are disabled", async () => {
     await playhtml.init({ cursors: { enabled: false } });
     const openRooms = getPresenceSockets()

--- a/packages/playhtml/src/__tests__/presence-transport-sharing.test.ts
+++ b/packages/playhtml/src/__tests__/presence-transport-sharing.test.ts
@@ -72,22 +72,18 @@ describe("presence transport sharing", () => {
     ]);
   });
 
-  it("uses a separate cursor Yjs provider when presence transport is unavailable", async () => {
+  it("uses only the main Yjs provider with a custom cursor room", async () => {
     const providers = (globalThis as any).PLAYHTML_TEST_PROVIDERS as Array<{
       roomname: string;
     }>;
-    const originalWebSocket = (globalThis as any).WebSocket;
-    (globalThis as any).WebSocket = undefined;
+    await playhtml.init({
+      cursors: { enabled: true, room: () => "/shared-cursors" },
+    });
 
-    try {
-      await playhtml.init({ cursors: { enabled: true, room: "domain" } });
-
-      expect(providers.map((provider) => provider.roomname)).toHaveLength(2);
-      expect(providers[0]?.roomname).toBe(playhtml.roomId);
-      expect(providers[1]?.roomname).not.toBe(playhtml.roomId);
-    } finally {
-      (globalThis as any).WebSocket = originalWebSocket;
-    }
+    expect(providers.map((provider) => provider.roomname)).toEqual([
+      playhtml.roomId,
+    ]);
+    expect(getPresenceSockets().filter((socket) => !socket.closed)).toHaveLength(2);
   });
 
   it("opens the page-room socket even when cursors are disabled", async () => {

--- a/packages/playhtml/src/__tests__/room-normalization.test.ts
+++ b/packages/playhtml/src/__tests__/room-normalization.test.ts
@@ -150,7 +150,7 @@ describe("Room normalization and cursor room matching", () => {
       expect(playhtml.roomId).toBe(expectedRoom);
     });
 
-    it("should create separate provider when cursor room is 'domain'", async () => {
+    it("should normalize a domain cursor room separately from the main room", async () => {
       mockLocation("example.com", "/test/playground");
       const playhtml = await freshPlayhtml();
       await playhtml.init({
@@ -166,12 +166,11 @@ describe("Room normalization and cursor room matching", () => {
       expect(playhtml.roomId).toBe(mainRoom);
 
       // Cursor room for domain would be: encodeURIComponent("example.com")
-      // They should be different, so a separate provider should be created
       const cursorDomainRoom = encodeURIComponent("example.com");
       expect(cursorDomainRoom).not.toBe(mainRoom);
     });
 
-    it("should create separate provider when cursor room is 'section'", async () => {
+    it("should normalize a section cursor room separately from the main room", async () => {
       mockLocation("example.com", "/test/playground/page");
       const playhtml = await freshPlayhtml();
       await playhtml.init({

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -1218,29 +1218,30 @@ function buildCursors(args: {
 
   if (cursorOptions.room) {
     const cursorRoomString = resolveCursorRoom(cursorOptions.room);
-    const cursorRoom = normalizeRoomId(getCurrentRoomHost(), cursorRoomString);
-
-    if (cursorRoom !== mainRoom) {
-      const cursorDoc = new Y.Doc();
-      cursorProvider = new YProvider(
-        partykitHost,
-        cursorRoom,
-        cursorDoc,
-      );
-      cursorProvider.on("error", () => {
-        onError?.();
-      });
-      providerForCursors = cursorProvider;
-      currentCursorRoomId = cursorRoom;
-    } else {
-      currentCursorRoomId = mainRoom;
-    }
+    currentCursorRoomId = normalizeRoomId(
+      getCurrentRoomHost(),
+      cursorRoomString,
+    );
   } else {
     currentCursorRoomId = mainRoom;
   }
 
   const cursorPresenceTransport =
     acquirePresenceTransport(currentCursorRoomId) ?? undefined;
+
+  if (!cursorPresenceTransport && currentCursorRoomId !== mainRoom) {
+    const cursorDoc = new Y.Doc();
+    cursorProvider = new YProvider(
+      partykitHost,
+      currentCursorRoomId,
+      cursorDoc,
+    );
+    cursorProvider.on("error", () => {
+      onError?.();
+    });
+    providerForCursors = cursorProvider;
+  }
+
   cursorPresenceTransportRoom = cursorPresenceTransport
     ? currentCursorRoomId
     : null;

--- a/packages/playhtml/src/index.ts
+++ b/packages/playhtml/src/index.ts
@@ -207,7 +207,6 @@ function getCurrentRoomHost(): string {
 }
 
 let yprovider: YProvider;
-let cursorProvider: YProvider | null = null;
 let cursorClient: CursorClientAwareness | null = null;
 let currentCursorRoomId = "";
 // The stable object returned by playhtml.presence for the instance lifetime.
@@ -980,7 +979,7 @@ function buildMainProvider(args: {
   return { sharedReferences };
 }
 
-/** Disconnect and destroy the cursor client + cursor provider. */
+/** Destroy the cursor client and release its presence transport. */
 function teardownCursors(): void {
   cursorPresenceHub.disconnect();
   try { cursorClient?.destroy?.(); } catch {}
@@ -989,9 +988,6 @@ function teardownCursors(): void {
     releasePresenceTransport(cursorPresenceTransportRoom);
     cursorPresenceTransportRoom = null;
   }
-  try { cursorProvider?.disconnect?.(); } catch {}
-  try { cursorProvider?.destroy?.(); } catch {}
-  cursorProvider = null;
 }
 
 /** Disconnect and destroy the main Yjs provider. */
@@ -1188,20 +1184,18 @@ function bindAwarenessListener(): void {
 }
 
 /**
- * Builds the cursor client and optional separate cursor provider for the
- * given main room. Side effects: assigns module-level `cursorProvider` and
- * `cursorClient`, and `currentCursorRoomId`. Returns without awaiting sync.
+ * Builds the cursor client for the given main room. Side effects: assigns
+ * module-level `cursorClient` and `currentCursorRoomId`.
+ * Returns without awaiting sync.
  *
- * Safe to call multiple times — assumes prior cursorClient/cursorProvider
- * were already torn down by the caller.
+ * Safe to call multiple times — assumes the prior cursor client
+ * was already torn down by the caller.
  */
 function buildCursors(args: {
   cursors: CursorOptions;
   mainRoom: string;
-  partykitHost: string;
-  onError: (() => void) | undefined;
 }): void {
-  const { cursors, mainRoom, partykitHost, onError } = args;
+  const { cursors, mainRoom } = args;
 
   if (!cursors.enabled) {
     currentCursorRoomId = "";
@@ -1213,8 +1207,6 @@ function buildCursors(args: {
   }
 
   const cursorOptions: CursorOptions = { ...cursors };
-
-  let providerForCursors: YProvider = yprovider;
 
   if (cursorOptions.room) {
     const cursorRoomString = resolveCursorRoom(cursorOptions.room);
@@ -1229,24 +1221,11 @@ function buildCursors(args: {
   const cursorPresenceTransport =
     acquirePresenceTransport(currentCursorRoomId) ?? undefined;
 
-  if (!cursorPresenceTransport && currentCursorRoomId !== mainRoom) {
-    const cursorDoc = new Y.Doc();
-    cursorProvider = new YProvider(
-      partykitHost,
-      currentCursorRoomId,
-      cursorDoc,
-    );
-    cursorProvider.on("error", () => {
-      onError?.();
-    });
-    providerForCursors = cursorProvider;
-  }
-
   cursorPresenceTransportRoom = cursorPresenceTransport
     ? currentCursorRoomId
     : null;
   cursorClient = new CursorClientAwareness(
-    providerForCursors,
+    yprovider,
     cursorOptions,
     cursorPresenceTransport,
     usersAPI,
@@ -1366,8 +1345,6 @@ async function resetCurrentRoomFromServer(): Promise<void> {
     buildCursors({
       cursors,
       mainRoom: __currentRoomId,
-      partykitHost: __currentHost,
-      onError: configuredOptions?.onError,
     });
   }
   usersAPI?.getAll();
@@ -1517,8 +1494,6 @@ async function runHandleNavigation(): Promise<void> {
       buildCursors({
         cursors: cursorOptions,
         mainRoom: newMainRoom,
-        partykitHost: __currentHost,
-        onError: configuredOptions?.onError,
       });
     }
   }
@@ -1680,8 +1655,6 @@ async function initPlayHTMLOnce() {
   buildCursors({
     cursors,
     mainRoom: room,
-    partykitHost,
-    onError,
   });
   usersAPI.getAll();
 


### PR DESCRIPTION
Domain-wide cursors (`cursors: { enabled: true, room: "domain" }`) created a separate Yjs document provider even when the dedicated presence transport already handled cursor traffic. A page on spencer.place therefore opened an unnecessary `/parties/main/spencer.place` connection alongside its page document and presence connections.

Resolve the cursor room and acquire its presence transport without creating a separate document provider. Remove the unused cursor-provider cleanup and host/error arguments. The missing-WebSocket condition cannot provide a working document-provider fallback because the main Yjs provider also requires WebSocket.

The September 2 traffic investigation found 385,141 requests to the domain document path versus 1,203 across page document paths. This change removes that unnecessary client connection; the exact cause of repeated reconnects was not reproduced, and the production traffic reduction must be measured after rollout.

Validation:

- All 537 core tests passed on 4a918b67, including domain and custom cursor-room coverage verifying that only the main document provider is created.
- Core type check and core package build passed on 4a918b67; all package builds passed on the preceding commit.
- A real Chromium browser on the local domain-cursor playground attempted one page document path and two presence paths (page and domain), with no domain document path. The local backend was unavailable, so this verifies connection selection, not successful end-to-end synchronization.

Includes a patch changeset. No public API, setup, or persisted-data changes; public docs and starter templates need no changes. Production rollout requires a package release and upgrading/redeploying spencer.place.
