### PR TITLE
Keep scrolling and typing installations continuously populated

### DIFF
--- a/extension/website/installation/live/live.tsx
+++ b/extension/website/installation/live/live.tsx
@@ -27,6 +27,7 @@ import {
 import { resolveLiveInstallationProfile } from "../../shared/utils/liveInstallationProfiles";
 
 const LIVE_INSTALLATION_SETTINGS_DEFAULTS = {
+  randomizeColors: false,
   scrollSpeed: 1,
   backgroundOpacity: 0.8,
   maxConcurrentScrolls: 30,
@@ -227,6 +228,7 @@ const LiveInstallation = () => {
           continuousLiveTrails ? "continuous-live" : hybrid.playbackKey
         }
         playbackSource={continuousLiveTrails ? "live" : hybrid.source}
+        installationRecordings={hybrid.continuousRecordings}
         playbackContextKey={
           continuousLiveTrails ? "continuous-live" : hybrid.playbackContextKey
         }

--- a/extension/website/shared/components/AnimatedScrollViewports.tsx
+++ b/extension/website/shared/components/AnimatedScrollViewports.tsx
@@ -18,6 +18,12 @@ import {
   colorizeLuminosity,
 } from "../utils/colorStyle";
 import { getViewportTitleText } from "../utils/titleText";
+import {
+  InstallationPlaybackQueue,
+  INSTALLATION_ARRIVAL_MS,
+  INSTALLATION_FADE_MS,
+  INSTALLATION_SCROLL_HOLD_MS,
+} from "../utils/installationPlaybackQueue";
 import { PagePreview } from "./PagePreview";
 import { useDebugHover } from "./DebugHover";
 
@@ -36,6 +42,7 @@ interface AnimatedScrollViewportsProps {
   canvasSize: { width: number; height: number };
   repeatAnimations?: boolean;
   onAnimationsComplete?: () => boolean;
+  installationLiveEventIds?: ReadonlySet<string>;
   settings: {
     scrollSpeed: number;
     backgroundOpacity: number;
@@ -234,6 +241,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
     canvasSize,
     repeatAnimations = true,
     onAnimationsComplete,
+    installationLiveEventIds,
     settings,
     urlMetadata,
   }) => {
@@ -252,6 +260,10 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
     const lastFrameUpdateRef = useRef(0);
     const startTimeRef = useRef<number | null>(null);
     const completionSignaledRef = useRef(false);
+    const continuous = installationLiveEventIds !== undefined;
+    const continuousQueue = useRef(new InstallationPlaybackQueue<ScrollAnimation>()).current;
+    const fadeInMs = continuous ? INSTALLATION_FADE_MS : FADE_IN_DURATION;
+    const fadeOutMs = continuous ? INSTALLATION_FADE_MS : FADE_OUT_DURATION;
 
     // Settings ref to avoid re-renders
     const settingsRef = useRef(settings);
@@ -276,6 +288,13 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
 
     // Initialize animation queue when animations change
     useEffect(() => {
+      if (continuous) {
+        continuousQueue.update(animations.map((animation) => {
+          if (!animation.eventId) throw new Error("Installation scroll recording requires an event id");
+          return { id: animation.eventId, live: installationLiveEventIds.has(animation.eventId), value: animation };
+        }));
+        return;
+      }
       if (animations.length > 0) {
         // Shuffle the animations for variety
         const shuffled = [...animations];
@@ -290,10 +309,13 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           `[Scroll Dynamic] Initialized queue with ${shuffled.length} animations`,
         );
       }
-    }, [animations]);
+    }, [animations, continuous, continuousQueue, installationLiveEventIds]);
 
     // Get the next animation from the queue
     const getNextAnimation = useCallback((): ScrollAnimation | null => {
+      if (continuous) {
+        return continuousQueue.take(new Set(activeViewportsRef.current.map((viewport) => viewport.animation.eventId!)));
+      }
       const queue = animationQueueRef.current;
       const nextIndex = getScrollQueueIndex(
         queueIndexRef.current,
@@ -305,7 +327,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
       const animation = queue[nextIndex];
       queueIndexRef.current = nextIndex + 1;
       return animation;
-    }, [repeatAnimations]);
+    }, [repeatAnimations, continuous, continuousQueue]);
 
     // Try to add a new viewport to an available space
     const tryAddViewport = useCallback(
@@ -315,10 +337,10 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           (v) => v.phase !== "fade-out",
         );
 
-        // Count non-fading-out viewports
-        const activeCount = visibleViewports.length;
+        // Every visible window counts toward the installation cap.
+        const activeCount = continuous ? activeViewportsRef.current.length : visibleViewports.length;
 
-        if (activeCount >= maxConcurrentScrolls) {
+        if (activeCount >= (continuous ? Math.min(30, maxConcurrentScrolls) : maxConcurrentScrolls)) {
           return; // At capacity
         }
 
@@ -430,7 +452,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           rect: { ...position, width: size.width, height: size.height },
           phase: "fade-in",
           phaseStartTime: currentTime,
-          animationStartTime: currentTime + FADE_IN_DURATION,
+          animationStartTime: currentTime + fadeInMs,
           durationMs: animation.endTime - animation.startTime,
           backgroundSeed: seed,
         };
