### PR TITLE
Reduce cursor trail and ripple rendering work

### DIFF
--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -1,6 +1,6 @@
 // ABOUTME: Shared ripple effect for click/hold visualization
 // ABOUTME: Used by AnimatedTrails and AnimatedClicks so ripple logic stays DRY
-import { useState, useEffect, useRef, memo } from "react";
+import { useEffect, useRef, memo } from "react";
 import { ClickEffect } from "../types";
 
 export interface RippleSettings {
@@ -63,10 +63,11 @@ export const RippleEffect = memo(
     settings: RippleSettings;
     onComplete?: (id: string) => void;
   }) => {
-    const [now, setNow] = useState(Date.now());
-    const [isAnimating, setIsAnimating] = useState(true);
-    /** Ensures onComplete runs once — render-phase callbacks can run twice in Strict Mode. */
+    const now = Date.now();
+    const ringRefs = useRef<Array<SVGCircleElement | null>>([]);
+    /** Ensures onComplete runs once even when effects restart in Strict Mode. */
     const completionFiredRef = useRef(false);
+    const completionIdRef = useRef(effect.id);
 
     const lifecycle = getRippleLifecycle(effect, rippleSettings, now);
     const { holdMultiplier, expansionDuration } = lifecycle;
@@ -84,34 +85,47 @@ export const RippleEffect = memo(
     const numRings = Math.max(1, rippleSettings.clickNumRings);
 
     useEffect(() => {
+      if (completionIdRef.current !== effect.id) {
+        completionIdRef.current = effect.id;
+        completionFiredRef.current = false;
+      }
+    }, [effect.id]);
+
+    useEffect(() => {
       let animationFrameId: number;
 
       const animate = () => {
-        setNow(Date.now());
-        animationFrameId = requestAnimationFrame(animate);
+        const timestamp = Date.now();
+        for (let i = 0; i < numRings; i++) {
+          const ring = ringRefs.current[i];
+          if (!ring) continue;
+          const radius = getRingRadius(i, timestamp);
+          if (radius === null) {
+            ring.style.display = "none";
+          } else {
+            ring.style.display = "";
+            const value = String(radius);
+            if (ring.getAttribute("r") !== value) ring.setAttribute("r", value);
+          }
+        }
+        if (getRippleLifecycle(effect, rippleSettings, timestamp).complete) {
+          if (!completionFiredRef.current) {
+            completionFiredRef.current = true;
+            onComplete?.(effect.id);
+          }
+        } else {
+          animationFrameId = requestAnimationFrame(animate);
+        }
       };
 
-      if (isAnimating) {
-        animationFrameId = requestAnimationFrame(animate);
-      }
+      animate();
 
       return () => {
         if (animationFrameId) {
           cancelAnimationFrame(animationFrameId);
         }
       };
-    }, [isAnimating]);
-
-    useEffect(() => {
-      completionFiredRef.current = false;
-    }, [effect.id]);
-
-    useEffect(() => {
-      if (!lifecycle.complete || completionFiredRef.current) return;
-      completionFiredRef.current = true;
-      onComplete?.(effect.id);
-      setIsAnimating(false);
-    }, [effect.id, lifecycle.complete, onComplete]);
+    }, [effect, rippleSettings, onComplete]);
 
     const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
 
@@ -134,9 +148,9 @@ export const RippleEffect = memo(
     );
     const expansionVelocity = outerTargetRadius / expansionDuration;
 
