### PR TITLE
Stop installation cursor trails restarting on data updates

### DIFF
--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -13,6 +13,7 @@ import {
   parseTimeOfDayFromUrl,
   parseVizFromUrl,
 } from "../../shared/config";
+import { useCursorArchiveEvents } from "../../shared/hooks/useCursorArchiveEvents";
 import { useHybridInstallationEvents } from "../../shared/hooks/useHybridInstallationEvents";
 import { useDailyPageReload } from "../../shared/hooks/useDailyPageReload";
 import { useInstallationReload } from "../../shared/hooks/useInstallationReload";
@@ -160,10 +161,10 @@ const LiveInstallation = () => {
     liveScreenEvents,
     continuousLiveTrails,
   );
-  const archiveFallbackEvents = useMemo(() => {
-    const liveIds = new Set(hybrid.liveEvents.map((event) => event.id));
-    return hybrid.archiveEvents.filter((event) => !liveIds.has(event.id));
-  }, [hybrid.archiveEvents, hybrid.liveEvents]);
+  const archiveFallbackEvents = useCursorArchiveEvents(
+    hybrid.archiveEvents,
+    hybrid.liveEvents,
+  );
   const previousFallbackMountedRef = useRef(archiveFallback.mounted);
 
   useEffect(() => {

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1238,20 +1238,23 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     enabled:
       live &&
       archiveFallback !== undefined &&
-      archiveFallback.visible &&
       archiveFallbackTrailStates.length > 0,
     cycleKey: archiveFallback?.playbackKey ?? "archive-fallback",
     durationMs: archiveFallbackTimeRange.duration,
     animationSpeed: settings.animationSpeed,
-    frozen: paused,
-    onComplete: archiveFallback?.onPlaybackCycleComplete,
+    frozen: paused || !archiveFallback?.visible,
+    onComplete: () =>
+      archiveFallback?.visible
+        ? archiveFallback.onPlaybackCycleComplete()
+        : false,
   });
 
   const getArchiveFallbackFrameMs = useCallback(
-    () => Math.min(
-      getArchiveFallbackElapsedMs(),
-      Math.max(0, archiveFallbackTimeRange.duration - 1),
-    ),
+    () =>
+      Math.min(
+        getArchiveFallbackElapsedMs(),
+        Math.max(0, archiveFallbackTimeRange.duration - 1),
+      ),
     [getArchiveFallbackElapsedMs, archiveFallbackTimeRange.duration],
   );
 

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -1006,6 +1006,14 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     viewportSize,
     archiveFallbackSettings,
   );
