### PR TITLE
Preserve participant colors in large archive responses

### DIFF
--- a/extension/worker/src/__tests__/participantColors.test.ts
+++ b/extension/worker/src/__tests__/participantColors.test.ts
@@ -1,0 +1,41 @@
+// ABOUTME: Tests bounded participant color loading across large event selections.
+// ABOUTME: Verifies complete coverage, duplicate IDs, and explicit lookup failures.
+
+import { describe, expect, it } from 'vitest';
+import { loadParticipantColors } from '../lib/participantColors';
+
+describe('participant colors', () => {
+  it('keeps public-key queries small while loading every participant', async () => {
+    const rows = Array.from({ length: 235 }, (_, i) => ({
+      pid: `pk_${i.toString(16).padStart(130, '0')}`,
+      cursor_color: `hsl(${i}, 70%, 50%)`,
+    }));
+    const batches: string[][] = [];
+    const colors = await loadParticipantColors(
+      [...rows.map(row => row.pid), rows[0].pid],
+      async ids => {
+        batches.push(ids);
+        const query = new URLSearchParams({ select: 'pid,cursor_color', pid: `in.(${ids.join(',')})` });
+        expect(new TextEncoder().encode(query.toString()).length).toBeLessThan(8000);
+        return { data: rows.filter(row => ids.includes(row.pid)), error: null };
+      },
+    );
+    expect(batches.map(batch => batch.length)).toEqual([50, 50, 50, 50, 35]);
+    expect(colors).toEqual(new Map(rows.map(row => [row.pid, row.cursor_color])));
+  });
+
+  it('does not turn a failed lookup into missing colors', async () => {
+    await expect(loadParticipantColors(['p'], async () => ({
+      data: null, error: { message: 'URI too long' },
+    }))).rejects.toThrow('Participant color lookup failed: URI too long');
+  });
+
+  it('distinguishes absent colors and participants from a failed query', async () => {
+    const colors = await loadParticipantColors(['p', 'absent'], async () => ({
+      data: [{ pid: 'p', cursor_color: null }], error: null,
+    }));
+    expect(colors.has('p')).toBe(true);
+    expect(colors.get('p')).toBeNull();
+    expect(colors.has('absent')).toBe(false);
+  });
+});

--- a/extension/worker/src/lib/participantColors.ts
+++ b/extension/worker/src/lib/participantColors.ts
@@ -1,0 +1,30 @@
+// ABOUTME: Loads participant colors in bounded batches for event responses.
+// ABOUTME: Surfaces lookup failures instead of treating them as missing identity colors.
+
+interface ParticipantColorRow {
+  pid: string;
+  cursor_color: string | null;
+}
+
+// Public-key participant IDs are 133 characters; 50 fit below the HTTP URL limit.
+const PARTICIPANT_COLOR_BATCH_SIZE = 50;
+
+export async function loadParticipantColors(
+  participantIds: readonly string[],
+  loadBatch: (ids: string[]) => PromiseLike<{
+    data: ParticipantColorRow[] | null;
+    error?: { message: string } | null;
+  }>,
+): Promise<Map<string, string | null>> {
+  const ids = [...new Set(participantIds)];
+  const colors = new Map<string, string | null>();
+  for (let offset = 0; offset < ids.length; offset += PARTICIPANT_COLOR_BATCH_SIZE) {
+    const { data, error } = await loadBatch(
+      ids.slice(offset, offset + PARTICIPANT_COLOR_BATCH_SIZE),
+    );
+    if (error) throw new Error(`Participant color lookup failed: ${error.message}`);
+    if (data === null) throw new Error('Participant color lookup returned no data');
+    for (const row of data) colors.set(row.pid, row.cursor_color);
+  }
+  return colors;
+}

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -3,7 +3,6 @@
 
 import type { CollectionEvent } from '@playhtml/extension-types';
 import { createSupabaseClient, type Env } from '../lib/supabase';
