### PR TITLE
Match installation cursor clicks to homepage

### DIFF
--- a/extension/website/portrait/live.tsx
+++ b/extension/website/portrait/live.tsx
@@ -5,6 +5,7 @@ import "../shared/portrait-styles.scss";
 import React, { useState, useEffect, useRef } from "react";
 import ReactDOM from "react-dom/client";
 import { MovementCanvas } from "../shared/components/MovementCanvas";
+import { LIVE_CURSOR_CLICK_SETTINGS } from "../shared/components/clickDefaults";
 import { WordmarkClock } from "../shared/components/WordmarkClock";
 import { DEFAULT_ACTIVE_VISUALIZATIONS } from "../shared/components/registry";
 import { parseFiltersFromUrl, parseVizFromUrl } from "../shared/config";
@@ -15,7 +16,7 @@ import type { FilterChip } from "../shared/utils/eventUtils";
 // Module-scoped so its reference stays stable across the frequent re-renders
 // the live stream triggers (otherwise MovementCanvas reattaches listeners each frame).
 const noOpFetch = () => {};
-const LIVE_SETTINGS_DEFAULTS = { clickMaxRadius: 30 };
+const LIVE_SETTINGS_DEFAULTS = LIVE_CURSOR_CLICK_SETTINGS;
 
 const LivePortrait = () => {
   const { events, connected } = useLiveEvents({ maxEvents: 500 });

--- a/extension/website/shared/components/clickDefaults.ts
+++ b/extension/website/shared/components/clickDefaults.ts
@@ -19,3 +19,8 @@ export const CLICK_DEFAULTS = {
    * cluster timing intact but don't want long pauses. */
   clickMaxGapMs: null as number | null,
 };
+
+export const LIVE_CURSOR_CLICK_SETTINGS = {
+  ...CLICK_DEFAULTS,
+  clickMaxRadius: 30,
+};

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -12,6 +12,8 @@ import {
   LIVE_INSTALLATION_PROFILES,
   resolveLiveInstallationProfile,
 } from "../liveInstallationProfiles";
+import { DEFAULT_SETTINGS } from "../../components/settingsDefaults";
+import { LIVE_CURSOR_CLICK_SETTINGS } from "../../components/clickDefaults";
 
 describe("live installation profiles", () => {
   it("resolves every named machine profile", () => {
@@ -42,7 +44,24 @@ describe("live installation profiles", () => {
       strokeWidth: 6,
       trailOpacity: 0.9,
       maxConcurrentTrails: 24,
+      clickMaxRadius: 30,
     });
+  });
+
+  it("uses the homepage click settings on the cursor field and followers", () => {
+    const cursorProfiles = [
+      LIVE_INSTALLATION_PROFILES.cursors,
+      LIVE_INSTALLATION_PROFILES["follower-a"],
+      LIVE_INSTALLATION_PROFILES["follower-b"],
+      LIVE_INSTALLATION_PROFILES["follower-c"],
+      LIVE_INSTALLATION_PROFILES["follower-d"],
+    ];
+
+    for (const profile of cursorProfiles) {
+      expect({ ...DEFAULT_SETTINGS, ...profile.settings }).toMatchObject(
+        LIVE_CURSOR_CLICK_SETTINGS,
+      );
+    }
   });
 
   it("enables sound only on the main cursor field", () => {

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -3,6 +3,7 @@
 
 import type { LiveInstallationScreenConfig } from "./liveInstallation";
 import type { MovementSettings } from "../components/settingsDefaults";
+import { LIVE_CURSOR_CLICK_SETTINGS } from "../components/clickDefaults";
 import {
   DEFAULT_CINEMATIC_CONFIG,
   type CinematicConfig,
@@ -49,11 +50,11 @@ export interface LiveInstallationProfile {
 }
 
 const CURSOR_SETTINGS = {
+  ...LIVE_CURSOR_CLICK_SETTINGS,
   trailAnimationMode: "natural",
   strokeWidth: 6,
   trailOpacity: 0.9,
   maxConcurrentTrails: 24,
-  clickOpacity: 0.3,
   textboxOpacity: 0.2,
 } satisfies Partial<MovementSettings>;
 

--- a/extension/website/src/App.tsx
+++ b/extension/website/src/App.tsx
@@ -14,7 +14,7 @@ import {
 import { LiveTrails } from "@movement/components/LiveTrails";
 import { LiveIndicator } from "@movement/components/LiveIndicator";
 import { WordmarkClock } from "@movement/components/WordmarkClock";
-import { CLICK_DEFAULTS } from "@movement/components/clickDefaults";
+import { LIVE_CURSOR_CLICK_SETTINGS } from "@movement/components/clickDefaults";
 import { useCursorTrails } from "@movement/hooks/useCursorTrails";
 import { summarizeActiveLocations } from "@movement/utils/eventUtils";
 import { useLiveEvents } from "@movement/hooks/useLiveEvents";
@@ -201,8 +201,7 @@ const ANIMATION_SETTINGS = {
   pointSize: 4,
   trailOpacity: 0.5,
   animationSpeed: 1.0,
-  ...CLICK_DEFAULTS,
-  clickMaxRadius: 30,
+  ...LIVE_CURSOR_CLICK_SETTINGS,
 };
 
 export default function App() {


### PR DESCRIPTION
## Summary

- Share one live-cursor click preset across the homepage, portrait, main installation cursor field, and four followers.
- Match the homepage ripple radius, opacity, ring count, timing, and stroke settings on every installation cursor screen.
- Add regression coverage for the main cursor profile and all follower profiles.

## Why

The installation cursor profiles inherited the global 80 px maximum ripple radius while the homepage used 30 px. They also overrode the homepage's 0.6 opacity with 0.3. This made installation clicks larger and fainter than homepage clicks.

## Verification

- `bunx vitest run --config extension/vitest.config.ts website/shared/utils/__tests__/liveInstallationProfiles.test.ts website/shared/utils/__tests__/shareUrl.test.ts` (11 tests passed)
- `bun run check:extension-website`
- `bun run build` in `extension/website`
- Browser verification on `screen=cursors` and `screen=follower-a`: 30 px maximum radius, 0.6 opacity, 3 rings, 160 ms ring delay, 2,400 ms expansion, 4 px stroke.

## Documentation

No public documentation, package changeset, or starter-template update is needed. This changes website installation rendering only.
