### PR TITLE
Keep restored tabs out of Commute while allowing deliberate navigation

### DIFF
--- a/extension/src/features/slowMode/slowMode.test.ts
+++ b/extension/src/features/slowMode/slowMode.test.ts
@@ -27,11 +27,11 @@ function emptyState(): SlowModeState {
 
 describe("isFarJump", () => {
   it.each(["typed", "auto_bookmark", "generated"] as const)(
-    "accepts deliberate %s navigation from a new tab",
+    "accepts deliberate %s navigation from an existing tab",
     (transitionType) => {
       expect(
         isFarJump({
-          previousUrl: "chrome://newtab/",
+          previousUrl: "https://garden.example/notes",
           destinationUrl: "https://museum.example/exhibit",
           transitionType,
           transitionQualifiers: [],
@@ -40,8 +40,8 @@ describe("isFarJump", () => {
     },
   );
 
-  it.each([null, "https://garden.example/notes", "https://museum.example/exhibit"])(
-    "rejects navigation from an existing or unknown page %s",
+  it.each([null, "https://museum.example/exhibit", "about:blank", "invalid"])(
+    "rejects restored or unknown previous page %s",
     (previousUrl) => {
       for (const transitionType of ["typed", "auto_bookmark", "generated", "other"]) {
         expect(isFarJump({
@@ -86,6 +86,18 @@ describe("isFarJump", () => {
           transitionQualifiers: [],
         }),
       ).toBe(false);
+    },
+  );
+
+  it.each(["link", "form_submit", "reload", "other"])(
+    "rejects automatic %s navigation from an existing tab",
+    (transitionType) => {
+      expect(isFarJump({
+        previousUrl: "https://garden.example/notes",
+        destinationUrl: "https://museum.example/exhibit",
+        transitionType,
+        transitionQualifiers: [],
+      })).toBe(false);
     },
   );
 

--- a/extension/src/features/slowMode/slowMode.test.ts
+++ b/extension/src/features/slowMode/slowMode.test.ts
@@ -27,11 +27,11 @@ function emptyState(): SlowModeState {
 
 describe("isFarJump", () => {
   it.each(["typed", "auto_bookmark", "generated"] as const)(
-    "accepts deliberate %s navigation",
+    "accepts deliberate %s navigation from a new tab",
     (transitionType) => {
       expect(
         isFarJump({
-          previousUrl: "https://garden.example/notes",
+          previousUrl: "chrome://newtab/",
           destinationUrl: "https://museum.example/exhibit",
           transitionType,
           transitionQualifiers: [],
@@ -40,10 +40,34 @@ describe("isFarJump", () => {
     },
   );
 
-  it("accepts a new-tab navigation", () => {
+  it.each([null, "https://garden.example/notes", "https://museum.example/exhibit"])(
+    "rejects navigation from an existing or unknown page %s",
+    (previousUrl) => {
+      for (const transitionType of ["typed", "auto_bookmark", "generated", "other"]) {
+        expect(isFarJump({
+          previousUrl,
+          destinationUrl: "https://museum.example/exhibit",
+          transitionType,
+          transitionQualifiers: [],
+        })).toBe(false);
+      }
+    },
+  );
+
+  it.each([
+    "chrome://newtab/",
+    "chrome://new-tab-page/",
+    "chrome://new-tab-page-third-party/",
+    "edge://newtab/",
+    "brave://newtab/",
+    "about:newtab",
+    "about:home",
+    "chrome-extension://extension-id/walking-record.html",
+    "moz-extension://extension-id/walking-record.html",
+  ])("accepts navigation from the new-tab page %s", (previousUrl) => {
     expect(
       isFarJump({
-        previousUrl: "chrome://newtab/",
+        previousUrl,
         destinationUrl: "https://museum.example/exhibit",
         transitionType: "other",
         transitionQualifiers: [],
@@ -56,7 +80,7 @@ describe("isFarJump", () => {
     (transitionType) => {
       expect(
         isFarJump({
-          previousUrl: "https://garden.example/notes",
+          previousUrl: "chrome://newtab/",
           destinationUrl: "https://museum.example/exhibit",
           transitionType,
           transitionQualifiers: [],
@@ -68,7 +92,7 @@ describe("isFarJump", () => {
   it("rejects back and forward navigation", () => {
     expect(
       isFarJump({
-        previousUrl: "https://garden.example/notes",
+        previousUrl: "chrome://newtab/",
         destinationUrl: "https://museum.example/exhibit",
         transitionType: "typed",
         transitionQualifiers: ["forward_back"],
@@ -102,7 +126,7 @@ describe("isFarJump", () => {
   ])("rejects protected destination %s", (destinationUrl) => {
     expect(
       isFarJump({
-        previousUrl: "https://garden.example/notes",
+        previousUrl: "chrome://newtab/",
         destinationUrl,
         transitionType: "typed",
         transitionQualifiers: [],
@@ -114,7 +138,7 @@ describe("isFarJump", () => {
 
 describe("Slow Mode consent gates", () => {
   const navigation = {
-    previousUrl: "https://garden.example/notes",
+    previousUrl: "chrome://newtab/",
     destinationUrl: "https://museum.example/exhibit",
     transitionType: "typed" as const,
     transitionQualifiers: [],

--- a/extension/src/features/slowMode/slowMode.ts
+++ b/extension/src/features/slowMode/slowMode.ts
@@ -71,6 +71,7 @@ export function isSlowModeRideOutcome(
   );
 }
 
+const DELIBERATE_TRANSITIONS = new Set(["typed", "auto_bookmark", "generated"]);
 const NEVER_TRANSITIONS = new Set(["link", "form_submit", "reload"]);
 const PROTECTED_HOST_PREFIXES = ["mail.", "calendar.", "docs."];
 const AUTHENTICATION_HOST_LABELS = new Set([
@@ -195,7 +196,7 @@ export function dayKey(timestamp: number): string {
 }
 
 export function isFarJump(navigation: FarJumpNavigation): boolean {
-  if (!isNewTabUrl(navigation.previousUrl)) return false;
+  if (!navigation.previousUrl) return false;
   if (NEVER_TRANSITIONS.has(navigation.transitionType)) return false;
   if (navigation.transitionQualifiers.includes("forward_back")) return false;
 
@@ -207,7 +208,20 @@ export function isFarJump(navigation: FarJumpNavigation): boolean {
   }
   if (!isWebUrl(destination) || isProtectedDestination(destination)) return false;
 
-  return true;
+  if (isNewTabUrl(navigation.previousUrl)) return true;
+  if (!DELIBERATE_TRANSITIONS.has(navigation.transitionType)) return false;
+
+  try {
+    const previous = new URL(navigation.previousUrl);
+    if (!isWebUrl(previous)) return false;
+    const previousSite = siteDomain(previous);
+    return (
+      previous.hostname !== destination.hostname &&
+      (!previousSite || previousSite !== siteDomain(destination))
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function getCooldownStatus(

--- a/extension/src/features/slowMode/slowMode.ts
+++ b/extension/src/features/slowMode/slowMode.ts
@@ -71,11 +71,6 @@ export function isSlowModeRideOutcome(
   );
 }
 
-const DELIBERATE_TRANSITIONS = new Set([
-  "typed",
-  "auto_bookmark",
-  "generated",
-]);
 const NEVER_TRANSITIONS = new Set(["link", "form_submit", "reload"]);
 const PROTECTED_HOST_PREFIXES = ["mail.", "calendar.", "docs."];
 const AUTHENTICATION_HOST_LABELS = new Set([
@@ -127,9 +122,13 @@ function isNewTabUrl(value: string | null): boolean {
   if (!value) return false;
   return (
     value === "about:newtab" ||
+    value === "about:home" ||
     value.startsWith("chrome://newtab") ||
+    value.startsWith("chrome://new-tab-page/") ||
+    value.startsWith("chrome://new-tab-page-third-party/") ||
     value.startsWith("edge://newtab") ||
-    value.startsWith("brave://newtab")
+    value.startsWith("brave://newtab") ||
+    /^(chrome-extension|moz-extension):\/\/[^/]+\/walking-record\.html(?:[?#]|$)/.test(value)
   );
 }
 
@@ -196,6 +195,7 @@ export function dayKey(timestamp: number): string {
 }
 
 export function isFarJump(navigation: FarJumpNavigation): boolean {
+  if (!isNewTabUrl(navigation.previousUrl)) return false;
   if (NEVER_TRANSITIONS.has(navigation.transitionType)) return false;
   if (navigation.transitionQualifiers.includes("forward_back")) return false;
 
@@ -207,23 +207,7 @@ export function isFarJump(navigation: FarJumpNavigation): boolean {
   }
   if (!isWebUrl(destination) || isProtectedDestination(destination)) return false;
 
-  if (navigation.previousUrl) {
-    try {
-      const previous = new URL(navigation.previousUrl);
-      const previousSite = siteDomain(previous);
-      const destinationSite = siteDomain(destination);
-      if (previousSite && destinationSite && previousSite === destinationSite) {
-        return false;
-      }
-    } catch {
-      if (!isNewTabUrl(navigation.previousUrl)) return false;
-    }
-  }
-
-  return (
-    DELIBERATE_TRANSITIONS.has(navigation.transitionType) ||
-    isNewTabUrl(navigation.previousUrl)
-  );
+  return true;
 }
 
 export function getCooldownStatus(

--- a/extension/src/features/slowMode/slowModeBackground.test.ts
+++ b/extension/src/features/slowMode/slowModeBackground.test.ts
@@ -41,7 +41,7 @@ describe("Slow Mode browser interception", () => {
       createRideId: () => "ride_1234567890",
     });
 
-    handler.rememberTabUrl(7, "https://garden.example/notes");
+    handler.rememberTabUrl(7, "chrome://newtab/");
     await handler.onCommitted({
       tabId: 7,
       frameId: 0,
@@ -68,6 +68,38 @@ describe("Slow Mode browser interception", () => {
     });
   });
 
+  it.each([null, "https://museum.example/exhibit", "https://garden.example/notes"])(
+    "leaves an existing tab alone when its remembered URL is %s",
+    async (previousUrl) => {
+      const state = emptyState();
+      const handler = createSlowModeNavigationHandler({
+        getStorage: async () => ({
+          [SLOW_MODE_SETTINGS_KEY]: {
+            enabled: true,
+            chancePercent: 100,
+            stopVisibility: "domain",
+          },
+          [SLOW_MODE_STATE_KEY]: state,
+        }),
+        setStorage: async () => { throw new Error("Unexpected ride write"); },
+        getCommutePageUrl: () => "https://wewere.online/commute/",
+        updateTab: async () => { throw new Error("Unexpected tab redirect"); },
+        now: () => Date.now(),
+        random: () => 0,
+        createRideId: () => "ride_1234567890",
+      });
+      if (previousUrl) handler.rememberTabUrl(7, previousUrl);
+      await handler.onCommitted({
+        tabId: 7,
+        frameId: 0,
+        url: "https://museum.example/exhibit",
+        transitionType: "typed",
+        transitionQualifiers: [],
+      });
+      expect(state).toEqual(emptyState());
+    },
+  );
+
   it("does not redirect subframes or link navigations", async () => {
     const updateTab = vi.fn().mockResolvedValue(undefined);
     const handler = createSlowModeNavigationHandler({
@@ -87,7 +119,7 @@ describe("Slow Mode browser interception", () => {
       createRideId: () => "ride_1234567890",
     });
 
-    handler.rememberTabUrl(7, "https://garden.example/notes");
+    handler.rememberTabUrl(7, "chrome://newtab/");
     await handler.onCommitted({
       tabId: 7,
       frameId: 2,

--- a/extension/src/features/slowMode/slowModeBackground.test.ts
+++ b/extension/src/features/slowMode/slowModeBackground.test.ts
@@ -18,7 +18,7 @@ function emptyState(): SlowModeState {
 }
 
 describe("Slow Mode browser interception", () => {
-  it("redirects a qualifying top-frame navigation and records the ride", async () => {
+  it.each(["chrome://newtab/", "https://garden.example/notes"])("redirects a deliberate navigation from %s and records the ride", async (previousUrl) => {
     const stored: Record<string, unknown> = {
       [SLOW_MODE_SETTINGS_KEY]: {
         enabled: true,
@@ -41,7 +41,7 @@ describe("Slow Mode browser interception", () => {
       createRideId: () => "ride_1234567890",
     });
 
-    handler.rememberTabUrl(7, "chrome://newtab/");
+    handler.rememberTabUrl(7, previousUrl);
     await handler.onCommitted({
       tabId: 7,
       frameId: 0,
@@ -68,7 +68,7 @@ describe("Slow Mode browser interception", () => {
     });
   });
 
-  it.each([null, "https://museum.example/exhibit", "https://garden.example/notes"])(
+  it.each([null, "https://museum.example/exhibit"])(
     "leaves an existing tab alone when its remembered URL is %s",
     async (previousUrl) => {
       const state = emptyState();


### PR DESCRIPTION
Commute leaves restored tabs alone while keeping deliberate navigation to another site eligible, including manually changing the address in an existing tab. Browser new-tab pages and the Walking Record new-tab page also remain eligible.

A `typed` navigation previously qualified even when the background worker had no record of the previous page. The worker starts with an empty tab map and seeds it asynchronously, leaving resumed tabs eligible without evidence of a fresh navigation. The policy now requires a known previous page and rejects same-site navigation. Existing web tabs qualify only for deliberate typed, bookmark, or address-bar generated transitions. Link, reload, history, protected-destination, chance, and cooldown exclusions remain covered.

Validation:
- Focused policy and background-handler regressions: 47 passed, including manual address changes, unknown previous URLs, restored same-page navigation, and same-site exclusions. The manual-navigation regressions failed against the new-tab-only policy before this adjustment.
- `bun run test:extension`: 171 files, 1,072 tests passed on the final run. The first run hit an unrelated identity-injection failure in `content-dev-features.test.ts`; that file passed in isolation, then the full suite passed.
- Development extension build, `bun run check:extension`, and `git diff --check` passed. Workspace packages were built before extension testing.
- Fresh isolated Chromium 147.0.7727.15 profiles with the built MV3 extension: returning to and reloading an existing tab recorded zero rides; typed cross-site navigation in that tab recorded exactly one ride and opened the hosted Commute page for the intended destination. A native new-tab navigation also recorded exactly one ride after resetting test cooldown state.
- Closed and restarted Chromium with session restoration and Commute enabled at 100% probability. The existing web tab restored at its original URL with zero rides. Temporary harnesses: `/tmp/commute-manual-browser.mjs` and `/tmp/commute-manual-restore.mjs`. They exercise browser navigation events, background interception, local storage, and the hosted redirect without mocked navigation callbacks.
- Separate `tabs.discard()` verification remains unavailable because the installed Chromium builds crashed inside that API. Full browser restart/session restoration passed independently. An unknown previous page deliberately remains ineligible, including during background startup.

Screenshots are attached in the PR Evidence comment. No package changeset or starter changes are needed because this changes only extension navigation policy. No PENDING entry: COMMUTE remains beta in the feature catalog.
