### PR TITLE
Prevent overlapping centered cursors on followers

### DIFF
--- a/extension/website/shared/components/LiveTrails.tsx
+++ b/extension/website/shared/components/LiveTrails.tsx
@@ -215,6 +215,7 @@ interface KeptTrail {
 interface LiveTrailsProps {
   trailStates: TrailState[];
   frozen?: boolean;
+  visible?: boolean;
   cinematic?: CinematicConfig | null;
   cinematicNextSignal?: number;
   showClickRipples?: boolean;
@@ -234,6 +235,7 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
   ({
     trailStates,
     frozen = false,
+    visible = true,
     cinematic = null,
     cinematicNextSignal = 0,
     showClickRipples = false,
@@ -800,7 +802,13 @@ export const LiveTrails: React.FC<LiveTrailsProps> = memo(
         width="100%"
         height="100%"
         preserveAspectRatio="none"
-        style={{ position: "absolute", top: 0, left: 0, pointerEvents: "none" }}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          pointerEvents: "none",
+          visibility: visible ? "visible" : "hidden",
+        }}
       >
         {showClickRipples &&
           activeClickEffects.map((effect) => (

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -461,6 +461,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     if (!isFollower || cinematic.mode !== "follow") return cinematic;
     return { ...cinematic, pickSubject };
   }, [cinematic, isFollower, pickSubject]);
+  // Each follow layer centers its own cursor, so only one may be visible.
+  const followsCursor = cinematicConfig?.mode === "follow";
 
   /** When set, only events whose timestamp falls in [start, end) are passed
    * downstream to the visualization hooks. Used by the Hotspots dev tool to
@@ -1693,9 +1695,16 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
                 position: "absolute",
                 inset: 0,
                 zIndex: 2,
-                opacity: archiveFallback.visible ? 1 : 0,
+                opacity: followsCursor
+                  ? 1
+                  : archiveFallback.visible ? 1 : 0,
+                visibility: followsCursor && !archiveFallback.visible
+                  ? "hidden"
+                  : "visible",
                 pointerEvents: "none",
-                transition: `opacity ${archiveFallback.fadeMs}ms ease-in-out`,
+                transition: followsCursor
+                  ? undefined
+                  : `opacity ${archiveFallback.fadeMs}ms ease-in-out`,
               }}
             >
               <AnimatedTrails
@@ -1718,6 +1727,8 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
             <LiveTrails
               key={`live-trails-${filtersKey((settings.filters as FilterChip[] | undefined) ?? [])}`}
               trailStates={trailStates}
+              visible={!(followsCursor && archiveFallback?.visible &&
+                archiveFallbackTrailStates.length > 0)}
               cinematic={cinematicConfig}
               cinematicNextSignal={cinematicNextSignal}
               frozen={paused}

--- a/extension/website/shared/components/__tests__/LiveTrails.test.ts
+++ b/extension/website/shared/components/__tests__/LiveTrails.test.ts
@@ -448,12 +448,13 @@ describe("LiveTrails camera", () => {
     const root = createRoot(container);
     const state = trailState();
     const cinematic = { ...DEFAULT_CINEMATIC_CONFIG, zoom: 0.1 };
-    const render = async (enabled: boolean, frozen = false) => {
+    const render = async (enabled: boolean, frozen = false, visible = true) => {
       await act(async () => root.render(React.createElement(LiveTrails, {
         trailStates: [state],
         cinematic: enabled ? cinematic : null,
         settings: DEFAULT_SETTINGS,
         frozen,
+        visible,
       })));
     };
     try {
@@ -475,6 +476,14 @@ describe("LiveTrails camera", () => {
       expect(box()[0]).toBeCloseTo(beforeGrowth[0]);
       act(() => frames.shift()?.(1900));
       expect(box()[0]).toBeGreaterThan(beforeGrowth[0]);
+      await render(true, false, false);
+      expect(svg.style.visibility).toBe("hidden");
+      const hiddenPosition = box()[0];
+      act(() => frames.shift()?.(2000));
+      expect(box()[0]).toBeGreaterThan(hiddenPosition);
+      await render(true);
+      expect(svg.style.visibility).toBe("visible");
+      expect(box()[0]).toBeGreaterThan(hiddenPosition);
       await render(true, true);
       const paused = svg.getAttribute("viewBox");
       act(() => frames.shift()?.(2100));


### PR DESCRIPTION
Follower screens show one playback layer at a time. During a quiet period, the archive fallback could appear while a live trail was still drawing; each layer's independent camera centered its own cursor, producing two overlapping cursors at the screen center.

Follow-mode playback switches visibility between archive and live layers. The live renderer stays mounted and continues advancing while hidden, preserving trail history and camera position. The main field retains its archive fade and layered presentation. This fix is independent of the two-minute retention PR #475.

Validation:
- Reproduced with the built installation page, real public stream data, and headless Chromium: both layers had visible cursor hotspots at (640, 400) in a 1280×800 viewport.
- Repeated the quiet-period transition after the fix, then reconnected to the stream: asserted at most one visible layer and centered cursor during fallback, and exactly one visible layer on return to live playback.
- Component test confirms a hidden live camera keeps advancing and reappears without restarting.
- All 1,018 extension tests passed; website typecheck and production build passed with the existing large-chunk advisory.
- Screenshots attached in PR Evidence.

Website-only fix; no package API, extension manifest, release-note, or starter changes.