@@ -442,7 +464,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           } active`,
         );
       },
-      [canvasSize, commitActiveViewports, getNextAnimation],
+      [canvasSize, commitActiveViewports, getNextAnimation, continuous, fadeInMs],
     );
 
     // Update viewport phases based on time
@@ -456,7 +478,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           // Check phase transitions
           if (viewport.phase === "fade-in") {
             const fadeInElapsed = currentTime - viewport.phaseStartTime;
-            if (fadeInElapsed >= FADE_IN_DURATION) {
+            if (fadeInElapsed >= fadeInMs) {
               changed = true;
               return {
                 ...viewport,
@@ -466,7 +488,9 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
             }
           } else if (viewport.phase === "animating") {
             const animElapsed = currentTime - viewport.animationStartTime;
-            if (animElapsed >= viewport.durationMs + FADE_OUT_DELAY) {
+            if (animElapsed >= (continuous
+              ? viewport.durationMs / settingsRef.current.scrollSpeed + INSTALLATION_SCROLL_HOLD_MS
+              : viewport.durationMs + FADE_OUT_DELAY)) {
               changed = true;
               return {
                 ...viewport,
@@ -482,7 +506,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
         const filtered = updated.filter((viewport) => {
           if (viewport.phase === "fade-out") {
             const fadeOutElapsed = currentTime - viewport.phaseStartTime;
-            if (fadeOutElapsed >= FADE_OUT_DURATION) {
+            if (fadeOutElapsed >= fadeOutMs) {
               changed = true;
               console.log(`[Scroll Dynamic] Removed viewport ${viewport.id}`);
               return false;
@@ -495,12 +519,12 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
           commitActiveViewports(() => filtered);
         }
       },
-      [commitActiveViewports],
+      [commitActiveViewports, continuous, fadeInMs, fadeOutMs],
     );
 
     // Main animation loop
     useEffect(() => {
-      if (animations.length === 0 || canvasSize.width === 0) return;
+      if ((!continuous && animations.length === 0) || canvasSize.width === 0) return;
 
       const animate = (timestamp: number) => {
         if (startTimeRef.current === null) {
@@ -513,10 +537,11 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
         updateViewports(currentTime);
 
         // Periodically try to fill empty spaces
-        if (currentTime - lastFillCheckRef.current >= FILL_CHECK_INTERVAL) {
+        if (currentTime - lastFillCheckRef.current >= (continuous ? INSTALLATION_ARRIVAL_MS : FILL_CHECK_INTERVAL)) {
           lastFillCheckRef.current = currentTime;
           tryAddViewport(currentTime);
           if (
+            !continuous &&
             !repeatAnimations &&
             queueIndexRef.current >= animationQueueRef.current.length &&
             activeViewportsRef.current.length === 0 &&
@@ -545,6 +570,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
       };
     }, [
       animations.length,
+      continuous,
       clock,
       canvasSize.width,
       onAnimationsComplete,
@@ -553,7 +579,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
       tryAddViewport,
     ]);
 
-    if (animations.length === 0) {
+    if (!continuous && animations.length === 0) {
       return null;
     }
 
@@ -616,7 +642,7 @@ export const AnimatedScrollViewports: React.FC<AnimatedScrollViewportsProps> =
               key={viewport.id}
               viewport={viewport}
               clock={clock}
-              settings={settings}
+              settings={{ ...settings, installationPlayback: continuous }}
               livePageTitle={live?.title}
               liveFaviconUrl={live?.favicon}
             />
@@ -803,6 +829,7 @@ export function getViewportFrame(
   timeline: ViewportAnimationTimeline,
   currentTime: number,
   scrollSpeed: number,
+  installationPlayback = false,
 ) {
   const {
     animation,
@@ -817,13 +844,13 @@ export function getViewportFrame(
   if (phase === "fade-in") {
     const fadeProgress = Math.min(
       1,
-      (currentTime - phaseStartTime) / FADE_IN_DURATION,
+      (currentTime - phaseStartTime) / (installationPlayback ? INSTALLATION_FADE_MS : FADE_IN_DURATION),
     );
     opacity = fadeProgress;
   } else if (phase === "fade-out") {
     const fadeProgress = Math.min(
       1,
-      (currentTime - phaseStartTime) / FADE_OUT_DURATION,
+      (currentTime - phaseStartTime) / (installationPlayback ? INSTALLATION_FADE_MS : FADE_OUT_DURATION),
     );
     opacity = 1 - fadeProgress;
   }
@@ -952,6 +979,7 @@ const DynamicViewportRect = memo(
     clock: ViewportClock;
     settings: {
       scrollSpeed: number;
+      installationPlayback?: boolean;
       backgroundOpacity: number;
       randomizeColors?: boolean;
       showPagePreview?: boolean;
@@ -977,6 +1005,7 @@ const DynamicViewportRect = memo(
       timeline,
       clock.currentTime,
       settings.scrollSpeed,
+      settings.installationPlayback,
     );
     const {
       opacity,
@@ -1008,6 +1037,7 @@ const DynamicViewportRect = memo(
           timeline,
           currentTime,
           settings.scrollSpeed,
+          settings.installationPlayback,
         );
         // Geometry and iframe previews need React; scroll and fade only change SVG attributes.
         if (
@@ -1613,6 +1643,8 @@ const DynamicViewportRect = memo(
     return (
       <g
         ref={groupRef}
+        data-scroll-recording={animation.eventId}
+        data-scroll-phase={viewport.phase}
         opacity={opacity}
         style={{
           transition: "opacity 0.1s ease-out",

--- a/extension/website/shared/components/AnimatedTyping.tsx
+++ b/extension/website/shared/components/AnimatedTyping.tsx
@@ -4,6 +4,12 @@ import React, { useState, useEffect, useRef, memo, useMemo } from "react";
 import { TypingState, TypingAction, ActiveTyping } from "../types";
 import { useDebugHover } from "./DebugHover";
 import { redactWithLegibility } from "@extension/utils/keyboardRedaction";
+import {
+  InstallationPlaybackQueue,
+  INSTALLATION_ARRIVAL_MS,
+  INSTALLATION_FADE_MS,
+  INSTALLATION_TYPING_HOLD_MS,
+} from "../utils/installationPlaybackQueue";
 import { RISO_COLORS } from "../utils/eventUtils";
 import {
   isMonochromeStyle,
@@ -783,3 +789,130 @@ export const AnimatedTyping: React.FC<AnimatedTypingProps> = memo(
     );
   },
 );
+
+interface VisibleTypingRecording {
+  track: TypingTrack;
+  startedAt: number;
+  speed: number;
+  durationMs: number;
+}
+
+export function ContinuousTyping({
+  typingStates,
+  settings,
+  liveEventIds,
+}: {
+  typingStates: TypingState[];
+  settings: TypingSettings;
+  liveEventIds: ReadonlySet<string>;
+}) {
+  const queue = useRef(new InstallationPlaybackQueue<TypingTrack>()).current;
+  const visible = useRef<VisibleTypingRecording[]>([]);
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const [frame, setFrame] = useState({
+    now: 0,
+    recordings: [] as VisibleTypingRecording[],
+  });
+
+  useEffect(() => {
+    const schedule = buildTypingPlaybackSchedule(typingStates);
+    queue.update(
+      schedule.tracks.map((track) => {
+        const id = track.state.animation.event.id;
+        return { id, live: liveEventIds.has(id), value: { ...track, id } };
+      }),
+    );
+  }, [queue, typingStates, liveEventIds]);
+
+  useEffect(() => {
+    let frameId = 0;
+    let lastArrival = -Infinity;
+    let lastFrame = -Infinity;
+    const animate = (now: number) => {
+      if (now - lastFrame >= 1000 / 30) {
+        lastFrame = now;
+        visible.current = visible.current.filter(
+          (recording) =>
+            now - recording.startedAt <
+            INSTALLATION_FADE_MS +
+              recording.durationMs +
+              INSTALLATION_TYPING_HOLD_MS +
+              INSTALLATION_FADE_MS,
+        );
+        if (
+          visible.current.length <
+            Math.min(30, settingsRef.current.maxConcurrentTyping) &&
+          now - lastArrival >= INSTALLATION_ARRIVAL_MS
+        ) {
+          const track = queue.take(
+            new Set(visible.current.map((recording) => recording.track.id)),
+          );
+          if (track) {
+            const speed =
+              settingsRef.current.keyboardAnimationSpeed *
+              settingsRef.current.animationSpeed;
+            visible.current.push({
+              track,
+              startedAt: now,
+              speed,
+              durationMs: track.state.durationMs / speed,
+            });
+            lastArrival = now;
+          }
+        }
+        setFrame({ now, recordings: [...visible.current] });
+      }
+      frameId = requestAnimationFrame(animate);
+    };
+    frameId = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frameId);
+  }, [queue]);
+
+  return (
+    <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+      {frame.recordings.map(({ track, startedAt, speed, durationMs }) => {
+        const elapsed = frame.now - startedAt;
+        const typingElapsed = Math.max(0, elapsed - INSTALLATION_FADE_MS);
+        const typing = typingElapsed < durationMs;
+        const fadeStart =
+          INSTALLATION_FADE_MS + durationMs + INSTALLATION_TYPING_HOLD_MS;
+        const opacity = Math.max(
+          0,
+          Math.min(
+            1,
+            elapsed / INSTALLATION_FADE_MS,
+            1 - (elapsed - fadeStart) / INSTALLATION_FADE_MS,
+          ),
+        );
+        const state = track.state;
+        const active: ActiveTyping = {
+          id: track.id,
+          x: state.animation.x,
+          y: state.animation.y,
+          color: state.animation.color,
+          currentText: typing
+            ? getTypingTextAtTime(track, typingElapsed, speed)
+            : track.finalText,
+          showCaret: typing && Math.floor(typingElapsed / 530) % 2 === 0,
+          textboxSize: state.textboxSize,
+          fontSize: state.fontSize,
+          positionOffset: state.positionOffset,
+          style: state.style,
+        };
+        return (
+          <div
+            key={track.id}
+            data-typing-recording={track.id}
+            data-typing-phase={
+              typing ? "typing" : elapsed >= fadeStart ? "fade-out" : "hold"
+            }
+            style={{ position: "absolute", inset: 0, opacity }}
+          >
+            <TypingBox typing={active} settings={settings} track={track} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/extension/website/shared/components/AnimatedTyping.tsx
+++ b/extension/website/shared/components/AnimatedTyping.tsx
@@ -6,7 +6,7 @@ import { useDebugHover } from "./DebugHover";
 import { redactWithLegibility } from "@extension/utils/keyboardRedaction";
 import {
   InstallationPlaybackQueue,
-  INSTALLATION_ARRIVAL_MS,
+  INSTALLATION_TYPING_ARRIVAL_MS,
   INSTALLATION_FADE_MS,
   INSTALLATION_TYPING_HOLD_MS,
 } from "../utils/installationPlaybackQueue";
@@ -835,15 +835,14 @@ export function ContinuousTyping({
         visible.current = visible.current.filter(
           (recording) =>
             now - recording.startedAt <
-            INSTALLATION_FADE_MS +
-              recording.durationMs +
+            recording.durationMs +
               INSTALLATION_TYPING_HOLD_MS +
               INSTALLATION_FADE_MS,
         );
         if (
           visible.current.length <
             Math.min(30, settingsRef.current.maxConcurrentTyping) &&
-          now - lastArrival >= INSTALLATION_ARRIVAL_MS
+          now - lastArrival >= INSTALLATION_TYPING_ARRIVAL_MS
         ) {
           const track = queue.take(
             new Set(visible.current.map((recording) => recording.track.id)),
@@ -873,15 +872,14 @@ export function ContinuousTyping({
     <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
       {frame.recordings.map(({ track, startedAt, speed, durationMs }) => {
         const elapsed = frame.now - startedAt;
-        const typingElapsed = Math.max(0, elapsed - INSTALLATION_FADE_MS);
+        const typingElapsed = elapsed;
         const typing = typingElapsed < durationMs;
         const fadeStart =
-          INSTALLATION_FADE_MS + durationMs + INSTALLATION_TYPING_HOLD_MS;
+          durationMs + INSTALLATION_TYPING_HOLD_MS;
         const opacity = Math.max(
           0,
           Math.min(
             1,
-            elapsed / INSTALLATION_FADE_MS,
             1 - (elapsed - fadeStart) / INSTALLATION_FADE_MS,
           ),
         );

--- a/extension/website/shared/components/Controls.tsx
+++ b/extension/website/shared/components/Controls.tsx
@@ -850,6 +850,26 @@ export const Controls: React.FC<ControlsProps> = memo(
           selectedTimeRange={selectedTimeRange ?? null}
         />
 
+        <div className="control-group">
+          <label htmlFor="animation-speed">Animation Speed</label>
+          <input
+            id="animation-speed"
+            type="range"
+            min="0.1"
+            max="10"
+            step="0.1"
+            value={settings.animationSpeed}
+            onChange={(e) =>
+              setSettings((s: any) => ({
+                ...s,
+                animationSpeed: parseFloat(e.target.value),
+              }))
+            }
+          />
+          <span>{settings.animationSpeed.toFixed(1)}x</span>
+        </div>
+
+
         {/* Visual Style (color vs monochrome) — top-level since it drives the
             cursors AND the window/typing visualizations, not just trails. */}
         <div className="control-group" style={{ marginBottom: "12px" }}>
@@ -1172,26 +1192,6 @@ export const Controls: React.FC<ControlsProps> = memo(
               <span>{(settings.chaosIntensity || 1.0).toFixed(1)}x</span>
             </div>
           )}
-
-          {/* Animation settings */}
-          <div className="control-group">
-            <label htmlFor="animation-speed">Animation Speed</label>
-            <input
-              id="animation-speed"
-              type="range"
-              min="0.1"
-              max="10"
-              step="0.1"
-              value={settings.animationSpeed}
-              onChange={(e) =>
-                setSettings((s: any) => ({
-                  ...s,
-                  animationSpeed: parseFloat(e.target.value),
-                }))
-              }
-            />
-            <span>{settings.animationSpeed.toFixed(1)}x</span>
-          </div>
 
           <div className="control-group">
             <label htmlFor="max-concurrent">Max Concurrent Trails</label>

--- a/extension/website/shared/components/MovementCanvas.tsx
+++ b/extension/website/shared/components/MovementCanvas.tsx
@@ -16,7 +16,7 @@ import { LiveIndicator } from "./LiveIndicator";
 import { SoundEngine } from "../sound/SoundEngine";
 import { attachSoundWakeListeners } from "../sound/soundWake";
 import { AnimatedClicks, type ScheduledClick } from "./AnimatedClicks";
-import { AnimatedTyping } from "./AnimatedTyping";
+import { AnimatedTyping, ContinuousTyping } from "./AnimatedTyping";
 import { AnimatedScrollViewports } from "./AnimatedScrollViewports";
 import { AnimatedNavigation } from "./AnimatedNavigation";
 import { AnimatedNavigationRadial } from "./AnimatedNavigationRadial";
@@ -331,6 +331,7 @@ const loadSettings = (
 };
 
 interface MovementCanvasProps {
+  installationRecordings?: { liveEventIds: ReadonlySet<string> };
   events: CollectionEvent[];
   loading: boolean;
   error: string | null;
@@ -397,6 +398,7 @@ interface MovementCanvasProps {
 }
 
 export const MovementCanvas: React.FC<MovementCanvasProps> = ({
+  installationRecordings,
   events,
   loading,
   error,
@@ -432,8 +434,14 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     () => ({ ...DEFAULT_SETTINGS, ...defaultSettings }),
     [defaultSettings],
   );
-  const [settings, setSettings] = useState(() =>
+  const [selectedSettings, setSettings] = useState(() =>
     loadSettings(defaultSettings, useStoredSettings),
+  );
+  const settings = useMemo(
+    () => installationRole
+      ? { ...selectedSettings, randomizeColors: false }
+      : selectedSettings,
+    [installationRole, selectedSettings],
   );
   const [controlsVisible, setControlsVisible] = useState(false);
   const [cinematic, setCinematic] = useState<CinematicConfig | null>(() =>
@@ -1186,11 +1194,17 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
 
   const viewportSettings = useMemo(
     () => ({
+      recordedTiming: installationRecordings !== undefined,
       filters: (settings.filters as FilterChip[] | undefined) ?? [],
       pidFilter: settings.pidFilter,
       viewportEventFilter: settings.viewportEventFilter,
     }),
-    [settings.filters, settings.pidFilter, settings.viewportEventFilter],
+    [
+      settings.filters,
+      settings.pidFilter,
+      settings.viewportEventFilter,
+      installationRecordings !== undefined,
+    ],
   );
 
   const { animations: scrollAnimations, urlMetadata: scrollUrlMetadata } =
@@ -1219,6 +1233,7 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
     enabled:
       !live &&
       !scrollingControlsPlayback &&
+      installationRecordings === undefined &&
       onPlaybackCycleComplete !== undefined,
     cycleKey: playbackKey,
     durationMs: playbackCycleDuration,
@@ -1765,7 +1780,15 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
           />
         )}
 
-        {showTyping && !paused && (
+        {showTyping && !paused && installationRecordings && (
+          <ContinuousTyping
+            key={`typing-${playbackContextKey}`}
+            typingStates={typingStates}
+            settings={typingSettings}
+            liveEventIds={installationRecordings.liveEventIds}
+          />
+        )}
+        {showTyping && !paused && !installationRecordings && (
           <AnimatedTyping
             key={`typing-${playbackKey}`}
             typingStates={typingStates}
@@ -1775,10 +1798,11 @@ export const MovementCanvas: React.FC<MovementCanvasProps> = ({
           />
         )}
 
-        {showScrolling && !paused && scrollAnimations && scrollAnimations.length > 0 && (
+        {showScrolling && !paused && scrollAnimations && (installationRecordings || scrollAnimations.length > 0) && (
           <AnimatedScrollViewports
             key={`scrolling-${playbackKey}`}
             animations={scrollAnimations}
+            installationLiveEventIds={installationRecordings?.liveEventIds}
             canvasSize={viewportSize}
             repeatAnimations={!scrollingControlsPlayback}
             onAnimationsComplete={

--- a/extension/website/shared/hooks/__tests__/useViewportScroll.test.ts
+++ b/extension/website/shared/hooks/__tests__/useViewportScroll.test.ts
@@ -1,0 +1,139 @@
+// ABOUTME: Tests recorded scroll, resize, and zoom timelines passed to viewport playback.
+// ABOUTME: Ensures long sessions retain every keyframe at its natural timestamp.
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import type { CollectionEvent } from "../../types";
+import {
+  useViewportScroll,
+  type UseViewportScrollResult,
+} from "../useViewportScroll";
+
+function recordedEvents(): CollectionEvent[] {
+  return [
+    { ts: 1000, data: { event: "scroll", scrollY: 0, scrollX: 0 } },
+    { ts: 11000, data: { event: "scroll", scrollY: 0.25, scrollX: 0 } },
+    { ts: 21000, data: { event: "resize", width: 900, height: 700 } },
+    { ts: 31000, data: { event: "zoom", zoom: 1.5 } },
+    { ts: 41000, data: { event: "scroll", scrollY: 1, scrollX: 0 } },
+  ].map((event, index) => ({
+    ...event,
+    id: `viewport-${index}`,
+    type: "viewport",
+    meta: {
+      pid: "person",
+      sid: "session",
+      url: "https://example.com",
+      vw: 1200,
+      vh: 800,
+      tz: "UTC",
+    },
+  }));
+}
+
+describe("useViewportScroll recorded timing", () => {
+  it("preserves natural timing and retains activity beyond 30 seconds", () => {
+    let result: UseViewportScrollResult | undefined;
+    function Harness() {
+      result = useViewportScroll(
+        recordedEvents(),
+        { width: 1200, height: 800 },
+        {
+          recordedTiming: true,
+          filters: [],
+          pidFilter: "",
+          viewportEventFilter: { scroll: true, resize: true, zoom: true },
+        },
+      );
+      return null;
+    }
+    renderToStaticMarkup(createElement(Harness));
+    expect(result?.animations).toHaveLength(1);
+    const animation = result!.animations[0];
+    expect(animation.scrollEvents.map((event) => event.timestamp)).toEqual([
+      1000, 11000, 41000,
+    ]);
+    expect(animation.resizeEvents?.[0].timestamp).toBe(21000);
+    expect(animation.zoomEvents?.[0].timestamp).toBe(31000);
+    expect(animation.endTime - animation.startTime).toBe(40000);
+  });
+});
+
+function processEvents(events: CollectionEvent[], recordedTiming?: boolean) {
+  let result: UseViewportScrollResult | undefined;
+  function Harness() {
+    result = useViewportScroll(
+      events,
+      { width: 1200, height: 800 },
+      {
+        recordedTiming,
+        filters: [],
+        pidFilter: "",
+        viewportEventFilter: { scroll: true, resize: true, zoom: true },
+      },
+    );
+    return null;
+  }
+  renderToStaticMarkup(createElement(Harness));
+  return result!.animations;
+}
+
+describe("scroll playback scope", () => {
+  it("bounds recorded resize and zoom to each visit", () => {
+    const first = recordedEvents();
+    const later = first.map((event) => ({
+      ...event,
+      id: `later-${event.id}`,
+      ts: event.ts + 3600000,
+    }));
+    const animations = processEvents([...first, ...later], true);
+    expect(animations).toHaveLength(2);
+    expect(
+      animations.map(({ startTime, endTime }) => [startTime, endTime]),
+    ).toEqual([
+      [1000, 41000],
+      [3601000, 3641000],
+    ]);
+    expect(animations[0].resizeEvents?.map((event) => event.timestamp)).toEqual(
+      [21000],
+    );
+    expect(animations[0].zoomEvents?.map((event) => event.timestamp)).toEqual([
+      31000,
+    ]);
+    expect(animations[1].resizeEvents?.map((event) => event.timestamp)).toEqual(
+      [3621000],
+    );
+    expect(animations[1].zoomEvents?.map((event) => event.timestamp)).toEqual([
+      3631000,
+    ]);
+  });
+
+  it("keeps the default 30-second cap", () => {
+    const events = recordedEvents();
+    events.push({ ...events[4], id: "last", ts: 71000 });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const animation = processEvents(events)[0];
+      expect(animation.endTime - animation.startTime).toBe(30000);
+      expect(animation.scrollEvents.map((event) => event.timestamp)).toEqual([
+        1000, 2000, 14000,
+      ]);
+      expect(log).toHaveBeenCalledWith(
+        "[Scroll] Animation 0 truncated: 43.0s → 30.0s",
+      );
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("preserves compressed timing when recorded playback is not requested", () => {
+    const animation = processEvents(recordedEvents())[0];
+    expect(animation.scrollEvents.map((event) => event.timestamp)).toEqual([
+      1000, 2000, 14000,
+    ]);
+    expect(animation.resizeEvents?.[0].timestamp).toBe(3000);
+    expect(animation.zoomEvents?.[0].timestamp).toBe(4000);
+    expect(animation.endTime).toBe(14000);
+  });
+});

--- a/extension/website/shared/hooks/useHybridInstallationEvents.ts
+++ b/extension/website/shared/hooks/useHybridInstallationEvents.ts
@@ -1,5 +1,5 @@
-// ABOUTME: Supplies finite installation chapters from archive and live browsing events.
-// ABOUTME: Rotates typing and scrolling reservoirs while other views move toward live playback.
+// ABOUTME: Supplies installation playback from archive and live browsing events.
+// ABOUTME: Keeps scrolling and typing continuous while other views advance through chapters.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CollectionEvent } from "../types";
@@ -14,15 +14,9 @@ import {
   unconsumedLiveEvents,
 } from "../utils/liveInstallation";
 import {
-  addTypingReservoirEvents,
-  createTypingReservoir,
-  takeTypingReservoirChapter,
-} from "../utils/typingInstallationReservoir";
-import {
-  addScrollReservoirEvents,
-  createScrollReservoir,
-  takeScrollReservoirChapter,
-} from "../utils/scrollInstallationReservoir";
+  useInstallationRecordings,
+  type InstallationRecordings,
+} from "./useInstallationRecordings";
 import type { parseTimeOfDayFromUrl } from "../config";
 
 type TimeOfDay = ReturnType<typeof parseTimeOfDayFromUrl> | null;
@@ -42,6 +36,7 @@ export interface HybridInstallationEventsState {
   advanceArchive: () => boolean;
   archivePlaybackKey: string;
   source: ChapterSource;
+  continuousRecordings?: InstallationRecordings;
 }
 
 export function useHybridInstallationEvents(params: {
@@ -70,22 +65,12 @@ export function useHybridInstallationEvents(params: {
   const [source, setSource] = useState<ChapterSource>("archive");
   const [liveChapter, setLiveChapter] = useState<CollectionEvent[]>([]);
   const [liveSequence, setLiveSequence] = useState(0);
-  const [typingChapter, setTypingChapter] = useState<CollectionEvent[]>([]);
-  const [typingSequence, setTypingSequence] = useState(0);
-  const [typingRotation, setTypingRotation] = useState(0);
-  const [scrollChapter, setScrollChapter] = useState<CollectionEvent[]>([]);
-  const [scrollSequence, setScrollSequence] = useState(0);
-  const [scrollRotation, setScrollRotation] = useState(0);
   const sourceRef = useRef<ChapterSource>(source);
   const liveEventsRef = useRef(live.events);
   const activeVisualizationsRef = useRef(activeVisualizations);
   const consumedIdsRef = useRef<Set<string>>(new Set());
   const seededInitialArchiveRef = useRef(false);
   const lastLiveTimestampRef = useRef(-Infinity);
-  const typingChapterRef = useRef<CollectionEvent[]>([]);
-  const typingReservoirRef = useRef(createTypingReservoir());
-  const scrollChapterRef = useRef<CollectionEvent[]>([]);
-  const scrollReservoirRef = useRef(createScrollReservoir());
   const typingContextKey = [
     selectedDay ?? "recent",
     `${timeOfDay?.centerMinutes ?? "all"}:${timeOfDay?.radiusMinutes ?? "all"}`,
@@ -97,21 +82,20 @@ export function useHybridInstallationEvents(params: {
   liveEventsRef.current = live.events;
   activeVisualizationsRef.current = activeVisualizations;
 
-  useEffect(() => {
-    typingReservoirRef.current = createTypingReservoir();
-    typingChapterRef.current = [];
-    setTypingChapter([]);
-    setTypingSequence(0);
-    setTypingRotation(0);
-  }, [typingContextKey, typingOnly]);
-
-  useEffect(() => {
-    scrollReservoirRef.current = createScrollReservoir();
-    scrollChapterRef.current = [];
-    setScrollChapter([]);
-    setScrollSequence(0);
-    setScrollRotation(0);
-  }, [typingContextKey, scrollingOnly]);
+  const screenArchive = useMemo(
+    () => eventsForInstallationScreen(archive.events, screen),
+    [archive.events, screen],
+  );
+  const screenLive = useMemo(
+    () => eventsForInstallationScreen(live.events, screen),
+    [live.events, screen],
+  );
+  const recordings = useInstallationRecordings(
+    screenArchive,
+    screenLive,
+    scrollingOnly ? "scrolling" : typingOnly ? "typing" : null,
+    hybridContextKey,
+  );
 
   useEffect(() => {
     if (reservoirOnly) return;
@@ -130,70 +114,6 @@ export function useHybridInstallationEvents(params: {
     for (const event of archive.events) consumedIdsRef.current.add(event.id);
     seededInitialArchiveRef.current = true;
   }, [archive.events, reservoirOnly]);
-
-  const takeNextTypingChapter = useCallback((): boolean => {
-    let reservoir = addTypingReservoirEvents(
-      typingReservoirRef.current,
-      eventsForInstallationScreen(archive.events, screen),
-      "archive",
-      Date.now(),
-    );
-    reservoir = addTypingReservoirEvents(
-      reservoir,
-      eventsForInstallationScreen(liveEventsRef.current, screen),
-      "live",
-      Date.now(),
-    );
-    const next = takeTypingReservoirChapter(reservoir);
-    typingReservoirRef.current = next.state;
-    if (next.events.length === 0) return false;
-
-    typingChapterRef.current = next.events;
-    setTypingChapter(next.events);
-    setTypingRotation(next.rotation);
-    setTypingSequence((sequence) => sequence + 1);
-      sourceRef.current = "archive";
-      setSource("archive");
-      return true;
-  }, [archive.events, screen]);
-
-  useEffect(() => {
-    if (!typingOnly || typingChapterRef.current.length > 0) return;
-    takeNextTypingChapter();
-  }, [archive.events, live.events, takeNextTypingChapter, typingOnly]);
-
-  const takeNextScrollChapter = useCallback((): boolean => {
-    let reservoir = addScrollReservoirEvents(
-      scrollReservoirRef.current,
-      eventsForInstallationScreen(archive.events, screen),
-      "archive",
-      Date.now(),
-    );
-    reservoir = addScrollReservoirEvents(
-      reservoir,
-      eventsForInstallationScreen(liveEventsRef.current, screen),
-      "live",
-      Date.now(),
-    );
-    const next = takeScrollReservoirChapter(reservoir);
-    scrollReservoirRef.current = next.state;
-    if (next.events.length === 0) return false;
-
-    scrollChapterRef.current = next.events;
-    setScrollChapter(next.events);
-    setScrollRotation(next.rotation);
-    setScrollSequence((sequence) => sequence + 1);
-    sourceRef.current = "archive";
-    setSource("archive");
-    return true;
-  }, [archive.events, screen]);
-
-  useEffect(() => {
-    if (!scrollingOnly || scrollChapterRef.current.length > 0) return;
-    takeNextScrollChapter();
-    const retry = window.setInterval(takeNextScrollChapter, 1000);
-    return () => window.clearInterval(retry);
-  }, [archive.events, live.events, scrollingOnly, takeNextScrollChapter]);
 
   const startReadyLiveChapter = useCallback((): boolean => {
     if (liveEventsRef.current.length > 0) {
@@ -221,16 +141,15 @@ export function useHybridInstallationEvents(params: {
     for (const event of screenEvents) consumedIdsRef.current.add(event.id);
     lastLiveTimestampRef.current =
       candidate.at(-1)?.ts ?? lastLiveTimestampRef.current;
-      setLiveChapter(candidate);
-      setLiveSequence((sequence) => sequence + 1);
-      sourceRef.current = "live";
-      setSource("live");
-      return true;
+    setLiveChapter(candidate);
+    setLiveSequence((sequence) => sequence + 1);
+    sourceRef.current = "live";
+    setSource("live");
+    return true;
   }, [screen]);
 
   const finishChapter = useCallback((): boolean => {
-    if (typingOnly) return takeNextTypingChapter();
-    if (scrollingOnly) return takeNextScrollChapter();
+    if (reservoirOnly) return false;
 
     const action = installationChapterAction(
       sourceRef.current,
@@ -240,25 +159,14 @@ export function useHybridInstallationEvents(params: {
     if (action === "wait-live") return false;
 
     return archive.advanceBatch();
-  }, [
-    archive.advanceBatch,
-    startReadyLiveChapter,
-    takeNextScrollChapter,
-    takeNextTypingChapter,
-    scrollingOnly,
-    typingOnly,
-  ]);
+  }, [archive.advanceBatch, startReadyLiveChapter, reservoirOnly]);
 
   const chapterEvents = source === "live" ? liveChapter : archive.events;
   const hybridEvents = useMemo(
     () => eventsForInstallationScreen(chapterEvents, screen),
     [chapterEvents, screen],
   );
-  const events = typingOnly
-    ? typingChapter
-    : scrollingOnly
-      ? scrollChapter
-      : hybridEvents;
+  const events = reservoirOnly ? recordings.events : hybridEvents;
 
   return {
     events,
@@ -268,13 +176,12 @@ export function useHybridInstallationEvents(params: {
     loading: archive.loading,
     error: archive.error,
     refresh: archive.refresh,
-    playbackKey: typingOnly
-      ? `typing:${typingRotation}:${typingSequence}`
-      : scrollingOnly
-        ? `scrolling:${scrollRotation}:${scrollSequence}`
-        : source === "live"
-          ? `live:${liveSequence}`
-          : `archive:${archive.batchKey}`,
+    continuousRecordings: reservoirOnly ? recordings : undefined,
+    playbackKey: reservoirOnly
+      ? hybridContextKey
+      : source === "live"
+        ? `live:${liveSequence}`
+        : `archive:${archive.batchKey}`,
     playbackContextKey: typingOnly
       ? `typing:${typingContextKey}`
       : scrollingOnly

--- a/extension/website/shared/hooks/useInstallationRecordings.ts
+++ b/extension/website/shared/hooks/useInstallationRecordings.ts
@@ -1,0 +1,96 @@
+// ABOUTME: Keeps complete scrolling and typing recordings available for continuous playback.
+// ABOUTME: Samples live arrivals and preserves archive supply while live groups are still forming.
+import { useEffect, useRef, useState } from "react";
+import type { CollectionEvent } from "../types";
+import { groupScrollEvents } from "../utils/scrollEventGroups";
+import { groupTypingEvents } from "../utils/typingEventGroups";
+
+export interface InstallationRecordings {
+  events: CollectionEvent[];
+  liveEventIds: ReadonlySet<string>;
+}
+
+export function collectInstallationRecordings(
+  archive: readonly CollectionEvent[],
+  live: readonly CollectionEvent[],
+  kind: "scrolling" | "typing",
+  now: number,
+): InstallationRecordings {
+  const liveIds = new Set(live.map((event) => event.id));
+  const events = new Map(archive.map((event) => [event.id, event]));
+  for (const event of live) events.set(event.id, event);
+  const group = kind === "scrolling" ? groupScrollEvents : groupTypingEvents;
+  const groups = group([...events.values()]).filter(
+    (recording) =>
+      !recording.events.some((event) => liveIds.has(event.id)) ||
+      recording.endTs <= now - 35_000,
+  );
+  return {
+    events: groups.flatMap((recording) => recording.events),
+    liveEventIds: liveIds,
+  };
+}
+
+export function useInstallationRecordings(
+  archive: CollectionEvent[],
+  live: CollectionEvent[],
+  kind: "scrolling" | "typing" | null,
+  contextKey: string,
+): InstallationRecordings {
+  const inputs = useRef({ archive, live });
+  inputs.current = { archive, live };
+  const [recordings, setRecordings] = useState<InstallationRecordings>({
+    events: [],
+    liveEventIds: new Set(),
+  });
+  useEffect(() => {
+    setRecordings({ events: [], liveEventIds: new Set() });
+    if (!kind) return;
+    const retainedLive = new Map<string, CollectionEvent>();
+    let signature = "";
+    let previousArchive: CollectionEvent[] | undefined;
+    let latestLiveTimestamp = 0;
+    let settled = false;
+    const update = () => {
+      let changed = inputs.current.archive !== previousArchive;
+      for (const event of inputs.current.live) {
+        if (
+          (kind === "typing" && event.type === "keyboard") ||
+          (kind === "scrolling" && event.type === "viewport")
+        ) {
+          if (!retainedLive.has(event.id)) {
+            retainedLive.set(event.id, event);
+            latestLiveTimestamp = Math.max(latestLiveTimestamp, event.ts);
+            changed = true;
+          }
+        }
+      }
+      if (!changed && settled) return;
+      previousArchive = inputs.current.archive;
+      const now = Date.now();
+      settled = now >= latestLiveTimestamp + 35_000;
+      // Bound retained live footage independently of the fetched archive.
+      while (retainedLive.size > 10_000) {
+        retainedLive.delete(retainedLive.keys().next().value!);
+      }
+      const next = collectInstallationRecordings(
+        inputs.current.archive,
+        [...retainedLive.values()],
+        kind,
+        now,
+      );
+      const nextSignature = next.events
+        .map(
+          (event) => `${event.id}:${next.liveEventIds.has(event.id) ? 1 : 0}`,
+        )
+        .join("|");
+      if (nextSignature === signature) return;
+      signature = nextSignature;
+      setRecordings(next);
+    };
+    update();
+    const interval = window.setInterval(update, 2000);
+    return () => window.clearInterval(interval);
+  }, [kind, contextKey]);
+  return recordings;
+}

--- a/extension/website/shared/hooks/useViewportScroll.ts
+++ b/extension/website/shared/hooks/useViewportScroll.ts
@@ -14,6 +14,7 @@ import { groupScrollEvents } from "../utils/scrollEventGroups";
 
 // Settings interface for viewport scroll
 export interface ViewportScrollSettings {
+  recordedTiming?: boolean;
   filters: readonly FilterChip[];
   pidFilter: string;
   viewportEventFilter: {
@@ -172,13 +173,20 @@ export function useViewportScroll(
             viewportHeight: e.meta.vh,
           }));
 
-        // Use resize/zoom events from the entire session
-        const resizeEvents = sessionResizeEvents;
-        const zoomEvents = sessionZoomEvents;
+        // Recorded playback keeps resize and zoom within this visit.
+        const withinVisit = (event: { timestamp: number }) =>
+          event.timestamp >= mergedSessionEvents[0].ts &&
+          event.timestamp <= mergedSessionEvents[mergedSessionEvents.length - 1].ts;
+        const resizeEvents = settings.recordedTiming
+          ? sessionResizeEvents.filter(withinVisit)
+          : sessionResizeEvents;
+        const zoomEvents = settings.recordedTiming
+          ? sessionZoomEvents.filter(withinVisit)
+          : sessionZoomEvents;
 
         // Compress timing for scroll events
         let compressedScrollEvents = scrollEvents;
-        if (scrollEvents.length > 0) {
+        if (!settings.recordedTiming && scrollEvents.length > 0) {
           const compressedStartTime = scrollEvents[0].timestamp;
           compressedScrollEvents = scrollEvents.map((e, i) => {
             if (i === 0) return e;
@@ -209,8 +217,8 @@ export function useViewportScroll(
             : mergedSessionEvents[0].ts;
 
         // Compress timing for resize events
-        let compressedResizeEvents: typeof resizeEvents = [];
-        if (resizeEvents.length > 0) {
+        let compressedResizeEvents = resizeEvents;
+        if (!settings.recordedTiming && resizeEvents.length > 0) {
           compressedResizeEvents = resizeEvents.map((e) => {
             const timeDelta = e.timestamp - baseStartTime;
             const compressedDelta = timeDelta * SCROLL_TIME_COMPRESSION;
@@ -222,8 +230,8 @@ export function useViewportScroll(
         }
 
         // Compress timing for zoom events
-        let compressedZoomEvents: typeof zoomEvents = [];
-        if (zoomEvents.length > 0) {
+        let compressedZoomEvents = zoomEvents;
+        if (!settings.recordedTiming && zoomEvents.length > 0) {
           compressedZoomEvents = zoomEvents.map((e) => {
             const timeDelta = e.timestamp - baseStartTime;
             const compressedDelta = timeDelta * SCROLL_TIME_COMPRESSION;
@@ -280,7 +288,7 @@ export function useViewportScroll(
           let cappedResizeEvents = compressedResizeEvents;
           let cappedZoomEvents = compressedZoomEvents;
 
-          if (originalDuration > MAX_VIEWPORT_ANIMATION_DURATION) {
+          if (!settings.recordedTiming && originalDuration > MAX_VIEWPORT_ANIMATION_DURATION) {
             cappedEndTime = startTime + MAX_VIEWPORT_ANIMATION_DURATION;
 
             // Keep only events within the capped duration
@@ -331,6 +339,7 @@ export function useViewportScroll(
           const animUrl = mergedSessionEvents[0].meta.url;
           const metadata = urlMetadata.get(animUrl);
           const anim = {
+            eventId: mergedSessionEvents[0].id,
             participantId: mergedSessionEvents[0].meta.pid,
             sessionId: mergedSessionEvents[0].meta.sid,
             pageUrl: animUrl,
@@ -430,6 +439,7 @@ export function useViewportScroll(
     viewportEvents,
     urlMetadata,
     viewportSize.width,
+    settings.recordedTiming,
     settings.filters,
     settings.pidFilter,
     settings.viewportEventFilter,

--- a/extension/website/shared/types.ts
+++ b/extension/website/shared/types.ts
@@ -133,6 +133,7 @@ export interface ActiveTyping {
 
 // Viewport animation types
 export interface ScrollAnimation {
+  eventId?: string;
   participantId: string;
   sessionId: string;
   pageUrl: string;

--- a/extension/website/shared/utils/__tests__/installationPlaybackQueue.test.ts
+++ b/extension/website/shared/utils/__tests__/installationPlaybackQueue.test.ts
@@ -1,0 +1,42 @@
+// ABOUTME: Tests continuous live-first admissions while archive playback remains available.
+// ABOUTME: Covers exhaustion, active-window exclusion, and fresh arrivals during playback.
+import { describe, expect, it } from "vitest";
+import { InstallationPlaybackQueue } from "../installationPlaybackQueue";
+
+const item = (id: string, live = false) => ({ id, live, value: id });
+describe("installation playback queue", () => {
+  it("inserts fresh live work ahead of waiting archive without replaying active work", () => {
+    const queue = new InstallationPlaybackQueue<string>();
+    queue.update([item("a"), item("b"), item("c")]);
+    expect(queue.take(new Set())).toBe("a");
+    queue.update([item("a"), item("b"), item("c"), item("live", true)]);
+    expect(queue.take(new Set(["a"]))).toBe("live");
+    expect(queue.take(new Set(["a", "live"]))).toBe("b");
+    expect(queue.take(new Set(["a", "live", "b"]))).toBe("c");
+  });
+  it("reuses the archive beside a live window without waiting for it to finish", () => {
+    const queue = new InstallationPlaybackQueue<string>();
+    queue.update([item("live", true), item("a"), item("b")]);
+    expect(queue.take(new Set())).toBe("live");
+    expect(queue.take(new Set(["live"]))).toBe("a");
+    expect(queue.take(new Set(["live", "a"]))).toBe("b");
+    expect(queue.take(new Set(["live", "b"]))).toBe("a");
+  });
+  it("does not duplicate active recordings or lose waiting work when full", () => {
+    const queue = new InstallationPlaybackQueue<string>();
+    queue.update([item("a")]);
+    expect(queue.take(new Set())).toBe("a");
+    expect(queue.take(new Set(["a"]))).toBeNull();
+    expect(queue.take(new Set())).toBe("a");
+    queue.update([]);
+    expect(queue.take(new Set())).toBeNull();
+  });
+  it("does not promote an already played live recording on each update", () => {
+    const queue = new InstallationPlaybackQueue<string>();
+    queue.update([item("live", true), item("a")]);
+    expect(queue.take(new Set())).toBe("live");
+    queue.update([item("live", true), item("a"), item("fresh", true)]);
+    expect(queue.take(new Set())).toBe("fresh");
+    expect(queue.take(new Set())).toBe("a");
+  });
+});

--- a/extension/website/shared/utils/__tests__/installationRecordings.test.ts
+++ b/extension/website/shared/utils/__tests__/installationRecordings.test.ts
@@ -1,0 +1,71 @@
+// ABOUTME: Tests completed live footage entering the continuous installation pool.
+// ABOUTME: Covers archive supply, quiet-time readiness, and whole-recording deduplication.
+import { describe, expect, it } from "vitest";
+import type { CollectionEvent } from "../../types";
+import { collectInstallationRecordings } from "../../hooks/useInstallationRecordings";
+
+function event(
+  id: string,
+  ts: number,
+  type: "viewport" | "keyboard",
+  sid = id,
+): CollectionEvent {
+  return {
+    id,
+    ts,
+    type,
+    meta: {
+      pid: "person",
+      sid,
+      url: "https://example.com",
+      vw: 1280,
+      vh: 720,
+      tz: "UTC",
+    },
+    data:
+      type === "viewport"
+        ? { event: "scroll", scrollX: 0, scrollY: 0.5 }
+        : {
+            x: 0.5,
+            y: 0.5,
+            t: "#input",
+            sequence: [{ action: "type", text: "hello", timestamp: 0 }],
+          },
+  };
+}
+
+for (const [kind, type] of [
+  ["scrolling", "viewport"],
+  ["typing", "keyboard"],
+] as const) {
+  describe(`${kind} installation recordings`, () => {
+    it("keeps archive available while live footage is incomplete, then adds live beside it", () => {
+      const archive = [event("archive", 0, type)];
+      const live = [event("live", 50_000, type)];
+      expect(
+        collectInstallationRecordings(archive, live, kind, 84_999).events.map(
+          (e) => e.id,
+        ),
+      ).toEqual(["archive"]);
+      const ready = collectInstallationRecordings(archive, live, kind, 85_000);
+      expect(ready.events.map((e) => e.id)).toEqual(["archive", "live"]);
+      expect(ready.liveEventIds.has("live")).toBe(true);
+    });
+    it("deduplicates archive/live overlap and waits for the entire input or visit to settle", () => {
+      const first = event("first", 40_000, type, "same");
+      const last = event("last", 50_000, type, "same");
+      expect(
+        collectInstallationRecordings([first], [first, last], kind, 80_000)
+          .events,
+      ).toEqual([]);
+      expect(
+        collectInstallationRecordings(
+          [first],
+          [first, last],
+          kind,
+          85_000,
+        ).events.map((e) => e.id),
+      ).toEqual(["first", "last"]);
+    });
+  });
+}

--- a/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
+++ b/extension/website/shared/utils/__tests__/liveInstallationProfiles.test.ts
@@ -23,14 +23,14 @@ describe("live installation profiles", () => {
   });
 
   it("keeps the current installation settings in centrally deployed profiles", () => {
-    expect(LIVE_INSTALLATION_PROFILES.scrolling.settings.scrollSpeed).toBe(1);
+    expect(LIVE_INSTALLATION_PROFILES.scrolling.settings.scrollSpeed).toBe(0.35);
     expect(
       LIVE_INSTALLATION_PROFILES.scrolling.settings.maxConcurrentScrolls,
-    ).toBe(42);
+    ).toBe(30);
     expect(LIVE_INSTALLATION_PROFILES.typing.settings).toMatchObject({
       textboxOpacity: 0.85,
       keyboardAnimationSpeed: 0.4,
-      maxConcurrentTyping: 50,
+      maxConcurrentTyping: 30,
     });
     expect(LIVE_INSTALLATION_PROFILES.clicks.settings).toMatchObject({
       clickMaxRadius: 55,
@@ -43,6 +43,12 @@ describe("live installation profiles", () => {
       trailOpacity: 0.9,
       maxConcurrentTrails: 24,
     });
+  });
+
+  it("uses recorded participant colors on every installation screen", () => {
+    for (const profile of Object.values(LIVE_INSTALLATION_PROFILES)) {
+      expect(profile.settings.randomizeColors).toBe(false);
+    }
   });
 
   it("enables sound only on the main cursor field", () => {

--- a/extension/website/shared/utils/installationPlaybackQueue.ts
+++ b/extension/website/shared/utils/installationPlaybackQueue.ts
@@ -46,6 +46,7 @@ export class InstallationPlaybackQueue<T> {
 }
 
 export const INSTALLATION_ARRIVAL_MS = 1500;
+export const INSTALLATION_TYPING_ARRIVAL_MS = 750;
 export const INSTALLATION_FADE_MS = 2000;
 export const INSTALLATION_SCROLL_HOLD_MS = 4000;
 export const INSTALLATION_TYPING_HOLD_MS = 8000;

--- a/extension/website/shared/utils/installationPlaybackQueue.ts
+++ b/extension/website/shared/utils/installationPlaybackQueue.ts
@@ -1,0 +1,51 @@
+// ABOUTME: Admits fresh live recordings before a continuously rotating archive.
+// ABOUTME: Excludes visible recordings and preserves waiting work across pool updates.
+export interface InstallationRecording<T> {
+  id: string;
+  live: boolean;
+  value: T;
+}
+
+export class InstallationPlaybackQueue<T> {
+  private recordings = new Map<string, InstallationRecording<T>>();
+  private seen = new Set<string>();
+  private playedLive = new Set<string>();
+
+  update(recordings: readonly InstallationRecording<T>[]) {
+    const incoming = new Map(
+      recordings.map((recording) => [recording.id, recording]),
+    );
+    for (const id of this.recordings.keys()) {
+      if (!incoming.has(id)) {
+        this.recordings.delete(id);
+        this.seen.delete(id);
+        this.playedLive.delete(id);
+      }
+    }
+    for (const [id, recording] of incoming) this.recordings.set(id, recording);
+  }
+
+  take(activeIds: ReadonlySet<string>): T | null {
+    const available = [...this.recordings.values()].filter(
+      (recording) => !activeIds.has(recording.id),
+    );
+    let next =
+      available.find(
+        (recording) => recording.live && !this.playedLive.has(recording.id),
+      ) ?? available.find((recording) => !this.seen.has(recording.id));
+    if (!next && available.length > 0) {
+      this.seen.clear();
+      for (const id of activeIds) this.seen.add(id);
+      next = available[0];
+    }
+    if (!next) return null;
+    this.seen.add(next.id);
+    if (next.live) this.playedLive.add(next.id);
+    return next.value;
+  }
+}
+
+export const INSTALLATION_ARRIVAL_MS = 1500;
+export const INSTALLATION_FADE_MS = 2000;
+export const INSTALLATION_SCROLL_HOLD_MS = 4000;
+export const INSTALLATION_TYPING_HOLD_MS = 8000;

--- a/extension/website/shared/utils/liveInstallationProfiles.ts
+++ b/extension/website/shared/utils/liveInstallationProfiles.ts
@@ -49,6 +49,7 @@ export interface LiveInstallationProfile {
 }
 
 const CURSOR_SETTINGS = {
+  randomizeColors: false,
   trailAnimationMode: "natural",
   strokeWidth: 6,
   trailOpacity: 0.9,
@@ -58,14 +59,15 @@ const CURSOR_SETTINGS = {
 } satisfies Partial<MovementSettings>;
 
 const SCROLLING_SETTINGS = {
+  randomizeColors: false,
   trailOpacity: 0.9,
   strokeWidth: 6.5,
-  animationSpeed: 3,
+  animationSpeed: 1,
   maxConcurrentTrails: 16,
   clickMaxGapMs: 850,
-  scrollSpeed: 1,
+  scrollSpeed: 0.35,
   backgroundOpacity: 0.9,
-  maxConcurrentScrolls: 42,
+  maxConcurrentScrolls: 30,
   allowOverlap: true,
   windowBleed: 0.25,
   windowScale: 0.7,
@@ -74,14 +76,15 @@ const SCROLLING_SETTINGS = {
 } satisfies Partial<MovementSettings>;
 
 const TYPING_SETTINGS = {
+  randomizeColors: false,
   trailOpacity: 0.9,
   strokeWidth: 6.5,
-  animationSpeed: 3,
+  animationSpeed: 1,
   maxConcurrentTrails: 16,
   clickMaxGapMs: 850,
   scrollSpeed: 0.2,
   backgroundOpacity: 1,
-  maxConcurrentScrolls: 42,
+  maxConcurrentScrolls: 30,
   allowOverlap: true,
   windowBleed: 0.25,
   windowScale: 0.7,
@@ -91,12 +94,13 @@ const TYPING_SETTINGS = {
   keyboardAnimationSpeed: 0.4,
   keyboardPositionRandomness: 0.8,
   keyboardRandomizeOrder: true,
-  maxConcurrentTyping: 50,
+  maxConcurrentTyping: 30,
   keyboardSizeCap: 0.3,
   keyboardMaxAspect: 2.5,
 } satisfies Partial<MovementSettings>;
 
 const CLICK_SETTINGS = {
+  randomizeColors: false,
   trailOpacity: 0.9,
   strokeWidth: 6.5,
   animationSpeed: 3,
@@ -165,7 +169,7 @@ export const LIVE_INSTALLATION_PROFILES: Record<
     role: "master",
     cinematic: null,
     visualizations: [],
-    settings: {},
+    settings: { randomizeColors: false },
     touchesSettings: TOUCHES_SETTINGS,
   },
   clicks: {


### PR DESCRIPTION
Scrolling and typing installations now insert completed live recordings ahead of waiting archive playback. Existing windows finish uninterrupted, and the archive continues supplying recordings without a batch-wide empty-screen transition.

Both screens cap the complete visible set at 30, including holds and fades, and admit scrolling windows every 1.5 seconds and typing boxes every 0.75 seconds. Scrolling uses complete recorded timing at 0.35×, holds for 4 seconds, and fades over 2 seconds. Typing runs at one-third its previous effective speed, appears immediately without a fade-in, holds completed text for 8 seconds, and fades out over 2 seconds. All named installation profiles disable random colors; a stale URL override cannot enable them.

Validation:
- 270 shared visualization tests pass, including live-first admission, archive reuse beside active windows, live quiet-time readiness, recorded scroll timing, and profile defaults.
- Extension and website TypeScript checks pass. Production build passes with its existing chunk-size warning.
- Both real installation routes render against the production API without application errors.
- Two 60-second browser checks replayed real API recordings through the renderers, inserted a priority recording during active playback, and verified that active windows continued, the priority recording played, the archive replenished afterward, no empty frames occurred, and the complete visible set stayed within the test cap of 3.
- Browser controls confirm typing's cap of 30 and Randomize Colors unchecked even with `randomizeColors=true` in the URL. Final production-build screenshots are attached separately.

The browser insertion checks use real captured footage as controlled inputs; they do not inject production events. Live recordings retain the 35-second quiet-time eligibility rule. Screens with fewer distinct eligible recordings may show fewer than 30 windows.

This includes the installation-only recorded-timing hook changes from #460. Reconcile that open PR before merging it afterward. No package API, release notes, or starter-template changes are needed for this installation-only website change.

Preview: [scrolling](https://049d9ee3.we-were-online-website.pages.dev/installation/live/?screen=scrolling) · [typing](https://049d9ee3.we-were-online-website.pages.dev/installation/live/?screen=typing). [Screenshots](https://github.com/spencerc99/playhtml/pull/479#issuecomment-5585034989) hide titles and redact typing text only for evidence publication.

Typing density follow-up: the real typing route reached 30 visible boxes; typing and hold phases remained fully opaque while exiting boxes faded. Queue tests and website TypeScript checks pass.

Animation Speed is now a top-level control, available with typing alone. Audited the remaining per-visual controls: other shared appearance/debug controls were already top-level. Browser verified changing Animation Speed from 1.0 to 1.1 and back with cursor trails disabled; website typecheck passes.
