### PR TITLE
Set touches installation scale to 2×

### DIFF
--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -24,6 +24,7 @@ export type LiveInstallationProfileName =
   (typeof LIVE_INSTALLATION_PROFILE_NAMES)[number];
 
 interface TouchesProfileSettings {
+  scale: number;
   touchRadius: number;
   speed: number;
   showCursors: boolean;
@@ -114,6 +115,7 @@ const CLICK_SETTINGS = {
 } satisfies Partial<MovementSettings>;
 
 const TOUCHES_SETTINGS: TouchesProfileSettings = {
+  scale: 2,
   touchRadius: 20,
   speed: 1,
   showCursors: true,

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -88,6 +88,10 @@ const styles = {
 
 const CursorTouches = () => {
   const profile = useMemo(() => resolveLiveInstallationProfile(), []);
+  const scale = useMemo(() => {
+    const value = Number(new URLSearchParams(window.location.search).get("scale"));
+    return Number.isFinite(value) && value > 0 ? Math.min(value, 4) : 1;
+  }, []);
   useDailyPageReload();
   useInstallationReload({ enabled: profile !== null });
   const chromeHidden = useChromeToggle(true);
@@ -238,7 +242,10 @@ const CursorTouches = () => {
 
   return (
     <div style={{ ...styles.page, background: night ? "#100d13" : "#faf7f2" }}>
-      <div ref={hostRef} style={styles.canvasHost} />
+      <div
+        ref={hostRef}
+        style={{ ...styles.canvasHost, transform: `scale(${scale})` }}
+      />
       {!chromeHidden && (
         <div style={{ ...styles.title, color: night ? "#e8e2d8" : "#3d3833" }}>
           cursor touches

--- a/extension/website/touches/touches.tsx
+++ b/extension/website/touches/touches.tsx
@@ -90,8 +90,10 @@ const CursorTouches = () => {
   const profile = useMemo(() => resolveLiveInstallationProfile(), []);
   const scale = useMemo(() => {
     const value = Number(new URLSearchParams(window.location.search).get("scale"));
-    return Number.isFinite(value) && value > 0 ? Math.min(value, 4) : 1;
-  }, []);
+    return Number.isFinite(value) && value > 0
+      ? Math.min(value, 4)
+      : (profile?.touchesSettings?.scale ?? 1);
+  }, [profile]);
   useDailyPageReload();
   useInstallationReload({ enabled: profile !== null });
   const chromeHidden = useChromeToggle(true);


### PR DESCRIPTION
The touches installation profile defaults to a centered 2× crop, matching the approved screen 5 preview. The scale enlarges the entire canvas, including hands, glows, cursors, and spacing.

Use `/touches/?screen=touches` for the configured default. A `scale` URL parameter overrides it (for example `&scale=1` or `&scale=2.5`, capped at 4). Missing or invalid values use the profile setting; ordinary `/touches/` stays at 1×. Detection radius and playback timing are unaffected.

Validation: six installation profile tests and website TypeScript check passed. Real Chromium checks cover the installation default, explicit 1×/2.5× overrides, invalid input fallback, and the ordinary page default. The actual installation canvas measures 2560×1440 in a 1280×720 viewport. Prior preview verification also covered resizing, and Spencer approved the 2× view. Screenshots are attached in PR evidence.
