### PR TITLE
extension: add local installation cursor mode

### DIFF
--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -310,6 +310,23 @@ Cloudflare Worker + Supabase PostgreSQL + Resend:
 
 ## Configuration
 
+### Installation cursor
+
+In extension Settings, press Cmd/Ctrl+Shift+8 to reveal **Installation mode**
+under Identity. The checkbox shows the participant's own colored cursor on web
+pages and persists across browser restarts. It starts off; while enabled, its
+checkbox stays visible in Settings. Color changes apply to open pages.
+
+This is a local display setting, independent of feature entitlements and
+collection modes. It does not start cursor presence connections. Browser pages
+and embedded frame contents retain their native cursor.
+
+Build with `bun run build-extension`, then run
+`node smoke-tests/installation-cursor.mjs` to exercise the real Settings flow in
+isolated Chromium. Set `INSTALLATION_EVIDENCE_DIR` to save screenshots.
+
+### Files
+
 - `src/config.ts`: `VERBOSE` debug logging flag
 - `src/flags.ts`: Feature flags (`COPRESENCE: true`)
 - `wxt.config.ts`: Manifest v3, permissions (storage, tabs, http/https host access), React module, ASCII charset output for Chrome compliance

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -319,7 +319,9 @@ checkbox stays visible in Settings. Color changes apply to open pages.
 
 This is a local display setting, independent of feature entitlements and
 collection modes. It does not start cursor presence connections. Browser pages
-and embedded frame contents retain their native cursor.
+and embedded frame contents retain their native cursor. Open shadow roots receive
+cursor suppression when the pointer enters, including roots attached later.
+Closed roots retain their native cursor while the installation overlay hides.
 
 Build with `bun run build-extension`, then run
 `node smoke-tests/installation-cursor.mjs` to exercise the real Settings flow in

