### PR TITLE
Render installation clicks with cached Canvas marks

### DIFF
--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -1,5 +1,5 @@
 // ABOUTME: Standalone click/hold ripple visualizer
-// ABOUTME: Uses same ripple logic as AnimatedTrails but renders only ripples (no trails/path/cursor)
+// ABOUTME: Schedules click sounds and retains bounded marks for the Canvas renderer.
 import React, {
   useState,
   useEffect,
@@ -8,8 +8,9 @@ import React, {
   useCallback,
   useMemo,
 } from "react";
-import { ClickEffect } from "../types";
-import { RippleEffect, RippleSettings } from "./ClickRipple";
+import { mergeClickEffects, type VisibleClickEffect } from "./clickResidue";
+import { ClickCanvas } from "./ClickCanvas";
+import { RippleSettings } from "./ClickRipple";
 import type { SoundEngine } from "../sound/SoundEngine";
 
 // Hidden tabs heavily throttle rAF; 100ms (~10fps) keeps audio/time progression
@@ -26,36 +27,12 @@ export interface ScheduledClick {
   holdDuration?: number;
 }
 
-export const MAX_VISIBLE_CLICK_EFFECTS = 4000;
-
-const MINIMUM_RESIDUE_OPACITY = 0.03;
-
-export function getClickResidueOpacity(
-  index: number,
-  total: number,
-  completed: boolean,
-): number {
-  if (!completed) return 1;
-
-  const distanceFromNewest = total - index - 1;
-  const fadeProgress = Math.min(
-    1,
-    distanceFromNewest / Math.max(1, MAX_VISIBLE_CLICK_EFFECTS - 1),
-  );
-  return 1 - (1 - MINIMUM_RESIDUE_OPACITY) * fadeProgress;
-}
-
-export type VisibleClickEffect = ClickEffect & {
-  sourceId: string;
-  completed: boolean;
-};
-
-export function mergeClickEffects(
-  current: VisibleClickEffect[],
-  incoming: VisibleClickEffect[],
-): VisibleClickEffect[] {
-  return [...current, ...incoming].slice(-MAX_VISIBLE_CLICK_EFFECTS);
-}
+export {
+  MAX_VISIBLE_CLICK_EFFECTS,
+  getClickResidueOpacity,
+  mergeClickEffects,
+} from "./clickResidue";
+export type { VisibleClickEffect } from "./clickResidue";
 
 interface AnimatedClicksProps {
   scheduledClicks: ScheduledClick[];
@@ -96,6 +73,7 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
         completedCycleEffectIdsRef.current.add(id);
       }
       const pending = pendingCompletionsRef.current;
+      if (pending.has(id)) return;
       pending.add(id);
       if (pending.size > 1) return;
       queueMicrotask(() => {
@@ -288,35 +266,11 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
     );
 
     return (
-      <svg
-        className="animated-clicks-svg"
-        width="100%"
-        height="100%"
-        style={{
-          position: "absolute",
-          top: 0,
-          left: 0,
-          pointerEvents: "none",
-        }}
-      >
-        {activeClickEffects.map((effect, index) => (
-          <g
-            key={effect.id}
-            opacity={getClickResidueOpacity(
-              index,
-              activeClickEffects.length,
-              effect.completed,
-            )}
-            style={{ transition: "opacity 200ms linear" }}
-          >
-            <RippleEffect
-              effect={effect}
-              settings={rippleSettings}
-              onComplete={handleClickComplete}
-            />
-          </g>
-        ))}
-      </svg>
+      <ClickCanvas
+        effects={activeClickEffects}
+        settings={rippleSettings}
+        onComplete={handleClickComplete}
+      />
     );
   },
   (prevProps, nextProps) => {

--- a/extension/website/shared/components/AnimatedClicks.tsx
+++ b/extension/website/shared/components/AnimatedClicks.tsx
@@ -1,6 +1,13 @@
 // ABOUTME: Standalone click/hold ripple visualizer
 // ABOUTME: Uses same ripple logic as AnimatedTrails but renders only ripples (no trails/path/cursor)
-import React, { useState, useEffect, useRef, memo, useCallback } from "react";
+import React, {
+  useState,
+  useEffect,
+  useRef,
+  memo,
+  useCallback,
+  useMemo,
+} from "react";
 import { ClickEffect } from "../types";
 import { RippleEffect, RippleSettings } from "./ClickRipple";
 import type { SoundEngine } from "../sound/SoundEngine";
@@ -83,15 +90,22 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
     // Finished ripples remain as residue while their event ids are replayed.
     // Track the current pass by rendered id so completions from a previous
     // archive batch cannot make the next pass finish early.
+    const pendingCompletionsRef = useRef(new Set<string>());
     const handleClickComplete = useCallback((id: string) => {
       if (currentCycleEffectIdsRef.current.has(id)) {
         completedCycleEffectIdsRef.current.add(id);
       }
-      setActiveClickEffects((effects) =>
-        effects.map((effect) =>
-          effect.id === id ? { ...effect, completed: true } : effect,
-        ),
-      );
+      const pending = pendingCompletionsRef.current;
+      pending.add(id);
+      if (pending.size > 1) return;
+      queueMicrotask(() => {
+        pendingCompletionsRef.current = new Set();
+        setActiveClickEffects((effects) =>
+          effects.map((effect) =>
+            pending.has(effect.id) ? { ...effect, completed: true } : effect,
+          ),
+        );
+      });
     }, []);
 
     // Microtask-batched commits so multiple per-frame spawns don't each cause
@@ -133,6 +147,10 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       soundEngineRef.current?.reset();
       pendingSpawnsRef.current = [];
 
+      const orderedClicks = [...scheduledClicks].sort(
+        (a, b) => a.spawnAtMs - b.spawnAtMs,
+      );
+      let nextClickIndex = 0;
       let startTime: number | null = null;
 
       const clearScheduledFrame = () => {
@@ -168,8 +186,12 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
         const scaledElapsed = realElapsed * animationSpeedRef.current;
 
         const spawned = spawnedThisCycleRef.current;
-        for (const sc of scheduledClicks) {
-          if (scaledElapsed >= sc.spawnAtMs && !spawned.has(sc.id)) {
+        while (
+          nextClickIndex < orderedClicks.length &&
+          scaledElapsed >= orderedClicks[nextClickIndex].spawnAtMs
+        ) {
+          const sc = orderedClicks[nextClickIndex++];
+          if (!spawned.has(sc.id)) {
             spawned.add(sc.id);
             soundEngineRef.current?.triggerClick({
               x: sc.x,
@@ -205,6 +227,7 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
 
         if (allSpawned && allDone) {
           startTime = timestamp;
+          nextClickIndex = 0;
           spawnedThisCycleRef.current.clear();
           currentCycleEffectIdsRef.current.clear();
           completedCycleEffectIdsRef.current.clear();
@@ -224,7 +247,10 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       scheduleNextFrame();
 
       return () => {
-        document.removeEventListener("visibilitychange", handleVisibilityChange);
+        document.removeEventListener(
+          "visibilitychange",
+          handleVisibilityChange,
+        );
         clearScheduledFrame();
         // Drop pending spawns so a queued microtask cannot commit after unmount.
         pendingSpawnsRef.current = [];
@@ -232,19 +258,34 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       };
     }, [scheduledClicks, timeRange.duration, scheduleFlushSpawns]);
 
-    const rippleSettings: RippleSettings = {
-      clickMinRadius: settings.clickMinRadius,
-      clickMaxRadius: settings.clickMaxRadius,
-      clickCoreRadius: settings.clickCoreRadius,
-      clickMinDuration: settings.clickMinDuration,
-      clickMaxDuration: settings.clickMaxDuration,
-      clickExpansionDuration: settings.clickExpansionDuration,
-      clickStrokeWidth: settings.clickStrokeWidth,
-      clickOpacity: settings.clickOpacity,
-      clickNumRings: settings.clickNumRings,
-      clickRingDelayMs: settings.clickRingDelayMs,
-      clickAnimationStopPoint: settings.clickAnimationStopPoint,
-    };
+    const rippleSettings: RippleSettings = useMemo(
+      () => ({
+        clickMinRadius: settings.clickMinRadius,
+        clickMaxRadius: settings.clickMaxRadius,
+        clickCoreRadius: settings.clickCoreRadius,
+        clickMinDuration: settings.clickMinDuration,
+        clickMaxDuration: settings.clickMaxDuration,
+        clickExpansionDuration: settings.clickExpansionDuration,
+        clickStrokeWidth: settings.clickStrokeWidth,
+        clickOpacity: settings.clickOpacity,
+        clickNumRings: settings.clickNumRings,
+        clickRingDelayMs: settings.clickRingDelayMs,
+        clickAnimationStopPoint: settings.clickAnimationStopPoint,
+      }),
+      [
+        settings.clickMinRadius,
+        settings.clickMaxRadius,
+        settings.clickCoreRadius,
+        settings.clickMinDuration,
+        settings.clickMaxDuration,
+        settings.clickExpansionDuration,
+        settings.clickStrokeWidth,
+        settings.clickOpacity,
+        settings.clickNumRings,
+        settings.clickRingDelayMs,
+        settings.clickAnimationStopPoint,
+      ],
+    );
 
     return (
       <svg
@@ -285,7 +326,8 @@ export const AnimatedClicks: React.FC<AnimatedClicksProps> = memo(
       prevProps.settings.animationSpeed === nextProps.settings.animationSpeed &&
       prevProps.settings.clickMinRadius === nextProps.settings.clickMinRadius &&
       prevProps.settings.clickMaxRadius === nextProps.settings.clickMaxRadius &&
-      prevProps.settings.clickCoreRadius === nextProps.settings.clickCoreRadius &&
+      prevProps.settings.clickCoreRadius ===
+        nextProps.settings.clickCoreRadius &&
       prevProps.settings.clickMinDuration ===
         nextProps.settings.clickMinDuration &&
       prevProps.settings.clickMaxDuration ===

--- a/extension/website/shared/components/ClickCanvas.tsx
+++ b/extension/website/shared/components/ClickCanvas.tsx
@@ -15,8 +15,8 @@ export const ClickCanvas = memo(function ClickCanvas({
   onComplete: (id: string) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rendererRef = useRef<ClickCanvasRenderer>();
-  const tickRef = useRef<() => void>();
+  const rendererRef = useRef<ClickCanvasRenderer | undefined>(undefined);
+  const tickRef = useRef<(() => void) | undefined>(undefined);
   const completeRef = useRef(onComplete);
   useEffect(() => {
     completeRef.current = onComplete;

--- a/extension/website/shared/components/ClickCanvas.tsx
+++ b/extension/website/shared/components/ClickCanvas.tsx
@@ -1,0 +1,93 @@
+// ABOUTME: Hosts the click drawing surface and follows its display size.
+// ABOUTME: Keeps ripple completion ticking while hidden without drawing hidden frames.
+import { memo, useEffect, useRef } from "react";
+import type { RippleSettings } from "./ClickRipple";
+import type { VisibleClickEffect } from "./clickResidue";
+import { ClickCanvasRenderer } from "./clickCanvasRenderer";
+
+export const ClickCanvas = memo(function ClickCanvas({
+  effects,
+  settings,
+  onComplete,
+}: {
+  effects: VisibleClickEffect[];
+  settings: RippleSettings;
+  onComplete: (id: string) => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rendererRef = useRef<ClickCanvasRenderer>();
+  const tickRef = useRef<() => void>();
+  const completeRef = useRef(onComplete);
+  useEffect(() => {
+    completeRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const renderer = new ClickCanvasRenderer(canvas, (id) =>
+      completeRef.current(id),
+    );
+    rendererRef.current = renderer;
+    let frame: number | undefined;
+    let timeout: number | undefined;
+    const cancel = () => {
+      if (frame !== undefined) cancelAnimationFrame(frame);
+      if (timeout !== undefined) window.clearTimeout(timeout);
+      frame = timeout = undefined;
+    };
+    const tick = () => {
+      cancel();
+      const visible = document.visibilityState !== "hidden";
+      renderer.tick(Date.now(), visible);
+      if (!renderer.needsFrame) return;
+      if (visible) frame = requestAnimationFrame(tick);
+      else timeout = window.setTimeout(tick, 100);
+    };
+    const resize = () => {
+      renderer.resize(
+        canvas.clientWidth,
+        canvas.clientHeight,
+        window.devicePixelRatio,
+      );
+      tick();
+    };
+    tickRef.current = tick;
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+    window.addEventListener("resize", resize);
+    document.addEventListener("visibilitychange", tick);
+    resize();
+    tick();
+    return () => {
+      cancel();
+      observer.disconnect();
+      window.removeEventListener("resize", resize);
+      document.removeEventListener("visibilitychange", tick);
+      renderer.destroy();
+      rendererRef.current = undefined;
+      tickRef.current = undefined;
+    };
+  }, []);
+
+  useEffect(() => {
+    rendererRef.current?.update(effects, settings, Date.now());
+    tickRef.current?.();
+  }, [effects, settings]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="animated-clicks-canvas"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+      }}
+    />
+  );
+});

--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -1,7 +1,8 @@
 // ABOUTME: Shared ripple effect for click/hold visualization
 // ABOUTME: Used by AnimatedTrails and AnimatedClicks so ripple logic stays DRY
-import { useEffect, useRef, memo } from "react";
+import { useEffect, useRef, memo, useMemo } from "react";
 import { ClickEffect } from "../types";
+import { subscribeRippleFrame } from "./rippleFrames";
 
 export interface RippleSettings {
   clickMinRadius: number;
@@ -49,6 +50,7 @@ export function getRippleLifecycle(
     effectTotalDuration,
     expansionDuration,
     opacity: rippleSettings.clickOpacity,
+    completedAt,
     complete: now >= completedAt,
   };
 }
@@ -63,130 +65,120 @@ export const RippleEffect = memo(
     settings: RippleSettings;
     onComplete?: (id: string) => void;
   }) => {
-    const now = Date.now();
-    const ringRefs = useRef<Array<SVGCircleElement | null>>([]);
-    /** Ensures onComplete runs once even when effects restart in Strict Mode. */
-    const completionFiredRef = useRef(false);
-    const completionIdRef = useRef(effect.id);
+    const circlesRef = useRef<Array<SVGCircleElement | null>>([]);
+    /** Tracks completion across repeated effect setup in Strict Mode. */
+    const completedIdRef = useRef<string | null>(null);
+    const onCompleteRef = useRef(onComplete);
+    useEffect(() => {
+      onCompleteRef.current = onComplete;
+    }, [onComplete]);
 
-    const lifecycle = getRippleLifecycle(effect, rippleSettings, now);
-    const { holdMultiplier, expansionDuration } = lifecycle;
+    const geometry = useMemo(() => {
+      const lifecycle = getRippleLifecycle(
+        effect,
+        rippleSettings,
+        effect.startTime,
+      );
+      const { holdMultiplier, expansionDuration } = lifecycle;
 
-    const baseMaxRadius =
-      rippleSettings.clickMinRadius +
-      effect.radiusFactor *
-        (rippleSettings.clickMaxRadius - rippleSettings.clickMinRadius);
-    const effectMaxRadius = baseMaxRadius * holdMultiplier;
+      const baseMaxRadius =
+        rippleSettings.clickMinRadius +
+        effect.radiusFactor *
+          (rippleSettings.clickMaxRadius - rippleSettings.clickMinRadius);
+      const effectMaxRadius = baseMaxRadius * holdMultiplier;
 
-    // Honor the configured ring delay directly — staggering is when each ring
-    // BEGINS expanding. The visual density comes from each ring freezing at
-    // a different target radius (see ring rendering below), not time stagger.
-    const ringStaggerMs = rippleSettings.clickRingDelayMs;
-    const numRings = Math.max(1, rippleSettings.clickNumRings);
+      // Honor the configured ring delay directly — staggering is when each ring
+      // BEGINS expanding. The visual density comes from each ring freezing at
+      // a different target radius (see ring rendering below), not time stagger.
+      const ringStaggerMs = rippleSettings.clickRingDelayMs;
+      const numRings = Math.max(1, rippleSettings.clickNumRings);
+
+      // Each ring freezes at its own target radius — spaced from a small fixed
+      // core out to (effectMaxRadius * clickAnimationStopPoint). Rings expand
+      // from 0 → their target at constant velocity, so the outermost ring
+      // takes the full expansionDuration and inner rings finish sooner.
+      // Pinning the innermost ring to clickCoreRadius (with ±2px jitter via
+      // radiusFactor) guarantees every ripple has a visible "core" mark where
+      // the click landed, regardless of size.
+      const outerTargetRadius =
+        effectMaxRadius * rippleSettings.clickAnimationStopPoint;
+      const coreJitterPx = (effect.radiusFactor - 0.5) * 4;
+      const coreRadius = Math.max(
+        1,
+        Math.min(
+          rippleSettings.clickCoreRadius + coreJitterPx,
+          outerTargetRadius,
+        ),
+      );
+      const expansionVelocity = outerTargetRadius / expansionDuration;
+
+      const rings = Array.from({ length: numRings }, (_, i) => {
+        const ringStartTime = effect.startTime + i * ringStaggerMs;
+
+        // Innermost ring sits at the core mark; outer rings interpolate
+        // linearly from core out to outerTargetRadius. With numRings === 1
+        // the lone ring goes all the way out (otherwise it'd be a tiny dot).
+        const ringTargetRadius =
+          numRings === 1
+            ? outerTargetRadius
+            : coreRadius +
+              (outerTargetRadius - coreRadius) * (i / (numRings - 1));
+
+        const ringDuration = Math.max(1, ringTargetRadius / expansionVelocity);
+        return { ringStartTime, ringTargetRadius, ringDuration };
+      });
+      return { rings, lifecycle };
+    }, [effect, rippleSettings]);
 
     useEffect(() => {
-      if (completionIdRef.current !== effect.id) {
-        completionIdRef.current = effect.id;
-        completionFiredRef.current = false;
-      }
-    }, [effect.id]);
-
-    useEffect(() => {
-      let animationFrameId: number;
-
-      const animate = () => {
-        const timestamp = Date.now();
-        for (let i = 0; i < numRings; i++) {
-          const ring = ringRefs.current[i];
-          if (!ring) continue;
-          const radius = getRingRadius(i, timestamp);
-          if (radius === null) {
-            ring.style.display = "none";
-          } else {
-            ring.style.display = "";
-            const value = String(radius);
-            if (ring.getAttribute("r") !== value) ring.setAttribute("r", value);
+      const previousRadii = new Array<number>(geometry.rings.length);
+      const previousVisibility = new Array<boolean>(geometry.rings.length);
+      const update = (now: number) => {
+        geometry.rings.forEach((ring, index) => {
+          const elapsed = now - ring.ringStartTime;
+          const visible = elapsed >= 0;
+          const circle = circlesRef.current[index];
+          if (circle && previousVisibility[index] !== visible) {
+            circle.style.display = visible ? "" : "none";
+            previousVisibility[index] = visible;
           }
-        }
-        if (getRippleLifecycle(effect, rippleSettings, timestamp).complete) {
-          if (!completionFiredRef.current) {
-            completionFiredRef.current = true;
-            onComplete?.(effect.id);
+          const progress = Math.max(
+            0,
+            Math.min(1, elapsed / ring.ringDuration),
+          );
+          const radius =
+            ring.ringTargetRadius * (1 - Math.pow(1 - progress, 3));
+          if (previousRadii[index] !== radius) {
+            circlesRef.current[index]?.setAttribute("r", String(radius));
+            previousRadii[index] = radius;
           }
-        } else {
-          animationFrameId = requestAnimationFrame(animate);
+        });
+        const complete = now >= geometry.lifecycle.completedAt;
+        if (complete && completedIdRef.current !== effect.id) {
+          completedIdRef.current = effect.id;
+          onCompleteRef.current?.(effect.id);
         }
+        return !complete;
       };
+      if (!update(Date.now())) return;
+      return subscribeRippleFrame(update);
+    }, [effect, rippleSettings, geometry]);
 
-      animate();
-
-      return () => {
-        if (animationFrameId) {
-          cancelAnimationFrame(animationFrameId);
-        }
-      };
-    }, [effect, rippleSettings, onComplete]);
-
-    const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
-
-    // Each ring freezes at its own target radius — spaced from a small fixed
-    // core out to (effectMaxRadius * clickAnimationStopPoint). Rings expand
-    // from 0 → their target at constant velocity, so the outermost ring
-    // takes the full expansionDuration and inner rings finish sooner.
-    // Pinning the innermost ring to clickCoreRadius (with ±2px jitter via
-    // radiusFactor) guarantees every ripple has a visible "core" mark where
-    // the click landed, regardless of size.
-    const outerTargetRadius =
-      effectMaxRadius * rippleSettings.clickAnimationStopPoint;
-    const coreJitterPx = (effect.radiusFactor - 0.5) * 4;
-    const coreRadius = Math.max(
-      1,
-      Math.min(
-        rippleSettings.clickCoreRadius + coreJitterPx,
-        outerTargetRadius,
-      ),
-    );
-    const expansionVelocity = outerTargetRadius / expansionDuration;
-
-    const getRingRadius = (i: number, timestamp: number): number | null => {
-      const ringStartTime = effect.startTime + i * ringStaggerMs;
-      const elapsed = timestamp - ringStartTime;
-
-      if (elapsed < 0) return null;
-
-      // Innermost ring sits at the core mark; outer rings interpolate
-      // linearly from core out to outerTargetRadius. With numRings === 1
-      // the lone ring goes all the way out (otherwise it'd be a tiny dot).
-      const ringTargetRadius =
-        numRings === 1
-          ? outerTargetRadius
-          : coreRadius +
-            (outerTargetRadius - coreRadius) * (i / (numRings - 1));
-
-      const ringDuration = Math.max(1, ringTargetRadius / expansionVelocity);
-      const rawProgress = Math.min(1, elapsed / ringDuration);
-      return ringTargetRadius * easeOutCubic(rawProgress);
-    };
-
-    const rings = Array.from({ length: numRings }, (_, i) => {
-      const ringRadius = getRingRadius(i, now);
+    const rings = geometry.rings.map((_, i) => {
       return (
         <circle
           key={i}
-          ref={(ring) => {
-            ringRefs.current[i] = ring;
+          ref={(circle) => {
+            circlesRef.current[i] = circle;
           }}
           cx={effect.x}
           cy={effect.y}
-          r={ringRadius ?? 0}
+          r={0}
           fill="none"
           stroke={effect.color}
           strokeWidth={rippleSettings.clickStrokeWidth}
-          opacity={Math.max(0, lifecycle.opacity)}
-          style={{
-            mixBlendMode: "multiply",
-            display: ringRadius === null ? "none" : "",
-          }}
+          opacity={Math.max(0, geometry.lifecycle.opacity)}
+          style={{ mixBlendMode: "multiply", display: "none" }}
         />
       );
     });

--- a/extension/website/shared/components/ClickRipple.tsx
+++ b/extension/website/shared/components/ClickRipple.tsx
@@ -55,6 +55,62 @@ export function getRippleLifecycle(
   };
 }
 
+export function getRippleGeometry(
+  effect: ClickEffect,
+  rippleSettings: RippleSettings,
+) {
+  const lifecycle = getRippleLifecycle(
+    effect,
+    rippleSettings,
+    effect.startTime,
+  );
+  const { holdMultiplier, expansionDuration } = lifecycle;
+
+  const baseMaxRadius =
+    rippleSettings.clickMinRadius +
+    effect.radiusFactor *
+      (rippleSettings.clickMaxRadius - rippleSettings.clickMinRadius);
+  const effectMaxRadius = baseMaxRadius * holdMultiplier;
+
+  // Honor the configured ring delay directly — staggering is when each ring
+  // BEGINS expanding. The visual density comes from each ring freezing at
+  // a different target radius (see ring rendering below), not time stagger.
+  const ringStaggerMs = rippleSettings.clickRingDelayMs;
+  const numRings = Math.max(1, rippleSettings.clickNumRings);
+
+  // Each ring freezes at its own target radius — spaced from a small fixed
+  // core out to (effectMaxRadius * clickAnimationStopPoint). Rings expand
+  // from 0 → their target at constant velocity, so the outermost ring
+  // takes the full expansionDuration and inner rings finish sooner.
+  // Pinning the innermost ring to clickCoreRadius (with ±2px jitter via
+  // radiusFactor) guarantees every ripple has a visible "core" mark where
+  // the click landed, regardless of size.
+  const outerTargetRadius =
+    effectMaxRadius * rippleSettings.clickAnimationStopPoint;
+  const coreJitterPx = (effect.radiusFactor - 0.5) * 4;
+  const coreRadius = Math.max(
+    1,
+    Math.min(rippleSettings.clickCoreRadius + coreJitterPx, outerTargetRadius),
+  );
+  const expansionVelocity = outerTargetRadius / expansionDuration;
+
+  const rings = Array.from({ length: numRings }, (_, i) => {
+    const ringStartTime = effect.startTime + i * ringStaggerMs;
+
+    // Innermost ring sits at the core mark; outer rings interpolate
+    // linearly from core out to outerTargetRadius. With numRings === 1
+    // the lone ring goes all the way out (otherwise it'd be a tiny dot).
+    const ringTargetRadius =
+      numRings === 1
+        ? outerTargetRadius
+        : coreRadius + (outerTargetRadius - coreRadius) * (i / (numRings - 1));
+
+    const ringDuration = Math.max(1, ringTargetRadius / expansionVelocity);
+    return { ringStartTime, ringTargetRadius, ringDuration };
+  });
+  return { rings, lifecycle };
+}
+
 export const RippleEffect = memo(
   ({
     effect,
@@ -73,62 +129,10 @@ export const RippleEffect = memo(
       onCompleteRef.current = onComplete;
     }, [onComplete]);
 
-    const geometry = useMemo(() => {
-      const lifecycle = getRippleLifecycle(
-        effect,
-        rippleSettings,
-        effect.startTime,
-      );
-      const { holdMultiplier, expansionDuration } = lifecycle;
-
-      const baseMaxRadius =
-        rippleSettings.clickMinRadius +
-        effect.radiusFactor *
-          (rippleSettings.clickMaxRadius - rippleSettings.clickMinRadius);
-      const effectMaxRadius = baseMaxRadius * holdMultiplier;
-
-      // Honor the configured ring delay directly — staggering is when each ring
-      // BEGINS expanding. The visual density comes from each ring freezing at
-      // a different target radius (see ring rendering below), not time stagger.
-      const ringStaggerMs = rippleSettings.clickRingDelayMs;
-      const numRings = Math.max(1, rippleSettings.clickNumRings);
-
-      // Each ring freezes at its own target radius — spaced from a small fixed
-      // core out to (effectMaxRadius * clickAnimationStopPoint). Rings expand
-      // from 0 → their target at constant velocity, so the outermost ring
-      // takes the full expansionDuration and inner rings finish sooner.
-      // Pinning the innermost ring to clickCoreRadius (with ±2px jitter via
-      // radiusFactor) guarantees every ripple has a visible "core" mark where
-      // the click landed, regardless of size.
-      const outerTargetRadius =
-        effectMaxRadius * rippleSettings.clickAnimationStopPoint;
-      const coreJitterPx = (effect.radiusFactor - 0.5) * 4;
-      const coreRadius = Math.max(
-        1,
-        Math.min(
-          rippleSettings.clickCoreRadius + coreJitterPx,
-          outerTargetRadius,
-        ),
-      );
-      const expansionVelocity = outerTargetRadius / expansionDuration;
-
-      const rings = Array.from({ length: numRings }, (_, i) => {
-        const ringStartTime = effect.startTime + i * ringStaggerMs;
-
-        // Innermost ring sits at the core mark; outer rings interpolate
-        // linearly from core out to outerTargetRadius. With numRings === 1
-        // the lone ring goes all the way out (otherwise it'd be a tiny dot).
-        const ringTargetRadius =
-          numRings === 1
-            ? outerTargetRadius
-            : coreRadius +
-              (outerTargetRadius - coreRadius) * (i / (numRings - 1));
-
-        const ringDuration = Math.max(1, ringTargetRadius / expansionVelocity);
-        return { ringStartTime, ringTargetRadius, ringDuration };
-      });
-      return { rings, lifecycle };
-    }, [effect, rippleSettings]);
+    const geometry = useMemo(
+      () => getRippleGeometry(effect, rippleSettings),
+      [effect, rippleSettings],
+    );
 
     useEffect(() => {
       const previousRadii = new Array<number>(geometry.rings.length);

--- a/extension/website/shared/components/__tests__/AnimatedClicksRuntime.test.tsx
+++ b/extension/website/shared/components/__tests__/AnimatedClicksRuntime.test.tsx
@@ -3,7 +3,6 @@
 import { act, Profiler, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { AnimatedClicks } from "../AnimatedClicks";
 import { RippleEffect } from "../ClickRipple";
 import { subscribeRippleFrame } from "../rippleFrames";
 import { CLICK_DEFAULTS } from "../clickDefaults";
@@ -129,80 +128,6 @@ describe("RippleEffect SVG animation", () => {
     } finally {
       stopFirst();
       stopSecond();
-    }
-  });
-});
-
-describe("AnimatedClicks playback", () => {
-  it("replays finished clicks while retaining earlier marks", async () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-    try {
-      await act(async () =>
-        root.render(
-          <AnimatedClicks
-            scheduledClicks={[
-              { id: "repeat", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
-            ]}
-            timeRange={{ duration: 1 }}
-            settings={{
-              ...CLICK_DEFAULTS,
-              animationSpeed: 1,
-              clickNumRings: 1,
-              clickMinDuration: 1,
-              clickMaxDuration: 1,
-              clickExpansionDuration: 1,
-            }}
-          />,
-        ),
-      );
-      for (let i = 0; i < 8; i++)
-        await act(async () => {
-          await frame();
-        });
-      expect(container.querySelectorAll("circle").length).toBeGreaterThan(1);
-      expect(
-        [...container.querySelectorAll("circle")].some(
-          (circle) => Number(circle.getAttribute("r")) > 0,
-        ),
-      ).toBe(true);
-    } finally {
-      await act(async () => root.unmount());
-    }
-  });
-
-  it("spawns an unsorted schedule in time order and deduplicates event ids", async () => {
-    const container = document.createElement("div");
-    const root = createRoot(container);
-    try {
-      await act(async () =>
-        root.render(
-          <AnimatedClicks
-            scheduledClicks={[
-              { id: "later", x: 90, y: 30, color: "#123456", spawnAtMs: 60 },
-              { id: "first", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
-              { id: "first", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
-            ]}
-            timeRange={{ duration: 100000 }}
-            settings={{
-              ...CLICK_DEFAULTS,
-              animationSpeed: 1,
-              clickNumRings: 1,
-            }}
-          />,
-        ),
-      );
-      for (let i = 0; i < 10; i++)
-        await act(async () => {
-          await frame();
-        });
-      expect(
-        [...container.querySelectorAll("circle")].map((circle) =>
-          circle.getAttribute("cx"),
-        ),
-      ).toEqual(["20", "90"]);
-    } finally {
-      await act(async () => root.unmount());
     }
   });
 });

--- a/extension/website/shared/components/__tests__/AnimatedClicksRuntime.test.tsx
+++ b/extension/website/shared/components/__tests__/AnimatedClicksRuntime.test.tsx
@@ -1,0 +1,208 @@
+// ABOUTME: Exercises SVG ripple animation with real frames and DOM elements.
+// ABOUTME: Checks settling, settings updates, shared scheduling, and cleanup.
+import { act, Profiler, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { AnimatedClicks } from "../AnimatedClicks";
+import { RippleEffect } from "../ClickRipple";
+import { subscribeRippleFrame } from "../rippleFrames";
+import { CLICK_DEFAULTS } from "../clickDefaults";
+
+const testGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+const previousActEnvironment = testGlobal.IS_REACT_ACT_ENVIRONMENT;
+beforeAll(() => {
+  testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => {
+  testGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+});
+
+const effect = {
+  id: "click",
+  x: 10,
+  y: 20,
+  color: "#123456",
+  radiusFactor: 0.5,
+  durationFactor: 0.5,
+  startTime: 0,
+  trailIndex: 0,
+};
+
+function frame() {
+  return new Promise<number>((resolve) => requestAnimationFrame(resolve));
+}
+
+describe("RippleEffect SVG animation", () => {
+  it("settles once and redraws retained marks when ring settings change", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const completed: string[] = [];
+    const render = (rings: number) => (
+      <StrictMode>
+        <svg>
+          <RippleEffect
+            effect={effect}
+            settings={{ ...CLICK_DEFAULTS, clickNumRings: rings }}
+            onComplete={(id) => completed.push(id)}
+          />
+        </svg>
+      </StrictMode>
+    );
+    try {
+      await act(async () => root.render(render(6)));
+      expect(container.querySelectorAll("circle")).toHaveLength(6);
+      const radii = [...container.querySelectorAll("circle")].map((c) =>
+        Number(c.getAttribute("r")),
+      );
+      expect(radii[0]).toBe(CLICK_DEFAULTS.clickCoreRadius);
+      expect(radii[5]).toBeGreaterThan(radii[0]);
+      expect(completed).toEqual(["click"]);
+      await act(async () => root.render(render(1)));
+      expect(container.querySelectorAll("circle")).toHaveLength(1);
+      expect(Number(container.querySelector("circle")!.getAttribute("r"))).toBe(
+        radii[5],
+      );
+      expect(completed).toEqual(["click"]);
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it("expands on real frames without React commits and stops after unmount", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    let commits = 0;
+    try {
+      await act(async () =>
+        root.render(
+          <Profiler id="ripple" onRender={() => commits++}>
+            <svg>
+              <RippleEffect
+                effect={{ ...effect, startTime: Date.now() }}
+                settings={{
+                  ...CLICK_DEFAULTS,
+                  clickNumRings: 1,
+                  clickExpansionDuration: 1000,
+                }}
+              />
+            </svg>
+          </Profiler>,
+        ),
+      );
+      const circle = container.querySelector("circle")!;
+      const initial = Number(circle.getAttribute("r"));
+      const initialCommits = commits;
+      await frame();
+      await frame();
+      expect(Number(circle.getAttribute("r"))).toBeGreaterThan(initial);
+      expect(commits).toBe(initialCommits);
+      await act(async () => root.unmount());
+      const radius = circle.getAttribute("r");
+      await frame();
+      expect(circle.getAttribute("r")).toBe(radius);
+    } finally {
+      if (container.childNodes.length) await act(async () => root.unmount());
+    }
+  });
+
+  it("shares a timestamp and retires completed and unsubscribed callbacks", async () => {
+    const first: number[] = [];
+    const second: number[] = [];
+    const stopFirst = subscribeRippleFrame((now) => {
+      first.push(now);
+      return false;
+    });
+    const stopSecond = subscribeRippleFrame((now) => {
+      second.push(now);
+      return true;
+    });
+    try {
+      await frame();
+      expect(first).toHaveLength(1);
+      expect(second).toEqual(first);
+      stopSecond();
+      await frame();
+      expect(first).toHaveLength(1);
+      expect(second).toHaveLength(1);
+    } finally {
+      stopFirst();
+      stopSecond();
+    }
+  });
+});
+
+describe("AnimatedClicks playback", () => {
+  it("replays finished clicks while retaining earlier marks", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          <AnimatedClicks
+            scheduledClicks={[
+              { id: "repeat", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
+            ]}
+            timeRange={{ duration: 1 }}
+            settings={{
+              ...CLICK_DEFAULTS,
+              animationSpeed: 1,
+              clickNumRings: 1,
+              clickMinDuration: 1,
+              clickMaxDuration: 1,
+              clickExpansionDuration: 1,
+            }}
+          />,
+        ),
+      );
+      for (let i = 0; i < 8; i++)
+        await act(async () => {
+          await frame();
+        });
+      expect(container.querySelectorAll("circle").length).toBeGreaterThan(1);
+      expect(
+        [...container.querySelectorAll("circle")].some(
+          (circle) => Number(circle.getAttribute("r")) > 0,
+        ),
+      ).toBe(true);
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it("spawns an unsorted schedule in time order and deduplicates event ids", async () => {
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    try {
+      await act(async () =>
+        root.render(
+          <AnimatedClicks
+            scheduledClicks={[
+              { id: "later", x: 90, y: 30, color: "#123456", spawnAtMs: 60 },
+              { id: "first", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
+              { id: "first", x: 20, y: 30, color: "#123456", spawnAtMs: 0 },
+            ]}
+            timeRange={{ duration: 100000 }}
+            settings={{
+              ...CLICK_DEFAULTS,
+              animationSpeed: 1,
+              clickNumRings: 1,
+            }}
+          />,
+        ),
+      );
+      for (let i = 0; i < 10; i++)
+        await act(async () => {
+          await frame();
+        });
+      expect(
+        [...container.querySelectorAll("circle")].map((circle) =>
+          circle.getAttribute("cx"),
+        ),
+      ).toEqual(["20", "90"]);
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+});

--- a/extension/website/shared/components/clickCanvasRenderer.ts
+++ b/extension/website/shared/components/clickCanvasRenderer.ts
@@ -1,0 +1,404 @@
+// ABOUTME: Draws click rings with bounded bitmap caching for settled marks.
+// ABOUTME: Preserves ripple geometry, ordered blending, and interpolated residue fades.
+import { getRippleGeometry, type RippleSettings } from "./ClickRipple";
+import {
+  getClickResidueOpacity,
+  type VisibleClickEffect,
+} from "./clickResidue";
+
+import { ClickMarkCache, type CachedClickMark } from "./clickMarkCache";
+
+const FADE_DURATION_MS = 200;
+const FRAME_INTERVAL_MS = 1000 / 30;
+// Less than a quarter of an 8-bit alpha step avoids repainting imperceptible fades.
+const RESIDUE_OPACITY_STEP = 1 / 1024;
+const RESIDUE_TILE_SIZE = 128;
+
+type Geometry = ReturnType<typeof getRippleGeometry>;
+interface Mark {
+  effect: VisibleClickEffect;
+  geometry: Geometry;
+  bounds: { left: number; top: number; width: number; height: number };
+  completed: boolean;
+  opacityFrom: number;
+  opacityTarget: number;
+  opacityChangedAt: number;
+  sprite?: CachedClickMark;
+}
+
+function opacityAt(mark: Mark, now: number) {
+  const progress = Math.min(
+    1,
+    Math.max(0, (now - mark.opacityChangedAt) / FADE_DURATION_MS),
+  );
+  return mark.opacityFrom + (mark.opacityTarget - mark.opacityFrom) * progress;
+}
+
+function boundsFor(
+  effect: VisibleClickEffect,
+  geometry: Geometry,
+  settings: RippleSettings,
+  pixelRatio: number,
+) {
+  let outerRadius = 0;
+  for (const ring of geometry.rings)
+    outerRadius = Math.max(outerRadius, ring.ringTargetRadius);
+  const margin = outerRadius + settings.clickStrokeWidth / 2 + 1;
+  const left = Math.floor((effect.x - margin) * pixelRatio);
+  const top = Math.floor((effect.y - margin) * pixelRatio);
+  return {
+    left,
+    top,
+    width: Math.ceil((effect.x + margin) * pixelRatio) - left,
+    height: Math.ceil((effect.y + margin) * pixelRatio) - top,
+  };
+}
+
+export class ClickCanvasRenderer {
+  private context: CanvasRenderingContext2D;
+  private scratch = document.createElement("canvas");
+  private scratchContext: CanvasRenderingContext2D;
+  private residue = document.createElement("canvas");
+  private residueContext: CanvasRenderingContext2D;
+  private residueTiles = new Map<
+    number,
+    Array<{ mark: Mark; opacity: number }>
+  >();
+  private residueDirty = true;
+  private marks = new Map<string, Mark>();
+  private active = new Set<Mark>();
+  private settings: RippleSettings | undefined;
+  private cache = new ClickMarkCache();
+  private pixelRatio = 1;
+  private dirty = true;
+  private lastDraw = -Infinity;
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    private onComplete: (id: string) => void,
+  ) {
+    const context = canvas.getContext("2d");
+    const scratchContext = this.scratch.getContext("2d");
+    const residueContext = this.residue.getContext("2d");
+    if (!context || !scratchContext || !residueContext)
+      throw new Error("Click visualization requires Canvas 2D");
+    this.context = context;
+    this.scratchContext = scratchContext;
+    this.residueContext = residueContext;
+  }
+
+  private discardSprite(mark: Mark) {
+    if (!mark.sprite) return;
+    this.cache.release(mark.sprite);
+    mark.sprite = undefined;
+  }
+
+  resize(width: number, height: number, pixelRatio: number) {
+    const w = Math.max(1, Math.round(width * pixelRatio));
+    const h = Math.max(1, Math.round(height * pixelRatio));
+    if (
+      this.canvas.width === w &&
+      this.canvas.height === h &&
+      this.pixelRatio === pixelRatio
+    )
+      return;
+    this.canvas.width = w;
+    this.canvas.height = h;
+    this.residue.width = w;
+    this.residue.height = h;
+    this.residueDirty = true;
+    if (this.pixelRatio !== pixelRatio) {
+      this.pixelRatio = pixelRatio;
+      this.cache.clear();
+      for (const mark of this.marks.values()) {
+        mark.sprite = undefined;
+        mark.bounds = boundsFor(
+          mark.effect,
+          mark.geometry,
+          this.settings!,
+          pixelRatio,
+        );
+      }
+    }
+    this.dirty = true;
+    this.lastDraw = -Infinity;
+  }
+
+  update(effects: VisibleClickEffect[], settings: RippleSettings, now: number) {
+    const settingsChanged = this.settings !== settings;
+    if (settingsChanged) {
+      this.residueDirty = true;
+      this.cache.clear();
+      for (const mark of this.marks.values()) mark.sprite = undefined;
+    }
+    this.settings = settings;
+    const retained = new Map<string, Mark>();
+    effects.forEach((effect, index) => {
+      let mark = this.marks.get(effect.id);
+      const target = getClickResidueOpacity(
+        index,
+        effects.length,
+        effect.completed,
+      );
+      if (!mark) {
+        const geometry = getRippleGeometry(effect, settings);
+        mark = {
+          effect,
+          geometry,
+          bounds: boundsFor(effect, geometry, settings, this.pixelRatio),
+          completed: effect.completed,
+          opacityFrom: target,
+          opacityTarget: target,
+          opacityChangedAt: now,
+        };
+      } else {
+        if (
+          settingsChanged ||
+          effect.x !== mark.effect.x ||
+          effect.y !== mark.effect.y ||
+          effect.color !== mark.effect.color ||
+          effect.radiusFactor !== mark.effect.radiusFactor ||
+          effect.durationFactor !== mark.effect.durationFactor ||
+          effect.holdDuration !== mark.effect.holdDuration ||
+          effect.startTime !== mark.effect.startTime
+        ) {
+          this.residueDirty = true;
+          this.discardSprite(mark);
+          mark.geometry = getRippleGeometry(effect, settings);
+          mark.bounds = boundsFor(
+            effect,
+            mark.geometry,
+            settings,
+            this.pixelRatio,
+          );
+        }
+        if (mark.opacityTarget !== target) {
+          mark.opacityFrom = opacityAt(mark, now);
+          mark.opacityTarget = target;
+          mark.opacityChangedAt = now;
+        }
+        mark.effect = effect;
+      }
+      retained.set(effect.id, mark);
+      if (!mark.completed || now < mark.geometry.lifecycle.completedAt)
+        this.active.add(mark);
+    });
+    for (const [id, mark] of this.marks) {
+      if (retained.has(id)) continue;
+      this.discardSprite(mark);
+      this.active.delete(mark);
+      // Evicted active marks cannot notify playback through a later frame.
+      if (!mark.completed) this.onComplete(id);
+    }
+    this.marks = retained;
+    this.dirty = true;
+  }
+
+  get needsFrame() {
+    return this.dirty || this.active.size > 0;
+  }
+
+  tick(now: number, visible: boolean) {
+    for (const mark of this.active) {
+      if (now < mark.geometry.lifecycle.completedAt) continue;
+      this.active.delete(mark);
+      if (!mark.completed) {
+        mark.completed = true;
+        this.onComplete(mark.effect.id);
+      }
+      this.dirty = true;
+    }
+    if (!visible || now - this.lastDraw < FRAME_INTERVAL_MS) return;
+    if (!this.dirty && this.active.size === 0) return;
+    const elapsed = now - this.lastDraw;
+    this.lastDraw = Number.isFinite(elapsed)
+      ? now - (elapsed % FRAME_INTERVAL_MS)
+      : now;
+    this.draw(now);
+  }
+
+  private draw(now: number) {
+    if (!this.settings) return;
+    let prefixLength = 0;
+    const columns = Math.ceil(this.canvas.width / RESIDUE_TILE_SIZE);
+    const rows = Math.ceil(this.canvas.height / RESIDUE_TILE_SIZE);
+    const tiles = new Map<number, Mark[]>();
+    for (const mark of this.marks.values()) {
+      const opacity = opacityAt(mark, now);
+      if (
+        !mark.completed ||
+        now < mark.geometry.lifecycle.completedAt ||
+        opacity === 1
+      )
+        break;
+      prefixLength++;
+      const bounds = mark.bounds;
+      const firstColumn = Math.max(
+        0,
+        Math.floor(bounds.left / RESIDUE_TILE_SIZE),
+      );
+      const lastColumn = Math.min(
+        columns - 1,
+        Math.floor((bounds.left + bounds.width - 1) / RESIDUE_TILE_SIZE),
+      );
+      const firstRow = Math.max(0, Math.floor(bounds.top / RESIDUE_TILE_SIZE));
+      const lastRow = Math.min(
+        rows - 1,
+        Math.floor((bounds.top + bounds.height - 1) / RESIDUE_TILE_SIZE),
+      );
+      for (let y = firstRow; y <= lastRow; y++)
+        for (let x = firstColumn; x <= lastColumn; x++) {
+          const key = y * columns + x;
+          let marks = tiles.get(key);
+          if (!marks) {
+            marks = [];
+            tiles.set(key, marks);
+          }
+          marks.push(mark);
+        }
+    }
+    for (const key of this.residueTiles.keys()) {
+      if (tiles.has(key)) continue;
+      this.residueContext.clearRect(
+        (key % columns) * RESIDUE_TILE_SIZE,
+        Math.floor(key / columns) * RESIDUE_TILE_SIZE,
+        RESIDUE_TILE_SIZE,
+        RESIDUE_TILE_SIZE,
+      );
+      this.residueTiles.delete(key);
+    }
+    for (const [key, marks] of tiles) {
+      const cached = this.residueTiles.get(key);
+      const changed =
+        this.residueDirty ||
+        cached?.length !== marks.length ||
+        marks.some(
+          (mark, index) =>
+            cached[index].mark !== mark ||
+            Math.abs(cached[index].opacity - opacityAt(mark, now)) >
+              RESIDUE_OPACITY_STEP,
+        );
+      if (!changed) continue;
+      const x = (key % columns) * RESIDUE_TILE_SIZE;
+      const y = Math.floor(key / columns) * RESIDUE_TILE_SIZE;
+      const ctx = this.residueContext;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(x, y, RESIDUE_TILE_SIZE, RESIDUE_TILE_SIZE);
+      ctx.clip();
+      ctx.clearRect(x, y, RESIDUE_TILE_SIZE, RESIDUE_TILE_SIZE);
+      const entries: Array<{ mark: Mark; opacity: number }> = [];
+      for (const mark of marks) {
+        const opacity = opacityAt(mark, now);
+        this.drawMark(ctx, mark, now, opacity);
+        entries.push({ mark, opacity });
+      }
+      ctx.restore();
+      this.residueTiles.set(key, entries);
+    }
+    this.residueDirty = false;
+    const ctx = this.context;
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+    if (prefixLength > 0) ctx.drawImage(this.residue, 0, 0);
+    this.dirty = false;
+    let index = 0;
+    for (const mark of this.marks.values()) {
+      const opacity = opacityAt(mark, now);
+      if (opacity !== mark.opacityTarget) this.dirty = true;
+      if (index++ >= prefixLength) this.drawMark(ctx, mark, now, opacity);
+    }
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = "source-over";
+  }
+
+  private drawMark(
+    ctx: CanvasRenderingContext2D,
+    mark: Mark,
+    now: number,
+    opacity: number,
+  ) {
+    if (this.settings!.clickStrokeWidth <= 0) return;
+    const { left, top, width, height } = mark.bounds;
+    const right = left + width;
+    const bottom = top + height;
+    if (
+      right <= 0 ||
+      bottom <= 0 ||
+      left >= this.canvas.width ||
+      top >= this.canvas.height
+    )
+      return;
+    const sprite =
+      mark.sprite ?? this.paintMark(mark, now, left, top, width, height);
+    ctx.globalAlpha = opacity;
+    // SVG group opacity isolates faded rings; fully opaque groups multiply
+    // their rings against the preceding marks instead.
+    ctx.globalCompositeOperation = opacity === 1 ? "multiply" : "source-over";
+    ctx.drawImage(
+      sprite.canvas,
+      sprite.x,
+      sprite.y,
+      width,
+      height,
+      left,
+      top,
+      width,
+      height,
+    );
+  }
+
+  private paintMark(
+    mark: Mark,
+    now: number,
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ) {
+    const settings = this.settings!;
+    if (this.scratch.width < width) this.scratch.width = width;
+    if (this.scratch.height < height) this.scratch.height = height;
+    const ctx = this.scratchContext;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, this.scratch.width, this.scratch.height);
+    ctx.setTransform(
+      this.pixelRatio,
+      0,
+      0,
+      this.pixelRatio,
+      mark.effect.x * this.pixelRatio - left,
+      mark.effect.y * this.pixelRatio - top,
+    );
+    ctx.globalAlpha = Math.max(0, Math.min(1, settings.clickOpacity));
+    ctx.globalCompositeOperation = "multiply";
+    ctx.strokeStyle = mark.effect.color;
+    ctx.lineWidth = settings.clickStrokeWidth;
+    for (const ring of mark.geometry.rings) {
+      const elapsed = now - ring.ringStartTime;
+      if (elapsed <= 0) continue;
+      const progress = Math.min(1, elapsed / ring.ringDuration);
+      const radius = ring.ringTargetRadius * (1 - Math.pow(1 - progress, 3));
+      if (radius <= 0) continue;
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, 0, 2 * Math.PI);
+      ctx.stroke();
+    }
+    if (now >= mark.geometry.lifecycle.completedAt) {
+      mark.sprite = this.cache.store(this.scratch, width, height);
+      if (mark.sprite) return mark.sprite;
+    }
+    return { canvas: this.scratch, x: 0, y: 0 };
+  }
+
+  destroy() {
+    for (const mark of this.marks.values()) this.discardSprite(mark);
+    this.cache.clear();
+    this.marks.clear();
+    this.active.clear();
+    this.scratch.width = this.scratch.height = 0;
+    this.residue.width = this.residue.height = 0;
+    this.residueTiles.clear();
+  }
+}

--- a/extension/website/shared/components/clickMarkCache.ts
+++ b/extension/website/shared/components/clickMarkCache.ts
@@ -1,0 +1,112 @@
+// ABOUTME: Packs settled click marks into a bounded set of shared bitmap pages.
+// ABOUTME: Reuses released slots as older marks leave the visualization.
+const PAGE_SIZE = 1024;
+const MAX_PAGES = 8;
+const ALIGNMENT = 4;
+
+export interface CachedClickMark {
+  canvas: HTMLCanvasElement;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+interface Page {
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  rows: Array<{ y: number; height: number; nextX: number }>;
+  nextY: number;
+}
+
+export class ClickMarkCache {
+  private pages: Page[] = [];
+  private free = new Map<string, CachedClickMark[]>();
+
+  get byteLength() {
+    return this.pages.length * PAGE_SIZE * PAGE_SIZE * 4;
+  }
+
+  store(
+    source: HTMLCanvasElement,
+    width: number,
+    height: number,
+  ): CachedClickMark | undefined {
+    const w = Math.ceil(width / ALIGNMENT) * ALIGNMENT;
+    const h = Math.ceil(height / ALIGNMENT) * ALIGNMENT;
+    if (w > PAGE_SIZE || h > PAGE_SIZE) return;
+    const key = `${w}:${h}`;
+    const available = this.free.get(key)?.pop();
+    let page = available
+      ? this.pages.find((page) => page.canvas === available.canvas)
+      : undefined;
+    let slot = available;
+    if (!slot) {
+      for (const candidate of this.pages) {
+        let row = candidate.rows.find(
+          (row) => row.height === h && row.nextX + w <= PAGE_SIZE,
+        );
+        if (!row && candidate.nextY + h <= PAGE_SIZE) {
+          row = { y: candidate.nextY, height: h, nextX: 0 };
+          candidate.rows.push(row);
+          candidate.nextY += h;
+        }
+        if (row) {
+          page = candidate;
+          slot = {
+            canvas: page.canvas,
+            x: row.nextX,
+            y: row.y,
+            width: w,
+            height: h,
+          };
+          row.nextX += w;
+          break;
+        }
+      }
+    }
+    if (!slot && this.pages.length < MAX_PAGES) {
+      const canvas = document.createElement("canvas");
+      canvas.width = canvas.height = PAGE_SIZE;
+      const context = canvas.getContext("2d");
+      if (!context) throw new Error("Click residue requires Canvas 2D");
+      page = {
+        canvas,
+        context,
+        rows: [{ y: 0, height: h, nextX: w }],
+        nextY: h,
+      };
+      this.pages.push(page);
+      slot = { canvas, x: 0, y: 0, width: w, height: h };
+    }
+    if (!slot || !page) return;
+    page.context.clearRect(slot.x, slot.y, w, h);
+    page.context.drawImage(
+      source,
+      0,
+      0,
+      width,
+      height,
+      slot.x,
+      slot.y,
+      width,
+      height,
+    );
+    return slot;
+  }
+
+  release(slot: CachedClickMark) {
+    const key = `${slot.width}:${slot.height}`;
+    let slots = this.free.get(key);
+    if (!slots) {
+      slots = [];
+      this.free.set(key, slots);
+    }
+    slots.push(slot);
+  }
+
+  clear() {
+    for (const page of this.pages) page.canvas.width = page.canvas.height = 0;
+    this.pages = [];
+    this.free.clear();
+  }
+}

--- a/extension/website/shared/components/clickResidue.ts
+++ b/extension/website/shared/components/clickResidue.ts
@@ -1,0 +1,34 @@
+// ABOUTME: Bounds retained click marks and computes their age-based opacity.
+// ABOUTME: Shares residue behavior between click playback and raster drawing.
+import type { ClickEffect } from "../types";
+
+export const MAX_VISIBLE_CLICK_EFFECTS = 4000;
+
+const MINIMUM_RESIDUE_OPACITY = 0.03;
+
+export function getClickResidueOpacity(
+  index: number,
+  total: number,
+  completed: boolean,
+): number {
+  if (!completed) return 1;
+
+  const distanceFromNewest = total - index - 1;
+  const fadeProgress = Math.min(
+    1,
+    distanceFromNewest / Math.max(1, MAX_VISIBLE_CLICK_EFFECTS - 1),
+  );
+  return 1 - (1 - MINIMUM_RESIDUE_OPACITY) * fadeProgress;
+}
+
+export type VisibleClickEffect = ClickEffect & {
+  sourceId: string;
+  completed: boolean;
+};
+
+export function mergeClickEffects(
+  current: VisibleClickEffect[],
+  incoming: VisibleClickEffect[],
+): VisibleClickEffect[] {
+  return [...current, ...incoming].slice(-MAX_VISIBLE_CLICK_EFFECTS);
+}

--- a/extension/website/shared/components/rippleFrames.ts
+++ b/extension/website/shared/components/rippleFrames.ts
@@ -1,0 +1,29 @@
+// ABOUTME: Shares one animation frame among active SVG click ripples.
+// ABOUTME: Removes settled ripples from frame work while retaining their marks.
+
+type RippleFrame = (now: number) => boolean;
+const frames = new Set<RippleFrame>();
+let animationFrame: number | undefined;
+
+function tick() {
+  const now = Date.now();
+  for (const frame of frames) {
+    if (!frame(now)) frames.delete(frame);
+  }
+  animationFrame = undefined;
+  if (frames.size > 0) animationFrame = requestAnimationFrame(tick);
+}
+
+export function subscribeRippleFrame(frame: RippleFrame): () => void {
+  frames.add(frame);
+  if (animationFrame === undefined) {
+    animationFrame = requestAnimationFrame(tick);
+  }
+  return () => {
+    frames.delete(frame);
+    if (frames.size === 0 && animationFrame !== undefined) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = undefined;
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "load-test": "bun tools/load-test/src/runner.ts",
     "load-test:full": "bun tools/load-test/src/runner.ts --config full-suite",
     "smoke": "cd smoke-tests && bun run test",
+    "smoke:clicks": "node smoke-tests/clicks-rendering.mjs",
     "smoke:extension": "VITE_WORKER_URL=http://127.0.0.1:18787 bun run --cwd extension build -- --mode development && node smoke-tests/extension-smoke.mjs",
     "smoke:partykit": "cd smoke-tests && bun run test:partykit",
     "smoke:partykit:bridge": "cd smoke-tests && bun run test:partykit:bridge",

--- a/smoke-tests/clicks-appearance.mjs
+++ b/smoke-tests/clicks-appearance.mjs
@@ -1,0 +1,140 @@
+// ABOUTME: Compares Canvas click pixels against the SVG renderer at matching times.
+// ABOUTME: Allows edge rasterization differences while checking overlap colors and geometry.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+
+export async function verifyClickAppearance(page, outputDirectory) {
+  if (outputDirectory) await mkdir(outputDirectory, { recursive: true });
+  const now = await page.evaluate(() => Date.now());
+  const results = [];
+  for (const state of ["expanding", "settled", "faded", "mixed"]) {
+    const effects = Array.from(
+      { length: state === "faded" ? 2003 : 3 },
+      (_, i) => ({
+        id: `${state}-${i}`,
+        sourceId: `${state}-${i}`,
+        x: i < 3 ? 100 + i * 38 : -1000,
+        y: i < 3 ? 140 + i * 9 : -1000,
+        color: ["#e35950", "#3a87bd", "#76a658"][i % 3],
+        radiusFactor: 0.65,
+        durationFactor: 0.5,
+        trailIndex: 0,
+        startTime:
+          state === "expanding" || (state === "mixed" && i === 1)
+            ? now - 744
+            : 0,
+        completed: state === "faded" || (state === "mixed" && i !== 1),
+      }),
+    );
+    const images = [];
+    for (const mode of ["svg", "canvas"]) {
+      if (mode === "svg") {
+        await page.evaluate(() => {
+          window.drawing?.destroy();
+          window.drawingCanvas?.remove();
+        });
+        await page.evaluate(
+          (effects) =>
+            window.renderScene(
+              effects,
+              { clickMinRadius: 80, clickMaxRadius: 80, clickStrokeWidth: 5 },
+              "svg",
+            ),
+          effects,
+        );
+        await page.waitForFunction(
+          () => Number(document.querySelector("circle")?.getAttribute("r")) > 0,
+        );
+      } else {
+        await page.evaluate(() => window.clearClicks());
+        await page.waitForFunction(() => !document.querySelector("svg"));
+        await page.evaluate((effects) => {
+          window.createDrawing();
+          const canvas = window.drawingCanvas;
+          canvas.style.cssText = "position:absolute;left:0;top:0";
+          document.body.append(canvas);
+          window.drawing.resize(400, 300, 1);
+          window.drawing.update(
+            effects,
+            {
+              ...window.defaultSettings,
+              clickNumRings: 6,
+              clickMinRadius: 80,
+              clickMaxRadius: 80,
+              clickStrokeWidth: 5,
+            },
+            Date.now(),
+          );
+          window.drawing.tick(Date.now(), true);
+        }, effects);
+      }
+      const image = await page.screenshot(
+        outputDirectory
+          ? { path: path.join(outputDirectory, `${state}-${mode}.png`) }
+          : {},
+      );
+      images.push(image.toString("base64"));
+    }
+    const difference = await page.evaluate(async (images) => {
+      const pixels = [];
+      for (const image of images) {
+        const img = new Image();
+        img.src = `data:image/png;base64,${image}`;
+        await img.decode();
+        const c = document.createElement("canvas");
+        c.width = img.width;
+        c.height = img.height;
+        const context = c.getContext("2d");
+        context.drawImage(img, 0, 0);
+        pixels.push(context.getImageData(0, 0, c.width, c.height).data);
+      }
+      const [svg, canvas] = pixels;
+      let error = 0,
+        interiorPixels = 0,
+        maximumInteriorDifference = 0;
+      for (let y = 1; y < 299; y++)
+        for (let x = 1; x < 399; x++) {
+          const i = (y * 400 + x) * 4;
+          let flat = Math.min(svg[i], svg[i + 1], svg[i + 2]) < 245;
+          for (let c = 0; c < 3; c++) {
+            const d = Math.abs(svg[i + c] - canvas[i + c]);
+            error += d;
+            for (const neighbor of [i - 4, i + 4, i - 1600, i + 1600])
+              if (Math.abs(svg[i + c] - svg[neighbor + c]) > 1) flat = false;
+          }
+          if (flat) {
+            interiorPixels++;
+            for (let c = 0; c < 3; c++)
+              maximumInteriorDifference = Math.max(
+                maximumInteriorDifference,
+                Math.abs(svg[i + c] - canvas[i + c]),
+              );
+          }
+        }
+      return {
+        meanChannelDifference: error / (398 * 298 * 3),
+        interiorPixels,
+        maximumInteriorDifference,
+      };
+    }, images);
+    assert.ok(
+      difference.interiorPixels > (state === "expanding" ? 10 : 100),
+      `${state}: missing visible rings`,
+    );
+    assert.ok(
+      difference.maximumInteriorDifference <= 5,
+      `${state}: overlap colors differ: ${JSON.stringify(difference)}`,
+    );
+    assert.ok(
+      difference.meanChannelDifference < 0.5,
+      `${state}: raster output differs: ${JSON.stringify(difference)}`,
+    );
+    results.push({ state, ...difference });
+  }
+  await page.evaluate(() => {
+    window.drawing.destroy();
+    window.drawingCanvas.remove();
+  });
+  return results;
+}

--- a/smoke-tests/clicks-rendering.mjs
+++ b/smoke-tests/clicks-rendering.mjs
@@ -1,0 +1,278 @@
+// ABOUTME: Verifies Canvas click playback and pixel output in real Chromium.
+// ABOUTME: Covers staggered clicks, replay, residue, resizing, and drawing cleanup.
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { createServer } from "vite";
+import { chromium } from "playwright";
+import { verifyClickAppearance } from "./clicks-appearance.mjs";
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const server = await createServer({
+  configFile: false,
+  root: rootDir,
+  esbuild: { jsx: "automatic" },
+  optimizeDeps: { entries: ["smoke-tests/fixtures/clicks.html"] },
+  resolve: {
+    alias: {
+      react: path.join(rootDir, "node_modules/react"),
+      "react-dom": path.join(rootDir, "node_modules/react-dom"),
+    },
+  },
+  server: { host: "127.0.0.1", port: 0 },
+});
+let browser;
+try {
+  await server.listen();
+  browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 400, height: 300 } });
+  const errors = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.clock.install({ time: new Date("2026-01-01") });
+  await page.goto(
+    `${server.resolvedUrls.local[0]}smoke-tests/fixtures/clicks.html`,
+  );
+  await page.waitForFunction(() => window.ready);
+  await page.clock.pauseAt(new Date("2026-01-01T00:00:01Z"));
+  const mark = (id, x, startTime, completed = false) => ({
+    id,
+    sourceId: id,
+    x,
+    y: 100,
+    color: "#345678",
+    radiusFactor: 0.5,
+    durationFactor: 0.5,
+    trailIndex: 0,
+    startTime,
+    completed,
+  });
+  const pixels = () =>
+    page.evaluate(() => {
+      const c = document.querySelector("canvas");
+      const data = c
+        .getContext("2d")
+        .getImageData(0, 0, c.width, c.height).data;
+      let left = 0,
+        right = 0;
+      for (let y = 0; y < c.height; y++)
+        for (let x = 0; x < c.width; x++) {
+          const alpha = data[(y * c.width + x) * 4 + 3];
+          if (x < 100) left += alpha;
+          else right += alpha;
+        }
+      return { left, right };
+    });
+
+  // These replay and schedule cases also exercise the actual parent timeline.
+  await page.evaluate(() =>
+    window.playClicks(
+      [
+        { id: "later", x: 180, y: 100, color: "#345678", spawnAtMs: 300 },
+        { id: "first", x: 40, y: 100, color: "#345678", spawnAtMs: 0 },
+        { id: "first", x: 40, y: 100, color: "#345678", spawnAtMs: 0 },
+      ],
+      { clickMinRadius: 20, clickMaxRadius: 20, clickExpansionDuration: 100 },
+    ),
+  );
+  await page.waitForSelector("canvas");
+  await page.clock.runFor(160);
+  assert.ok((await pixels()).left > 0);
+  assert.equal((await pixels()).right, 0);
+  await page.clock.runFor(320);
+  assert.ok((await pixels()).right > 0);
+
+  await page.evaluate(() =>
+    window.playClicks(
+      [{ id: "repeat", x: 80, y: 100, color: "#345678", spawnAtMs: 0 }],
+      { clickMinDuration: 1, clickMaxDuration: 1, clickExpansionDuration: 1 },
+      100,
+    ),
+  );
+  await page.clock.runFor(80);
+  const firstPass = await pixels();
+  await page.clock.runFor(320);
+  assert.ok(
+    (await pixels()).left > firstPass.left,
+    "Replay must retain earlier marks",
+  );
+
+  await page.evaluate(() => window.clearClicks());
+  await page.waitForFunction(() => !document.querySelector("canvas"));
+  await page.clock.runFor(100);
+  await page.evaluate(() => {
+    window.completions = [];
+    window.createDrawing();
+  });
+  const now = await page.evaluate(() => Date.now());
+  await page.evaluate(
+    ({ mark, now }) => {
+      const settings = {
+        clickMinRadius: 30,
+        clickMaxRadius: 30,
+        clickCoreRadius: 3,
+        clickMinDuration: 500,
+        clickMaxDuration: 500,
+        clickExpansionDuration: 100,
+        clickStrokeWidth: 3,
+        clickOpacity: 0.6,
+        clickNumRings: 6,
+        clickRingDelayMs: 10,
+        clickAnimationStopPoint: 0.45,
+      };
+      window.sceneSettings = settings;
+      window.drawing.resize(400, 300, 1);
+      window.drawing.update([mark], settings, now);
+      window.drawing.tick(now + 600, true);
+    },
+    { mark: mark("settle", 80, now), now },
+  );
+  assert.deepEqual(await page.evaluate(() => window.completions), ["settle"]);
+  const retained = await page.evaluate(() => window.drawingCanvas.toDataURL());
+  await page.evaluate((now) => window.drawing.tick(now + 900, true), now);
+  assert.equal(
+    await page.evaluate(() => window.drawingCanvas.toDataURL()),
+    retained,
+  );
+  await page.evaluate(() => window.drawing.resize(200, 150, 2));
+  await page.evaluate((now) => window.drawing.tick(now + 1000, true), now);
+  assert.equal(await page.evaluate(() => window.drawingCanvas.width), 400);
+  assert.notEqual(
+    await page.evaluate(() => window.drawingCanvas.toDataURL()),
+    retained,
+  );
+
+  // An active mark removed by the retention cap must not stall the replay clock.
+  await page.evaluate(
+    ({ mark, now }) => {
+      window.drawing.update([mark], window.sceneSettings, now);
+      window.drawing.update([], window.sceneSettings, now);
+      window.drawing.tick(now + 2000, true);
+      window.drawing.destroy();
+    },
+    { mark: mark("evicted", 80, now + 1000), now },
+  );
+  assert.equal(
+    (await page.evaluate(() => window.completions)).filter(
+      (id) => id === "evicted",
+    ).length,
+    1,
+  );
+  const fade = await page.evaluate(() => {
+    window.createDrawing();
+    const drawing = window.drawing;
+    const canvas = window.drawingCanvas;
+    const now = Date.now();
+    const settings = { ...window.defaultSettings, clickNumRings: 6 };
+    const effects = Array.from({ length: 2003 }, (_, i) => ({
+      id: `fade-${i}`,
+      sourceId: `fade-${i}`,
+      x: i === 0 ? 100 : -1000,
+      y: i === 0 ? 100 : -1000,
+      color: "#345678",
+      radiusFactor: 0.5,
+      durationFactor: 0.5,
+      startTime: 0,
+      trailIndex: 0,
+      completed: false,
+    }));
+    drawing.resize(400, 300, 1);
+    const alpha = () => {
+      const data = canvas.getContext("2d").getImageData(0, 0, 400, 300).data;
+      let total = 0;
+      for (let i = 3; i < data.length; i += 4) total += data[i];
+      return total;
+    };
+    drawing.update(effects, settings, now);
+    drawing.tick(now, true);
+    const before = alpha();
+    drawing.update(
+      effects.map((effect) => ({ ...effect, completed: true })),
+      settings,
+      now + 1000,
+    );
+    drawing.tick(now + 1100, true);
+    const halfway = alpha();
+    drawing.tick(now + 1200, true);
+    const after = alpha();
+    const finished = effects.map((effect) => ({ ...effect, completed: true }));
+    drawing.update(finished, { ...settings, clickStrokeWidth: 0 }, now + 1300);
+    drawing.tick(now + 1300, true);
+    const zeroStroke = alpha();
+    drawing.update(finished, settings, now + 1400);
+    drawing.tick(now + 1400, true);
+    const settled = canvas.toDataURL();
+    const future = {
+      ...effects[0],
+      id: "hidden",
+      sourceId: "hidden",
+      startTime: now + 2000,
+      completed: false,
+    };
+    drawing.update([future], settings, now + 2000);
+    drawing.tick(now + 20000, false);
+    const hiddenUnchanged = canvas.toDataURL() === settled;
+    drawing.destroy();
+    return { before, halfway, after, hiddenUnchanged, zeroStroke };
+  });
+  assert.ok(fade.before > fade.halfway && fade.halfway > fade.after);
+  assert.ok(
+    Math.abs(fade.halfway - (fade.before + fade.after) / 2) <
+      fade.before * 0.01,
+  );
+  assert.equal(fade.hiddenUnchanged, true);
+  assert.equal(fade.zeroStroke, 0);
+  assert.ok((await page.evaluate(() => window.completions)).includes("hidden"));
+
+  const budget = await page.evaluate(() => {
+    const cache = window.createCache();
+    const source = document.createElement("canvas");
+    source.width = source.height = 64;
+    const ctx = source.getContext("2d");
+    ctx.fillStyle = "#123456";
+    ctx.fillRect(0, 0, 64, 64);
+    const slots = [];
+    for (let i = 0; i < 10000; i++) {
+      const slot = cache.store(source, 64, 64);
+      if (!slot) break;
+      slots.push(slot);
+    }
+    const bytes = cache.byteLength;
+    const full = cache.store(source, 64, 64) === undefined;
+    cache.release(slots[0]);
+    ctx.fillStyle = "#ff0000";
+    ctx.fillRect(0, 0, 64, 64);
+    const reused = cache.store(source, 64, 64);
+    const pixel = Array.from(
+      reused.canvas
+        .getContext("2d")
+        .getImageData(reused.x + 4, reused.y + 4, 1, 1).data,
+    );
+    const sameSlot =
+      reused.canvas === slots[0].canvas &&
+      reused.x === slots[0].x &&
+      reused.y === slots[0].y;
+    cache.clear();
+    return { bytes, full, sameSlot, pixel, afterClear: cache.byteLength };
+  });
+  assert.ok(budget.bytes <= 32 * 1024 * 1024);
+  assert.equal(budget.full, true);
+  assert.equal(budget.sameSlot, true);
+  assert.deepEqual(budget.pixel, [255, 0, 0, 255]);
+  assert.equal(budget.afterClear, 0);
+
+  const appearance = await verifyClickAppearance(
+    page,
+    process.env.CLICK_SCREENSHOT_DIR,
+  );
+  console.log("Appearance:", JSON.stringify(appearance));
+  assert.deepEqual(errors, []);
+  console.log(
+    "PASS: click scheduling, replay residue, settling, resizing, eviction, and cleanup in Chromium",
+  );
+} finally {
+  await browser?.close();
+  await server.close();
+}

--- a/smoke-tests/fixtures/clicks.html
+++ b/smoke-tests/fixtures/clicks.html
@@ -1,0 +1,38 @@
+<!-- ABOUTME: Exercises the click installation renderer with deterministic events. -->
+<!-- ABOUTME: Exposes scene controls for real-browser rendering and replay checks. -->
+<html><body style="margin:0;background:white"><div id="root" style="position:relative;width:100vw;height:100vh"></div>
+<script type="module">
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { AnimatedClicks } from "../../extension/website/shared/components/AnimatedClicks.tsx";
+import { ClickCanvas } from "../../extension/website/shared/components/ClickCanvas.tsx";
+import { RippleEffect } from "../../extension/website/shared/components/ClickRipple.tsx";
+import { getClickResidueOpacity } from "../../extension/website/shared/components/clickResidue.ts";
+import { CLICK_DEFAULTS } from "../../extension/website/shared/components/clickDefaults.ts";
+import { ClickMarkCache } from "../../extension/website/shared/components/clickMarkCache.ts";
+import { ClickCanvasRenderer } from "../../extension/website/shared/components/clickCanvasRenderer.ts";
+const root = createRoot(document.getElementById("root"));
+window.defaultSettings = CLICK_DEFAULTS;
+window.completions = [];
+window.renderScene = (effects, options = {}, mode = "canvas") => {
+  const settings = { ...CLICK_DEFAULTS, clickNumRings: 6, ...options };
+  const complete = id => window.completions.push(id);
+  root.render(mode === "canvas" ? React.createElement(ClickCanvas, { effects, settings, onComplete: complete }) :
+    React.createElement("svg", {width: "100%", height: "100%", style: {position:"absolute",top:0,left:0}},
+      effects.map((effect, index) => React.createElement("g", { key: effect.id, opacity: getClickResidueOpacity(index,effects.length,effect.completed), style:{transition:"opacity 200ms linear"}},
+        React.createElement(RippleEffect, {effect,settings,onComplete:complete})))));
+};
+window.playClicks = (clicks, options = {}, duration = 100000) => {
+  root.render(React.createElement(AnimatedClicks, { key: crypto.randomUUID(), scheduledClicks: clicks,
+    settings:{...CLICK_DEFAULTS,animationSpeed:1,clickNumRings:1,...options}, timeRange:{duration} }));
+};
+window.clearClicks = () => root.render(null);
+window.createDrawing = () => {
+  const canvas=document.createElement("canvas");
+  const drawing=new ClickCanvasRenderer(canvas,id=>window.completions.push(id));
+  window.drawing=drawing;
+  window.drawingCanvas=canvas;
+};
+window.createCache = () => new ClickMarkCache();
+window.ready=true;
+</script></body></html>


### PR DESCRIPTION
At the clicks installation's 4,000-mark limit, six rings per mark leave 24,000 SVG circles to composite. Render the clicks on Canvas with cached settled marks and a 30 fps drawing cadence. The parent timeline continues to schedule clicks and sound independently.

Ring geometry, core jitter, easing, hold scaling, colors, chronological overlap order, the 200 ms fade, and the 4,000-mark limit are preserved. Shared geometry also feeds the SVG trail ripples. This builds on #468 and retains its comparator and visibility behavior.

### Rendering and memory

- Cache settled marks in shared bitmap pages, with a 32 MiB raw RGBA allocation limit, instead of allocating thousands of Canvas textures. Reuse slots when marks leave; uncached marks still render.
- Cache the settled prefix behind the oldest active mark in 128-pixel tiles. Insertions and evictions invalidate intersecting tiles. Small fade changes are sampled at less than 0.1% opacity increments; larger fades repaint at the drawing cadence.
- Preserve SVG's distinction between multiply blending at full group opacity and isolated compositing for faded groups.
- Stop drawing settled scenes, follow element size and display pixel ratio, and release cache surfaces on unmount. Hidden ticks complete ripples without drawing. Evicting an active mark cannot stall the replay cycle.

The cache limit excludes browser/GPU bookkeeping, the visible Canvas, one full-size residue surface, and the scratch surface.

### Appearance

This is not pixel-identical rendering: edge antialiasing, compositing against the paper background, and sub-0.1% fade precision can differ. Drawing targets 30 fps. There is no reduction in ring count or retained density.

Real Chromium comparisons at identical timestamps cover expanding, settled, faded, and interleaved marks. The maximum sampled flat-region color-channel difference was 2 out of 255. Side-by-side screenshots and the actual installation captures are attached through PR Evidence.

### Performance

Matched production builds at 1920×1080: 4,000 retained marks, six rings each, and ten incoming clicks per second. Measure ten seconds after a 10.5-second warm-up. The SVG reference is the implementation at `8197ff23`.

| Browser metric | SVG | Canvas |
| --- | ---: | ---: |
| Main-thread task time | 9.373 s | 2.172 s |
| JavaScript time, including Canvas drawing calls | 0.570 s | 1.680 s |
| Style recalculation | 2.034 s | 0 s |

Main-thread time fell approximately 77% in this local headless Chromium measurement. JavaScript time increases because Canvas drawing calls are charged there; total main-thread work is the useful comparison. This is not a Raspberry Pi benchmark or a Pi frame-rate guarantee.

### Validation

- 17 focused unit/component tests pass for residue bounds, lifecycle, geometry, shared SVG scheduling, and cleanup.
- `bun run smoke:clicks` passes in real Chromium: scheduling/deduplication, replay residue, settling, resize, eviction, 200 ms fades, zero-width strokes, hidden completion, cache limits, slot reuse, cleanup, and pixel comparisons. The parent playback tests were moved from jsdom to this browser harness so Canvas is not mocked.
- `CLICK_SCREENSHOT_DIR=/tmp/click-appearance bun run smoke:clicks` saves the comparison captures.
- Website type check and an explicit type check of the changed click components pass. Final CI lint/build and extension performance checks pass.
- Production website build passes with Vite's existing large-chunk advisory.
- Both the local production build and the [deployed preview](https://7e27e91a.we-were-online-website.pages.dev/installation/live/?clean=2&screen=clicks), with the real Worker event API, pass cold start, accumulation, resize from 1920×1080 to 1280×720, and reload with no page errors.

No published-package API, starter, manifest permission, or extension release-note change is involved. The website deploys separately. Leave unmerged for review and testing on the installation's Pi 3.
