### PR TITLE
Keep pale typing backgrounds visibly tinted

### DIFF
--- a/extension/website/shared/components/AnimatedTyping.tsx
+++ b/extension/website/shared/components/AnimatedTyping.tsx
@@ -15,6 +15,7 @@ import {
   isMonochromeStyle,
   colorWash,
   colorShade,
+  typingBackgroundColor,
   readableTextLightness,
 } from "../utils/colorStyle";
 
@@ -417,7 +418,7 @@ const TypingBox = memo(
       // Wash of the hue, lightened so dark cursor colors still read as a light
       // input rather than a saturated panel. Letters + border take a readable
       // shade of the same hue.
-      backgroundColor = colorWash(vizColor, fillAlpha, 30);
+      backgroundColor = typingBackgroundColor(vizColor, fillAlpha);
       textColor = colorShade(vizColor, readableTextLightness(vizColor));
       borderColor = colorWash(vizColor, 0.55, 0);
     }

--- a/extension/website/shared/utils/__tests__/colorStyle.test.ts
+++ b/extension/website/shared/utils/__tests__/colorStyle.test.ts
@@ -12,9 +12,15 @@ describe("typingBackgroundColor", () => {
       expect(match).not.toBeNull();
       const lightness = Number(match![1]);
       expect(lightness).toBeGreaterThan(previous);
-      expect(lightness).toBeLessThan(92);
+      expect(lightness).toBeLessThan(98);
       previous = lightness;
     }
+  });
+  it("starts tapering at 85% and keeps very pale colors near the ceiling", () => {
+    expect(typingBackgroundColor("hsl(160, 70%, 55%)", 0.85)).toBe("hsla(160, 70%, 85%, 0.85)");
+    const result = typingBackgroundColor("hsl(160, 70%, 95%)", 0.85);
+    const lightness = Number(result.match(/^hsla\(160, 70%, ([\d.]+)%, 0.85\)$/)![1]);
+    expect(lightness).toBeCloseTo(97.4, 1);
   });
   it("keeps dark-color lightening and handles unparseable colors", () => {
     expect(typingBackgroundColor("hsl(160, 70%, 20%)", 0.75)).toBe("hsla(160, 70%, 50%, 0.75)");

--- a/extension/website/shared/utils/__tests__/colorStyle.test.ts
+++ b/extension/website/shared/utils/__tests__/colorStyle.test.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Tests typing background tints across dark and pale participant colors.
+// ABOUTME: Ensures the lightness curve retains hue, opacity, and a visible tint.
+import { describe, expect, it } from "vitest";
+import { typingBackgroundColor } from "../colorStyle";
+
+describe("typingBackgroundColor", () => {
+  it("retains hue, saturation and opacity without whitening pale colors", () => {
+    let previous = 0;
+    for (let l = 0; l <= 100; l++) {
+      const result = typingBackgroundColor(`hsl(160, 70%, ${l}%)`, 0.85);
+      const match = result.match(/^hsla\(160, 70%, ([\d.]+)%, 0.85\)$/);
+      expect(match).not.toBeNull();
+      const lightness = Number(match![1]);
+      expect(lightness).toBeGreaterThan(previous);
+      expect(lightness).toBeLessThan(92);
+      previous = lightness;
+    }
+  });
+  it("keeps dark-color lightening and handles unparseable colors", () => {
+    expect(typingBackgroundColor("hsl(160, 70%, 20%)", 0.75)).toBe("hsla(160, 70%, 50%, 0.75)");
+    expect(typingBackgroundColor("transparent", 0.75)).toBe("rgba(180, 175, 168, 0.75)");
+  });
+});

--- a/extension/website/shared/utils/colorStyle.ts
+++ b/extension/website/shared/utils/colorStyle.ts
@@ -29,10 +29,10 @@ export function typingBackgroundColor(color: string, alpha: number): string {
   const hsl = parseColorToHsl(color);
   if (!hsl) return colorWash(color, alpha);
   const lifted = hsl.l + 30;
-  // Above 65%, lightness approaches 92% exponentially instead of reaching white.
-  const lightness = lifted <= 65
+  // Above 85%, lightness approaches 98% exponentially instead of reaching white.
+  const lightness = lifted <= 85
     ? lifted
-    : 65 + 27 * (1 - Math.exp(-(lifted - 65) / 27));
+    : 85 + 13 * (1 - Math.exp(-(lifted - 85) / 13));
   return `hsla(${hsl.h}, ${hsl.s}%, ${lightness}%, ${alpha})`;
 }
 

--- a/extension/website/shared/utils/colorStyle.ts
+++ b/extension/website/shared/utils/colorStyle.ts
@@ -24,6 +24,18 @@ export function colorWash(
   return `hsla(${hsl.h}, ${hsl.s}%, ${l}%, ${alpha})`;
 }
 
+/** Lightens typing fills with a soft ceiling so pale participant hues remain visible. */
+export function typingBackgroundColor(color: string, alpha: number): string {
+  const hsl = parseColorToHsl(color);
+  if (!hsl) return colorWash(color, alpha);
+  const lifted = hsl.l + 30;
+  // Above 65%, lightness approaches 92% exponentially instead of reaching white.
+  const lightness = lifted <= 65
+    ? lifted
+    : 65 + 27 * (1 - Math.exp(-(lifted - 65) / 27));
+  return `hsla(${hsl.h}, ${hsl.s}%, ${lightness}%, ${alpha})`;
+}
+
 /** A solid, readable shade of `color` at a target lightness — used for text and
  * borders so the hue reads as the participant's but stays legible on the warm
  * paper background. */


### PR DESCRIPTION
Pale participant colors could produce white typing boxes because the background added 30 lightness points and clamped at 100%. Typing fills now use an exponential lightness curve above 85%, approaching a 98% ceiling so pale backgrounds retain a subtle participant tint. A 95% input lightness produces about 97.4% background lightness.

This applies to the shared typing renderer, including installation and archive. Scrolling fills, text and border colors, opacity settings, and monochrome rendering are unchanged. Neutral participant colors remain neutral.

Validation: six focused color tests and the website TypeScript check pass. Chrome verification on the real local installation route rendered pale tinted fills without page errors. Screenshot text is fully redacted using the supported legibility setting.