+  const renderedArchiveFallbackTrailStates = useArchiveTrailHandoff(
+    archiveFallbackTrailStates,
+    archiveFallback?.playbackKey ?? "archive-fallback",
+    playbackContextKey,
+    archiveFallback !== undefined,
+    settings.maxConcurrentTrails * 2,
+    COMPLETION_FADE_MS,
+  );
   const archiveFallbackTimeRange = useMemo(
     () => ({
       min: archiveFallbackTimeBounds.min,
@@ -1226,7 +1234,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     frozen: paused,
     onComplete: onPlaybackCycleComplete,
   });
-  usePlaybackCycle({
+  const getArchiveFallbackElapsedMs = usePlaybackCycle({
     enabled:
       live &&
       archiveFallback !== undefined &&
@@ -1238,6 +1246,14 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     frozen: paused,
     onComplete: archiveFallback?.onPlaybackCycleComplete,
   });
+
+  const getArchiveFallbackFrameMs = useCallback(
+    () => Math.min(
+      getArchiveFallbackElapsedMs(),
+      Math.max(0, archiveFallbackTimeRange.duration - 1),
+    ),
+    [getArchiveFallbackElapsedMs, archiveFallbackTimeRange.duration],
+  );
 
   // For viewports whose URL has no captured title (no navigation event), ask
   // the worker's /page-meta endpoint to resolve title + favicon live (oEmbed
@@ -1699,10 +1715,10 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
               }}
             >
               <AnimatedTrails
-                key={`archive-fallback-${archiveFallback.playbackKey}`}
                 cinematic={cinematicConfig}
                 cinematicNextSignal={cinematicNextSignal}
-                trailStates={archiveFallbackTrailStates}
+                trailStates={renderedArchiveFallbackTrailStates}
+                getInstallationElapsedMs={getArchiveFallbackFrameMs}
                 timeRange={archiveFallbackTimeRange}
                 showClickRipples={!showClicks}
                 windowSize={settings.maxConcurrentTrails * 2}

--- a/extension/website/shared/hooks/__tests__/useAccumulatedEvents.test.tsx
+++ b/extension/website/shared/hooks/__tests__/useAccumulatedEvents.test.tsx
@@ -1,0 +1,74 @@
+// ABOUTME: Exercises live trail retirement across React renders and incoming event windows.
+// ABOUTME: Ensures unrelated renders cannot discard pending trail evictions.
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it } from "vitest";
+import { useAccumulatedEvents } from "../useAccumulatedEvents";
+import type { CollectionEvent } from "../../types";
+
+it("retains pending evictions until an accumulation pass consumes them", async () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  const evictIdsRef = { current: new Set<string>() };
+  const events = [
+    {
+      id: "a",
+      ts: 100,
+      type: "cursor",
+      data: { event: "move", x: 0, y: 0 },
+      meta: { pid: "p", sid: "s", url: "u", vw: 1000, vh: 800, tz: "UTC" },
+    },
+  ] as CollectionEvent[];
+  let rendered: CollectionEvent[] = [];
+  function Probe({ incoming }: { incoming: CollectionEvent[] }) {
+    rendered = useAccumulatedEvents(incoming, { evictIdsRef });
+    return null;
+  }
+  try {
+    await act(async () => root.render(<Probe incoming={events} />));
+    evictIdsRef.current.add("p|u");
+    await act(async () => root.render(<Probe incoming={events} />));
+    expect(evictIdsRef.current.has("p|u")).toBe(true);
+    await act(async () => root.render(<Probe incoming={[...events]} />));
+    expect(rendered).toEqual([]);
+    expect(evictIdsRef.current.size).toBe(0);
+    await act(async () => root.render(<Probe incoming={[...events]} />));
+    expect(rendered).toEqual([]);
+  } finally {
+    await act(async () => root.unmount());
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  }
+});
+
+it("does not replay density-evicted history when its participant moves again", async () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  const root = createRoot(document.createElement("div"));
+  const event = (id: string, pid: string, ts: number): CollectionEvent => ({
+    id,
+    ts,
+    type: "cursor",
+    data: { event: "move", x: 0, y: 0 },
+    meta: { pid, sid: "s", url: "u", vw: 1000, vh: 800, tz: "UTC" },
+  });
+  const history = [event("a", "p", 100), event("b", "p", 200)];
+  let rendered: CollectionEvent[] = [];
+  function Probe({ incoming }: { incoming: CollectionEvent[] }) {
+    rendered = useAccumulatedEvents(incoming, { maxGroups: 1 });
+    return null;
+  }
+  try {
+    await act(async () => root.render(<Probe incoming={history} />));
+    const crowded = [...history, event("c", "q", 300)];
+    await act(async () => root.render(<Probe incoming={crowded} />));
+    expect(rendered.map((item) => item.id)).toEqual(["c"]);
+    const resumed = [...crowded, event("d", "p", 400)];
+    await act(async () => root.render(<Probe incoming={resumed} />));
+    expect(rendered.map((item) => item.id)).toEqual(["d"]);
+  } finally {
+    await act(async () => root.unmount());
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  }
+});

