### PR TITLE
Play installation cursor followers live

### DIFF
--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -19,6 +19,7 @@ import { useInstallationReload } from "../../shared/hooks/useInstallationReload"
 import { summarizeActiveLocations } from "../../shared/utils/eventUtils";
 import {
   LIVE_INSTALLATION_VISUALIZATIONS,
+  eventsForInstallationScreen,
   parseLiveInstallationScreen,
   resolveLiveInstallationVisualizations,
   showsInstallationPeopleCount,
@@ -146,13 +147,17 @@ const LiveInstallation = () => {
     activeVisualizations,
     screen,
   });
+  const liveScreenEvents = useMemo(
+    () => eventsForInstallationScreen(hybrid.liveEvents, screen),
+    [hybrid.liveEvents, screen],
+  );
   const activity = useMemo(
     () => summarizeActiveLocations(hybrid.liveEvents),
     [hybrid.liveEvents],
   );
   const continuousLiveTrails = profile?.continuousLiveTrails === true;
   const archiveFallback = useCursorArchiveFallback(
-    hybrid.liveEvents,
+    liveScreenEvents,
     continuousLiveTrails,
   );
   const archiveFallbackEvents = useMemo(() => {
@@ -201,7 +206,7 @@ const LiveInstallation = () => {
   return (
     <>
       <MovementCanvas
-        events={continuousLiveTrails ? hybrid.liveEvents : hybrid.events}
+        events={continuousLiveTrails ? liveScreenEvents : hybrid.events}
         loading={hybrid.loading}
         error={hybrid.error}
         fetchEvents={hybrid.refresh}

--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -12,6 +12,7 @@ import {
   retainClickEffectsForActiveTrails,
   type LiveClickEffect,
 } from "./clickEffects";
+import { CinematicCamera, type CinematicConfig, type CameraFrame } from "../utils/cinematicCamera";
 import { pathLength } from "../utils/trailSequence";
 import {
   TrailPath,
@@ -214,6 +215,8 @@ interface KeptTrail {
 interface LiveTrailsProps {
   trailStates: TrailState[];
   frozen?: boolean;
+  cinematic?: CinematicConfig | null;
+  cinematicNextSignal?: number;
   showClickRipples?: boolean;
   soundEngine?: SoundEngine | null;
   /** Called with trail ids once they have fully faded out and been removed, so
@@ -231,6 +234,8 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
   ({
     trailStates,
     frozen = false,
+    cinematic = null,
+    cinematicNextSignal = 0,
     showClickRipples = false,
     soundEngine = null,
     onTrailsRemoved,
@@ -244,6 +249,21 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
       activeClickEffectsRef.current = activeClickEffects;
     }, [activeClickEffects]);
     const svgRef = useRef<SVGSVGElement>(null);
+    const cameraRef = useRef<CinematicCamera | null>(null);
+    const cameraIndicesRef = useRef(new Map<string, number>());
+    const nextCameraIndexRef = useRef(0);
+    useEffect(() => {
+      if (cinematic) {
+        if (cameraRef.current) cameraRef.current.setConfig(cinematic);
+        else cameraRef.current = new CinematicCamera(cinematic);
+      } else {
+        cameraRef.current = null;
+        svgRef.current?.removeAttribute("viewBox");
+      }
+    }, [cinematic]);
+    useEffect(() => {
+      if (cinematicNextSignal > 0) cameraRef.current?.requestNext();
+    }, [cinematicNextSignal]);
     const pathLayerRef = useRef<SVGGElement>(null);
     const animationRef = useRef<number | undefined>(undefined);
     const consecutiveErrorsRef = useRef(0);
@@ -558,6 +578,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         const visibilityByTrail = new Map<string, number>();
 
         const present = new Set<string>();
+        const cameraTrails: CameraFrame["activeTrails"] = [];
 
         for (const entry of entries) {
           const ts = entry.trail;
@@ -645,6 +666,18 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
             !caughtUp &&
             !draw.settled &&
             entry.visibility?.toOpacity !== 0;
+          if (cameraRef.current && activelyTracing) {
+            let index = cameraIndicesRef.current.get(key);
+            if (index === undefined) {
+              index = nextCameraIndexRef.current++;
+              cameraIndicesRef.current.set(key, index);
+            }
+            cameraTrails.push({
+              index,
+              ...result.cursorPosition,
+              progress: result.trailProgress,
+            });
+          }
           if (soundEngine && activelyTracing) {
             let soundTrailIndex = soundTrailIndicesRef.current.get(key);
             if (soundTrailIndex === undefined) {
@@ -725,6 +758,21 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
           }
         }
 
+        const viewBox = cameraRef.current?.tick({
+          screenW: window.innerWidth,
+          screenH: window.innerHeight,
+          nowMs: clockMs,
+          activeTrails: cameraTrails,
+        });
+        if (viewBox) {
+          svgRef.current?.setAttribute(
+            "viewBox",
+            `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`,
+          );
+        }
+        for (const key of cameraIndicesRef.current.keys()) {
+          if (!present.has(key)) cameraIndicesRef.current.delete(key);
+        }
         soundEngine?.tick(clockMs, soundFrames);
 
         // Prune draw tracking for trails that left so the map can't grow.

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1700,6 +1700,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             >
               <AnimatedTrails
                 key={`archive-fallback-${archiveFallback.playbackKey}`}
+                cinematic={cinematicConfig}
+                cinematicNextSignal={cinematicNextSignal}
                 trailStates={archiveFallbackTrailStates}
                 timeRange={archiveFallbackTimeRange}
                 showClickRipples={!showClicks}
@@ -1716,6 +1718,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             <LiveTrails
               key={`live-trails-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
               trailStates={trailStates}
+              cinematic={cinematicConfig}
+              cinematicNextSignal={cinematicNextSignal}
               frozen={paused}
               showClickRipples={!showClicks}
               soundEngine={!soundEnabled ? null : soundEngineReady}

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -19,6 +19,7 @@ import {
   LiveTrails,
   shouldDepartTrail,
 } from "../LiveTrails";
+import { DEFAULT_CINEMATIC_CONFIG } from "../../utils/cinematicCamera";
 import { COMPLETED_OPACITY } from "../trailPrimitives";
 import {
   DEPART_FADE_MS,
@@ -427,5 +428,64 @@ describe("LiveTrails sound", () => {
     container.remove();
     vi.unstubAllGlobals();
     delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
+  });
+});
+
+describe("LiveTrails camera", () => {
+  it("follows an extending trail without restarting and releases the camera when disabled", async () => {
+    const testGlobal = globalThis as typeof globalThis & {
+      IS_REACT_ACT_ENVIRONMENT?: boolean;
+    };
+    testGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+    const frames: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const state = trailState();
+    const cinematic = { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.1 };
+    const render = async (enabled: boolean, frozen = false) => {
+      await act(async () => root.render(React.createElement(LiveTrails, {
+        trailStates: [state],
+        cinematic: enabled ? cinematic : null,
+        settings: DEFAULT_SETTINGS,
+        frozen,
+      })));
+    };
+    try {
+      await render(true);
+      act(() => frames.shift()?.(1000));
+      act(() => frames.shift()?.(1500));
+      const svg = container.querySelector("svg.trails-svg")!;
+      const box = () => svg.getAttribute("viewBox")!.split(" ").map(Number);
+      expect(box()[2]).toBeCloseTo(window.innerWidth * 0.1);
+      const initial = box();
+      act(() => frames.shift()?.(1700));
+      expect(box()[0]).toBeGreaterThan(initial[0]);
+      const beforeGrowth = box();
+      state.trail.points.push({ x: 200, y: 200, ts: 2000 });
+      state.variedPoints.push({ x: 200, y: 200 });
+      state.durationMs = 2000;
+      await render(true);
+      act(() => frames.shift()?.(1700));
+      expect(box()[0]).toBeCloseTo(beforeGrowth[0]);
+      act(() => frames.shift()?.(1900));
+      expect(box()[0]).toBeGreaterThan(beforeGrowth[0]);
+      await render(true, true);
+      const paused = svg.getAttribute("viewBox");
+      act(() => frames.shift()?.(2100));
+      expect(svg.getAttribute("viewBox")).toBe(paused);
+      await render(false);
+      expect(svg.hasAttribute("viewBox")).toBe(false);
+    } finally {
+      await act(async () => root.unmount());
+      container.remove();
+      vi.unstubAllGlobals();
+      delete testGlobal.IS_REACT_ACT_ENVIRONMENT;
+    }
   });
 });

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -54,12 +54,13 @@ describe("live installation profiles", () => {
     }
   });
 
-  it("uses continuous live trails only on the main cursor field", () => {
+  it("uses continuous live trails on the cursor field and every follower", () => {
     expect(LIVE_INSTALLATION_PROFILES.cursors.continuousLiveTrails).toBe(true);
 
     for (const [name, profile] of Object.entries(LIVE_INSTALLATION_PROFILES)) {
-      if (name === "cursors") continue;
-      expect(profile.continuousLiveTrails).not.toBe(true);
+      expect(profile.continuousLiveTrails === true).toBe(
+        name === "cursors" || name.startsWith("follower-"),
+      );
     }
   });
 

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -196,6 +196,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     cinematic: { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.1 },
     visualizations: ["trails"],
     screen: follower(0),
+    continuousLiveTrails: true,
     settings: CURSOR_SETTINGS,
   },
   "follower-b": {
@@ -206,6 +207,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     cinematic: { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.125 },
     visualizations: ["trails"],
     screen: follower(1),
+    continuousLiveTrails: true,
     settings: CURSOR_SETTINGS,
   },
   "follower-c": {
@@ -216,6 +218,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     cinematic: { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.125 },
     visualizations: ["trails"],
     screen: follower(2),
+    continuousLiveTrails: true,
     settings: CURSOR_SETTINGS,
   },
   "follower-d": {
@@ -226,6 +229,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     cinematic: { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.1 },
     visualizations: ["trails"],
     screen: follower(3),
+    continuousLiveTrails: true,
     settings: CURSOR_SETTINGS,
   },
 };


### PR DESCRIPTION
The installation follower screens now render incoming cursor events continuously. They previously replayed finite archive/live chapters, so fresh movement could wait for a chapter boundary even while the main cursor field updated.

All four named follower profiles use the live renderer with their existing participant slots and zoom settings. The renderer feeds its moving draw heads into the existing cinematic camera, preserving subject identity as trails grow and disappear. Archived footage remains the quiet-period fallback and retains the follower camera. Followers remain silent by default.

Validation:
- Reproduced the profile mismatch with a failing regression test, then passed it with the fix.
- All 1,018 extension tests passed, including camera movement, extending a trail without restarting, pause, and disabling the camera.
- Website typecheck and production build passed. Vite reports its existing large-chunk advisory.
- Automated headless Chromium against the built `/installation/live/?screen=...` routes and the real public `/stream` WebSocket: the main field and all four followers received live events; followers had moving viewBoxes at their configured zoom; the main field had no camera transform; follower-a reload returned to live playback. No page errors. Each screen received 610–683 events during its check, including stream frames after connection.
- Deployed Pages preview also passed follower-a live camera movement and reload against the public stream, with no page errors.
- [Screenshots and verification evidence](https://github.com/spencerc99/playhtml/pull/474#issuecomment-5584208918).

[Try follower A](https://72024630.we-were-online-website.pages.dev/installation/live/?screen=follower-a).

This is a website-only fix: no package API, starter, manifest, or extension-release changes. Actual installation-device frame rate and exact synchronization between computers were not measured.
