### PR TITLE
Keep full cursor trails visible

### DIFF
--- a/extension/website/shared/components/__tests__/trailPrimitives.test.ts
+++ b/extension/website/shared/components/__tests__/trailPrimitives.test.ts
@@ -28,6 +28,17 @@ function trailState(): TrailState {
 }
 
 describe("computeTrailFrame", () => {
+  it.each([0.75, 1])("retains the beginning of a long trail at progress %s", (progress) => {
+    const state = trailState();
+    state.variedPoints = Array.from({ length: 2001 }, (_, x) => ({ x, y: 0 }));
+    const frame = computeTrailFrame(state, progress * state.durationMs, 4);
+    const coordinates = frame!.pathData.match(/-?\d+(?:\.\d+)?/g)!.map(Number);
+    const xs = coordinates.filter((_, index) => index % 2 === 0);
+
+    expect(Math.min(...xs)).toBeLessThan(5);
+    expect(Math.max(...xs)).toBeGreaterThan(2000 * progress - 5);
+  });
+
   it("returns null before the trail starts", () => {
     expect(computeTrailFrame(trailState(), -10, 4)).toBeNull();
   });

--- a/extension/website/shared/components/trailPrimitives.tsx
+++ b/extension/website/shared/components/trailPrimitives.tsx
@@ -21,9 +21,6 @@ export const EVICTION_FADE_MS = 3000;
 export const COMPLETED_OPACITY = 0.5;
 export const COMPLETION_FADE_MS = 3000;
 
-// How many points to show behind the cursor while drawing
-export const TAIL_LENGTH = 1000;
-
 // Compute visible points and path data for a trail at a given elapsed time.
 // strokeSize is baked into the freehand outline geometry, so the path must be
 // rebuilt whenever it changes.
@@ -58,9 +55,7 @@ export function computeTrailFrame(
   const headIndex = Math.floor(exactVariedPosition);
   const headFraction = exactVariedPosition - headIndex;
 
-  const tailStart = isFinished
-    ? Math.max(0, totalVariedPoints - TAIL_LENGTH)
-    : Math.max(0, headIndex - TAIL_LENGTH + 1);
+  const tailStart = 0;
   const tailEnd = Math.min(headIndex, totalVariedPoints - 1);
 
   let interpolatedHead: { x: number; y: number } | undefined;


### PR DESCRIPTION
Long cursor trails lose their beginning once the drawing head passes 1,000 rendered points. Keep the full drawn path visible in live and replay views so the tail does not disappear as the cursor advances. Whole-trail dimming and removal retain their existing timing.

Validation: 23 focused trail tests pass, including a 2,001-point regression that failed before the fix at both 75% and 100% progress. Website typecheck and production build pass; Vite reports large bundle warnings. Chrome loaded the local `/portrait/?viz=trails&clean=2` surface with real live data and no page errors. A separate synthetic long-trail geometry probe in Chrome confirms the path retains its starting point during drawing and on completion. Synthetic-only real-surface screenshots are attached in [PR Evidence](https://github.com/spencerc99/playhtml/pull/485#issuecomment-5626366572). Chrome loaded the actual `/portrait/` route with 480 generated spiral events from a loopback WebSocket, producing 1,816 rendered points. External page requests were blocked. Captures show the trail during drawing and after completion; both retain the starting point and produced no page errors. Browser time was advanced to capture these states, so this is visual correctness evidence, not a performance measurement. No live browsing-data screenshot was uploaded.

Long trails require more path geometry; installation hardware performance has not been measured. This is a website rendering fix with no published package API, starter template, or released extension change.