--- a/extension/website/shared/hooks/__tests__/useCursorArchiveEvents.test.tsx
+++ b/extension/website/shared/hooks/__tests__/useCursorArchiveEvents.test.tsx
@@ -1,0 +1,80 @@
+// ABOUTME: Verifies cursor archive batches remain intact throughout live updates.
+// ABOUTME: Covers field and follower footage with overlapping stream events.
+// @vitest-environment jsdom
+
+import React, { act, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it } from "vitest";
+import { useCursorArchiveEvents } from "../useCursorArchiveEvents";
+import {
+  eventsForInstallationScreen,
+  participantInstallationSlot,
+} from "../../utils/liveInstallation";
+import { LIVE_INSTALLATION_PROFILES } from "../../utils/liveInstallationProfiles";
+import type { CollectionEvent } from "../../types";
+
+it.each([
+  "cursors",
+  "follower-a",
+  "follower-b",
+  "follower-c",
+  "follower-d",
+] as const)(
+  "preserves %s footage until the archive batch changes",
+  async (profileName) => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    const root = createRoot(document.createElement("div"));
+    const screen = LIVE_INSTALLATION_PROFILES[profileName].screen!;
+    let participant = 0;
+    while (
+      participantInstallationSlot(`p${participant}`, screen.slots) !==
+      screen.slot
+    )
+      participant++;
+    const pid = `p${participant}`;
+    const event = (id: string): CollectionEvent => ({
+      id,
+      ts: 100,
+      type: "cursor",
+      data: { event: "move", x: 0, y: 0 },
+      meta: { pid, sid: "s", url: "u", vw: 1000, vh: 800, tz: "UTC" },
+    });
+    const archive = [event("a"), event("b"), event("c")];
+    let rendered: CollectionEvent[] = [];
+    function Probe({
+      footage,
+      live,
+    }: {
+      footage: CollectionEvent[];
+      live: CollectionEvent[];
+    }) {
+      const filtered = useMemo(
+        () => eventsForInstallationScreen(footage, screen),
+        [footage],
+      );
+      rendered = useCursorArchiveEvents(filtered, live);
+      return null;
+    }
+    try {
+      await act(async () =>
+        root.render(<Probe footage={archive} live={[archive[0]]} />),
+      );
+      expect(rendered.map((event) => event.id)).toEqual(["b", "c"]);
+      const initial = rendered;
+      await act(async () =>
+        root.render(<Probe footage={archive} live={[...archive]} />),
+      );
+      expect(rendered).toBe(initial);
+      await act(async () => root.render(<Probe footage={archive} live={[]} />));
+      expect(rendered).toBe(initial);
+      const next = [...archive, event("d")];
+      await act(async () =>
+        root.render(<Probe footage={next} live={archive} />),
+      );
+      expect(rendered.map((event) => event.id)).toEqual(["d"]);
+    } finally {
+      await act(async () => root.unmount());
+      Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+    }
+  },
+);

--- a/extension/website/shared/hooks/__tests__/usePlaybackCycle.test.tsx
+++ b/extension/website/shared/hooks/__tests__/usePlaybackCycle.test.tsx
@@ -1,0 +1,46 @@
+// ABOUTME: Exercises finite playback clocks through completion and visibility fades.
+// ABOUTME: Keeps the current animation frame available while playback is paused.
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, it, vi } from "vitest";
+import { usePlaybackCycle } from "../usePlaybackCycle";
+
+it("holds the current frame while fading and waits at the end for footage", async () => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  vi.useFakeTimers({
+    toFake: ["performance", "requestAnimationFrame", "cancelAnimationFrame"],
+  });
+  const root = createRoot(document.createElement("div"));
+  let elapsed = () => 0;
+  function Probe({ frozen }: { frozen: boolean }) {
+    elapsed = usePlaybackCycle({
+      enabled: true,
+      cycleKey: "batch",
+      durationMs: 1000,
+      animationSpeed: 1,
+      frozen,
+      onComplete: () => false,
+    });
+    return null;
+  }
+  try {
+    await act(async () => root.render(<Probe frozen={false} />));
+    act(() => vi.advanceTimersByTime(500));
+    const fadingFrame = elapsed();
+    expect(fadingFrame).toBeGreaterThan(0);
+    await act(async () => root.render(<Probe frozen={true} />));
+    act(() => vi.advanceTimersByTime(3000));
+    expect(elapsed()).toBe(fadingFrame);
+    await act(async () => root.render(<Probe frozen={false} />));
+    act(() => vi.advanceTimersByTime(3000));
+    expect(elapsed()).toBe(1000);
+    act(() => vi.advanceTimersByTime(3000));
+    expect(elapsed()).toBe(1000);
+  } finally {
+    await act(async () => root.unmount());
+    vi.useRealTimers();
+    Reflect.deleteProperty(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+  }
+});