--- a/extension/src/components/InstallationModeSettings.tsx
+++ b/extension/src/components/InstallationModeSettings.tsx
@@ -1,0 +1,100 @@
+// ABOUTME: Reveals a local installation cursor setting through a settings-only shortcut.
+// ABOUTME: Keeps the control visible while enabled and reports storage failures.
+
+import { useEffect, useState } from "react";
+import browser from "webextension-polyfill";
+import { INSTALLATION_MODE_KEY } from "../features/installationMode";
+
+export function InstallationModeSettings() {
+  const [revealed, setRevealed] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [ready, setReady] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    let changed = false;
+    const onStorage = (
+      changes: Record<string, browser.Storage.StorageChange>,
+      area: string,
+    ) => {
+      if (area !== "local" || !changes[INSTALLATION_MODE_KEY]) return;
+      changed = true;
+      setEnabled(changes[INSTALLATION_MODE_KEY].newValue === true);
+    };
+    browser.storage.onChanged.addListener(onStorage);
+    void browser.storage.local
+      .get(INSTALLATION_MODE_KEY)
+      .then((stored) => {
+        if (!active) return;
+        if (!changed) setEnabled(stored[INSTALLATION_MODE_KEY] === true);
+        setReady(true);
+      })
+      .catch(() => {
+        if (active) setError(true);
+      });
+
+    const onKey = (event: KeyboardEvent) => {
+      if (
+        !(event.metaKey || event.ctrlKey) ||
+        !event.shiftKey ||
+        event.altKey ||
+        event.code !== "Digit8" ||
+        event.repeat
+      )
+        return;
+      event.preventDefault();
+      setRevealed(true);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      active = false;
+      browser.storage.onChanged.removeListener(onStorage);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, []);
+
+  if (!revealed && !enabled) return null;
+
+  return (
+    <div className="options-page__setting-row">
+      <div>
+        <h2>Installation mode</h2>
+        <p>
+          Show your own colored cursor on web pages. Stays on until you turn it
+          off.
+        </p>
+        {error && (
+          <p role="alert">
+            Could not save or load installation mode. Reopen Settings to try
+            again.
+          </p>
+        )}
+      </div>
+      <input
+        type="checkbox"
+        aria-label="Installation mode"
+        checked={enabled}
+        disabled={!ready || saving}
+        onChange={async (event) => {
+          const checked = event.target.checked;
+          setEnabled(checked);
+          setRevealed(true);
+          setSaving(true);
+          setError(false);
+          try {
+            await browser.storage.local.set({
+              [INSTALLATION_MODE_KEY]: checked,
+            });
+          } catch {
+            setEnabled(!checked);
+            setError(true);
+          } finally {
+            setSaving(false);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/extension/src/components/OptionsPage.tsx
+++ b/extension/src/components/OptionsPage.tsx
@@ -6,6 +6,7 @@ import browser from "webextension-polyfill";
 import { WORKER_URL } from "@movement/config";
 import type { GameInventory, PlayerIdentity, PlayHTMLStatus } from "../types";
 import { CursorSvg } from "./icons";
+import { InstallationModeSettings } from "./InstallationModeSettings";
 import {
   DataCollectionSection,
   DeveloperModeSection,
@@ -329,6 +330,7 @@ export function OptionsPage() {
         <section id="identity" className="options-page__section">
           <h1>Identity</h1>
           <div className="options-page__card">
+            <InstallationModeSettings />
             <div className="options-page__setting-row">
               <div>
                 <h2>Cursor color</h2>

--- a/extension/src/entrypoints/content.ts
+++ b/extension/src/entrypoints/content.ts
@@ -33,6 +33,7 @@ import {
 import { markExtensionInstalled } from "../utils/extensionInstallMarker";
 import { isExtensionPageUrl } from "../utils/extensionPage";
 import { initHostedSlowModeContentBridge } from "../features/slowMode/slowModeHostedContentBridge";
+import { initInstallationCursor } from "./content/installationCursor";
 
 // Scraps are local-only, so normalize any unsupported stored mode before the
 // collector starts.
@@ -61,6 +62,8 @@ export default defineContentScript({
     markExtensionInstalled(document.documentElement);
     const removeSlowModeBridge = initHostedSlowModeContentBridge();
     ctx?.onInvalidated(removeSlowModeBridge);
+    const removeInstallationCursor = initInstallationCursor();
+    ctx?.onInvalidated(removeInstallationCursor);
 
     let currentPresenceCount = 0;
 

--- a/extension/src/entrypoints/content/installationCursor.ts
+++ b/extension/src/entrypoints/content/installationCursor.ts
@@ -11,22 +11,76 @@ export function initInstallationCursor(): () => void {
   let disposed = false;
   let revision = 0;
   let ui: InjectedReactUI | null = null;
+  const shadowStyles = new Map<ShadowRoot, HTMLStyleElement>();
   const hide = () => {
     if (ui) ui.host.style.visibility = "hidden";
     document.documentElement.removeAttribute("data-wwo-installation-cursor");
+    for (const style of shadowStyles.values()) {
+      if (style.sheet) style.sheet.disabled = true;
+    }
   };
   const remove = () => {
     hide();
     ui?.destroy();
     ui = null;
+    for (const style of shadowStyles.values()) style.remove();
+    shadowStyles.clear();
   };
   const move = (event: PointerEvent) => {
     if (!ui || event.pointerType === "touch") return;
-    ui.host.style.transform = `translate(${event.clientX - 12}px, ${event.clientY - 8.4}px)`;
-    ui.host.style.visibility = "visible";
-    if (!document.documentElement.hasAttribute("data-wwo-installation-cursor")) {
+    const path = event.composedPath();
+    for (const node of path) {
+      if (!(node instanceof HTMLElement)) continue;
+      // Extension APIs can identify closed roots without modifying their contents.
+      const root =
+        node.shadowRoot ??
+        (typeof chrome !== "undefined" && chrome.dom?.openOrClosedShadowRoot
+          ? chrome.dom.openOrClosedShadowRoot(node)
+          : (
+              node as HTMLElement & {
+                openOrClosedShadowRoot?: ShadowRoot | null;
+              }
+            ).openOrClosedShadowRoot);
+      // Opaque custom elements retain their native pointer on browsers without
+      // closed-root access, since their internal cursor styles cannot be checked.
+      if (root?.mode === "closed" || (!root && node.localName.includes("-"))) {
+        hide();
+        return;
+      }
+    }
+    for (const node of path) {
+      if (!(node instanceof ShadowRoot)) continue;
+      let style = shadowStyles.get(node);
+      if (!style?.isConnected) {
+        style = document.createElement("style");
+        style.textContent = "* { cursor: none !important; }";
+        node.append(style);
+        shadowStyles.set(node, style);
+      }
+      if (style.sheet?.disabled) style.sheet.disabled = false;
+    }
+    for (const [root, style] of shadowStyles) {
+      if (!root.host.isConnected) {
+        style.remove();
+        shadowStyles.delete(root);
+      }
+    }
+    if (
+      !document.documentElement.hasAttribute("data-wwo-installation-cursor")
+    ) {
       document.documentElement.setAttribute("data-wwo-installation-cursor", "");
     }
+    // A page can override even an injected rule, for example with inline
+    // !important styles. Keep one native cursor if suppression did not apply.
+    if (
+      path[0] instanceof Element &&
+      getComputedStyle(path[0]).cursor !== "none"
+    ) {
+      hide();
+      return;
+    }
+    ui.host.style.transform = `translate(${event.clientX - 12}px, ${event.clientY - 8.4}px)`;
+    ui.host.style.visibility = "visible";
   };
   const leave = (event: PointerEvent) => {
     if (

--- a/extension/src/entrypoints/content/installationCursor.ts
+++ b/extension/src/entrypoints/content/installationCursor.ts
@@ -43,7 +43,11 @@ export function initInstallationCursor(): () => void {
             ).openOrClosedShadowRoot);
       // Opaque custom elements retain their native pointer on browsers without
       // closed-root access, since their internal cursor styles cannot be checked.
-      if (root?.mode === "closed" || (!root && node.localName.includes("-"))) {
+      // A null result confirms there is no root; undefined means access is unavailable.
+      if (
+        root?.mode === "closed" ||
+        (root === undefined && node.localName.includes("-"))
+      ) {
         hide();
         return;
       }

--- a/extension/src/entrypoints/content/installationCursor.ts
+++ b/extension/src/entrypoints/content/installationCursor.ts
@@ -1,0 +1,116 @@
+// ABOUTME: Shows the participant's own cursor locally for installation displays.
+// ABOUTME: Follows profile settings without joining rooms or publishing pointer movement.
+
+import browser from "webextension-polyfill";
+import { CursorSvg } from "../../components/icons";
+import { INSTALLATION_MODE_KEY } from "../../features/installationMode";
+import { PLAYER_IDENTITY_STORAGE_KEY } from "../../storage/playerIdentity";
+import { injectShadowReact, type InjectedReactUI } from "./inject-ui";
+
+export function initInstallationCursor(): () => void {
+  let disposed = false;
+  let revision = 0;
+  let ui: InjectedReactUI | null = null;
+  const hide = () => {
+    if (ui) ui.host.style.visibility = "hidden";
+    document.documentElement.removeAttribute("data-wwo-installation-cursor");
+  };
+  const remove = () => {
+    hide();
+    ui?.destroy();
+    ui = null;
+  };
+  const move = (event: PointerEvent) => {
+    if (!ui || event.pointerType === "touch") return;
+    ui.host.style.transform = `translate(${event.clientX - 12}px, ${event.clientY - 8.4}px)`;
+    ui.host.style.visibility = "visible";
+    if (!document.documentElement.hasAttribute("data-wwo-installation-cursor")) {
+      document.documentElement.setAttribute("data-wwo-installation-cursor", "");
+    }
+  };
+  const leave = (event: PointerEvent) => {
+    if (
+      event.relatedTarget === null ||
+      event.relatedTarget instanceof HTMLIFrameElement
+    )
+      hide();
+  };
+  const visibility = () => {
+    if (document.hidden) hide();
+  };
+
+  const refresh = async () => {
+    const currentRevision = ++revision;
+    try {
+      const stored = await browser.storage.local.get(INSTALLATION_MODE_KEY);
+      if (disposed || currentRevision !== revision) return;
+      if (stored[INSTALLATION_MODE_KEY] !== true) {
+        remove();
+        return;
+      }
+      const identity = await browser.runtime.sendMessage({
+        type: "GET_PUBLIC_PLAYER_IDENTITY",
+      });
+      if (disposed || currentRevision !== revision) return;
+      const color = identity?.playerStyle?.colorPalette?.[0];
+      if (typeof color !== "string" || !CSS.supports("color", color)) {
+        remove();
+        return;
+      }
+      if (ui) {
+        ui.render({ size: 32, color });
+      } else {
+        ui = injectShadowReact(
+          CursorSvg,
+          { size: 32, color },
+          {
+            hostId: "wwo-installation-cursor",
+            hostStyle:
+              "all:initial;position:fixed;top:0;left:0;width:32px;height:32px;pointer-events:none;z-index:2147483647;visibility:hidden;",
+            css: "svg { display:block; filter:drop-shadow(1px 0 0 white) drop-shadow(-1px 0 0 white) drop-shadow(0 1px 0 white) drop-shadow(0 -1px 0 white) drop-shadow(1px 2px 1px #0006); }",
+          },
+        );
+        ui.host.setAttribute("aria-hidden", "true");
+      }
+    } catch (error) {
+      if (disposed || currentRevision !== revision) return;
+      remove();
+      console.error(
+        "[we-were-online] Could not load installation cursor:",
+        error,
+      );
+    }
+  };
+  const onStorage = (
+    changes: Record<string, browser.Storage.StorageChange>,
+    area: string,
+  ) => {
+    if (
+      area === "local" &&
+      (changes[INSTALLATION_MODE_KEY] || changes[PLAYER_IDENTITY_STORAGE_KEY])
+    ) {
+      void refresh();
+    }
+  };
+  browser.storage.onChanged.addListener(onStorage);
+  document.addEventListener("pointermove", move, true);
+  document.addEventListener("pointerout", leave, true);
+  document.addEventListener("visibilitychange", visibility);
+  window.addEventListener("blur", hide);
+  window.addEventListener("pagehide", hide);
+  window.addEventListener("pageshow", refresh);
+  void refresh();
+
+  return () => {
+    disposed = true;
+    revision++;
+    remove();
+    browser.storage.onChanged.removeListener(onStorage);
+    document.removeEventListener("pointermove", move, true);
+    document.removeEventListener("pointerout", leave, true);
+    document.removeEventListener("visibilitychange", visibility);
+    window.removeEventListener("blur", hide);
+    window.removeEventListener("pagehide", hide);
+    window.removeEventListener("pageshow", refresh);
+  };
+}

--- a/extension/src/entrypoints/content/style.css
+++ b/extension/src/entrypoints/content/style.css
@@ -2,6 +2,11 @@
 /* ABOUTME: Only contains styles that must affect host page elements directly. */
 /* All extension-owned UI (toasts, overlays) uses Shadow DOM with inline styles — see content.ts. */
 
+html[data-wwo-installation-cursor],
+html[data-wwo-installation-cursor] * {
+  cursor: none !important;
+}
+
 .playhtml-extension-element-picker {
   outline: 2px dashed #6366f1 !important;
   background: rgba(99, 102, 241, 0.1) !important;

--- a/extension/src/features/installationMode.ts
+++ b/extension/src/features/installationMode.ts
@@ -1,0 +1,4 @@
+// ABOUTME: Names the local installation cursor preference shared by settings and pages.
+// ABOUTME: Installation mode is opt-in and persists in this browser profile.
+
+export const INSTALLATION_MODE_KEY = "wwoInstallationMode";

--- a/smoke-tests/installation-cursor.mjs
+++ b/smoke-tests/installation-cursor.mjs
@@ -146,6 +146,23 @@ try {
       if (mode === "closed") window.closedCursorProbe = root;
     }
   });
+  await page.evaluate(() => {
+    const host = document.createElement("cursor-probe");
+    host.id = "light-probe";
+    host.innerHTML = '<button style="cursor:pointer">Light DOM cursor</button>';
+    document.querySelector("main").append(host);
+  });
+  const lightButton = page.getByRole("button", {
+    name: "Light DOM cursor",
+    exact: true,
+  });
+  await lightButton.hover();
+  await expect(page.locator("#wwo-installation-cursor")).toBeVisible();
+  await expect
+    .poll(() => lightButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("none");
+  if (evidence)
+    await page.screenshot({ path: resolve(evidence, "cursor-light-dom.png") });
   const shadowButton = page.getByRole("button", {
     name: "open shadow cursor",
     exact: true,
@@ -188,6 +205,9 @@ try {
   await expect(page.locator("#wwo-installation-cursor")).toBeVisible();
   await settings.bringToFront();
   await toggle.uncheck();
+  await expect
+    .poll(() => lightButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("pointer");
   await expect
     .poll(() => shadowButton.evaluate((el) => getComputedStyle(el).cursor))
     .toBe("crosshair");

--- a/smoke-tests/installation-cursor.mjs
+++ b/smoke-tests/installation-cursor.mjs
@@ -132,6 +132,71 @@ try {
     await settings.screenshot({ path: resolve(evidence, "settings-on.png") });
   await assertCursor(page);
 
+  // Real custom elements cover nested roots, roots attached while enabled,
+  // and closed-root retargeting without simulating any extension APIs.
+  await page.evaluate(() => {
+    customElements.define("cursor-probe", class extends HTMLElement {});
+    for (const mode of ["open", "closed"]) {
+      const host = document.createElement("cursor-probe");
+      host.id = `${mode}-probe`;
+      host.style.cssText = "display:block;margin:12px 0";
+      document.querySelector("main").append(host);
+      const root = host.attachShadow({ mode });
+      root.innerHTML = `<style>button{cursor:crosshair;padding:12px;font:18px system-ui}</style><button>${mode} shadow cursor</button>`;
+      if (mode === "closed") window.closedCursorProbe = root;
+    }
+  });
+  const shadowButton = page.getByRole("button", {
+    name: "open shadow cursor",
+    exact: true,
+  });
+  await shadowButton.hover();
+  await expect
+    .poll(() => shadowButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("none");
+  await expect(page.locator("#wwo-installation-cursor")).toBeVisible();
+  if (evidence)
+    await page.screenshot({
+      path: resolve(evidence, "cursor-shadow-open.png"),
+    });
+  await page.locator("#closed-probe").hover({ position: { x: 30, y: 20 } });
+  await expect(page.locator("#wwo-installation-cursor")).toBeHidden();
+  assert.equal(
+    await page.evaluate(
+      () =>
+        getComputedStyle(window.closedCursorProbe.querySelector("button"))
+          .cursor,
+    ),
+    "crosshair",
+  );
+  if (evidence)
+    await page.screenshot({
+      path: resolve(evidence, "cursor-shadow-closed.png"),
+    });
+  await page.evaluate(() => {
+    const host = document.createElement("cursor-probe");
+    host.id = "nested-probe";
+    document.querySelector("#open-probe").shadowRoot.append(host);
+    host.attachShadow({ mode: "open" }).innerHTML =
+      '<button style="cursor:help;padding:12px">Nested late shadow cursor</button>';
+  });
+  const nestedButton = page.locator("#nested-probe button");
+  await nestedButton.hover();
+  await expect
+    .poll(() => nestedButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("none");
+  await expect(page.locator("#wwo-installation-cursor")).toBeVisible();
+  await settings.bringToFront();
+  await toggle.uncheck();
+  await expect
+    .poll(() => shadowButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("crosshair");
+  await expect
+    .poll(() => nestedButton.evaluate((el) => getComputedStyle(el).cursor))
+    .toBe("help");
+  await toggle.check();
+  await assertCursor(page);
+
   // Change color through the actual settings form and verify storage and DOM.
   await settings.bringToFront();
   await settings.locator('input[type="color"]').fill("#e04488");

--- a/smoke-tests/installation-cursor.mjs
+++ b/smoke-tests/installation-cursor.mjs
@@ -1,0 +1,258 @@
+// ABOUTME: Exercises installation mode through the built extension's Settings in Chromium.
+// ABOUTME: Verifies local cursor rendering, color changes, navigation, restart, and removal.
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium, expect } from "@playwright/test";
+
+const workspace = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const extensionPath = resolve(workspace, "extension/dist/chrome-mv3");
+const evidence = process.env.INSTALLATION_EVIDENCE_DIR;
+if (evidence) await mkdir(evidence, { recursive: true });
+const profile = await mkdtemp(resolve(tmpdir(), "wwo-installation-"));
+const errors = [];
+const webSockets = [];
+const externalRequests = [];
+const server = createServer((request, response) => {
+  response.writeHead(200, { "content-type": "text/html" });
+  response.end(`<!doctype html><html><head><title>Installation cursor test</title>
+    <style>body{font:20px system-ui;margin:80px;background:#f8f7f3;color:#34312c}
+    main{max-width:640px}h1{font-size:36px}button,input,a{font:inherit;margin:16px 16px 16px 0}
+    button{padding:12px 20px;cursor:pointer}input{padding:12px}a{display:block}</style>
+    </head><body><main><h1>Installation cursor</h1><p>An ordinary web page with the extension installed.</p>
+    <button onclick="this.textContent='Clicked'">Try a click</button>
+    <input aria-label="Test text" placeholder="Try typing here">
+    <a href="/next">Another page</a><p>${request.url === "/next" ? "Second page" : "First page"}</p>
+    </main></body></html>`);
+});
+await new Promise((done, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", done);
+});
+const origin = `http://127.0.0.1:${server.address().port}`;
+let context;
+
+async function launch() {
+  context = await chromium.launchPersistentContext(profile, {
+    channel: "chromium",
+    headless: true,
+    viewport: { width: 1100, height: 760 },
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      "--disable-background-networking",
+      "--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE localhost, EXCLUDE 127.0.0.1",
+    ],
+  });
+  // Block external traffic; this feature uses browser storage and DOM only.
+  // No Worker API responses, extension APIs, identity, or storage are simulated.
+  await context.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.protocol === "chrome-extension:" || url.hostname === "127.0.0.1") {
+      return route.continue();
+    }
+    externalRequests.push(url.href);
+    await route.abort("blockedbyclient");
+  });
+  await context.routeWebSocket("**/*", (socket) => {
+    webSockets.push(socket.url());
+    socket.close();
+  });
+  context.on("page", (page) => {
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (
+        message.type() === "error" &&
+        message.text().includes("installation cursor")
+      ) {
+        errors.push(message.text());
+      }
+    });
+  });
+  const worker =
+    context.serviceWorkers()[0] ??
+    (await context.waitForEvent("serviceworker"));
+  const extensionId = new URL(worker.url()).host;
+  return {
+    worker,
+    settingsUrl: `chrome-extension://${extensionId}/options.html`,
+  };
+}
+
+async function assertCursor(page) {
+  await expect(page.locator("#wwo-installation-cursor")).toBeAttached();
+  await page.bringToFront();
+  await page.mouse.move(360, 350);
+  await expect(page.locator("#wwo-installation-cursor")).toBeVisible();
+  assert.equal(
+    await page.locator("body").evaluate((el) => getComputedStyle(el).cursor),
+    "none",
+  );
+  assert.equal(
+    await page
+      .locator("#wwo-installation-cursor")
+      .evaluate((el) => el.style.transform),
+    "translate(348px, 341.6px)",
+  );
+}
+
+try {
+  let { worker, settingsUrl } = await launch();
+  const settings = await context.newPage();
+  await settings.goto(settingsUrl);
+  await expect(
+    settings.getByRole("heading", { name: "Identity", exact: true }),
+  ).toBeVisible();
+  await expect(
+    settings.getByRole("checkbox", { name: "Installation mode" }),
+  ).toHaveCount(0);
+  const page = await context.newPage();
+  await page.goto(`${origin}/first`);
+  await page.mouse.move(360, 350);
+  await expect(page.locator("#wwo-installation-cursor")).toHaveCount(0);
+
+  await settings.bringToFront();
+  await settings.keyboard.press("8");
+  await expect(
+    settings.getByRole("checkbox", { name: "Installation mode" }),
+  ).toHaveCount(0);
+  await settings.keyboard.press("Control+Shift+Digit8");
+  const toggle = settings.getByRole("checkbox", { name: "Installation mode" });
+  await expect(toggle).toBeEnabled();
+  await expect(toggle).not.toBeChecked();
+  if (evidence)
+    await settings.screenshot({ path: resolve(evidence, "settings-off.png") });
+  await toggle.check();
+  await expect(toggle).toBeChecked();
+  if (evidence)
+    await settings.screenshot({ path: resolve(evidence, "settings-on.png") });
+  await assertCursor(page);
+
+  // Change color through the actual settings form and verify storage and DOM.
+  await settings.bringToFront();
+  await settings.locator('input[type="color"]').fill("#e04488");
+  await settings.getByRole("button", { name: "Save", exact: true }).click();
+  await expect
+    .poll(async () =>
+      worker.evaluate(async () => {
+        const { playerIdentity } =
+          await chrome.storage.local.get("playerIdentity");
+        return playerIdentity?.public?.playerStyle?.colorPalette?.[0];
+      }),
+    )
+    .toBe("#e04488");
+  // CDP inspects the real closed shadow tree without changing production code.
+  const session = await context.newCDPSession(page);
+  await session.send("DOM.enable");
+  await expect
+    .poll(async () => {
+      const { nodes } = await session.send("DOM.getFlattenedDocument", {
+        depth: -1,
+        pierce: true,
+      });
+      return nodes.some(
+        (node) =>
+          node.nodeName === "path" && node.attributes?.includes("#e04488"),
+      );
+    })
+    .toBe(true);
+  await assertCursor(page);
+  if (evidence)
+    await page.screenshot({ path: resolve(evidence, "cursor-on.png") });
+  await page.getByRole("button", { name: "Try a click" }).click();
+  await expect(page.getByRole("button", { name: "Clicked" })).toBeVisible();
+  await page.getByRole("textbox").fill("The cursor does not block typing.");
+  await expect(page.getByRole("textbox")).toHaveValue(
+    "The cursor does not block typing.",
+  );
+  await page.getByRole("link", { name: "Another page" }).click();
+  await expect(page).toHaveURL(`${origin}/next`);
+  await assertCursor(page);
+  await page.goBack();
+  await assertCursor(page);
+  await page.reload();
+  await assertCursor(page);
+
+  await context.close();
+  ({ worker, settingsUrl } = await launch());
+  const restartedPage = await context.newPage();
+  await restartedPage.goto(`${origin}/after-restart`);
+  await assertCursor(restartedPage);
+  const otherPage = await context.newPage();
+  await otherPage.goto(`${origin}/another-tab`);
+  await assertCursor(otherPage);
+  const restartedSettings = await context.newPage();
+  await restartedSettings.goto(settingsUrl);
+  const persistedToggle = restartedSettings.getByRole("checkbox", {
+    name: "Installation mode",
+  });
+  await expect(persistedToggle).toBeChecked();
+  await persistedToggle.uncheck();
+  for (const openPage of [restartedPage, otherPage]) {
+    await expect(openPage.locator("#wwo-installation-cursor")).toHaveCount(0);
+    assert.equal(
+      await openPage
+        .locator("html")
+        .getAttribute("data-wwo-installation-cursor"),
+      null,
+    );
+    assert.equal(
+      await openPage
+        .getByRole("button")
+        .evaluate((el) => getComputedStyle(el).cursor),
+      "pointer",
+    );
+    assert.equal(
+      await openPage
+        .getByRole("textbox")
+        .evaluate((el) => getComputedStyle(el).cursor),
+      "text",
+    );
+  }
+  if (evidence)
+    await restartedPage.screenshot({
+      path: resolve(evidence, "cursor-off.png"),
+    });
+  await restartedPage.reload();
+  await expect(restartedPage.locator("#wwo-installation-cursor")).toHaveCount(
+    0,
+  );
+  await restartedSettings.reload();
+  await expect(
+    restartedSettings.getByRole("heading", { name: "Identity", exact: true }),
+  ).toBeVisible();
+  await expect(
+    restartedSettings.getByRole("checkbox", { name: "Installation mode" }),
+  ).toHaveCount(0);
+  await restartedSettings.keyboard.press("Meta+Shift+Digit8");
+  await expect(
+    restartedSettings.getByRole("checkbox", { name: "Installation mode" }),
+  ).toBeVisible();
+  assert.deepEqual(errors, [], "no page or installation cursor errors");
+  assert.deepEqual(
+    webSockets,
+    [],
+    "installation mode never joins a presence room",
+  );
+  console.log(
+    JSON.stringify(
+      {
+        result: "passed",
+        browser: context.browser()?.version(),
+        externalRequestsBlocked: externalRequests.length,
+        webSockets: webSockets.length,
+        evidence,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await context?.close();
+  await new Promise((done) => server.close(done));
+  await rm(profile, { recursive: true, force: true });
+}


### PR DESCRIPTION
Installation displays can show the participant’s own colored cursor across ordinary web pages. Open extension Settings, press Cmd/Ctrl+Shift+8, and enable **Installation mode** under Identity. The setting starts off, persists across browser restarts, and remains visible while enabled.

The cursor uses the existing arrow and saved profile color in a shadow-root overlay. Color and toggle changes reach open tabs through local storage. Disabling removes the overlay and restores the page’s cursor. The setting does not join multiplayer rooms or change collection preferences. Browser pages and embedded frame contents retain their native cursor.

Validation:
- Production extension build and `bun run check:extension` passed.
- Settings and presence-policy suites passed: 20 tests.
- `node smoke-tests/installation-cursor.mjs` passed against the built MV3 extension in Chromium 147.0.7727.15. The test uses the real Settings UI, service worker, identity, storage, and content script. It covers both shortcut modifiers, opt-in, color changes, clicking, typing, navigation/back/reload, browser restart, and disabling across two open tabs. No multiplayer sockets opened. External traffic was blocked; no backend responses or extension APIs were mocked.
- Finished settings and cursor screenshots are attached in PR Evidence.

This hidden installation setting has no public release-note entry. No package API, manifest permissions, or starter templates change.
