### PR TITLE
Keep finished live cursor trails for two minutes

### DIFF
--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -50,7 +50,7 @@ const MIN_DRAW_MS_PER_SEGMENT = 32;
 // before removing it, so finished trails persist as a dim backdrop rather than
 // vanishing. After this it depart-fades out. (The maxGroups cap upstream also
 // bounds how many accumulate regardless.)
-const REMOVE_AFTER_DIM_MS = 60_000;
+const REMOVE_AFTER_DIM_MS = 120_000;
 
 export interface LiveTrailDrawState {
   seenAt: number;

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -189,13 +189,14 @@ describe("shouldDepartTrail", () => {
     activeDimmedAt: null,
   };
 
-  it("keeps a settled trail for 60 seconds before departure", () => {
-    expect(shouldDepartTrail(settledDraw, 69_999)).toBe(false);
-    expect(shouldDepartTrail(settledDraw, 70_000)).toBe(true);
+  it("keeps a settled trail for two minutes before departure", () => {
+    expect(shouldDepartTrail(settledDraw, 70_000)).toBe(false);
+    expect(shouldDepartTrail(settledDraw, 129_999)).toBe(false);
+    expect(shouldDepartTrail(settledDraw, 130_000)).toBe(true);
   });
 
   it("does not depart a trail that has resumed", () => {
-    expect(shouldDepartTrail(settledDraw, 70_000, true)).toBe(false);
+    expect(shouldDepartTrail(settledDraw, 130_000, true)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Finished live cursor trails stay dimmed for two minutes before fading out, giving the installation more time to build a dense background of ink. This applies to the main cursor screen and all four live followers.

The 60-group cap, eight-second settling delay, eight-second departure fade, camera behavior, and live drawing timing are unchanged.

Validation:
- Updated the retention boundary regression test; confirmed it failed at the one-minute boundary before the fix.
- All 26 focused live-renderer and accumulation tests passed, including resumed trails and the group cap.
- Website production build passed with the existing large-chunk advisory.
- Headless Chromium loaded the built main and follower-a installation routes with real public stream data. After disconnecting, browser clock advancement confirmed the live trail layer remains 90 seconds after settling and empties after the two-minute hold plus departure fade. No page errors. Screenshots include the usual idle archive fallback; retention assertions specifically target the live layer.
- Screenshots are attached in PR Evidence.

Website-only change; no package release or extension changelog entry required.