-import { loadParticipantColors } from '../lib/participantColors';
 import { HUB_NAME } from './constants';
 
 /**
@@ -193,12 +192,15 @@ async function resolveCursorColors(
   if (missing.length > 0) {
     try {
       const supabase = createSupabaseClient(env);
-      const found = await loadParticipantColors(missing, ids =>
-        supabase
-          .from('participants')
-          .select('pid, cursor_color')
-          .in('pid', ids),
-      );
+      const { data } = await supabase
+        .from('participants')
+        .select('pid, cursor_color')
+        .in('pid', missing);
+
+      const found = new Map<string, string | null>();
+      for (const row of data ?? []) {
+        found.set(row.pid as string, (row.cursor_color as string) ?? null);
+      }
       // Record every requested-but-missing pid (even those with no row) so we
       // don't re-query for participants who simply have no stored color.
       for (const pid of missing) {

--- a/extension/worker/src/live/broadcast.ts
+++ b/extension/worker/src/live/broadcast.ts
@@ -3,6 +3,7 @@
 
 import type { CollectionEvent } from '@playhtml/extension-types';
 import { createSupabaseClient, type Env } from '../lib/supabase';
+import { loadParticipantColors } from '../lib/participantColors';
 import { HUB_NAME } from './constants';
 
 /**
@@ -192,15 +193,12 @@ async function resolveCursorColors(
   if (missing.length > 0) {
     try {
       const supabase = createSupabaseClient(env);
-      const { data } = await supabase
-        .from('participants')
-        .select('pid, cursor_color')
-        .in('pid', missing);
-
-      const found = new Map<string, string | null>();
-      for (const row of data ?? []) {
-        found.set(row.pid as string, (row.cursor_color as string) ?? null);
-      }
+      const found = await loadParticipantColors(missing, ids =>
+        supabase
+          .from('participants')
+          .select('pid, cursor_color')
+          .in('pid', ids),
+      );
       // Record every requested-but-missing pid (even those with no row) so we
       // don't re-query for participants who simply have no stored color.
       for (const pid of missing) {

--- a/extension/worker/src/routes/recent.ts
+++ b/extension/worker/src/routes/recent.ts
@@ -4,6 +4,7 @@
 // ABOUTME: this handler re-joins them by page_ref before returning.
 
 import { createSupabaseClient, type Env } from '../lib/supabase';
+import { loadParticipantColors } from '../lib/participantColors';
 import type { CollectionEvent, EventMeta } from '@playhtml/extension-types';
 import { canonicalizeUrl, buildPageRef } from '../../../src/utils/pageMetadata';
 
@@ -216,20 +217,12 @@ export async function handleRecent(
 
     // ── Look up cursor colors ─────────────────────────────────────────────────
     const participantIds = [...new Set(rows.map((row) => row.participant_id as string))];
-    const participantColors = new Map<string, string>();
-
-    if (participantIds.length > 0) {
-      const { data: participants } = await supabase
+    const participantColors = await loadParticipantColors(participantIds, ids =>
+      supabase
         .from('participants')
         .select('pid, cursor_color')
-        .in('pid', participantIds);
-
-      if (participants) {
-        for (const p of participants) {
-          participantColors.set(p.pid, p.cursor_color);
-        }
-      }
-    }
+        .in('pid', ids),
+    );
 
     // ── Build response events ─────────────────────────────────────────────────
     const allEvents: CollectionEvent[] = rows.map((row: Record<string, unknown>) => {


### PR DESCRIPTION
Large archive requests silently lost participant colors: a production request for 20,000 keyboard events returned no colors, while all 1,000 matching events in a smaller response had colors. The participant lookup put hundreds of public-key IDs in one URL and ignored query errors.

Load archive colors in batches of 50 IDs. Archive lookup failures now return an error instead of a successful uncolored response. Live broadcasting, event storage, and playback are unchanged.

Verification:

- All 152 Worker tests and the Worker TypeScript check pass. The sandboxed D1 test startup timed out; the complete suite passed with local runtime permissions.
- Real database verification of the changed handler returned colors on all 20,000 keyboard events across 240 participants.
- Automated Chrome verification loaded the production installation typing page with its archive request forwarded to the changed local HTTP handler using the real database. All 22 inspected rendered boxes carried participant colors and randomizeColors was false. The live WebSocket remained connected to production. This verifies the handler and renderer, not a deployed Worker version.
- Production live sample: all 746 events, including three keyboard events, carried colors.

No schema changes or extension release required. A Worker deployment and reload of already-open installation pages are needed for the production fix.
