### PR TITLE
Keep installation cursor field continuously live

### DIFF
--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -1,11 +1,13 @@
-// ABOUTME: Renders the dedicated WWO live installation field or deterministic follower view.
-// ABOUTME: Uses live-forward chapters for movement and rotating reservoirs for typing and scrolling.
+// ABOUTME: Renders continuous cursor activity or finite visualization chapters for the WWO installation.
+// ABOUTME: Layers archived cursor footage under the live field only while current activity is quiet.
 
 import "../../shared/portrait-styles.scss";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { MovementCanvas } from "../../shared/components/MovementCanvas";
 import { LiveIndicator } from "../../shared/components/LiveIndicator";
+import type { CollectionEvent } from "../../shared/types";
+import { latestDrawableCursorEventId } from "../../shared/utils/cursorInstallation";
 import {
   parseDayFromUrl,
   parseTimeOfDayFromUrl,
@@ -36,6 +38,75 @@ const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
   showResizeEvents: true,
   showZoomEvents: true,
 };
+
+const CURSOR_ARCHIVE_IDLE_MS = 20_000;
+const CURSOR_ARCHIVE_FADE_MS = 3_000;
+
+function useCursorArchiveFallback(
+  liveEvents: readonly CollectionEvent[],
+  enabled: boolean,
+): { mounted: boolean; visible: boolean } {
+  const latestId = useMemo(
+    () => (enabled ? latestDrawableCursorEventId(liveEvents) : null),
+    [enabled, liveEvents],
+  );
+  const previousLatestIdRef = useRef<string | null>(null);
+  const lastCursorArrivalRef = useRef<number | null>(null);
+  const [idle, setIdle] = useState(enabled);
+  const [mounted, setMounted] = useState(enabled);
+  const [visible, setVisible] = useState(enabled);
+
+  useEffect(() => {
+    if (!enabled) {
+      previousLatestIdRef.current = null;
+      lastCursorArrivalRef.current = null;
+      setIdle(false);
+      return;
+    }
+    if (latestId === null || latestId === previousLatestIdRef.current) return;
+    previousLatestIdRef.current = latestId;
+    lastCursorArrivalRef.current = Date.now();
+    setIdle(false);
+  }, [enabled, latestId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const updateVisibility = () => {
+      const lastArrival = lastCursorArrivalRef.current;
+      setIdle(
+        lastArrival === null ||
+          Date.now() - lastArrival >= CURSOR_ARCHIVE_IDLE_MS,
+      );
+    };
+    const interval = window.setInterval(updateVisibility, 1_000);
+    return () => window.clearInterval(interval);
+  }, [enabled]);
+
+  useEffect(() => {
+    if (idle) {
+      setMounted(true);
+      let secondFrame: number | undefined;
+      const firstFrame = window.requestAnimationFrame(() => {
+        secondFrame = window.requestAnimationFrame(() => setVisible(true));
+      });
+      return () => {
+        window.cancelAnimationFrame(firstFrame);
+        if (secondFrame !== undefined) {
+          window.cancelAnimationFrame(secondFrame);
+        }
+      };
+    }
+
+    setVisible(false);
+    const timeout = window.setTimeout(
+      () => setMounted(false),
+      CURSOR_ARCHIVE_FADE_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [idle]);
+
+  return { mounted, visible };
+}
 
 const LiveInstallation = () => {
   const profile = useMemo(() => resolveLiveInstallationProfile(), []);
@@ -79,18 +150,58 @@ const LiveInstallation = () => {
     () => summarizeActiveLocations(hybrid.liveEvents),
     [hybrid.liveEvents],
   );
+  const continuousLiveTrails = profile?.continuousLiveTrails === true;
+  const archiveFallback = useCursorArchiveFallback(
+    hybrid.liveEvents,
+    continuousLiveTrails,
+  );
+  const archiveFallbackEvents = useMemo(() => {
+    const liveIds = new Set(hybrid.liveEvents.map((event) => event.id));
+    return hybrid.archiveEvents.filter((event) => !liveIds.has(event.id));
+  }, [hybrid.archiveEvents, hybrid.liveEvents]);
+  const previousFallbackMountedRef = useRef(archiveFallback.mounted);
+
+  useEffect(() => {
+    const wasMounted = previousFallbackMountedRef.current;
+    previousFallbackMountedRef.current = archiveFallback.mounted;
+    if (!continuousLiveTrails || !wasMounted || archiveFallback.mounted) return;
+
+    let timeout: number | undefined;
+    const advance = () => {
+      if (!hybrid.advanceArchive()) {
+        timeout = window.setTimeout(advance, 500);
+      }
+    };
+    advance();
+    return () => {
+      if (timeout !== undefined) window.clearTimeout(timeout);
+    };
+  }, [archiveFallback.mounted, continuousLiveTrails, hybrid.advanceArchive]);
 
   useEffect(() => {
     document.body.dataset.installationView = screen.view;
     document.body.dataset.installationSlot = String(screen.slot);
-    document.body.dataset.installationSource = hybrid.source;
-    document.body.dataset.installationPlaybackKey = hybrid.playbackKey;
-  }, [hybrid.playbackKey, hybrid.source, screen.slot, screen.view]);
+    document.body.dataset.installationSource = continuousLiveTrails
+      ? archiveFallback.visible
+        ? "archive-fallback"
+        : "live"
+      : hybrid.source;
+    document.body.dataset.installationPlaybackKey = continuousLiveTrails
+      ? "continuous-live"
+      : hybrid.playbackKey;
+  }, [
+    archiveFallback.visible,
+    continuousLiveTrails,
+    hybrid.playbackKey,
+    hybrid.source,
+    screen.slot,
+    screen.view,
+  ]);
 
   return (
     <>
       <MovementCanvas
-        events={hybrid.events}
+        events={continuousLiveTrails ? hybrid.liveEvents : hybrid.events}
         loading={hybrid.loading}
         error={hybrid.error}
         fetchEvents={hybrid.refresh}
@@ -105,10 +216,29 @@ const LiveInstallation = () => {
         installationRole={profile?.role}
         installationFollowerId={profile?.followerId}
         minimumCleanLevel={2}
-        playbackKey={hybrid.playbackKey}
-        playbackSource={hybrid.source}
-        playbackContextKey={hybrid.playbackContextKey}
-        onPlaybackCycleComplete={hybrid.finishChapter}
+        live={continuousLiveTrails}
+        connected={hybrid.connected}
+        playbackKey={
+          continuousLiveTrails ? "continuous-live" : hybrid.playbackKey
+        }
+        playbackSource={continuousLiveTrails ? "live" : hybrid.source}
+        playbackContextKey={
+          continuousLiveTrails ? "continuous-live" : hybrid.playbackContextKey
+        }
+        onPlaybackCycleComplete={
+          continuousLiveTrails ? undefined : hybrid.finishChapter
+        }
+        archiveFallback={
+          continuousLiveTrails && archiveFallback.mounted
+            ? {
+                events: archiveFallbackEvents,
+                visible: archiveFallback.visible,
+                playbackKey: hybrid.archivePlaybackKey,
+                fadeMs: CURSOR_ARCHIVE_FADE_MS,
+                onPlaybackCycleComplete: hybrid.advanceArchive,
+              }
+            : undefined
+        }
       />
       {showsInstallationPeopleCount(screen, activeVisualizations) && (
         <LiveIndicator

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -385,6 +385,15 @@ interface MovementCanvasProps {
   playbackContextKey?: string;
   /** Called when finite archive playback reaches the end of its batch. */
   onPlaybackCycleComplete?: () => boolean;
+  /** Archived cursor footage shown behind a continuous live cursor field while
+   * that field is quiet. */
+  archiveFallback?: {
+    events: CollectionEvent[];
+    visible: boolean;
+    playbackKey: string;
+    fadeMs: number;
+    onPlaybackCycleComplete: () => boolean;
+  };
 }
 
 export const MovementCanvas: React.FC<MovementCanvasProps> = ({
@@ -417,6 +426,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
   playbackSource,
   playbackContextKey = playbackKey,
   onPlaybackCycleComplete,
+  archiveFallback,
 }) => {
   const settingsDefaults = useMemo(
     () => ({ ...DEFAULT_SETTINGS, ...defaultSettings }),
@@ -979,6 +989,31 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     timeBounds: cursorTimeBounds,
     cycleDuration: cursorCycleDuration,
   } = useCursorTrails(activeTrailEvents, viewportSize, cursorSettings);
+  const archiveFallbackSettings = useMemo(
+    () => ({
+      ...cursorSettings,
+      trailAnimationMode: settings.trailAnimationMode,
+      singleSegmentPerGroup: false,
+    }),
+    [cursorSettings, settings.trailAnimationMode],
+  );
+  const {
+    trailStates: archiveFallbackTrailStates,
+    timeBounds: archiveFallbackTimeBounds,
+    cycleDuration: archiveFallbackCycleDuration,
+  } = useCursorTrails(
+    archiveFallback?.events ?? EMPTY_EVENTS,
+    viewportSize,
+    archiveFallbackSettings,
+  );
+  const archiveFallbackTimeRange = useMemo(
+    () => ({
+      min: archiveFallbackTimeBounds.min,
+      max: archiveFallbackTimeBounds.max,
+      duration: Math.max(archiveFallbackCycleDuration, 60_000),
+    }),
+    [archiveFallbackCycleDuration, archiveFallbackTimeBounds],
+  );
   const activeTrailIds = useMemo(
     () => new Set(trailStates.map(({ trail }) => trail.id)),
     [trailStates],
@@ -1190,6 +1225,18 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     animationSpeed: settings.animationSpeed,
     frozen: paused,
     onComplete: onPlaybackCycleComplete,
+  });
+  usePlaybackCycle({
+    enabled:
+      live &&
+      archiveFallback !== undefined &&
+      archiveFallback.visible &&
+      archiveFallbackTrailStates.length > 0,
+    cycleKey: archiveFallback?.playbackKey ?? "archive-fallback",
+    durationMs: archiveFallbackTimeRange.duration,
+    animationSpeed: settings.animationSpeed,
+    frozen: paused,
+    onComplete: archiveFallback?.onPlaybackCycleComplete,
   });
 
   // For viewports whose URL has no captured title (no navigation event), ask
@@ -1635,6 +1682,34 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             style={{ opacity: 0.3 }}
           />
         </svg>
+
+        {showTrails &&
+          live &&
+          archiveFallback &&
+          archiveFallbackTrailStates.length > 0 && (
+            <div
+              aria-hidden="true"
+              style={{
+                position: "absolute",
+                inset: 0,
+                zIndex: 2,
+                opacity: archiveFallback.visible ? 1 : 0,
+                pointerEvents: "none",
+                transition: `opacity ${archiveFallback.fadeMs}ms ease-in-out`,
+              }}
+            >
+              <AnimatedTrails
+                key={`archive-fallback-${archiveFallback.playbackKey}`}
+                trailStates={archiveFallbackTrailStates}
+                timeRange={archiveFallbackTimeRange}
+                showClickRipples={!showClicks}
+                windowSize={settings.maxConcurrentTrails * 2}
+                soundEngine={null}
+                settings={trailAnimationSettings}
+                frozen={paused}
+              />
+            </div>
+          )}
 
         {showTrails &&
           (live ? (

--- a/extension/website/shared/hooks/useHybridInstallationEvents.ts
+++ b/extension/website/shared/hooks/useHybridInstallationEvents.ts
@@ -30,6 +30,7 @@ type ChapterSource = "archive" | "live";
 
 export interface HybridInstallationEventsState {
   events: CollectionEvent[];
+  archiveEvents: CollectionEvent[];
   liveEvents: CollectionEvent[];
   connected: boolean;
   loading: boolean;
@@ -38,6 +39,8 @@ export interface HybridInstallationEventsState {
   playbackKey: string;
   playbackContextKey: string;
   finishChapter: () => boolean;
+  advanceArchive: () => boolean;
+  archivePlaybackKey: string;
   source: ChapterSource;
 }
 
@@ -259,6 +262,7 @@ export function useHybridInstallationEvents(params: {
 
   return {
     events,
+    archiveEvents: eventsForInstallationScreen(archive.events, screen),
     liveEvents: live.events,
     connected: live.connected,
     loading: archive.loading,
@@ -277,6 +281,8 @@ export function useHybridInstallationEvents(params: {
         ? `scrolling:${typingContextKey}`
         : `hybrid:${archive.batchContextKey}`,
     finishChapter,
+    advanceArchive: archive.advanceBatch,
+    archivePlaybackKey: `archive:${archive.batchKey}`,
     source: reservoirOnly ? "archive" : source,
   };
 }

--- a/extension/website/shared/utils/__tests__/cursorInstallation.test.ts
+++ b/extension/website/shared/utils/__tests__/cursorInstallation.test.ts
@@ -1,0 +1,58 @@
+// ABOUTME: Tests when live cursor data is dense enough to replace archived installation footage.
+// ABOUTME: Protects the fallback from disappearing for cursor events that cannot draw a trail.
+
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import { latestDrawableCursorEventId } from "../cursorInstallation";
+
+function move(
+  id: string,
+  pid = "person",
+  url = "https://example.com",
+  ts = Date.now(),
+) {
+  return {
+    id,
+    type: "cursor",
+    ts,
+    data: { event: "move", x: 0.5, y: 0.5 },
+    meta: { pid, sid: "session", url, vw: 1000, vh: 800, tz: "UTC" },
+  } satisfies CollectionEvent;
+}
+
+describe("latestDrawableCursorEventId", () => {
+  it("requires two moves from the same cursor group", () => {
+    expect(latestDrawableCursorEventId([move("one")])).toBeNull();
+    expect(latestDrawableCursorEventId([move("one"), move("two")])).toBe(
+      "two",
+    );
+  });
+
+  it("does not combine moves from different people or pages", () => {
+    expect(
+      latestDrawableCursorEventId([
+        move("one", "a"),
+        move("two", "b"),
+        move("three", "a", "https://other.example"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("ignores cursor events that do not move", () => {
+    const click = {
+      ...move("click"),
+      data: { event: "click", x: 0.5, y: 0.5, quantity: 1 },
+    } satisfies CollectionEvent;
+    expect(latestDrawableCursorEventId([click, move("one")])).toBeNull();
+  });
+
+  it("does not combine moves separated into different trail segments", () => {
+    const now = Date.now();
+    expect(
+      latestDrawableCursorEventId([
+        move("old", "person", "https://example.com", now - 6 * 60_000),
+        move("new", "person", "https://example.com", now),
+      ]),
+    ).toBeNull();
+  });
+});

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -54,6 +54,15 @@ describe("live installation profiles", () => {
     }
   });
 
+  it("uses continuous live trails only on the main cursor field", () => {
+    expect(LIVE_INSTALLATION_PROFILES.cursors.continuousLiveTrails).toBe(true);
+
+    for (const [name, profile] of Object.entries(LIVE_INSTALLATION_PROFILES)) {
+      if (name === "cursors") continue;
+      expect(profile.continuousLiveTrails).not.toBe(true);
+    }
+  });
+
   it("uses explicit follower query parameters over profile defaults", () => {
     const profile = LIVE_INSTALLATION_PROFILES["follower-c"];
     expect(parseLiveInstallationScreen("", profile.screen)).toEqual({

--- a/extension/website/shared/utils/cursorInstallation.ts
+++ b/extension/website/shared/utils/cursorInstallation.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Identifies live cursor batches that can draw at least one installation trail.
+// ABOUTME: Keeps single cursor events from hiding the archive fallback with a blank live field.
+
+import type { CollectionEvent } from "../types";
+import { TRAIL_TIME_THRESHOLD } from "./eventUtils";
+
+export function latestDrawableCursorEventId(
+  events: readonly CollectionEvent[],
+): string | null {
+  const groups = new Map<
+    string,
+    { count: number; newestId: string; earliestTs: number; closed: boolean }
+  >();
+  const moves = events
+    .map((event, index) => ({ event, index }))
+    .filter(
+      ({ event }) =>
+        event.type === "cursor" && event.data.event === "move",
+    )
+    .sort((a, b) => b.event.ts - a.event.ts || b.index - a.index);
+
+  for (const { event } of moves) {
+    const key = `${event.meta.pid}|${event.meta.sid}|${event.meta.url}`;
+    const existing = groups.get(key);
+    if (existing?.closed) continue;
+    if (existing && existing.earliestTs - event.ts > TRAIL_TIME_THRESHOLD) {
+      existing.closed = true;
+      continue;
+    }
+    const group = existing ?? {
+      count: 0,
+      newestId: event.id,
+      earliestTs: event.ts,
+      closed: false,
+    };
+    group.count++;
+    group.earliestTs = event.ts;
+    groups.set(key, group);
+    if (group.count >= 2) return group.newestId;
+  }
+  return null;
+}

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -44,6 +44,7 @@ export interface LiveInstallationProfile {
   screen?: LiveInstallationScreenConfig;
   settings: Partial<MovementSettings>;
   touchesSettings?: TouchesProfileSettings;
+  continuousLiveTrails?: boolean;
 }
 
 const CURSOR_SETTINGS = {
@@ -183,6 +184,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     visualizations: ["trails"],
     screen: field(),
     settings: CURSOR_SETTINGS,
+    continuousLiveTrails: true,
   },
   "follower-a": {
     label: "cursor follower 1",


### PR DESCRIPTION
## Summary

- Keep the named main cursor installation screen on the live cursor stream continuously instead of moving through finite archive and live chapters.
- Fade a silent archive layer in after 20 seconds without drawable cursor activity, then remove it immediately when live movement resumes.
- Avoid exact live/archive event duplicates and advance interrupted archive playback before the next idle period.
- Leave follower screens and the scrolling, typing, touches, and clicks visualizations unchanged.

## Why

The main cursor screen could appear stopped between chapters and then restart in bursts. Its live segment had a finite playback window even while the WebSocket continued receiving events. The installation should behave like the wewere.online homepage: live cursor movement remains the primary timeline, with archive material only filling genuinely quiet periods.

## Verification

- `bunx vitest run --config extension/vitest.config.ts website/shared/utils/__tests__/cursorInstallation.test.ts website/shared/utils/__tests__/liveInstallationProfiles.test.ts website/shared/utils/__tests__/liveInstallation.test.ts website/shared/components/__tests__/LiveTrails.test.ts` — 42 tests passed.
- `bun run check:extension-website` — passed.
- `bun run build` in `extension/website` — passed.
- Deployed real-browser smoke confirmed a stable `continuous-live` playback key while live geometry continued changing, with no page errors.
- A deployed lifecycle test paused incoming cursor messages after live playback began. After the real 20-second idle threshold, the screen changed to `archive-fallback` while retaining the `continuous-live` playback key.
- Deployed follower smoke confirmed followers remain on their existing finite cinematic playback path.
- [Visual evidence](https://pr-evidence.spencerc99.workers.dev/review/ev-mtsh1kbi-678f1d35) covers the live field, post-idle archive fallback, and unchanged follower state.

## Scope boundary

This uses the same aggregate live event stream as the current wewere.online homepage. It does not introduce a new per-pointer low-latency transport.

## Documentation

No public documentation, package changeset, or starter-template update is needed. This is installation-only website behavior; the design decision is recorded in the internal installation plan.
