### PR TITLE
Enable sound on the installation cursor screen

### DIFF
--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -95,6 +95,7 @@ const LiveInstallation = () => {
         activeVisualizations={activeVisualizations}
         onSetActiveVisualizations={setActiveVisualizations}
         availableVisualizations={LIVE_INSTALLATION_VISUALIZATIONS}
+        defaultSoundEnabled={profile?.defaultSoundEnabled}
         defaultSettings={settingsDefaults}
         useStoredSettings={profile === null}
         syncSettingsToUrl={profile === null}

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -14,6 +14,7 @@ import { AnimatedTrails } from "./AnimatedTrails";
 import { LiveTrails } from "./LiveTrails";
 import { LiveIndicator } from "./LiveIndicator";
 import { SoundEngine } from "../sound/SoundEngine";
+import { attachSoundWakeListeners } from "../sound/soundWake";
 import { AnimatedClicks, type ScheduledClick } from "./AnimatedClicks";
 import { AnimatedTyping } from "./AnimatedTyping";
 import { AnimatedScrollViewports } from "./AnimatedScrollViewports";
@@ -353,8 +354,8 @@ interface MovementCanvasProps {
   onSetActiveVisualizations: (vizIds: string[]) => void;
   /** Route-specific visualization ids shown in the developer controls. */
   availableVisualizations?: readonly string[];
-  /** Initial sound-on state. The AudioContext will still start suspended
-   * until the user's first gesture (browser autoplay policy). */
+  /** Initial sound-on state. The AudioContext may remain suspended until the
+   * browser permits playback through interaction or autoplay policy. */
   defaultSoundEnabled?: boolean;
   /** Route-specific defaults applied before stored settings and URL overrides. */
   defaultSettings?: Partial<MovementSettings>;
@@ -572,6 +573,11 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
       soundEngineRef.current = null;
       setSoundEngineReady(null);
     };
+  }, [soundEnabled]);
+
+  useEffect(() => {
+    if (!soundEnabled) return;
+    return attachSoundWakeListeners(() => soundEngineRef.current?.resume());
   }, [soundEnabled]);
 
   useEffect(() => {

--- a/extension/website/shared/sound/SoundEngine.ts
+++ b/extension/website/shared/sound/SoundEngine.ts
@@ -127,12 +127,11 @@ export class SoundEngine {
 
     this.enabled = true;
 
-    // init() is triggered by a user gesture (sound-toggle click), so resuming
-    // here satisfies the browser autoplay policy. Without this, the context
-    // stays suspended until tick() happens to fire from AnimatedTrails' rAF
-    // loop, which can delay audible sound by seconds.
+    // The installation cursor profile can initialize sound before a gesture.
+    // Keep the graph available for a later user gesture or wake-time retry if
+    // the browser's autoplay policy leaves this resume request pending.
     if (this.ctx.state === "suspended") {
-      await this.ctx.resume();
+      void this.resume().catch(() => undefined);
     }
   }
 
@@ -185,10 +184,6 @@ export class SoundEngine {
 
   tick(elapsedMs: number, activeTrails: TrailSoundFrame[]): void {
     if (!this.enabled || !this.ctx || !this.masterGain) return;
-
-    if (this.ctx.state === "suspended") {
-      this.ctx.resume();
-    }
 
     const activeIndices = new Set(activeTrails.map((t) => t.trailIndex));
     if (activeTrails.length !== this.lastActiveTrailCount) {

--- a/extension/website/shared/sound/__tests__/SoundEngine.test.ts
+++ b/extension/website/shared/sound/__tests__/SoundEngine.test.ts
@@ -1,7 +1,7 @@
 // ABOUTME: Tests audio-graph transitions in the movement visualization sound engine.
 // ABOUTME: Verifies cursor timbre changes crossfade without stacking full-level oscillators.
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SoundEngine } from "../SoundEngine";
 
 type ParamEvent = {
@@ -157,6 +157,32 @@ afterEach(() => {
 });
 
 describe("SoundEngine cursor instruments", () => {
+  it("keeps the audio graph initialized when autoplay blocks its first resume", async () => {
+    context.state = "suspended";
+    const resume = vi
+      .spyOn(context, "resume")
+      .mockRejectedValue(new Error("NotAllowedError"));
+    const engine = new SoundEngine();
+
+    await expect(engine.init()).resolves.toBeUndefined();
+
+    expect(resume).toHaveBeenCalledOnce();
+    expect(engine.isEnabled()).toBe(true);
+  });
+
+  it("finishes initialization while an autoplay resume request remains pending", async () => {
+    context.state = "suspended";
+    const resume = vi
+      .spyOn(context, "resume")
+      .mockReturnValue(new Promise(() => {}));
+    const engine = new SoundEngine();
+
+    await expect(engine.init()).resolves.toBeUndefined();
+
+    expect(resume).toHaveBeenCalledOnce();
+    expect(engine.isEnabled()).toBe(true);
+  });
+
   it("does not restart the master gain ramp when trail count is unchanged", async () => {
     const engine = new SoundEngine();
     await engine.init();

--- a/extension/website/shared/sound/__tests__/soundWake.test.ts
+++ b/extension/website/shared/sound/__tests__/soundWake.test.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Tests wake-time audio resume listeners for movement visualizations.
+// ABOUTME: Covers visible-page filtering, cached-page restoration, rejection, and cleanup.
+
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachSoundWakeListeners } from "../soundWake";
+
+const originalVisibilityState = Object.getOwnPropertyDescriptor(
+  document,
+  "visibilityState",
+);
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value: state,
+  });
+}
+
+afterEach(() => {
+  if (originalVisibilityState) {
+    Object.defineProperty(document, "visibilityState", originalVisibilityState);
+  } else {
+    delete (document as Partial<Document>).visibilityState;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("attachSoundWakeListeners", () => {
+  it("resumes on visible wake and pageshow, but not when becoming hidden", () => {
+    const resume = vi.fn(() => Promise.resolve());
+    const detach = attachSoundWakeListeners(resume);
+
+    setVisibilityState("hidden");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(resume).not.toHaveBeenCalled();
+
+    setVisibilityState("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("pageshow"));
+    expect(resume).toHaveBeenCalledTimes(2);
+
+    detach();
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("pageshow"));
+    expect(resume).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles autoplay-policy rejection without an unhandled rejection", async () => {
+    const resume = vi.fn(() => Promise.reject(new Error("NotAllowedError")));
+    const detach = attachSoundWakeListeners(resume);
+
+    window.dispatchEvent(new Event("pageshow"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(resume).toHaveBeenCalledOnce();
+    detach();
+  });
+
+  it("allows wake events before an engine has been created", () => {
+    const resume = vi.fn(() => undefined);
+    const detach = attachSoundWakeListeners(resume);
+
+    window.dispatchEvent(new Event("pageshow"));
+
+    expect(resume).toHaveBeenCalledOnce();
+    detach();
+  });
+});

--- a/extension/website/shared/sound/soundWake.ts
+++ b/extension/website/shared/sound/soundWake.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Retries suspended movement audio when a visible page wakes or returns from cache.
+// ABOUTME: Treats autoplay rejection as expected browser policy rather than an application error.
+
+type ResumeSound = () => Promise<void> | undefined;
+
+export function attachSoundWakeListeners(resumeSound: ResumeSound): () => void {
+  const attemptResume = () => {
+    void resumeSound()?.catch(() => undefined);
+  };
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === "visible") attemptResume();
+  };
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  window.addEventListener("pageshow", attemptResume);
+
+  return () => {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    window.removeEventListener("pageshow", attemptResume);
+  };
+}

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -45,6 +45,15 @@ describe("live installation profiles", () => {
     });
   });
 
+  it("enables sound only on the main cursor field", () => {
+    expect(LIVE_INSTALLATION_PROFILES.cursors.defaultSoundEnabled).toBe(true);
+
+    for (const [name, profile] of Object.entries(LIVE_INSTALLATION_PROFILES)) {
+      if (name === "cursors") continue;
+      expect(profile.defaultSoundEnabled).not.toBe(true);
+    }
+  });
+
   it("uses explicit follower query parameters over profile defaults", () => {
     const profile = LIVE_INSTALLATION_PROFILES["follower-c"];
     expect(parseLiveInstallationScreen("", profile.screen)).toEqual({

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -37,6 +37,7 @@ export interface LiveInstallationProfile {
   label: string;
   pathname: "/installation/live/" | "/touches/";
   role: "master" | "follower";
+  defaultSoundEnabled?: boolean;
   followerId?: string;
   cinematic: CinematicConfig | null;
   visualizations: string[];
@@ -177,6 +178,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     label: "cursor field",
     pathname: "/installation/live/",
     role: "master",
+    defaultSoundEnabled: true,
     cinematic: null,
     visualizations: ["trails"],
     screen: field(),


### PR DESCRIPTION
## Summary

- enable sound by default only for the named `screen=cursors` installation profile
- retry suspended audio when the page becomes visible or returns from the back-forward cache
- keep audio initialization available when autoplay leaves a resume request pending
- remove per-frame resume retries so blocked playback cannot accumulate pending promises

Followers and the scrolling, keypresses, touches, and clicks screens remain silent by default.

## Verification

- extension tests: 988 passed
- focused sound and profile tests: 18 passed
- extension website typecheck passed
- extension website production build passed
- cursor and follower localhost routes loaded successfully
- two independent diff reviews completed; all findings addressed

## Installation requirement

The webpage does not bypass browser autoplay policy. Configure the main cursor computer with an autoplay allowlist for `https://wewere.online` or launch its dedicated Chrome session with `--autoplay-policy=no-user-gesture-required` for reliable unattended cold starts.