-    const rings = Array.from({ length: numRings }, (_, i) => {
+    const getRingRadius = (i: number, timestamp: number): number | null => {
       const ringStartTime = effect.startTime + i * ringStaggerMs;
-      const elapsed = now - ringStartTime;
+      const elapsed = timestamp - ringStartTime;
 
       if (elapsed < 0) return null;
 
@@ -151,23 +165,48 @@ export const RippleEffect = memo(
 
       const ringDuration = Math.max(1, ringTargetRadius / expansionVelocity);
       const rawProgress = Math.min(1, elapsed / ringDuration);
-      const ringRadius = ringTargetRadius * easeOutCubic(rawProgress);
+      return ringTargetRadius * easeOutCubic(rawProgress);
+    };
 
+    const rings = Array.from({ length: numRings }, (_, i) => {
+      const ringRadius = getRingRadius(i, now);
       return (
         <circle
           key={i}
+          ref={(ring) => {
+            ringRefs.current[i] = ring;
+          }}
           cx={effect.x}
           cy={effect.y}
-          r={ringRadius}
+          r={ringRadius ?? 0}
           fill="none"
           stroke={effect.color}
           strokeWidth={rippleSettings.clickStrokeWidth}
           opacity={Math.max(0, lifecycle.opacity)}
-          style={{ mixBlendMode: "multiply" }}
+          style={{
+            mixBlendMode: "multiply",
+            display: ringRadius === null ? "none" : "",
+          }}
         />
       );
     });
 
     return <g>{rings}</g>;
   },
+  (previous, next) =>
+    previous.effect === next.effect &&
+    previous.onComplete === next.onComplete &&
+    previous.settings.clickMinRadius === next.settings.clickMinRadius &&
+    previous.settings.clickMaxRadius === next.settings.clickMaxRadius &&
+    previous.settings.clickCoreRadius === next.settings.clickCoreRadius &&
+    previous.settings.clickMinDuration === next.settings.clickMinDuration &&
+    previous.settings.clickMaxDuration === next.settings.clickMaxDuration &&
+    previous.settings.clickExpansionDuration ===
+      next.settings.clickExpansionDuration &&
+    previous.settings.clickStrokeWidth === next.settings.clickStrokeWidth &&
+    previous.settings.clickOpacity === next.settings.clickOpacity &&
+    previous.settings.clickNumRings === next.settings.clickNumRings &&
+    previous.settings.clickRingDelayMs === next.settings.clickRingDelayMs &&
+    previous.settings.clickAnimationStopPoint ===
+      next.settings.clickAnimationStopPoint,
 );

--- a/extension/website/shared/components/__tests__/RippleEffect.test.tsx
+++ b/extension/website/shared/components/__tests__/RippleEffect.test.tsx
@@ -1,0 +1,176 @@
+// ABOUTME: Verifies rendered ripple geometry and completion across animation frames.
+// ABOUTME: Covers staggered rings, settings changes, residue, and effect cleanup.
+
+import React, { act, Profiler, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RippleEffect } from "../ClickRipple";
+import { CLICK_DEFAULTS } from "../clickDefaults";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const effect = {
+  id: "ripple",
+  x: 10,
+  y: 20,
+  color: "#123456",
+  radiusFactor: 0.5,
+  durationFactor: 0,
+  startTime: 1000,
+  trailIndex: 0,
+};
+const settings = {
+  ...CLICK_DEFAULTS,
+  clickMinRadius: 100,
+  clickMaxRadius: 100,
+  clickCoreRadius: 4,
+  clickAnimationStopPoint: 1,
+  clickExpansionDuration: 1000,
+  clickRingDelayMs: 200,
+  clickMinDuration: 3000,
+  clickMaxDuration: 3000,
+};
+
+describe("RippleEffect", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it("animates staggered radii without React commits and preserves completed residue", () => {
+    let commits = 0;
+    const completed: string[] = [];
+    act(() =>
+      root.render(
+        <Profiler
+          id="ripple"
+          onRender={() => {
+            commits++;
+          }}
+        >
+          <svg>
+            <RippleEffect
+              effect={effect}
+              settings={settings}
+              onComplete={(id) => completed.push(id)}
+            />
+          </svg>
+        </Profiler>,
+      ),
+    );
+    expect(
+      [...container.querySelectorAll("circle")].filter(
+        (ring) => ring.style.display !== "none",
+      ),
+    ).toHaveLength(1);
+    const initialCommits = commits;
+    act(() => vi.advanceTimersByTime(480));
+    const circles = container.querySelectorAll("circle");
+    expect(Number(circles[0].getAttribute("r"))).toBe(4);
+    expect(Number(circles[2].getAttribute("r"))).toBeCloseTo(
+      100 * (1 - 0.92 ** 3),
+    );
+    expect(circles[2].style.display).toBe("");
+    expect(commits).toBe(initialCommits);
+    expect(completed).toEqual([]);
+    act(() => vi.advanceTimersByTime(2608));
+    expect(completed).toEqual(["ripple"]);
+    expect(Number(circles[2].getAttribute("r"))).toBe(100);
+    expect(circles[2].getAttribute("opacity")).toBe(
+      String(settings.clickOpacity),
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("applies settings changes and cancels animation when unmounted", () => {
+    act(() =>
+      root.render(
+        <svg>
+          <RippleEffect effect={effect} settings={settings} />
+        </svg>,
+      ),
+    );
+    act(() => vi.advanceTimersByTime(480));
+    act(() =>
+      root.render(
+        <svg>
+          <RippleEffect
+            effect={effect}
+            settings={{
+              ...settings,
+              clickNumRings: 1,
+              clickMaxRadius: 200,
+              clickMinRadius: 200,
+              clickOpacity: 0.2,
+            }}
+          />
+        </svg>,
+      ),
+    );
+    const circles = container.querySelectorAll("circle");
+    expect(circles).toHaveLength(1);
+    expect(Number(circles[0].getAttribute("r"))).toBeCloseTo(
+      200 * (1 - 0.52 ** 3),
+    );
+    expect(circles[0].getAttribute("opacity")).toBe("0.2");
+    act(() => root.render(null));
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("completes an already expired ripple once in Strict Mode", () => {
+    const completed: string[] = [];
+    vi.setSystemTime(5000);
+    act(() =>
+      root.render(
+        <StrictMode>
+          <svg>
+            <RippleEffect
+              effect={effect}
+              settings={settings}
+              onComplete={(id) => completed.push(id)}
+            />
+          </svg>
+        </StrictMode>,
+      ),
+    );
+    expect(completed).toEqual(["ripple"]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("scales hold rings and keeps them until the hold lifetime expires", () => {
+    const completed: string[] = [];
+    act(() =>
+      root.render(
+        <svg>
+          <RippleEffect
+            effect={{ ...effect, holdDuration: 2000 }}
+            settings={settings}
+            onComplete={(id) => completed.push(id)}
+          />
+        </svg>,
+      ),
+    );
+    act(() => vi.advanceTimersByTime(3504));
+    expect(
+      Number(container.querySelectorAll("circle")[2].getAttribute("r")),
+    ).toBe(300);
+    expect(completed).toEqual([]);
+    act(() => vi.advanceTimersByTime(5504));
+    expect(completed).toEqual(["ripple"]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/extension/website/shared/utils/__tests__/trailAnimation.test.ts
+++ b/extension/website/shared/utils/__tests__/trailAnimation.test.ts
@@ -92,6 +92,42 @@ describe("buildFreehandPathSegment", () => {
     expect(buildFreehandPathSegment(points, 2, 1, 4, true)).toBe("");
     expect(buildFreehandPathSegment([], 0, 0, 4, true)).toBe("");
   });
+
+  it("preserves every curve when replay grows, wraps, changes width, or moves its tail", () => {
+    const trajectory = Array.from({ length: 1200 }, (_, i) => ({
+      x: i * 2,
+      y: 100 * Math.sin(i / 20),
+    }));
+    for (const [start, end, size, complete] of [
+      [0, 100, 4, false],
+      [0, 101, 4, false],
+      [0, 400, 4, false],
+      [0, 400, 8, false],
+      [0, 999, 8, false],
+      [1, 1000, 8, false],
+      [200, 1199, 8, true],
+      [0, 1, 4, false],
+    ] as const) {
+      const head = complete ? undefined : { x: trajectory[end].x + 1, y: 40 };
+      const cached = buildFreehandPathSegment(
+        trajectory,
+        start,
+        end,
+        size,
+        complete,
+        head,
+      );
+      const uncached = buildFreehandPathSegment(
+        [...trajectory],
+        start,
+        end,
+        size,
+        complete,
+        head,
+      );
+      expect(cached).toBe(uncached);
+    }
+  });
 });
 
 describe("getFinishedTrailRenderRange", () => {
@@ -104,13 +140,13 @@ describe("getFinishedTrailRenderRange", () => {
   ];
 
   it("keeps the visible finished window plus trails still fading after eviction", () => {
-    expect(getFinishedTrailRenderRange(sortedFinishOrder, 550, 2, 3000)).toEqual(
-      {
-        start: 0,
-        end: 5,
-        finishedCount: 5,
-      },
-    );
+    expect(
+      getFinishedTrailRenderRange(sortedFinishOrder, 550, 2, 3000),
+    ).toEqual({
+      start: 0,
+      end: 5,
+      finishedCount: 5,
+    });
   });
 
   it("skips finished trails whose eviction fade has completed", () => {
@@ -121,5 +157,32 @@ describe("getFinishedTrailRenderRange", () => {
       end: 5,
       finishedCount: 5,
     });
+  });
+
+  it("matches eviction timing across tied finishes, empty windows, and exact fade boundaries", () => {
+    const order = Array.from({ length: 100 }, (_, i) => ({
+      originalIndex: i,
+      finishedAtMs: Math.floor(i / 3) * 100,
+    }));
+    for (const windowSize of [0, 1, 24, 100, 200]) {
+      for (const elapsed of [-1, 0, 99, 100, 3000, 3099, 3100, 6000, 10000]) {
+        const finishedCount = order.filter(
+          (entry) => entry.finishedAtMs <= elapsed,
+        ).length;
+        let start = 0;
+        while (
+          start < finishedCount - windowSize &&
+          order[start + windowSize].finishedAtMs <= elapsed - 3000
+        )
+          start++;
+        expect(
+          getFinishedTrailRenderRange(order, elapsed, windowSize, 3000),
+        ).toEqual({
+          start,
+          end: finishedCount,
+          finishedCount,
+        });
+      }
+    }
   });
 });

--- a/extension/website/shared/utils/trailAnimation.ts
+++ b/extension/website/shared/utils/trailAnimation.ts
@@ -68,19 +68,54 @@ export interface FreehandStrokeStyle {
   taper?: number;
 }
 
+interface StrokePath {
+  outline: number[][];
+  curves: string[];
+}
+
+const strokePaths = new WeakMap<Array<{ x: number; y: number }>, StrokePath>();
+
 // Converts a perfect-freehand outline polygon into a closed SVG path,
 // smoothing between outline points with quadratic midpoint curves.
-function getSvgPathFromStroke(outline: number[][]): string {
+function getSvgPathFromStroke(
+  outline: number[][],
+  points: Array<{ x: number; y: number }>,
+): string {
   if (outline.length < 3) return "";
 
-  let path = `M ${outline[0][0].toFixed(2)} ${outline[0][1].toFixed(2)} Q`;
+  const previous = strokePaths.get(points);
+  const curves = new Array<string>(outline.length);
+  const matches = (
+    index: number,
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+  ) => {
+    if (!previous || index < 0 || index >= previous.outline.length)
+      return false;
+    const a = previous.outline[index];
+    const b = previous.outline[(index + 1) % previous.outline.length];
+    return a[0] === x0 && a[1] === y0 && b[0] === x1 && b[1] === y1;
+  };
   for (let i = 0; i < outline.length; i++) {
     const [x0, y0] = outline[i];
     const [x1, y1] = outline[(i + 1) % outline.length];
-    path += ` ${x0.toFixed(2)} ${y0.toFixed(2)} ${((x0 + x1) / 2).toFixed(2)} ${((y0 + y1) / 2).toFixed(2)}`;
+    // The outline runs forward along one side and backward along the other.
+    // Growing heads leave both a stable prefix and a stable suffix.
+    const suffixIndex = i + (previous?.outline.length ?? 0) - outline.length;
+    if (previous && matches(i, x0, y0, x1, y1)) {
+      curves[i] = previous.curves[i];
+    } else if (previous && matches(suffixIndex, x0, y0, x1, y1)) {
+      curves[i] = previous.curves[suffixIndex];
+    } else {
+      curves[i] =
+        ` ${x0.toFixed(2)} ${y0.toFixed(2)} ${((x0 + x1) / 2).toFixed(2)} ${((y0 + y1) / 2).toFixed(2)}`;
+    }
   }
 
-  return path + " Z";
+  strokePaths.set(points, { outline, curves });
+  return `M ${outline[0][0].toFixed(2)} ${outline[0][1].toFixed(2)} Q${curves.join("")} Z`;
 }
 
 // Builds a filled freehand-stroke outline for a window of trail points. The
@@ -121,7 +156,10 @@ export function buildFreehandPathSegment(
       : { taper: 0, cap: true },
   });
 
-  return getSvgPathFromStroke(outline);
+  const path = getSvgPathFromStroke(outline, points);
+  // Completed frames are retained by TrailPath; their curve cache can be freed.
+  if (isComplete) strokePaths.delete(points);
+  return path;
 }
 
 export function getFinishedTrailRenderRange(
@@ -141,13 +179,13 @@ export function getFinishedTrailRenderRange(
   }
 
   const evictionCutoffMs = elapsedTimeMs - evictionFadeMs;
-  let start = 0;
-  while (
-    start < excessCount &&
-    sortedFinishOrder[start + windowSize].finishedAtMs <= evictionCutoffMs
-  ) {
-    start++;
-  }
+  const start = Math.min(
+    excessCount,
+    Math.max(
+      0,
+      getFinishedCount(sortedFinishOrder, evictionCutoffMs) - windowSize,
+    ),
+  );
 
   return { start, end: finishedCount, finishedCount };
 }


### PR DESCRIPTION
Cursor playback was formatting every quadratic curve of every moving freehand trail into an SVG string on every frame. Reuse curve strings when their endpoint coordinates match the preceding outline, including both sides of a growing stroke. The generated SVG remains byte-for-byte identical. Cache entries use weak trail-point keys and are released when a trail completes.

Click and hold ripples now update SVG ring radii directly instead of committing React state every frame. Equal settings objects no longer cause unchanged ripples to render when other clicks arrive. Expansion math, ring delays, hold scaling, and residue are preserved. Completion callbacks are guarded across Strict Mode effect restarts.

Also use binary search for the expired-trail boundary, so each frame no longer scans all previously evicted trails.

Validation:
- Ripple benchmark: real Chromium at 1920x1080, 4x CPU throttling, 48 generated six-ring hold effects, four alternating 5-second runs. JavaScript time dropped from 3.53–3.59 seconds to 0.45–0.49 seconds (about 87% less); main-thread task time dropped from 4.97–5.00 seconds to 2.26–2.33 seconds (about 54% less). React profiler commits dropped from 446–459 to the initial mount only. No page errors.
- Full-component Chromium benchmark at 1920x1080 with 4x CPU throttling: 24 identical generated 1,200-point cursor trajectories rendered by the real `AnimatedTrails` component, using the original versus optimized helper. Four alternating runs (original/optimized/optimized/original), 5 seconds each after warm-up: original 131/139 frames (~26–28 FPS), optimized 202/212 (~40–42 FPS). Frame-time p95 improved from 50.4–51.1 ms to 33.3–33.9 ms. No page errors. This controlled desktop stress test does not emulate a specific Raspberry Pi or GPU.
- Chromium comparison against the original implementation at e45ad14d: 600 identical moving-head frames over a 1,000-point curved trajectory, five alternating-order runs. Median path-building time fell from 168.4 ms to 59.7 ms (2.8x faster, 65% less time). Additional comparison of 100 frames produced identical SVG strings. This is a geometry microbenchmark on a Mac, not a Raspberry Pi FPS measurement.
- 42 focused tests passed, covering geometry, trail renderers, live/archive playback, and cursor hooks. The no-frame-commit regression test was also run against the original ripple component and failed at the React commit assertion. Added coverage for ripple geometry, settings changes, hold lifetimes, cleanup, Strict Mode completion, growing/shrinking outlines, width changes, moving tails, completion, replay wrap, and eviction boundaries.
- Extension and website typechecks passed. Website production build passed with Vite's existing large-chunk advisory.
- Automated headless Chromium at 1920x1080 against the production-built `/installation/live/?screen=cursors` , `?screen=follower-a`, and `?screen=clicks`, using the real production event feed. Asserted changing path geometry, cursor pause/resume, follower viewBox presence, and movement after reload. No page or console errors. Screenshots cover the cursor field, frozen field, follower close-up, and click ripples. PR evidence is refreshed for the current commit.

No package API or dependency changes; changesets, starter templates, and public API docs do not apply. This is website cursor rendering maintenance and does not need a released-extension changelog entry. Raspberry Pi hardware, GPU acceleration, and the installation's exact browser configuration remain unverified.

Current commit 6bafa897 passed PR validation CI: common/core/docs/React/extension/Worker tests, lint, site build, and extension/site smoke tests.