--- a/extension/website/shared/hooks/useAccumulatedEvents.ts
+++ b/extension/website/shared/hooks/useAccumulatedEvents.ts
@@ -196,7 +196,7 @@ export function useAccumulatedEvents(
   const finishedEventIdsRef = useRef<Set<string>>(new Set());
 
   const flat = useMemo(() => {
-    if (!enabled) return events;
+    if (!enabled) return { events, evictions: new Set<string>() };
 
     // Apply any pending evictions reported by the animator. We READ the set here
     // (and clear it in the effect below) rather than clearing it inside the memo:
@@ -205,7 +205,7 @@ export function useAccumulatedEvents(
     // (deleting an already-deleted group is a no-op).
     const evict =
       evictIdsRef && evictIdsRef.current.size > 0
-        ? evictIdsRef.current
+        ? new Set(evictIdsRef.current)
         : undefined;
 
     finishedEventIdsRef.current = collectFinishedEventIds(
@@ -223,6 +223,13 @@ export function useAccumulatedEvents(
       finishedEventIdsRef.current,
     );
 
+    // Density-evicted history remains retired while it is in the live window.
+    for (const event of events) {
+      if (!groupsRef.current.has(groupKey(event))) {
+        finishedEventIdsRef.current.add(event.id);
+      }
+    }
+
     // Flatten groups into a single ts-ordered array. The total-event budget is
     // enforced inside accumulateEvents by evicting whole oldest groups, so no
     // mid-trail truncation happens here.
@@ -231,16 +238,16 @@ export function useAccumulatedEvents(
       result.push(...group.events);
     }
     result.sort((a, b) => a.ts - b.ts);
-    return result;
+    return { events: result, evictions: evict };
   }, [events, maxGroups, enabled, evictIdsRef]);
 
   // Clear the applied evictions after commit (not inside the memo, so a
   // double-invoked memo can't drop them).
   useEffect(() => {
-    if (evictIdsRef && evictIdsRef.current.size > 0) {
-      evictIdsRef.current = new Set();
+    if (evictIdsRef && flat.evictions) {
+      for (const id of flat.evictions) evictIdsRef.current.delete(id);
     }
-  });
+  }, [flat, evictIdsRef]);
 
-  return flat;
+  return flat.events;
 }

--- a/extension/website/shared/hooks/useCursorArchiveEvents.ts
+++ b/extension/website/shared/hooks/useCursorArchiveEvents.ts
@@ -1,0 +1,17 @@
+// ABOUTME: Captures archive cursor footage without events already present in the live field.
+// ABOUTME: Keeps each archive batch intact while subsequent live events arrive.
+
+import { useMemo, useRef } from "react";
+import type { CollectionEvent } from "../types";
+
+export function useCursorArchiveEvents(
+  archiveEvents: CollectionEvent[],
+  liveEvents: CollectionEvent[],
+): CollectionEvent[] {
+  const liveEventsRef = useRef(liveEvents);
+  liveEventsRef.current = liveEvents;
+  return useMemo(() => {
+    const liveIds = new Set(liveEventsRef.current.map((event) => event.id));
+    return archiveEvents.filter((event) => !liveIds.has(event.id));
+  }, [archiveEvents]);
+}

--- a/extension/website/shared/hooks/useHybridInstallationEvents.ts
+++ b/extension/website/shared/hooks/useHybridInstallationEvents.ts
@@ -249,6 +249,10 @@ export function useHybridInstallationEvents(params: {
     typingOnly,
   ]);
 
+  const archiveEvents = useMemo(
+    () => eventsForInstallationScreen(archive.events, screen),
+    [archive.events, screen],
+  );
   const chapterEvents = source === "live" ? liveChapter : archive.events;
   const hybridEvents = useMemo(
     () => eventsForInstallationScreen(chapterEvents, screen),
@@ -262,7 +266,7 @@ export function useHybridInstallationEvents(params: {
 
   return {
     events,
-    archiveEvents: eventsForInstallationScreen(archive.events, screen),
+    archiveEvents,
     liveEvents: live.events,
     connected: live.connected,
     loading: archive.loading,


### PR DESCRIPTION
Cursor trails on `/installation/live/?screen=cursors` and all four follower screens can restart when data updates arrive, replay retired buffered events, or clear at archive boundaries.

This keeps archive footage stable for its batch, memoizes follower archive selection, consumes only evictions that were actually applied, and retires density-evicted event IDs while they remain buffered. Archive fallback playback carries completed trails into the next batch and holds its current frame through fades or while waiting for footage.

Validation:
- 55 targeted tests pass, including React regressions for lost retirement requests, density-driven replay, live/archive overlap for all five profiles, and playback during fades and end-of-batch waits. The retirement and density tests both failed before their fixes.
- Website TypeScript check and production build pass. Vite reports its large-chunk advisory.
- Checked the built installation routes in the Codex browser against the real Worker stream: cursor field plus follower-a/b/c/d render trails; followers use slots 0/1/2/3 and their zoomed camera views. No browser errors observed. Cursor and follower screenshots are attached in PR evidence.

Website-only change: no package API, extension release, or persisted data changes. Production deployment has not been changed.
